### PR TITLE
automation: add new issues to the team GH board

### DIFF
--- a/.github/workflows/github_projects_tagger.yml
+++ b/.github/workflows/github_projects_tagger.yml
@@ -1,0 +1,19 @@
+name: GitHub Projects Tagger
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: abernix/github-issue-pull-api-hook@v1.0.0
+        with:
+          # These are both set in Org level secrets and work on a safe-listed
+          # set of repositories that affect the Polaris team.  This allows them to
+          # be updated in a single place.  If you want a NEW repo to work, you'll
+          # need an org admin to add it as a repo to (both) the existing secrets.
+          # https://github.com/organizations/apollographql/settings/secrets/actions
+          api_url: ${{ secrets.POLARIS_TAGGER_API_URL }}
+          bearer_token: ${{ secrets.POLARIS_TAGGER_BEARER_TOKEN }}


### PR DESCRIPTION
This workflow automatically adds newly opened GitHub Issues to our team project board in the "Triage" status and assigned to the "Router" area.

Behind the scenes, this uses a [Custom GitHub Action] I put together that just does a `GET` call to a Netlify Function (an AWS Lambda) that lives in our internal `polaris-planning` repository with the `url` of the issue that was opened.  Via logic that lives within the Netlify Function, that's all the information it needs to do the assignment.

It's authenticated via Org-level GitHub Actions Secrets.

[Custom GitHub Action]: https://github.com/abernix/github-issue-pull-api-hook/