### PR TITLE
fix(apollo-parser): create nodes for all value kinds

### DIFF
--- a/crates/apollo-parser/src/parser/generated/syntax_kind.rs
+++ b/crates/apollo-parser/src/parser/generated/syntax_kind.rs
@@ -69,9 +69,9 @@ pub enum SyntaxKind {
     ENUM_VALUE_KW,
     INPUT_OBJECT_KW,
     INPUT_FIELD_DEFINITION_KW,
-    INT_VALUE,
-    FLOAT_VALUE,
-    STRING_VALUE,
+    INT,
+    FLOAT,
+    STRING,
     IDENT,
     WHITESPACE,
     COMMENT,
@@ -103,6 +103,9 @@ pub enum SyntaxKind {
     ARGUMENTS,
     ARGUMENT,
     VALUE,
+    STRING_VALUE,
+    INT_VALUE,
+    FLOAT_VALUE,
     FRAGMENT_NAME,
     TYPE_CONDITION,
     VARIABLE,
@@ -218,9 +221,7 @@ impl SyntaxKind {
                 | COLON
         )
     }
-    pub fn is_literal(self) -> bool {
-        matches!(self, INT_VALUE | FLOAT_VALUE | STRING_VALUE)
-    }
+    pub fn is_literal(self) -> bool { matches!(self, INT | FLOAT | STRING) }
     pub fn from_keyword(ident: &str) -> Option<SyntaxKind> {
         let kw = match ident {
             "query" => query_KW,

--- a/crates/apollo-parser/src/parser/grammar/value.rs
+++ b/crates/apollo-parser/src/parser/grammar/value.rs
@@ -16,20 +16,36 @@ use crate::{
 ///     ListValue<sub>\[?Const\]</sub>
 ///     ObjectValue<sub>\[?Const\]</sub>
 pub(crate) fn value(p: &mut Parser) {
-    let _g = p.start_node(SyntaxKind::VALUE);
     match p.peek() {
         Some(T![$]) => variable::variable(p),
-        Some(TokenKind::Int) => p.bump(SyntaxKind::INT_VALUE),
-        Some(TokenKind::Float) => p.bump(SyntaxKind::FLOAT_VALUE),
-        Some(TokenKind::StringValue) => p.bump(SyntaxKind::STRING_VALUE),
+        Some(TokenKind::Int) => {
+            let _g = p.start_node(SyntaxKind::INT_VALUE);
+            p.bump(SyntaxKind::INT);
+        }
+        Some(TokenKind::Float) => {
+            let _g = p.start_node(SyntaxKind::FLOAT_VALUE);
+            p.bump(SyntaxKind::FLOAT);
+        }
+        Some(TokenKind::StringValue) => {
+            let _g = p.start_node(SyntaxKind::STRING_VALUE);
+            p.bump(SyntaxKind::STRING);
+        }
         Some(TokenKind::Name) => {
             let node = p.peek_data().unwrap();
-            if matches!(node.as_str(), "true" | "false") {
-                p.bump(SyntaxKind::BOOLEAN_VALUE);
-            } else if matches!(node.as_str(), "null") {
-                p.bump(SyntaxKind::NULL_VALUE);
-            } else {
-                enum_value(p);
+            match node.as_str() {
+                "true" => {
+                    let _g = p.start_node(SyntaxKind::BOOLEAN_VALUE);
+                    p.bump(SyntaxKind::true_KW);
+                }
+                "false" => {
+                    let _g = p.start_node(SyntaxKind::BOOLEAN_VALUE);
+                    p.bump(SyntaxKind::false_KW);
+                }
+                "null" => {
+                    let _g = p.start_node(SyntaxKind::NULL_VALUE);
+                    p.bump(SyntaxKind::null_KW)
+                }
+                _ => enum_value(p),
             }
         }
         Some(T!['[']) => list_value(p),

--- a/graphql.ungram
+++ b/graphql.ungram
@@ -94,13 +94,13 @@ Value =
   | ObjectValue
 
 StringValue =
-  'string_value'
+  'string'
 
 FloatValue =
-  'float_value'
+  'float'
 
 IntValue =
-  'int_value'
+  'int'
 
 BooleanValue =
   'true'

--- a/xtask/src/ast_src.rs
+++ b/xtask/src/ast_src.rs
@@ -64,9 +64,7 @@ pub(crate) const KINDS_SRC: KindsSrc = KindsSrc {
         "INPUT_OBJECT",
         "INPUT_FIELD_DEFINITION",
     ],
-    literals: &["INT_VALUE", "FLOAT_VALUE", "STRING_VALUE"],
-    // NOTE @lrlna: IDENT is definitely a token we need, not entirely sure about
-    // WHITESPACE and COMMENT.
+    literals: &["INT", "FLOAT", "STRING"],
     tokens: &["IDENT", "WHITESPACE", "COMMENT"],
     // These are all the "DOCUMENT" items defined in the GraphQL spec --
     // https://spec.graphql.org/draft/#sec-Appendix-Grammar-Summary.Document,
@@ -100,6 +98,9 @@ pub(crate) const KINDS_SRC: KindsSrc = KindsSrc {
         "ARGUMENTS",
         "ARGUMENT",
         "VALUE",
+        "STRING_VALUE",
+        "INT_VALUE",
+        "FLOAT_VALUE",
         "FRAGMENT_NAME",
         "TYPE_CONDITION",
         "VARIABLE",


### PR DESCRIPTION
We were only creating nodes for some of the Value kinds, like ObjectValue and ListValue, but were missing nodes for StringValue, FloatValue, IntValue, BooleanValue and NullValue. This commit introduces new nodes for these variants of the Value. We are also dropping creating a Value node, since by creating NullValue et al nodes, it is already considered to be a Value Node.

This commit fixes being able to iterate and query values in arguments and other nodes they are present.