### PR TITLE
allow types to follow query shorthand definitions

### DIFF
--- a/crates/apollo-parser/src/parser/grammar/operation.rs
+++ b/crates/apollo-parser/src/parser/grammar/operation.rs
@@ -45,25 +45,27 @@ pub(crate) fn operation_definition(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::OPERATION_DEFINITION);
 
     match p.peek() {
-        Some(TokenKind::Name) => operation_type(p),
+        Some(TokenKind::Name) => {
+            operation_type(p);
+
+            if let Some(TokenKind::Name) = p.peek() {
+                name::name(p);
+            }
+
+            if let Some(T!['(']) = p.peek() {
+                variable::variable_definitions(p)
+            }
+
+            if let Some(T![@]) = p.peek() {
+                directive::directives(p);
+            }
+
+            if let Some(T!['{']) = p.peek() {
+                selection::selection_set(p)
+            }
+        }
         Some(T!['{']) => selection::selection_set(p),
         _ => p.err("expected an Operation Type or a Selection Set"),
-    }
-
-    if let Some(TokenKind::Name) = p.peek() {
-        name::name(p);
-    }
-
-    if let Some(T!['(']) = p.peek() {
-        variable::variable_definitions(p)
-    }
-
-    if let Some(T![@]) = p.peek() {
-        directive::directives(p);
-    }
-
-    if let Some(T!['{']) = p.peek() {
-        selection::selection_set(p)
     }
 }
 

--- a/crates/apollo-parser/test_data/parser/ok/0033_directive_on_argument_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0033_directive_on_argument_definition.txt
@@ -1,49 +1,49 @@
-- DOCUMENT@0..91
-    - OBJECT_TYPE_DEFINITION@0..91
+- DOCUMENT@0..93
+    - OBJECT_TYPE_DEFINITION@0..93
         - type_KW@0..4 "type"
         - WHITESPACE@4..5 " "
         - NAME@5..14
             - IDENT@5..13 "Mutation"
             - WHITESPACE@13..14 " "
-        - FIELDS_DEFINITION@14..91
+        - FIELDS_DEFINITION@14..93
             - L_CURLY@14..15 "{"
-            - WHITESPACE@15..18 "\n  "
-            - FIELD_DEFINITION@18..90
-                - NAME@18..23
-                    - IDENT@18..23 "login"
-                - ARGUMENTS@23..83
-                    - L_PAREN@23..24 "("
-                    - INPUT_VALUE_DEFINITION@24..82
-                        - NAME@24..30
-                            - IDENT@24..30 "userId"
-                        - COLON@30..31 ":"
-                        - WHITESPACE@31..32 " "
-                        - TYPE@32..39
-                            - WHITESPACE@32..33 " "
-                            - NAMED_TYPE@33..39
-                                - NAME@33..39
-                                    - IDENT@33..39 "String"
-                        - DIRECTIVES@39..82
-                            - DIRECTIVE@39..82
-                                - AT@39..40 "@"
-                                - NAME@40..50
-                                    - IDENT@40..50 "deprecated"
-                                - ARGUMENTS@50..82
-                                    - L_PAREN@50..51 "("
-                                    - ARGUMENT@51..81
-                                        - NAME@51..57
-                                            - IDENT@51..57 "reason"
-                                        - COLON@57..58 ":"
-                                        - WHITESPACE@58..59 " "
-                                        - STRING_VALUE@59..81
-                                            - STRING@59..81 "\"Use username instead\""
-                                    - R_PAREN@81..82 ")"
-                    - R_PAREN@82..83 ")"
-                - COLON@83..84 ":"
-                - WHITESPACE@84..85 " "
-                - TYPE@85..90
-                    - WHITESPACE@85..86 "\n"
-                    - NAMED_TYPE@86..90
-                        - NAME@86..90
-                            - IDENT@86..90 "User"
-            - R_CURLY@90..91 "}"
+            - WHITESPACE@15..19 "\r\n  "
+            - FIELD_DEFINITION@19..92
+                - NAME@19..24
+                    - IDENT@19..24 "login"
+                - ARGUMENTS@24..84
+                    - L_PAREN@24..25 "("
+                    - INPUT_VALUE_DEFINITION@25..83
+                        - NAME@25..31
+                            - IDENT@25..31 "userId"
+                        - COLON@31..32 ":"
+                        - WHITESPACE@32..33 " "
+                        - TYPE@33..40
+                            - WHITESPACE@33..34 " "
+                            - NAMED_TYPE@34..40
+                                - NAME@34..40
+                                    - IDENT@34..40 "String"
+                        - DIRECTIVES@40..83
+                            - DIRECTIVE@40..83
+                                - AT@40..41 "@"
+                                - NAME@41..51
+                                    - IDENT@41..51 "deprecated"
+                                - ARGUMENTS@51..83
+                                    - L_PAREN@51..52 "("
+                                    - ARGUMENT@52..82
+                                        - NAME@52..58
+                                            - IDENT@52..58 "reason"
+                                        - COLON@58..59 ":"
+                                        - WHITESPACE@59..60 " "
+                                        - STRING_VALUE@60..82
+                                            - STRING@60..82 "\"Use username instead\""
+                                    - R_PAREN@82..83 ")"
+                    - R_PAREN@83..84 ")"
+                - COLON@84..85 ":"
+                - WHITESPACE@85..86 " "
+                - TYPE@86..92
+                    - WHITESPACE@86..88 "\r\n"
+                    - NAMED_TYPE@88..92
+                        - NAME@88..92
+                            - IDENT@88..92 "User"
+            - R_CURLY@92..93 "}"

--- a/crates/apollo-parser/test_data/parser/ok/0034_query_shorthand_followed_by_fragment_definition.graphql
+++ b/crates/apollo-parser/test_data/parser/ok/0034_query_shorthand_followed_by_fragment_definition.graphql
@@ -1,0 +1,8 @@
+{
+  ...friendFields
+}
+
+fragment friendFields on User {
+  id
+  name
+}

--- a/crates/apollo-parser/test_data/parser/ok/0034_query_shorthand_followed_by_fragment_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0034_query_shorthand_followed_by_fragment_definition.txt
@@ -1,0 +1,39 @@
+- DOCUMENT@0..68
+    - OPERATION_DEFINITION@0..23
+        - SELECTION_SET@0..23
+            - L_CURLY@0..1 "{"
+            - WHITESPACE@1..4 "\n  "
+            - FRAGMENT_SPREAD@4..20
+                - SPREAD@4..7 "..."
+                - FRAGMENT_NAME@7..20
+                    - NAME@7..20
+                        - IDENT@7..19 "friendFields"
+                        - WHITESPACE@19..20 "\n"
+            - R_CURLY@20..21 "}"
+            - WHITESPACE@21..23 "\n\n"
+    - FRAGMENT_DEFINITION@23..68
+        - fragment_KW@23..31 "fragment"
+        - WHITESPACE@31..32 " "
+        - FRAGMENT_NAME@32..45
+            - NAME@32..45
+                - IDENT@32..44 "friendFields"
+                - WHITESPACE@44..45 " "
+        - TYPE_CONDITION@45..53
+            - on_KW@45..47 "on"
+            - WHITESPACE@47..48 " "
+            - NAMED_TYPE@48..53
+                - NAME@48..53
+                    - IDENT@48..52 "User"
+                    - WHITESPACE@52..53 " "
+        - SELECTION_SET@53..68
+            - L_CURLY@53..54 "{"
+            - WHITESPACE@54..57 "\n  "
+            - FIELD@57..62
+                - NAME@57..62
+                    - IDENT@57..59 "id"
+                    - WHITESPACE@59..62 "\n  "
+            - FIELD@62..67
+                - NAME@62..67
+                    - IDENT@62..66 "name"
+                    - WHITESPACE@66..67 "\n"
+            - R_CURLY@67..68 "}"


### PR DESCRIPTION
fixes #101

We were not accommodating parsing any other types following a query shorthand:
```graphql
{
  id
  name
  ...friendsFields
}

fragment friendsFields on User {
  id
  name
}
```

This PR allows for the AST to be built for these sorts of queries as well. 