### PR TITLE
fix: pop current token off when creating a syntax error

### DIFF
--- a/crates/apollo-parser/src/lexer/mod.rs
+++ b/crates/apollo-parser/src/lexer/mod.rs
@@ -385,19 +385,7 @@ mod test {
 
     #[test]
     fn tests() {
-        let gql_1 = r#"
-enum core__Purpose {
-  """
-  `EXECUTION` features provide metadata necessary to for operation execution.
-  """
-  EXECUTION
-
-  """
-  `SECURITY` features provide metadata necessary to securely resolve fields.
-  """
-  SECURITY
-}
-        "#;
+        let gql_1 = r#"dtzt7777777777t7777777777z7"#;
         let lexer_1 = Lexer::new(gql_1);
         dbg!(lexer_1.tokens);
         dbg!(lexer_1.errors);

--- a/crates/apollo-parser/src/parser/grammar/document.rs
+++ b/crates/apollo-parser/src/parser/grammar/document.rs
@@ -34,6 +34,23 @@ pub(crate) fn document(p: &mut Parser) {
     doc.finish_node();
 }
 
+fn select_definition(def: String, p: &mut Parser) {
+    match def.as_str() {
+        "directive" => directive::directive_definition(p),
+        "enum" => enum_::enum_type_definition(p),
+        "extend" => extensions::extensions(p),
+        "fragment" => fragment::fragment_definition(p),
+        "input" => input::input_object_type_definition(p),
+        "interface" => interface::interface_type_definition(p),
+        "type" => object::object_type_definition(p),
+        "query" | "mutation" | "subscription" | "{" => operation::operation_definition(p),
+        "scalar" => scalar::scalar_type_definition(p),
+        "schema" => schema::schema_definition(p),
+        "union" => union_::union_type_definition(p),
+        _ => p.err("expected definition"),
+    }
+}
+
 pub(crate) fn is_definition(def: String) -> bool {
     matches!(
         def.as_str(),
@@ -54,26 +71,22 @@ pub(crate) fn is_definition(def: String) -> bool {
     )
 }
 
-fn select_definition(def: String, p: &mut Parser) {
-    match def.as_str() {
-        "directive" => directive::directive_definition(p),
-        "enum" => enum_::enum_type_definition(p),
-        "extend" => extensions::extensions(p),
-        "fragment" => fragment::fragment_definition(p),
-        "input" => input::input_object_type_definition(p),
-        "interface" => interface::interface_type_definition(p),
-        "type" => object::object_type_definition(p),
-        "query" | "mutation" | "subscription" | "{" => operation::operation_definition(p),
-        "scalar" => scalar::scalar_type_definition(p),
-        "schema" => schema::schema_definition(p),
-        "union" => union_::union_type_definition(p),
-        _ => p.err("expected definition"),
-    }
-}
-
 #[cfg(test)]
 mod test {
     use crate::{ast::Definition, Parser};
+
+    #[test]
+    fn test_invalid() {
+        let schema = r#"dtzt7777777777t7777777777z7"#;
+        let parser = Parser::new(schema);
+
+        let ast = parser.parse();
+        assert_eq!(ast.errors().len(), 1);
+
+        let doc = ast.document();
+        let nodes: Vec<_> = doc.definitions().into_iter().collect();
+        assert!(nodes.is_empty());
+    }
 
     #[test]
     fn core_schema() {

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -100,21 +100,25 @@ impl Parser {
 
     /// Get current token's data.
     pub(crate) fn current(&mut self) -> &Token {
-        self.peek_token().unwrap()
+        self.peek_token()
+            .expect("Could not peek at the current token")
     }
 
     /// Consume a token from the lexer and add it to the AST.
     fn eat(&mut self, kind: SyntaxKind) {
-        let token = self.tokens.pop().unwrap();
+        let token = self
+            .tokens
+            .pop()
+            .expect("Could not eat a token from the AST");
         self.builder.borrow_mut().token(kind, token.data());
     }
 
     /// Create a parser error and push it into the error vector.
     pub(crate) fn err(&mut self, message: &str) {
-        let current = self.current();
+        let current = self.tokens.pop().expect("Could not get current token.");
         // this needs to be the computed location
         let err = Error::with_loc(message, current.data().to_string(), current.index());
-        self.push_err(err)
+        self.push_err(err);
     }
 
     /// Consume the next token if it is `kind` or emit an error
@@ -144,7 +148,9 @@ impl Parser {
 
     /// Consume a token from the lexer.
     pub(crate) fn pop(&mut self) -> Token {
-        self.tokens.pop().unwrap()
+        self.tokens
+            .pop()
+            .expect("Could not pop a token from the AST")
     }
 
     /// Insert a token into the AST.


### PR DESCRIPTION
We were not removing the current token from the token vector when creating errors, which caused some continuous looping. That is, the parser kept parsing the same syntactically incorrect token, without breaking when it should have been.

fixes #104