### PR TITLE
Optimize peek n

### DIFF
--- a/crates/apollo-parser/benches/peek_n.rs
+++ b/crates/apollo-parser/benches/peek_n.rs
@@ -1,0 +1,35 @@
+#![feature(test)]
+extern crate test;
+use apollo_parser::ast;
+use test::{black_box, Bencher};
+
+#[bench]
+fn bench_peek_n(b: &mut Bencher) {
+    let query = "query ExampleQuery($topProductsFirst: Int) {\n  me { \n    id\n  }\n  topProducts(first:  $topProductsFirst) {\n    name\n    price\n    inStock\n weight\n test test test test test test test test test test test test }\n}";
+
+    b.iter(|| {
+        let parser = apollo_parser::Parser::new(query);
+        let tree = parser.parse();
+
+        if !tree.errors().is_empty() {
+            panic!("error parsing query: {:?}", tree.errors());
+        }
+        let document = tree.document();
+
+        for definition in document.definitions() {
+            if let ast::Definition::OperationDefinition(operation) = definition {
+                let selection_set = operation
+                    .selection_set()
+                    .expect("the node SelectionSet is not optional in the spec; qed");
+                for selection in selection_set.selections() {
+                    match selection {
+                        ast::Selection::Field(field) => {
+                            let _selection_set = field.selection_set();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    });
+}

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -195,13 +195,12 @@ impl Parser {
 
     /// Peek Token `n` and return its TokenKind.
     pub(crate) fn peek_n(&self, n: usize) -> Option<TokenKind> {
-        let tok = self
-            .tokens
-            .clone()
-            .into_iter()
+        self.tokens
+            .iter()
+            .rev()
             .filter(|token| !matches!(token.kind(), TokenKind::Whitespace | TokenKind::Comment))
-            .collect::<Vec<Token>>();
-        tok.get(tok.len() - n).map(|token| token.kind())
+            .nth(n - 1)
+            .map(|token| token.kind())
     }
 
     /// Peek next Token's `data` property.
@@ -211,13 +210,12 @@ impl Parser {
 
     /// Peek `n` Token's `data` property.
     pub(crate) fn peek_data_n(&self, n: usize) -> Option<String> {
-        let tok = self
-            .tokens
-            .clone()
-            .into_iter()
+        self.tokens
+            .iter()
+            .rev()
             .filter(|token| !matches!(token.kind(), TokenKind::Whitespace | TokenKind::Comment))
-            .collect::<Vec<Token>>();
-        tok.get(tok.len() - n).map(|token| token.data().to_string())
+            .nth(n - 1)
+            .map(|token| token.data().to_string())
     }
 }
 


### PR DESCRIPTION
Fix #108
related to https://github.com/apollographql/router/issues/100

this avoids collecting the list of tokens in peek_n and peek_data_n. When running the benchmarks locally, I get:
- on e6e79d684b6f26df02e12633b6f10fa589c1d67b 25µs per iteration
- on 625fa4665cd37f280d5828f7a17220cdcee16472 11µs per iteration