### PR TITLE
cast SyntaxNode to a Type

### DIFF
--- a/crates/apollo-parser/src/ast/generated/nodes.rs
+++ b/crates/apollo-parser/src/ast/generated/nodes.rs
@@ -11,39 +11,27 @@ pub struct Name {
     pub(crate) syntax: SyntaxNode,
 }
 impl Name {
-    pub fn ident_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![ident])
-    }
+    pub fn ident_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![ident]) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Document {
     pub(crate) syntax: SyntaxNode,
 }
 impl Document {
-    pub fn definitions(&self) -> AstChildren<Definition> {
-        support::children(&self.syntax)
-    }
+    pub fn definitions(&self) -> AstChildren<Definition> { support::children(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OperationDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl OperationDefinition {
-    pub fn operation_type(&self) -> Option<OperationType> {
-        support::child(&self.syntax)
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn operation_type(&self) -> Option<OperationType> { support::child(&self.syntax) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
     pub fn variable_definitions(&self) -> Option<VariableDefinitions> {
         support::child(&self.syntax)
     }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn selection_set(&self) -> Option<SelectionSet> {
-        support::child(&self.syntax)
-    }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn selection_set(&self) -> Option<SelectionSet> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FragmentDefinition {
@@ -53,171 +41,101 @@ impl FragmentDefinition {
     pub fn fragment_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![fragment])
     }
-    pub fn fragment_name(&self) -> Option<FragmentName> {
-        support::child(&self.syntax)
-    }
-    pub fn type_condition(&self) -> Option<TypeCondition> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn selection_set(&self) -> Option<SelectionSet> {
-        support::child(&self.syntax)
-    }
+    pub fn fragment_name(&self) -> Option<FragmentName> { support::child(&self.syntax) }
+    pub fn type_condition(&self) -> Option<TypeCondition> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn selection_set(&self) -> Option<SelectionSet> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DirectiveDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl DirectiveDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
     pub fn directive_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![directive])
     }
-    pub fn at_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![@])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn at_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![@]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
     pub fn arguments_definition(&self) -> Option<ArgumentsDefinition> {
         support::child(&self.syntax)
     }
-    pub fn on_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![on])
-    }
-    pub fn directive_locations(&self) -> Option<DirectiveLocations> {
-        support::child(&self.syntax)
-    }
+    pub fn on_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![on]) }
+    pub fn directive_locations(&self) -> Option<DirectiveLocations> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SchemaDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl SchemaDefinition {
-    pub fn schema_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![schema])
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn l_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['{'])
-    }
+    pub fn schema_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![schema]) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn l_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['{']) }
     pub fn root_operation_type_definitions(&self) -> AstChildren<RootOperationTypeDefinition> {
         support::children(&self.syntax)
     }
-    pub fn r_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['}'])
-    }
+    pub fn r_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['}']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ScalarTypeDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl ScalarTypeDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
-    pub fn scalar_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![scalar])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
+    pub fn scalar_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![scalar]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ObjectTypeDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl ObjectTypeDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
-    pub fn type_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![type])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![type]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
     pub fn implements_interfaces(&self) -> Option<ImplementsInterfaces> {
         support::child(&self.syntax)
     }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn fields_definition(&self) -> Option<FieldsDefinition> {
-        support::child(&self.syntax)
-    }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn fields_definition(&self) -> Option<FieldsDefinition> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InterfaceTypeDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl InterfaceTypeDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
     pub fn interface_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![interface])
     }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
     pub fn implements_interfaces(&self) -> Option<ImplementsInterfaces> {
         support::child(&self.syntax)
     }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn fields_definition(&self) -> Option<FieldsDefinition> {
-        support::child(&self.syntax)
-    }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn fields_definition(&self) -> Option<FieldsDefinition> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnionTypeDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl UnionTypeDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
-    pub fn union_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![union])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn union_member_types(&self) -> Option<UnionMemberTypes> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
+    pub fn union_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![union]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn union_member_types(&self) -> Option<UnionMemberTypes> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnumTypeDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl EnumTypeDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
-    pub fn enum_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![enum])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
+    pub fn enum_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![enum]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
     pub fn enum_values_definition(&self) -> Option<EnumValuesDefinition> {
         support::child(&self.syntax)
     }
@@ -227,18 +145,10 @@ pub struct InputObjectTypeDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl InputObjectTypeDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
-    pub fn input_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![input])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
+    pub fn input_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![input]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
     pub fn input_fields_definition(&self) -> Option<InputFieldsDefinition> {
         support::child(&self.syntax)
     }
@@ -248,129 +158,75 @@ pub struct SchemaExtension {
     pub(crate) syntax: SyntaxNode,
 }
 impl SchemaExtension {
-    pub fn extend_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![extend])
-    }
-    pub fn schema_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![schema])
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn l_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['{'])
-    }
+    pub fn extend_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![extend]) }
+    pub fn schema_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![schema]) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn l_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['{']) }
     pub fn root_operation_type_definitions(&self) -> AstChildren<RootOperationTypeDefinition> {
         support::children(&self.syntax)
     }
-    pub fn r_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['}'])
-    }
+    pub fn r_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['}']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ScalarTypeExtension {
     pub(crate) syntax: SyntaxNode,
 }
 impl ScalarTypeExtension {
-    pub fn extend_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![extend])
-    }
-    pub fn scalar_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![scalar])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn extend_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![extend]) }
+    pub fn scalar_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![scalar]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ObjectTypeExtension {
     pub(crate) syntax: SyntaxNode,
 }
 impl ObjectTypeExtension {
-    pub fn extend_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![extend])
-    }
-    pub fn type_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![type])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn extend_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![extend]) }
+    pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![type]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
     pub fn implements_interfaces(&self) -> Option<ImplementsInterfaces> {
         support::child(&self.syntax)
     }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn fields_definition(&self) -> Option<FieldsDefinition> {
-        support::child(&self.syntax)
-    }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn fields_definition(&self) -> Option<FieldsDefinition> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InterfaceTypeExtension {
     pub(crate) syntax: SyntaxNode,
 }
 impl InterfaceTypeExtension {
-    pub fn extend_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![extend])
-    }
+    pub fn extend_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![extend]) }
     pub fn interface_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![interface])
     }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
     pub fn implements_interfaces(&self) -> Option<ImplementsInterfaces> {
         support::child(&self.syntax)
     }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn fields_definition(&self) -> Option<FieldsDefinition> {
-        support::child(&self.syntax)
-    }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn fields_definition(&self) -> Option<FieldsDefinition> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnionTypeExtension {
     pub(crate) syntax: SyntaxNode,
 }
 impl UnionTypeExtension {
-    pub fn extend_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![extend])
-    }
-    pub fn union_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![union])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn union_member_types(&self) -> Option<UnionMemberTypes> {
-        support::child(&self.syntax)
-    }
+    pub fn extend_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![extend]) }
+    pub fn union_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![union]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn union_member_types(&self) -> Option<UnionMemberTypes> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnumTypeExtension {
     pub(crate) syntax: SyntaxNode,
 }
 impl EnumTypeExtension {
-    pub fn extend_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![extend])
-    }
-    pub fn enum_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![enum])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn extend_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![extend]) }
+    pub fn enum_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![enum]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
     pub fn enum_values_definition(&self) -> Option<EnumValuesDefinition> {
         support::child(&self.syntax)
     }
@@ -380,18 +236,10 @@ pub struct InputObjectTypeExtension {
     pub(crate) syntax: SyntaxNode,
 }
 impl InputObjectTypeExtension {
-    pub fn extend_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![extend])
-    }
-    pub fn input_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![input])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn extend_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![extend]) }
+    pub fn input_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![input]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
     pub fn input_fields_definition(&self) -> Option<InputFieldsDefinition> {
         support::child(&self.syntax)
     }
@@ -401,9 +249,7 @@ pub struct OperationType {
     pub(crate) syntax: SyntaxNode,
 }
 impl OperationType {
-    pub fn query_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![query])
-    }
+    pub fn query_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![query]) }
     pub fn mutation_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![mutation])
     }
@@ -416,177 +262,113 @@ pub struct VariableDefinitions {
     pub(crate) syntax: SyntaxNode,
 }
 impl VariableDefinitions {
-    pub fn l_paren_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['('])
-    }
+    pub fn l_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['(']) }
     pub fn variable_definitions(&self) -> AstChildren<VariableDefinition> {
         support::children(&self.syntax)
     }
-    pub fn r_paren_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![')'])
-    }
+    pub fn r_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![')']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Directives {
     pub(crate) syntax: SyntaxNode,
 }
 impl Directives {
-    pub fn directives(&self) -> AstChildren<Directive> {
-        support::children(&self.syntax)
-    }
+    pub fn directives(&self) -> AstChildren<Directive> { support::children(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SelectionSet {
     pub(crate) syntax: SyntaxNode,
 }
 impl SelectionSet {
-    pub fn l_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['{'])
-    }
-    pub fn selections(&self) -> AstChildren<Selection> {
-        support::children(&self.syntax)
-    }
-    pub fn r_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['}'])
-    }
+    pub fn l_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['{']) }
+    pub fn selections(&self) -> AstChildren<Selection> { support::children(&self.syntax) }
+    pub fn r_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['}']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
     pub(crate) syntax: SyntaxNode,
 }
 impl Field {
-    pub fn alias(&self) -> Option<Alias> {
-        support::child(&self.syntax)
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn arguments(&self) -> Option<Arguments> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn selection_set(&self) -> Option<SelectionSet> {
-        support::child(&self.syntax)
-    }
+    pub fn alias(&self) -> Option<Alias> { support::child(&self.syntax) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn arguments(&self) -> Option<Arguments> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn selection_set(&self) -> Option<SelectionSet> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FragmentSpread {
     pub(crate) syntax: SyntaxNode,
 }
 impl FragmentSpread {
-    pub fn dotdotdot_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![...])
-    }
-    pub fn fragment_name(&self) -> Option<FragmentName> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn dotdotdot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![...]) }
+    pub fn fragment_name(&self) -> Option<FragmentName> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InlineFragment {
     pub(crate) syntax: SyntaxNode,
 }
 impl InlineFragment {
-    pub fn dotdotdot_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![...])
-    }
-    pub fn type_condition(&self) -> Option<TypeCondition> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
-    pub fn selection_set(&self) -> Option<SelectionSet> {
-        support::child(&self.syntax)
-    }
+    pub fn dotdotdot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![...]) }
+    pub fn type_condition(&self) -> Option<TypeCondition> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
+    pub fn selection_set(&self) -> Option<SelectionSet> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Alias {
     pub(crate) syntax: SyntaxNode,
 }
 impl Alias {
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn colon_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![:])
-    }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![:]) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Arguments {
     pub(crate) syntax: SyntaxNode,
 }
 impl Arguments {
-    pub fn l_paren_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['('])
-    }
-    pub fn arguments(&self) -> AstChildren<Argument> {
-        support::children(&self.syntax)
-    }
-    pub fn r_paren_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![')'])
-    }
+    pub fn l_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['(']) }
+    pub fn arguments(&self) -> AstChildren<Argument> { support::children(&self.syntax) }
+    pub fn r_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![')']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Argument {
     pub(crate) syntax: SyntaxNode,
 }
 impl Argument {
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn colon_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![:])
-    }
-    pub fn value(&self) -> Option<Value> {
-        support::child(&self.syntax)
-    }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![:]) }
+    pub fn value(&self) -> Option<Value> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FragmentName {
     pub(crate) syntax: SyntaxNode,
 }
 impl FragmentName {
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeCondition {
     pub(crate) syntax: SyntaxNode,
 }
 impl TypeCondition {
-    pub fn on_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![on])
-    }
-    pub fn named_type(&self) -> Option<NamedType> {
-        support::child(&self.syntax)
-    }
+    pub fn on_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![on]) }
+    pub fn named_type(&self) -> Option<NamedType> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NamedType {
     pub(crate) syntax: SyntaxNode,
 }
 impl NamedType {
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Variable {
     pub(crate) syntax: SyntaxNode,
 }
 impl Variable {
-    pub fn dollar_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![$])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn dollar_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![$]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StringValue {
@@ -598,192 +380,124 @@ pub struct FloatValue {
     pub(crate) syntax: SyntaxNode,
 }
 impl FloatValue {
-    pub fn float_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![float])
-    }
+    pub fn float_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![float]) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IntValue {
     pub(crate) syntax: SyntaxNode,
 }
 impl IntValue {
-    pub fn int_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![int])
-    }
+    pub fn int_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![int]) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BooleanValue {
     pub(crate) syntax: SyntaxNode,
 }
 impl BooleanValue {
-    pub fn true_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![true])
-    }
-    pub fn false_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![false])
-    }
+    pub fn true_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![true]) }
+    pub fn false_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![false]) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NullValue {
     pub(crate) syntax: SyntaxNode,
 }
 impl NullValue {
-    pub fn null_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![null])
-    }
+    pub fn null_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![null]) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnumValue {
     pub(crate) syntax: SyntaxNode,
 }
 impl EnumValue {
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ListValue {
     pub(crate) syntax: SyntaxNode,
 }
 impl ListValue {
-    pub fn l_brack_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['['])
-    }
-    pub fn r_brack_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![']'])
-    }
-    pub fn values(&self) -> AstChildren<Value> {
-        support::children(&self.syntax)
-    }
+    pub fn l_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['[']) }
+    pub fn r_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![']']) }
+    pub fn values(&self) -> AstChildren<Value> { support::children(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ObjectValue {
     pub(crate) syntax: SyntaxNode,
 }
 impl ObjectValue {
-    pub fn l_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['{'])
-    }
-    pub fn r_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['}'])
-    }
-    pub fn object_fields(&self) -> AstChildren<ObjectField> {
-        support::children(&self.syntax)
-    }
+    pub fn l_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['{']) }
+    pub fn r_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['}']) }
+    pub fn object_fields(&self) -> AstChildren<ObjectField> { support::children(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ObjectField {
     pub(crate) syntax: SyntaxNode,
 }
 impl ObjectField {
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn colon_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![:])
-    }
-    pub fn value(&self) -> Option<Value> {
-        support::child(&self.syntax)
-    }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![:]) }
+    pub fn value(&self) -> Option<Value> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VariableDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl VariableDefinition {
-    pub fn variable(&self) -> Option<Variable> {
-        support::child(&self.syntax)
-    }
-    pub fn colon_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![:])
-    }
-    pub fn ty(&self) -> Option<Type> {
-        support::child(&self.syntax)
-    }
-    pub fn default_value(&self) -> Option<DefaultValue> {
-        support::child(&self.syntax)
-    }
+    pub fn variable(&self) -> Option<Variable> { support::child(&self.syntax) }
+    pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![:]) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
+    pub fn default_value(&self) -> Option<DefaultValue> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DefaultValue {
     pub(crate) syntax: SyntaxNode,
 }
 impl DefaultValue {
-    pub fn eq_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![=])
-    }
-    pub fn value(&self) -> Option<Value> {
-        support::child(&self.syntax)
-    }
+    pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![=]) }
+    pub fn value(&self) -> Option<Value> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ListType {
     pub(crate) syntax: SyntaxNode,
 }
 impl ListType {
-    pub fn l_brack_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['['])
-    }
-    pub fn ty(&self) -> Option<Type> {
-        support::child(&self.syntax)
-    }
-    pub fn r_brack_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![']'])
-    }
+    pub fn l_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['[']) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
+    pub fn r_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![']']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NonNullType {
     pub(crate) syntax: SyntaxNode,
 }
 impl NonNullType {
-    pub fn named_type(&self) -> Option<NamedType> {
-        support::child(&self.syntax)
-    }
-    pub fn excl_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![!])
-    }
-    pub fn list_type(&self) -> Option<ListType> {
-        support::child(&self.syntax)
-    }
+    pub fn named_type(&self) -> Option<NamedType> { support::child(&self.syntax) }
+    pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![!]) }
+    pub fn list_type(&self) -> Option<ListType> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Directive {
     pub(crate) syntax: SyntaxNode,
 }
 impl Directive {
-    pub fn at_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![@])
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn arguments(&self) -> Option<Arguments> {
-        support::child(&self.syntax)
-    }
+    pub fn at_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![@]) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn arguments(&self) -> Option<Arguments> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RootOperationTypeDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl RootOperationTypeDefinition {
-    pub fn operation_type(&self) -> Option<OperationType> {
-        support::child(&self.syntax)
-    }
-    pub fn colon_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![:])
-    }
-    pub fn named_type(&self) -> Option<NamedType> {
-        support::child(&self.syntax)
-    }
+    pub fn operation_type(&self) -> Option<OperationType> { support::child(&self.syntax) }
+    pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![:]) }
+    pub fn named_type(&self) -> Option<NamedType> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Description {
     pub(crate) syntax: SyntaxNode,
 }
 impl Description {
-    pub fn string_value(&self) -> Option<StringValue> {
-        support::child(&self.syntax)
-    }
+    pub fn string_value(&self) -> Option<StringValue> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ImplementsInterfaces {
@@ -793,150 +507,96 @@ impl ImplementsInterfaces {
     pub fn implements_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![implements])
     }
-    pub fn amp_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![&])
-    }
-    pub fn named_types(&self) -> AstChildren<NamedType> {
-        support::children(&self.syntax)
-    }
+    pub fn amp_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![&]) }
+    pub fn named_types(&self) -> AstChildren<NamedType> { support::children(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FieldsDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl FieldsDefinition {
-    pub fn l_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['{'])
-    }
+    pub fn l_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['{']) }
     pub fn field_definitions(&self) -> AstChildren<FieldDefinition> {
         support::children(&self.syntax)
     }
-    pub fn r_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['}'])
-    }
+    pub fn r_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['}']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FieldDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl FieldDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
     pub fn arguments_definition(&self) -> Option<ArgumentsDefinition> {
         support::child(&self.syntax)
     }
-    pub fn colon_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![:])
-    }
-    pub fn ty(&self) -> Option<Type> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![:]) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ArgumentsDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl ArgumentsDefinition {
-    pub fn l_paren_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['('])
-    }
+    pub fn l_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['(']) }
     pub fn input_value_definitions(&self) -> AstChildren<InputValueDefinition> {
         support::children(&self.syntax)
     }
-    pub fn r_paren_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![')'])
-    }
+    pub fn r_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![')']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InputValueDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl InputValueDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
-    pub fn name(&self) -> Option<Name> {
-        support::child(&self.syntax)
-    }
-    pub fn colon_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![:])
-    }
-    pub fn ty(&self) -> Option<Type> {
-        support::child(&self.syntax)
-    }
-    pub fn default_value(&self) -> Option<DefaultValue> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
+    pub fn name(&self) -> Option<Name> { support::child(&self.syntax) }
+    pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![:]) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
+    pub fn default_value(&self) -> Option<DefaultValue> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UnionMemberTypes {
     pub(crate) syntax: SyntaxNode,
 }
 impl UnionMemberTypes {
-    pub fn eq_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![=])
-    }
-    pub fn pipe_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![|])
-    }
-    pub fn named_types(&self) -> AstChildren<NamedType> {
-        support::children(&self.syntax)
-    }
+    pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![=]) }
+    pub fn pipe_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![|]) }
+    pub fn named_types(&self) -> AstChildren<NamedType> { support::children(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnumValuesDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl EnumValuesDefinition {
-    pub fn l_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['{'])
-    }
+    pub fn l_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['{']) }
     pub fn enum_value_definitions(&self) -> AstChildren<EnumValueDefinition> {
         support::children(&self.syntax)
     }
-    pub fn r_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['}'])
-    }
+    pub fn r_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['}']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnumValueDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl EnumValueDefinition {
-    pub fn description(&self) -> Option<Description> {
-        support::child(&self.syntax)
-    }
-    pub fn enum_value(&self) -> Option<EnumValue> {
-        support::child(&self.syntax)
-    }
-    pub fn directives(&self) -> Option<Directives> {
-        support::child(&self.syntax)
-    }
+    pub fn description(&self) -> Option<Description> { support::child(&self.syntax) }
+    pub fn enum_value(&self) -> Option<EnumValue> { support::child(&self.syntax) }
+    pub fn directives(&self) -> Option<Directives> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InputFieldsDefinition {
     pub(crate) syntax: SyntaxNode,
 }
 impl InputFieldsDefinition {
-    pub fn l_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['{'])
-    }
+    pub fn l_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['{']) }
     pub fn input_value_definitions(&self) -> AstChildren<InputValueDefinition> {
         support::children(&self.syntax)
     }
-    pub fn r_curly_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S!['}'])
-    }
+    pub fn r_curly_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S!['}']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DirectiveLocations {
@@ -952,18 +612,14 @@ pub struct DirectiveLocation {
     pub(crate) syntax: SyntaxNode,
 }
 impl DirectiveLocation {
-    pub fn query_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![QUERY])
-    }
+    pub fn query_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![QUERY]) }
     pub fn mutation_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![MUTATION])
     }
     pub fn subscription_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![SUBSCRIPTION])
     }
-    pub fn field_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![FIELD])
-    }
+    pub fn field_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![FIELD]) }
     pub fn fragment_definition_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![FRAGMENT_DEFINITION])
     }
@@ -976,15 +632,9 @@ impl DirectiveLocation {
     pub fn variable_definition_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![VARIABLE_DEFINITION])
     }
-    pub fn schema_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![SCHEMA])
-    }
-    pub fn scalar_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![SCALAR])
-    }
-    pub fn object_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![OBJECT])
-    }
+    pub fn schema_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![SCHEMA]) }
+    pub fn scalar_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![SCALAR]) }
+    pub fn object_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![OBJECT]) }
     pub fn field_definition_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![FIELD_DEFINITION])
     }
@@ -994,12 +644,8 @@ impl DirectiveLocation {
     pub fn interface_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![INTERFACE])
     }
-    pub fn union_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![UNION])
-    }
-    pub fn enum_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, S![ENUM])
-    }
+    pub fn union_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![UNION]) }
+    pub fn enum_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, S![ENUM]) }
     pub fn enum_value_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, S![ENUM_VALUE])
     }
@@ -1055,9 +701,7 @@ pub enum Type {
     NonNullType(NonNullType),
 }
 impl AstNode for Name {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == NAME
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1065,14 +709,10 @@ impl AstNode for Name {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Document {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == DOCUMENT
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DOCUMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1080,14 +720,10 @@ impl AstNode for Document {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for OperationDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == OPERATION_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == OPERATION_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1095,14 +731,10 @@ impl AstNode for OperationDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for FragmentDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == FRAGMENT_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == FRAGMENT_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1110,14 +742,10 @@ impl AstNode for FragmentDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for DirectiveDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == DIRECTIVE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DIRECTIVE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1125,14 +753,10 @@ impl AstNode for DirectiveDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for SchemaDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == SCHEMA_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == SCHEMA_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1140,14 +764,10 @@ impl AstNode for SchemaDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ScalarTypeDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == SCALAR_TYPE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == SCALAR_TYPE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1155,14 +775,10 @@ impl AstNode for ScalarTypeDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ObjectTypeDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == OBJECT_TYPE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == OBJECT_TYPE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1170,14 +786,10 @@ impl AstNode for ObjectTypeDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for InterfaceTypeDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INTERFACE_TYPE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == INTERFACE_TYPE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1185,14 +797,10 @@ impl AstNode for InterfaceTypeDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for UnionTypeDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == UNION_TYPE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == UNION_TYPE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1200,14 +808,10 @@ impl AstNode for UnionTypeDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for EnumTypeDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ENUM_TYPE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ENUM_TYPE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1215,14 +819,10 @@ impl AstNode for EnumTypeDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for InputObjectTypeDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INPUT_OBJECT_TYPE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == INPUT_OBJECT_TYPE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1230,14 +830,10 @@ impl AstNode for InputObjectTypeDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for SchemaExtension {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == SCHEMA_EXTENSION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == SCHEMA_EXTENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1245,14 +841,10 @@ impl AstNode for SchemaExtension {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ScalarTypeExtension {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == SCALAR_TYPE_EXTENSION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == SCALAR_TYPE_EXTENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1260,14 +852,10 @@ impl AstNode for ScalarTypeExtension {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ObjectTypeExtension {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == OBJECT_TYPE_EXTENSION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == OBJECT_TYPE_EXTENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1275,14 +863,10 @@ impl AstNode for ObjectTypeExtension {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for InterfaceTypeExtension {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INTERFACE_TYPE_EXTENSION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == INTERFACE_TYPE_EXTENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1290,14 +874,10 @@ impl AstNode for InterfaceTypeExtension {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for UnionTypeExtension {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == UNION_TYPE_EXTENSION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == UNION_TYPE_EXTENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1305,14 +885,10 @@ impl AstNode for UnionTypeExtension {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for EnumTypeExtension {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ENUM_TYPE_EXTENSION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ENUM_TYPE_EXTENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1320,14 +896,10 @@ impl AstNode for EnumTypeExtension {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for InputObjectTypeExtension {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INPUT_OBJECT_TYPE_EXTENSION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == INPUT_OBJECT_TYPE_EXTENSION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1335,14 +907,10 @@ impl AstNode for InputObjectTypeExtension {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for OperationType {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == OPERATION_TYPE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == OPERATION_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1350,14 +918,10 @@ impl AstNode for OperationType {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for VariableDefinitions {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == VARIABLE_DEFINITIONS
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == VARIABLE_DEFINITIONS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1365,14 +929,10 @@ impl AstNode for VariableDefinitions {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Directives {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == DIRECTIVES
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DIRECTIVES }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1380,14 +940,10 @@ impl AstNode for Directives {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for SelectionSet {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == SELECTION_SET
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == SELECTION_SET }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1395,14 +951,10 @@ impl AstNode for SelectionSet {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Field {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == FIELD
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == FIELD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1410,14 +962,10 @@ impl AstNode for Field {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for FragmentSpread {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == FRAGMENT_SPREAD
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == FRAGMENT_SPREAD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1425,14 +973,10 @@ impl AstNode for FragmentSpread {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for InlineFragment {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INLINE_FRAGMENT
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == INLINE_FRAGMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1440,14 +984,10 @@ impl AstNode for InlineFragment {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Alias {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ALIAS
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ALIAS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1455,14 +995,10 @@ impl AstNode for Alias {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Arguments {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ARGUMENTS
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ARGUMENTS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1470,14 +1006,10 @@ impl AstNode for Arguments {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Argument {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ARGUMENT
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ARGUMENT }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1485,14 +1017,10 @@ impl AstNode for Argument {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for FragmentName {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == FRAGMENT_NAME
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == FRAGMENT_NAME }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1500,14 +1028,10 @@ impl AstNode for FragmentName {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for TypeCondition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == TYPE_CONDITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == TYPE_CONDITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1515,14 +1039,10 @@ impl AstNode for TypeCondition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for NamedType {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == NAMED_TYPE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == NAMED_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1530,14 +1050,10 @@ impl AstNode for NamedType {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Variable {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == VARIABLE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == VARIABLE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1545,14 +1061,10 @@ impl AstNode for Variable {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for StringValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == STRING_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == STRING_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1560,14 +1072,10 @@ impl AstNode for StringValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for FloatValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == FLOAT_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == FLOAT_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1575,14 +1083,10 @@ impl AstNode for FloatValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for IntValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INT_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == INT_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1590,14 +1094,10 @@ impl AstNode for IntValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for BooleanValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == BOOLEAN_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == BOOLEAN_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1605,14 +1105,10 @@ impl AstNode for BooleanValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for NullValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == NULL_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == NULL_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1620,14 +1116,10 @@ impl AstNode for NullValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for EnumValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ENUM_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ENUM_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1635,14 +1127,10 @@ impl AstNode for EnumValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ListValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == LIST_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == LIST_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1650,14 +1138,10 @@ impl AstNode for ListValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ObjectValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == OBJECT_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == OBJECT_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1665,14 +1149,10 @@ impl AstNode for ObjectValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ObjectField {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == OBJECT_FIELD
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == OBJECT_FIELD }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1680,14 +1160,10 @@ impl AstNode for ObjectField {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for VariableDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == VARIABLE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == VARIABLE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1695,14 +1171,10 @@ impl AstNode for VariableDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for DefaultValue {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == DEFAULT_VALUE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DEFAULT_VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1710,14 +1182,10 @@ impl AstNode for DefaultValue {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ListType {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == LIST_TYPE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == LIST_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1725,14 +1193,10 @@ impl AstNode for ListType {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for NonNullType {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == NON_NULL_TYPE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == NON_NULL_TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1740,14 +1204,10 @@ impl AstNode for NonNullType {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Directive {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == DIRECTIVE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DIRECTIVE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1755,14 +1215,10 @@ impl AstNode for Directive {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for RootOperationTypeDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ROOT_OPERATION_TYPE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ROOT_OPERATION_TYPE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1770,14 +1226,10 @@ impl AstNode for RootOperationTypeDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for Description {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == DESCRIPTION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DESCRIPTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1785,14 +1237,10 @@ impl AstNode for Description {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ImplementsInterfaces {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == IMPLEMENTS_INTERFACES
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == IMPLEMENTS_INTERFACES }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1800,14 +1248,10 @@ impl AstNode for ImplementsInterfaces {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for FieldsDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == FIELDS_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == FIELDS_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1815,14 +1259,10 @@ impl AstNode for FieldsDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for FieldDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == FIELD_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == FIELD_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1830,14 +1270,10 @@ impl AstNode for FieldDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for ArgumentsDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ARGUMENTS_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ARGUMENTS_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1845,14 +1281,10 @@ impl AstNode for ArgumentsDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for InputValueDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INPUT_VALUE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == INPUT_VALUE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1860,14 +1292,10 @@ impl AstNode for InputValueDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for UnionMemberTypes {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == UNION_MEMBER_TYPES
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == UNION_MEMBER_TYPES }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1875,14 +1303,10 @@ impl AstNode for UnionMemberTypes {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for EnumValuesDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ENUM_VALUES_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ENUM_VALUES_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1890,14 +1314,10 @@ impl AstNode for EnumValuesDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for EnumValueDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == ENUM_VALUE_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == ENUM_VALUE_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1905,14 +1325,10 @@ impl AstNode for EnumValueDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for InputFieldsDefinition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INPUT_FIELDS_DEFINITION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == INPUT_FIELDS_DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1920,14 +1336,10 @@ impl AstNode for InputFieldsDefinition {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for DirectiveLocations {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == DIRECTIVE_LOCATIONS
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DIRECTIVE_LOCATIONS }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1935,14 +1347,10 @@ impl AstNode for DirectiveLocations {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl AstNode for DirectiveLocation {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == DIRECTIVE_LOCATION
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DIRECTIVE_LOCATION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
             Some(Self { syntax })
@@ -1950,39 +1358,25 @@ impl AstNode for DirectiveLocation {
             None
         }
     }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
 }
 impl From<OperationDefinition> for Definition {
-    fn from(node: OperationDefinition) -> Definition {
-        Definition::OperationDefinition(node)
-    }
+    fn from(node: OperationDefinition) -> Definition { Definition::OperationDefinition(node) }
 }
 impl From<FragmentDefinition> for Definition {
-    fn from(node: FragmentDefinition) -> Definition {
-        Definition::FragmentDefinition(node)
-    }
+    fn from(node: FragmentDefinition) -> Definition { Definition::FragmentDefinition(node) }
 }
 impl From<DirectiveDefinition> for Definition {
-    fn from(node: DirectiveDefinition) -> Definition {
-        Definition::DirectiveDefinition(node)
-    }
+    fn from(node: DirectiveDefinition) -> Definition { Definition::DirectiveDefinition(node) }
 }
 impl From<SchemaDefinition> for Definition {
-    fn from(node: SchemaDefinition) -> Definition {
-        Definition::SchemaDefinition(node)
-    }
+    fn from(node: SchemaDefinition) -> Definition { Definition::SchemaDefinition(node) }
 }
 impl From<ScalarTypeDefinition> for Definition {
-    fn from(node: ScalarTypeDefinition) -> Definition {
-        Definition::ScalarTypeDefinition(node)
-    }
+    fn from(node: ScalarTypeDefinition) -> Definition { Definition::ScalarTypeDefinition(node) }
 }
 impl From<ObjectTypeDefinition> for Definition {
-    fn from(node: ObjectTypeDefinition) -> Definition {
-        Definition::ObjectTypeDefinition(node)
-    }
+    fn from(node: ObjectTypeDefinition) -> Definition { Definition::ObjectTypeDefinition(node) }
 }
 impl From<InterfaceTypeDefinition> for Definition {
     fn from(node: InterfaceTypeDefinition) -> Definition {
@@ -1990,14 +1384,10 @@ impl From<InterfaceTypeDefinition> for Definition {
     }
 }
 impl From<UnionTypeDefinition> for Definition {
-    fn from(node: UnionTypeDefinition) -> Definition {
-        Definition::UnionTypeDefinition(node)
-    }
+    fn from(node: UnionTypeDefinition) -> Definition { Definition::UnionTypeDefinition(node) }
 }
 impl From<EnumTypeDefinition> for Definition {
-    fn from(node: EnumTypeDefinition) -> Definition {
-        Definition::EnumTypeDefinition(node)
-    }
+    fn from(node: EnumTypeDefinition) -> Definition { Definition::EnumTypeDefinition(node) }
 }
 impl From<InputObjectTypeDefinition> for Definition {
     fn from(node: InputObjectTypeDefinition) -> Definition {
@@ -2005,34 +1395,22 @@ impl From<InputObjectTypeDefinition> for Definition {
     }
 }
 impl From<SchemaExtension> for Definition {
-    fn from(node: SchemaExtension) -> Definition {
-        Definition::SchemaExtension(node)
-    }
+    fn from(node: SchemaExtension) -> Definition { Definition::SchemaExtension(node) }
 }
 impl From<ScalarTypeExtension> for Definition {
-    fn from(node: ScalarTypeExtension) -> Definition {
-        Definition::ScalarTypeExtension(node)
-    }
+    fn from(node: ScalarTypeExtension) -> Definition { Definition::ScalarTypeExtension(node) }
 }
 impl From<ObjectTypeExtension> for Definition {
-    fn from(node: ObjectTypeExtension) -> Definition {
-        Definition::ObjectTypeExtension(node)
-    }
+    fn from(node: ObjectTypeExtension) -> Definition { Definition::ObjectTypeExtension(node) }
 }
 impl From<InterfaceTypeExtension> for Definition {
-    fn from(node: InterfaceTypeExtension) -> Definition {
-        Definition::InterfaceTypeExtension(node)
-    }
+    fn from(node: InterfaceTypeExtension) -> Definition { Definition::InterfaceTypeExtension(node) }
 }
 impl From<UnionTypeExtension> for Definition {
-    fn from(node: UnionTypeExtension) -> Definition {
-        Definition::UnionTypeExtension(node)
-    }
+    fn from(node: UnionTypeExtension) -> Definition { Definition::UnionTypeExtension(node) }
 }
 impl From<EnumTypeExtension> for Definition {
-    fn from(node: EnumTypeExtension) -> Definition {
-        Definition::EnumTypeExtension(node)
-    }
+    fn from(node: EnumTypeExtension) -> Definition { Definition::EnumTypeExtension(node) }
 }
 impl From<InputObjectTypeExtension> for Definition {
     fn from(node: InputObjectTypeExtension) -> Definition {
@@ -2040,68 +1418,68 @@ impl From<InputObjectTypeExtension> for Definition {
     }
 }
 impl AstNode for Definition {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        matches!(
-            kind,
-            OPERATION_DEFINITION
-                | FRAGMENT_DEFINITION
-                | DIRECTIVE_DEFINITION
-                | SCHEMA_DEFINITION
-                | SCALAR_TYPE_DEFINITION
-                | OBJECT_TYPE_DEFINITION
-                | INTERFACE_TYPE_DEFINITION
-                | UNION_TYPE_DEFINITION
-                | ENUM_TYPE_DEFINITION
-                | INPUT_OBJECT_TYPE_DEFINITION
-                | SCHEMA_EXTENSION
-                | SCALAR_TYPE_EXTENSION
-                | OBJECT_TYPE_EXTENSION
-                | INTERFACE_TYPE_EXTENSION
-                | UNION_TYPE_EXTENSION
-                | ENUM_TYPE_EXTENSION
-                | INPUT_OBJECT_TYPE_EXTENSION
-        )
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == DEFINITION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            OPERATION_DEFINITION => Definition::OperationDefinition(OperationDefinition { syntax }),
-            FRAGMENT_DEFINITION => Definition::FragmentDefinition(FragmentDefinition { syntax }),
-            DIRECTIVE_DEFINITION => Definition::DirectiveDefinition(DirectiveDefinition { syntax }),
-            SCHEMA_DEFINITION => Definition::SchemaDefinition(SchemaDefinition { syntax }),
+        if syntax.kind() != DEFINITION {
+            return None;
+        }
+        let syntax = syntax.first_child()?;
+        match syntax.kind() {
+            OPERATION_DEFINITION => Some(Definition::OperationDefinition(OperationDefinition {
+                syntax,
+            })),
+            FRAGMENT_DEFINITION => Some(Definition::FragmentDefinition(FragmentDefinition {
+                syntax,
+            })),
+            DIRECTIVE_DEFINITION => Some(Definition::DirectiveDefinition(DirectiveDefinition {
+                syntax,
+            })),
+            SCHEMA_DEFINITION => Some(Definition::SchemaDefinition(SchemaDefinition { syntax })),
             SCALAR_TYPE_DEFINITION => {
-                Definition::ScalarTypeDefinition(ScalarTypeDefinition { syntax })
+                Some(Definition::ScalarTypeDefinition(ScalarTypeDefinition {
+                    syntax,
+                }))
             }
             OBJECT_TYPE_DEFINITION => {
-                Definition::ObjectTypeDefinition(ObjectTypeDefinition { syntax })
+                Some(Definition::ObjectTypeDefinition(ObjectTypeDefinition {
+                    syntax,
+                }))
             }
-            INTERFACE_TYPE_DEFINITION => {
-                Definition::InterfaceTypeDefinition(InterfaceTypeDefinition { syntax })
-            }
-            UNION_TYPE_DEFINITION => {
-                Definition::UnionTypeDefinition(UnionTypeDefinition { syntax })
-            }
-            ENUM_TYPE_DEFINITION => Definition::EnumTypeDefinition(EnumTypeDefinition { syntax }),
-            INPUT_OBJECT_TYPE_DEFINITION => {
-                Definition::InputObjectTypeDefinition(InputObjectTypeDefinition { syntax })
-            }
-            SCHEMA_EXTENSION => Definition::SchemaExtension(SchemaExtension { syntax }),
-            SCALAR_TYPE_EXTENSION => {
-                Definition::ScalarTypeExtension(ScalarTypeExtension { syntax })
-            }
-            OBJECT_TYPE_EXTENSION => {
-                Definition::ObjectTypeExtension(ObjectTypeExtension { syntax })
-            }
+            INTERFACE_TYPE_DEFINITION => Some(Definition::InterfaceTypeDefinition(
+                InterfaceTypeDefinition { syntax },
+            )),
+            UNION_TYPE_DEFINITION => Some(Definition::UnionTypeDefinition(UnionTypeDefinition {
+                syntax,
+            })),
+            ENUM_TYPE_DEFINITION => Some(Definition::EnumTypeDefinition(EnumTypeDefinition {
+                syntax,
+            })),
+            INPUT_OBJECT_TYPE_DEFINITION => Some(Definition::InputObjectTypeDefinition(
+                InputObjectTypeDefinition { syntax },
+            )),
+            SCHEMA_EXTENSION => Some(Definition::SchemaExtension(SchemaExtension { syntax })),
+            SCALAR_TYPE_EXTENSION => Some(Definition::ScalarTypeExtension(ScalarTypeExtension {
+                syntax,
+            })),
+            OBJECT_TYPE_EXTENSION => Some(Definition::ObjectTypeExtension(ObjectTypeExtension {
+                syntax,
+            })),
             INTERFACE_TYPE_EXTENSION => {
-                Definition::InterfaceTypeExtension(InterfaceTypeExtension { syntax })
+                Some(Definition::InterfaceTypeExtension(InterfaceTypeExtension {
+                    syntax,
+                }))
             }
-            UNION_TYPE_EXTENSION => Definition::UnionTypeExtension(UnionTypeExtension { syntax }),
-            ENUM_TYPE_EXTENSION => Definition::EnumTypeExtension(EnumTypeExtension { syntax }),
-            INPUT_OBJECT_TYPE_EXTENSION => {
-                Definition::InputObjectTypeExtension(InputObjectTypeExtension { syntax })
+            UNION_TYPE_EXTENSION => Some(Definition::UnionTypeExtension(UnionTypeExtension {
+                syntax,
+            })),
+            ENUM_TYPE_EXTENSION => {
+                Some(Definition::EnumTypeExtension(EnumTypeExtension { syntax }))
             }
-            _ => return None,
-        };
-        Some(res)
+            INPUT_OBJECT_TYPE_EXTENSION => Some(Definition::InputObjectTypeExtension(
+                InputObjectTypeExtension { syntax },
+            )),
+            _ => None,
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
@@ -2126,32 +1504,27 @@ impl AstNode for Definition {
     }
 }
 impl From<Field> for Selection {
-    fn from(node: Field) -> Selection {
-        Selection::Field(node)
-    }
+    fn from(node: Field) -> Selection { Selection::Field(node) }
 }
 impl From<FragmentSpread> for Selection {
-    fn from(node: FragmentSpread) -> Selection {
-        Selection::FragmentSpread(node)
-    }
+    fn from(node: FragmentSpread) -> Selection { Selection::FragmentSpread(node) }
 }
 impl From<InlineFragment> for Selection {
-    fn from(node: InlineFragment) -> Selection {
-        Selection::InlineFragment(node)
-    }
+    fn from(node: InlineFragment) -> Selection { Selection::InlineFragment(node) }
 }
 impl AstNode for Selection {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        matches!(kind, FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT)
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == SELECTION }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            FIELD => Selection::Field(Field { syntax }),
-            FRAGMENT_SPREAD => Selection::FragmentSpread(FragmentSpread { syntax }),
-            INLINE_FRAGMENT => Selection::InlineFragment(InlineFragment { syntax }),
-            _ => return None,
-        };
-        Some(res)
+        if syntax.kind() != SELECTION {
+            return None;
+        }
+        let syntax = syntax.first_child()?;
+        match syntax.kind() {
+            FIELD => Some(Selection::Field(Field { syntax })),
+            FRAGMENT_SPREAD => Some(Selection::FragmentSpread(FragmentSpread { syntax })),
+            INLINE_FRAGMENT => Some(Selection::InlineFragment(InlineFragment { syntax })),
+            _ => None,
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
@@ -2162,79 +1535,51 @@ impl AstNode for Selection {
     }
 }
 impl From<Variable> for Value {
-    fn from(node: Variable) -> Value {
-        Value::Variable(node)
-    }
+    fn from(node: Variable) -> Value { Value::Variable(node) }
 }
 impl From<StringValue> for Value {
-    fn from(node: StringValue) -> Value {
-        Value::StringValue(node)
-    }
+    fn from(node: StringValue) -> Value { Value::StringValue(node) }
 }
 impl From<FloatValue> for Value {
-    fn from(node: FloatValue) -> Value {
-        Value::FloatValue(node)
-    }
+    fn from(node: FloatValue) -> Value { Value::FloatValue(node) }
 }
 impl From<IntValue> for Value {
-    fn from(node: IntValue) -> Value {
-        Value::IntValue(node)
-    }
+    fn from(node: IntValue) -> Value { Value::IntValue(node) }
 }
 impl From<BooleanValue> for Value {
-    fn from(node: BooleanValue) -> Value {
-        Value::BooleanValue(node)
-    }
+    fn from(node: BooleanValue) -> Value { Value::BooleanValue(node) }
 }
 impl From<NullValue> for Value {
-    fn from(node: NullValue) -> Value {
-        Value::NullValue(node)
-    }
+    fn from(node: NullValue) -> Value { Value::NullValue(node) }
 }
 impl From<EnumValue> for Value {
-    fn from(node: EnumValue) -> Value {
-        Value::EnumValue(node)
-    }
+    fn from(node: EnumValue) -> Value { Value::EnumValue(node) }
 }
 impl From<ListValue> for Value {
-    fn from(node: ListValue) -> Value {
-        Value::ListValue(node)
-    }
+    fn from(node: ListValue) -> Value { Value::ListValue(node) }
 }
 impl From<ObjectValue> for Value {
-    fn from(node: ObjectValue) -> Value {
-        Value::ObjectValue(node)
-    }
+    fn from(node: ObjectValue) -> Value { Value::ObjectValue(node) }
 }
 impl AstNode for Value {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        matches!(
-            kind,
-            VARIABLE
-                | STRING_VALUE
-                | FLOAT_VALUE
-                | INT_VALUE
-                | BOOLEAN_VALUE
-                | NULL_VALUE
-                | ENUM_VALUE
-                | LIST_VALUE
-                | OBJECT_VALUE
-        )
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == VALUE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            VARIABLE => Value::Variable(Variable { syntax }),
-            STRING_VALUE => Value::StringValue(StringValue { syntax }),
-            FLOAT_VALUE => Value::FloatValue(FloatValue { syntax }),
-            INT_VALUE => Value::IntValue(IntValue { syntax }),
-            BOOLEAN_VALUE => Value::BooleanValue(BooleanValue { syntax }),
-            NULL_VALUE => Value::NullValue(NullValue { syntax }),
-            ENUM_VALUE => Value::EnumValue(EnumValue { syntax }),
-            LIST_VALUE => Value::ListValue(ListValue { syntax }),
-            OBJECT_VALUE => Value::ObjectValue(ObjectValue { syntax }),
-            _ => return None,
-        };
-        Some(res)
+        if syntax.kind() != VALUE {
+            return None;
+        }
+        let syntax = syntax.first_child()?;
+        match syntax.kind() {
+            VARIABLE => Some(Value::Variable(Variable { syntax })),
+            STRING_VALUE => Some(Value::StringValue(StringValue { syntax })),
+            FLOAT_VALUE => Some(Value::FloatValue(FloatValue { syntax })),
+            INT_VALUE => Some(Value::IntValue(IntValue { syntax })),
+            BOOLEAN_VALUE => Some(Value::BooleanValue(BooleanValue { syntax })),
+            NULL_VALUE => Some(Value::NullValue(NullValue { syntax })),
+            ENUM_VALUE => Some(Value::EnumValue(EnumValue { syntax })),
+            LIST_VALUE => Some(Value::ListValue(ListValue { syntax })),
+            OBJECT_VALUE => Some(Value::ObjectValue(ObjectValue { syntax })),
+            _ => None,
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
@@ -2251,38 +1596,27 @@ impl AstNode for Value {
     }
 }
 impl From<NamedType> for Type {
-    fn from(node: NamedType) -> Type {
-        Type::NamedType(node)
-    }
+    fn from(node: NamedType) -> Type { Type::NamedType(node) }
 }
 impl From<ListType> for Type {
-    fn from(node: ListType) -> Type {
-        Type::ListType(node)
-    }
+    fn from(node: ListType) -> Type { Type::ListType(node) }
 }
 impl From<NonNullType> for Type {
-    fn from(node: NonNullType) -> Type {
-        Type::NonNullType(node)
-    }
+    fn from(node: NonNullType) -> Type { Type::NonNullType(node) }
 }
 impl AstNode for Type {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == TYPE
-    }
+    fn can_cast(kind: SyntaxKind) -> bool { kind == TYPE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if syntax.kind() == TYPE {
-            if let Some(s) = syntax.first_child() {
-                let res = match s.kind() {
-                    NAMED_TYPE => Type::NamedType(NamedType { syntax: s }),
-                    LIST_TYPE => Type::ListType(ListType { syntax: s }),
-                    NON_NULL_TYPE => Type::NonNullType(NonNullType { syntax: s }),
-                    _ => return None,
-                };
-                return Some(res);
-            }
+        if syntax.kind() != TYPE {
+            return None;
         }
-
-        None
+        let syntax = syntax.first_child()?;
+        match syntax.kind() {
+            NAMED_TYPE => Some(Type::NamedType(NamedType { syntax })),
+            LIST_TYPE => Some(Type::ListType(ListType { syntax })),
+            NON_NULL_TYPE => Some(Type::NonNullType(NonNullType { syntax })),
+            _ => None,
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {

--- a/crates/apollo-parser/src/ast/generated/nodes.rs
+++ b/crates/apollo-parser/src/ast/generated/nodes.rs
@@ -2267,16 +2267,22 @@ impl From<NonNullType> for Type {
 }
 impl AstNode for Type {
     fn can_cast(kind: SyntaxKind) -> bool {
-        matches!(kind, NAMED_TYPE | LIST_TYPE | NON_NULL_TYPE)
+        kind == TYPE
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            NAMED_TYPE => Type::NamedType(NamedType { syntax }),
-            LIST_TYPE => Type::ListType(ListType { syntax }),
-            NON_NULL_TYPE => Type::NonNullType(NonNullType { syntax }),
-            _ => return None,
-        };
-        Some(res)
+        if syntax.kind() == TYPE {
+            if let Some(s) = syntax.first_child() {
+                let res = match s.kind() {
+                    NAMED_TYPE => Type::NamedType(NamedType { syntax }),
+                    LIST_TYPE => Type::ListType(ListType { syntax }),
+                    NON_NULL_TYPE => Type::NonNullType(NonNullType { syntax }),
+                    _ => return None,
+                };
+                return Some(res);
+            }
+        }
+
+        None
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {

--- a/crates/apollo-parser/src/ast/generated/nodes.rs
+++ b/crates/apollo-parser/src/ast/generated/nodes.rs
@@ -2273,9 +2273,9 @@ impl AstNode for Type {
         if syntax.kind() == TYPE {
             if let Some(s) = syntax.first_child() {
                 let res = match s.kind() {
-                    NAMED_TYPE => Type::NamedType(NamedType { syntax }),
-                    LIST_TYPE => Type::ListType(ListType { syntax }),
-                    NON_NULL_TYPE => Type::NonNullType(NonNullType { syntax }),
+                    NAMED_TYPE => Type::NamedType(NamedType { syntax: s }),
+                    LIST_TYPE => Type::ListType(ListType { syntax: s }),
+                    NON_NULL_TYPE => Type::NonNullType(NonNullType { syntax: s }),
                     _ => return None,
                 };
                 return Some(res);

--- a/crates/apollo-parser/src/ast/generated/nodes.rs
+++ b/crates/apollo-parser/src/ast/generated/nodes.rs
@@ -1418,12 +1418,33 @@ impl From<InputObjectTypeExtension> for Definition {
     }
 }
 impl AstNode for Definition {
-    fn can_cast(kind: SyntaxKind) -> bool { kind == DEFINITION }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if syntax.kind() != DEFINITION {
-            return None;
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == DEFINITION
+            || matches!(
+                kind,
+                OPERATION_DEFINITION
+                    | FRAGMENT_DEFINITION
+                    | DIRECTIVE_DEFINITION
+                    | SCHEMA_DEFINITION
+                    | SCALAR_TYPE_DEFINITION
+                    | OBJECT_TYPE_DEFINITION
+                    | INTERFACE_TYPE_DEFINITION
+                    | UNION_TYPE_DEFINITION
+                    | ENUM_TYPE_DEFINITION
+                    | INPUT_OBJECT_TYPE_DEFINITION
+                    | SCHEMA_EXTENSION
+                    | SCALAR_TYPE_EXTENSION
+                    | OBJECT_TYPE_EXTENSION
+                    | INTERFACE_TYPE_EXTENSION
+                    | UNION_TYPE_EXTENSION
+                    | ENUM_TYPE_EXTENSION
+                    | INPUT_OBJECT_TYPE_EXTENSION
+            )
+    }
+    fn cast(mut syntax: SyntaxNode) -> Option<Self> {
+        if syntax.kind() == DEFINITION {
+            syntax = syntax.first_child()?;
         }
-        let syntax = syntax.first_child()?;
         match syntax.kind() {
             OPERATION_DEFINITION => Some(Definition::OperationDefinition(OperationDefinition {
                 syntax,
@@ -1513,12 +1534,13 @@ impl From<InlineFragment> for Selection {
     fn from(node: InlineFragment) -> Selection { Selection::InlineFragment(node) }
 }
 impl AstNode for Selection {
-    fn can_cast(kind: SyntaxKind) -> bool { kind == SELECTION }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if syntax.kind() != SELECTION {
-            return None;
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == SELECTION || matches!(kind, FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT)
+    }
+    fn cast(mut syntax: SyntaxNode) -> Option<Self> {
+        if syntax.kind() == SELECTION {
+            syntax = syntax.first_child()?;
         }
-        let syntax = syntax.first_child()?;
         match syntax.kind() {
             FIELD => Some(Selection::Field(Field { syntax })),
             FRAGMENT_SPREAD => Some(Selection::FragmentSpread(FragmentSpread { syntax })),
@@ -1562,12 +1584,25 @@ impl From<ObjectValue> for Value {
     fn from(node: ObjectValue) -> Value { Value::ObjectValue(node) }
 }
 impl AstNode for Value {
-    fn can_cast(kind: SyntaxKind) -> bool { kind == VALUE }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if syntax.kind() != VALUE {
-            return None;
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == VALUE
+            || matches!(
+                kind,
+                VARIABLE
+                    | STRING_VALUE
+                    | FLOAT_VALUE
+                    | INT_VALUE
+                    | BOOLEAN_VALUE
+                    | NULL_VALUE
+                    | ENUM_VALUE
+                    | LIST_VALUE
+                    | OBJECT_VALUE
+            )
+    }
+    fn cast(mut syntax: SyntaxNode) -> Option<Self> {
+        if syntax.kind() == VALUE {
+            syntax = syntax.first_child()?;
         }
-        let syntax = syntax.first_child()?;
         match syntax.kind() {
             VARIABLE => Some(Value::Variable(Variable { syntax })),
             STRING_VALUE => Some(Value::StringValue(StringValue { syntax })),
@@ -1605,12 +1640,13 @@ impl From<NonNullType> for Type {
     fn from(node: NonNullType) -> Type { Type::NonNullType(node) }
 }
 impl AstNode for Type {
-    fn can_cast(kind: SyntaxKind) -> bool { kind == TYPE }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if syntax.kind() != TYPE {
-            return None;
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == TYPE || matches!(kind, NAMED_TYPE | LIST_TYPE | NON_NULL_TYPE)
+    }
+    fn cast(mut syntax: SyntaxNode) -> Option<Self> {
+        if syntax.kind() == TYPE {
+            syntax = syntax.first_child()?;
         }
-        let syntax = syntax.first_child()?;
         match syntax.kind() {
             NAMED_TYPE => Some(Type::NamedType(NamedType { syntax })),
             LIST_TYPE => Some(Type::ListType(ListType { syntax })),

--- a/xtask/src/codegen/gen_syntax_nodes.rs
+++ b/xtask/src/codegen/gen_syntax_nodes.rs
@@ -97,14 +97,12 @@ pub(crate) fn generate_nodes(kinds: KindsSrc<'_>, grammar: &AstSrc) -> Result<St
                 quote! {
                     impl AstNode for #name {
                         fn can_cast(kind: SyntaxKind) -> bool {
-                            kind == #kind
+                            kind == #kind || matches!(kind, #(#kinds)|*)
                         }
-                        fn cast(syntax: SyntaxNode) -> Option<Self> {
-                            if syntax.kind() != #kind {
-                                return None;
+                        fn cast(mut syntax: SyntaxNode) -> Option<Self> {
+                            if syntax.kind() == #kind {
+                                syntax = syntax.first_child()?;
                             }
-
-                            let syntax = syntax.first_child()?;
 
                             match syntax.kind() {
                                 #(


### PR DESCRIPTION
fix #125 

at creation, the parser wraps the NAMED_TYPE and other node kinds in a
TYPE node, so we need to go one level below when casting