### PR TITLE
Separate "enum StringValue" to "struct StringValue"s

### DIFF
--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{InputValue, StringValue};
+use crate::{InputValue, TopStringValue};
 
 /// The `__Directive` type represents a Directive that a service supports.
 ///
@@ -35,7 +35,7 @@ pub struct Directive {
     // Name must return a String.
     name: String,
     // Description may return a String or null.
-    description: StringValue,
+    description: TopStringValue,
     // Args returns a Vector of __InputValue representing the arguments this
     // directive accepts.
     args: Vec<InputValue>,
@@ -49,7 +49,7 @@ impl Directive {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            description: StringValue::Top { source: None },
+            description: Default::default(),
             args: Vec::new(),
             locations: Vec::new(),
         }
@@ -57,9 +57,7 @@ impl Directive {
 
     /// Set the Directive's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+        self.description = TopStringValue::new(description);
     }
 
     /// Set the Directive's location.

--- a/crates/apollo-encoder/src/enum_def.rs
+++ b/crates/apollo-encoder/src/enum_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{EnumValue, StringValue};
+use crate::{EnumValue, TopStringValue};
 
 /// Enums are special scalars that can only have a defined set of values.
 ///
@@ -42,7 +42,7 @@ pub struct EnumDef {
     // Name must return a String.
     name: String,
     // Description may return a String or null.
-    description: StringValue,
+    description: TopStringValue,
     // A vector of EnumValue. There must be at least one and they must have
     // unique names.
     values: Vec<EnumValue>,
@@ -53,16 +53,14 @@ impl EnumDef {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            description: StringValue::Top { source: None },
+            description: Default::default(),
             values: Vec::new(),
         }
     }
 
     /// Set the Enum Definition's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+        self.description = TopStringValue::new(description);
     }
 
     /// Set the Enum Definitions's values.

--- a/crates/apollo-encoder/src/enum_value.rs
+++ b/crates/apollo-encoder/src/enum_value.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::StringValue;
+use crate::{FieldStringValue, ReasonStringValue};
 
 /// The __EnumValue type represents one of possible values of an enum.
 ///
@@ -28,11 +28,11 @@ pub struct EnumValue {
     // Name must return a String.
     name: String,
     // Description may return a String or null.
-    description: StringValue,
+    description: FieldStringValue,
     // Deprecated returns true if this enum value should no longer be used, otherwise false.
     is_deprecated: bool,
     // Deprecation reason optionally provides a reason why this enum value is deprecated.
-    deprecation_reason: StringValue,
+    deprecation_reason: ReasonStringValue,
 }
 
 impl EnumValue {
@@ -41,22 +41,20 @@ impl EnumValue {
         Self {
             name,
             is_deprecated: false,
-            description: StringValue::Field { source: None },
-            deprecation_reason: StringValue::Reason { source: None },
+            description: Default::default(),
+            deprecation_reason: Default::default(),
         }
     }
 
     /// Set the Enum Value's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Field {
-            source: description,
-        };
+        self.description = FieldStringValue::new(description);
     }
 
     /// Set the Enum Value's deprecation properties.
     pub fn deprecated(&mut self, reason: Option<String>) {
         self.is_deprecated = true;
-        self.deprecation_reason = StringValue::Reason { source: reason };
+        self.deprecation_reason = ReasonStringValue::new(reason);
     }
 }
 
@@ -67,7 +65,7 @@ impl fmt::Display for EnumValue {
 
         if self.is_deprecated {
             write!(f, " @deprecated")?;
-            if let StringValue::Reason { source: _ } = &self.deprecation_reason {
+            if self.deprecation_reason.is_empty() {
                 write!(f, "(reason:")?;
                 write!(f, "{}", self.deprecation_reason)?;
                 write!(f, ")")?

--- a/crates/apollo-encoder/src/field.rs
+++ b/crates/apollo-encoder/src/field.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{InputValue, StringValue, Type_};
+use crate::{InputValue, FieldStringValue, ReasonStringValue, Type_};
 /// The __Field type represents each field in an Object or Interface type.
 ///
 /// *FieldDefinition*:
@@ -36,7 +36,7 @@ pub struct Field {
     // Name must return a String.
     name: String,
     // Description may return a String.
-    description: StringValue,
+    description: FieldStringValue,
     // Args returns a List of __InputValue representing the arguments this field accepts.
     args: Vec<InputValue>,
     // Type must return a __Type that represents the type of value returned by this field.
@@ -44,33 +44,31 @@ pub struct Field {
     // Deprecated returns true if this field should no longer be used, otherwise false.
     is_deprecated: bool,
     // Deprecation reason optionally provides a reason why this field is deprecated.
-    deprecation_reason: StringValue,
+    deprecation_reason: ReasonStringValue,
 }
 
 impl Field {
     /// Create a new instance of Field.
     pub fn new(name: String, type_: Type_) -> Self {
         Self {
-            description: StringValue::Field { source: None },
+            description: Default::default(),
             name,
             type_,
             args: Vec::new(),
             is_deprecated: false,
-            deprecation_reason: StringValue::Reason { source: None },
+            deprecation_reason: Default::default(),
         }
     }
 
     /// Set the Field's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Field {
-            source: description,
-        };
+        self.description = FieldStringValue::new(description);
     }
 
     /// Set the Field's deprecation properties.
     pub fn deprecated(&mut self, reason: Option<String>) {
         self.is_deprecated = true;
-        self.deprecation_reason = StringValue::Reason { source: reason };
+        self.deprecation_reason = ReasonStringValue::new(reason);
     }
 
     /// Set the Field's arguments.
@@ -99,7 +97,7 @@ impl fmt::Display for Field {
         if self.is_deprecated {
             write!(f, " @deprecated")?;
 
-            if let StringValue::Reason { source: _ } = &self.deprecation_reason {
+            if self.deprecation_reason.is_empty() {
                 write!(f, "(reason:")?;
                 write!(f, "{}", self.deprecation_reason)?;
                 write!(f, ")")?

--- a/crates/apollo-encoder/src/input_field.rs
+++ b/crates/apollo-encoder/src/input_field.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{StringValue, Type_};
+use crate::{FieldStringValue, Type_};
 
 #[derive(Debug, PartialEq, Clone)]
 /// Input Field in a given Input Object.
@@ -25,7 +25,7 @@ pub struct InputField {
     // Name must return a String.
     name: String,
     // Description may return a String.
-    description: StringValue,
+    description: FieldStringValue,
     // Type must return a __Type that represents the type of value returned by this field.
     type_: Type_,
     // Default value for this input field.
@@ -36,7 +36,7 @@ impl InputField {
     /// Create a new instance of InputField.
     pub fn new(name: String, type_: Type_) -> Self {
         Self {
-            description: StringValue::Field { source: None },
+            description: Default::default(),
             name,
             type_,
             default_value: None,
@@ -45,9 +45,7 @@ impl InputField {
 
     /// Set the InputField's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Field {
-            source: description,
-        };
+        self.description = FieldStringValue::new(description);
     }
 
     /// Set the InputField's default value.

--- a/crates/apollo-encoder/src/input_object_def.rs
+++ b/crates/apollo-encoder/src/input_object_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{InputField, StringValue};
+use crate::{InputField, TopStringValue};
 
 /// Input objects are composite types used as inputs into queries defined as a list of named input values..
 ///
@@ -53,7 +53,7 @@ pub struct InputObjectDef {
     // Name must return a String.
     name: String,
     // Description may return a String or null.
-    description: StringValue,
+    description: TopStringValue,
     // A vector of fields
     fields: Vec<InputField>,
 }
@@ -63,16 +63,14 @@ impl InputObjectDef {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            description: StringValue::Top { source: None },
+            description: Default::default(),
             fields: Vec::new(),
         }
     }
 
     /// Set the InputObjectDef's description field.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+        self.description = TopStringValue::new(description);
     }
 
     /// Push a Field to InputObjectDef's fields vector.

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{StringValue, Type_};
+use crate::{InputStringValue, Type_};
 
 // NOTE(@lrlna): __InputValue is also meant to be used for InputFields on an
 // InputObject. We currently do not differentiate between InputFields and
@@ -38,7 +38,7 @@ pub struct InputValue {
     // Name must return a String.
     name: String,
     // Description may return a String.
-    description: StringValue,
+    description: InputStringValue,
     // Type must return a __Type that represents the type this input value expects.
     type_: Type_,
     // Default may return a String encoding (using the GraphQL language) of
@@ -56,7 +56,7 @@ impl InputValue {
     /// Create a new instance of InputValue.
     pub fn new(name: String, type_: Type_) -> Self {
         Self {
-            description: StringValue::Input { source: None },
+            description: Default::default(),
             name,
             type_,
             is_deprecated: false,
@@ -67,9 +67,7 @@ impl InputValue {
 
     /// Set the InputValue's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Input {
-            source: description,
-        };
+        self.description = InputStringValue::new(description);
     }
 
     /// Set the InputValue's default value.

--- a/crates/apollo-encoder/src/interface_def.rs
+++ b/crates/apollo-encoder/src/interface_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{Field, StringValue};
+use crate::{Field, TopStringValue};
 
 /// InterfaceDefs are an abstract type where there are common fields declared.
 ///
@@ -75,7 +75,7 @@ pub struct InterfaceDef {
     // Name must return a String.
     name: String,
     // Description may return a String or null.
-    description: StringValue,
+    description: TopStringValue,
     // The vector of interfaces that this interface implements.
     interfaces: Vec<String>,
     // The vector of fields required by this interface.
@@ -87,7 +87,7 @@ impl InterfaceDef {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            description: StringValue::Top { source: None },
+            description: Default::default(),
             fields: Vec::new(),
             interfaces: Vec::new(),
         }
@@ -95,9 +95,7 @@ impl InterfaceDef {
 
     /// Set the schema def's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+        self.description = TopStringValue::new(description);
     }
 
     /// Set the interfaces ObjectDef implements.

--- a/crates/apollo-encoder/src/lib.rs
+++ b/crates/apollo-encoder/src/lib.rs
@@ -136,5 +136,5 @@ pub use object_def::ObjectDef;
 pub use scalar_def::ScalarDef;
 pub use schema::Schema;
 pub use schema_def::SchemaDef;
-pub use string_value::StringValue;
+pub use string_value::{TopStringValue, FieldStringValue, InputStringValue, ReasonStringValue};
 pub use union_def::UnionDef;

--- a/crates/apollo-encoder/src/object_def.rs
+++ b/crates/apollo-encoder/src/object_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{Field, StringValue};
+use crate::{Field, TopStringValue};
 /// Object types represent concrete instantiations of sets of fields.
 ///
 /// The introspection types (e.g. `__Type`, `__Field`, etc) are examples of
@@ -57,7 +57,7 @@ pub struct ObjectDef {
     // Name must return a String.
     name: String,
     // Description may return a String or null.
-    description: StringValue,
+    description: TopStringValue,
     // The vector of interfaces that an object implements.
     interfaces: Vec<String>,
     // The vector of fields query‐able on this type.
@@ -69,7 +69,7 @@ impl ObjectDef {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            description: StringValue::Top { source: None },
+            description: Default::default(),
             interfaces: Vec::new(),
             fields: Vec::new(),
         }
@@ -77,9 +77,7 @@ impl ObjectDef {
 
     /// Set the ObjectDef's description field.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+        self.description = TopStringValue::new(description);
     }
 
     /// Set the interfaces ObjectDef implements.

--- a/crates/apollo-encoder/src/scalar_def.rs
+++ b/crates/apollo-encoder/src/scalar_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::StringValue;
+use crate::TopStringValue;
 /// Represents scalar types such as Int, String, and Boolean.
 /// Scalars cannot have fields.
 ///
@@ -29,7 +29,7 @@ pub struct ScalarDef {
     // Name must return a String.
     name: String,
     // Description may return a String or null.
-    description: StringValue,
+    description: TopStringValue,
 }
 
 impl ScalarDef {
@@ -37,15 +37,13 @@ impl ScalarDef {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            description: StringValue::Top { source: None },
+            description: Default::default(),
         }
     }
 
     /// Set the ScalarDef's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+        self.description = TopStringValue::new(description);
     }
 }
 

--- a/crates/apollo-encoder/src/schema_def.rs
+++ b/crates/apollo-encoder/src/schema_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::StringValue;
+use crate::TopStringValue;
 
 /// A GraphQL service’s collective type system capabilities are referred to as that service’s “schema”.
 ///
@@ -34,7 +34,7 @@ use crate::StringValue;
 #[derive(Debug, Clone)]
 pub struct SchemaDef {
     // Description may be a String.
-    description: StringValue,
+    description: TopStringValue,
     // The vector of fields in a schema to represent root operation type
     // definition.
     query: Option<String>,
@@ -46,7 +46,7 @@ impl SchemaDef {
     /// Create a new instance of SchemaDef.
     pub fn new() -> Self {
         Self {
-            description: StringValue::Top { source: None },
+            description: Default::default(),
             query: None,
             mutation: None,
             subscription: None,
@@ -55,9 +55,7 @@ impl SchemaDef {
 
     /// Set the SchemaDef's description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+        self.description = TopStringValue::new(description);
     }
 
     /// Set the schema def's query type.

--- a/crates/apollo-encoder/src/union_def.rs
+++ b/crates/apollo-encoder/src/union_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::StringValue;
+use crate::TopStringValue;
 
 /// UnionDefs are an abstract type where no common fields are declared.
 ///
@@ -28,7 +28,7 @@ pub struct UnionDef {
     // Name must return a String.
     name: String,
     // Description may return a String.
-    description: StringValue,
+    description: TopStringValue,
     // The vector of members that can be represented within this union.
     members: Vec<String>,
 }
@@ -38,16 +38,14 @@ impl UnionDef {
     pub fn new(name: String) -> Self {
         Self {
             name,
-            description: StringValue::Top { source: None },
+            description: Default::default(),
             members: Vec::new(),
         }
     }
 
     /// Set the UnionDefs description.
     pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+        self.description = TopStringValue::new(description);
     }
 
     /// Set a UnionDef member.


### PR DESCRIPTION
I'm glad I found apollo-rs.
Looking at the source code, it seems that it is not yet complete.
I tried to correct the part that was difficult to understand the intention.

The purpose of PR is simple.
Four StringValues grouped by enum are separated into each struct.
The reason for the separation is that each StringValue is used in a different context.
