### PR TITLE
String to &str and replace to Builder

### DIFF
--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -46,9 +46,9 @@ pub struct Directive {
 
 impl Directive {
     /// Create a new instance of Directive definition.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             description: StringValue::Top { source: None },
             args: Vec::new(),
             locations: Vec::new(),
@@ -56,15 +56,15 @@ impl Directive {
     }
 
     /// Set the Directive's description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Top {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 
     /// Set the Directive's location.
-    pub fn location(&mut self, location: String) {
-        self.locations.push(location);
+    pub fn location(&mut self, location: &str) {
+        self.locations.push(location.to_string());
     }
 
     /// Set the Directive's args.

--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -170,8 +170,7 @@ directive @infer on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
     #[test]
     fn it_encodes_directives_with_arguments() {
         let arg = {
-            let ty = Type_::named_type("SpaceProgram");
-            let ty = Type_::list(Box::new(ty));
+            let ty = Type_::list(Type_::named("SpaceProgram"));
 
             InputValueBuilder::new("cat", ty).build()
         };

--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -14,11 +14,11 @@ use crate::{InputValue, StringValue};
 /// use apollo_encoder::{Directive};
 /// use indoc::indoc;
 ///
-/// let mut directive = Directive::new("infer".to_string());
-/// directive.description(Some("Infer field types\nfrom field values.".to_string()));
-/// directive.location("OBJECT".to_string());
-/// directive.location("FIELD_DEFINITION".to_string());
-/// directive.location("INPUT_FIELD_DEFINITION".to_string());
+/// let mut directive = Directive::new("infer");
+/// directive.description("Infer field types\nfrom field values.");
+/// directive.location("OBJECT");
+/// directive.location("FIELD_DEFINITION");
+/// directive.location("INPUT_FIELD_DEFINITION");
 ///
 /// assert_eq!(
 ///     directive.to_string(),
@@ -109,9 +109,12 @@ mod tests {
 
     #[test]
     fn it_encodes_directives_for_a_single_location() {
-        let mut directive = Directive::new("infer".to_string());
-        directive.description(Some("Infer field types from field values.".to_string()));
-        directive.location("OBJECT".to_string());
+        let directive = {
+            let mut directive = Directive::new("infer");
+            directive.description("Infer field types from field values.");
+            directive.location("OBJECT");
+            directive
+        };
 
         assert_eq!(
             directive.to_string(),
@@ -123,11 +126,14 @@ directive @infer on OBJECT
 
     #[test]
     fn it_encodes_directives_for_multiple_location() {
-        let mut directive = Directive::new("infer".to_string());
-        directive.description(Some("Infer field types\nfrom field values.".to_string()));
-        directive.location("OBJECT".to_string());
-        directive.location("FIELD_DEFINITION".to_string());
-        directive.location("INPUT_FIELD_DEFINITION".to_string());
+        let directive = {
+            let mut directive = Directive::new("infer");
+            directive.description("Infer field types\nfrom field values.");
+            directive.location("OBJECT");
+            directive.location("FIELD_DEFINITION");
+            directive.location("INPUT_FIELD_DEFINITION");
+            directive
+        };
 
         assert_eq!(
             directive.to_string(),
@@ -142,17 +148,17 @@ directive @infer on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
     #[test]
     fn it_encodes_directives_with_arguments() {
-        let mut directive = Directive::new("infer".to_string());
-        directive.description(Some("Infer field types from field values.".to_string()));
-        directive.location("OBJECT".to_string());
+        let directive = {
+            let ty = Type_::named_type("SpaceProgram");
+            let ty = Type_::list(Box::new(ty));
+            let arg = InputValue::new("cat", ty);
 
-        let ty_1 = Type_::NamedType {
-            name: "SpaceProgram".to_string(),
+            let mut directive = Directive::new("infer");
+            directive.description("Infer field types from field values.");
+            directive.location("OBJECT");
+            directive.arg(arg);
+            directive
         };
-
-        let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let arg = InputValue::new("cat".to_string(), ty_2);
-        directive.arg(arg);
 
         assert_eq!(
             directive.to_string(),

--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -8,28 +8,6 @@ use crate::{InputValue, StringValue};
 ///     Description? **directive @** Name Arguments Definition? **repeatable**? **on** DirectiveLocations
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Type-System.Directives).
-///
-/// ### Example
-/// ```rust
-/// use apollo_encoder::{Directive};
-/// use indoc::indoc;
-///
-/// let mut directive = Directive::new("infer");
-/// directive.description("Infer field types\nfrom field values.");
-/// directive.location("OBJECT");
-/// directive.location("FIELD_DEFINITION");
-/// directive.location("INPUT_FIELD_DEFINITION");
-///
-/// assert_eq!(
-///     directive.to_string(),
-///     r#""""
-/// Infer field types
-/// from field values.
-/// """
-/// directive @infer on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-/// "#
-/// );
-/// ```
 #[derive(Debug)]
 pub struct Directive {
     // Name must return a String.
@@ -44,6 +22,28 @@ pub struct Directive {
     locations: Vec<String>,
 }
 
+/// ### Example
+/// ```rust
+/// use apollo_encoder::{DirectiveBuilder};
+/// use indoc::indoc;
+///
+/// let directive = DirectiveBuilder::new("infer")
+///     .description("Infer field types\nfrom field values.")
+///     .location("OBJECT")
+///     .location("FIELD_DEFINITION")
+///     .location("INPUT_FIELD_DEFINITION")
+///     .build();
+///
+/// assert_eq!(
+///     directive.to_string(),
+///     r#""""
+/// Infer field types
+/// from field values.
+/// """
+/// directive @infer on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+/// "#
+/// );
+/// ```
 #[derive(Debug)]
 pub struct DirectiveBuilder {
     // Name must return a String.
@@ -129,19 +129,15 @@ impl fmt::Display for Directive {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    // use indoc::indoc;
-    use crate::Type_;
+    use crate::{DirectiveBuilder, InputValueBuilder, Type_};
     use pretty_assertions::assert_eq;
 
     #[test]
     fn it_encodes_directives_for_a_single_location() {
-        let directive = {
-            let mut directive = Directive::new("infer");
-            directive.description("Infer field types from field values.");
-            directive.location("OBJECT");
-            directive
-        };
+        let directive = DirectiveBuilder::new("infer")
+            .description("Infer field types from field values.")
+            .location("OBJECT")
+            .build();
 
         assert_eq!(
             directive.to_string(),
@@ -153,14 +149,12 @@ directive @infer on OBJECT
 
     #[test]
     fn it_encodes_directives_for_multiple_location() {
-        let directive = {
-            let mut directive = Directive::new("infer");
-            directive.description("Infer field types\nfrom field values.");
-            directive.location("OBJECT");
-            directive.location("FIELD_DEFINITION");
-            directive.location("INPUT_FIELD_DEFINITION");
-            directive
-        };
+        let directive = DirectiveBuilder::new("infer")
+            .description("Infer field types\nfrom field values.")
+            .location("OBJECT")
+            .location("FIELD_DEFINITION")
+            .location("INPUT_FIELD_DEFINITION")
+            .build();
 
         assert_eq!(
             directive.to_string(),
@@ -175,17 +169,18 @@ directive @infer on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
     #[test]
     fn it_encodes_directives_with_arguments() {
-        let directive = {
+        let arg = {
             let ty = Type_::named_type("SpaceProgram");
             let ty = Type_::list(Box::new(ty));
-            let arg = InputValue::new("cat", ty);
 
-            let mut directive = Directive::new("infer");
-            directive.description("Infer field types from field values.");
-            directive.location("OBJECT");
-            directive.arg(arg);
-            directive
+            InputValueBuilder::new("cat", ty).build()
         };
+
+        let directive = DirectiveBuilder::new("infer")
+            .description("Infer field types from field values.")
+            .location("OBJECT")
+            .arg(arg)
+            .build();
 
         assert_eq!(
             directive.to_string(),

--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -44,32 +44,59 @@ pub struct Directive {
     locations: Vec<String>,
 }
 
-impl Directive {
-    /// Create a new instance of Directive definition.
+#[derive(Debug)]
+pub struct DirectiveBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: Option<String>,
+    // Args returns a Vector of __InputValue representing the arguments this
+    // directive accepts.
+    args: Vec<InputValue>,
+    // Locations returns a List of __DirectiveLocation representing the valid
+    // locations this directive may be placed.
+    locations: Vec<String>,
+}
+
+impl DirectiveBuilder {
+    /// Create a new instance of DirectiveBuilder.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            description: StringValue::Top { source: None },
+            description: None,
             args: Vec::new(),
             locations: Vec::new(),
         }
     }
 
     /// Set the Directive's description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Top {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the Directive's location.
-    pub fn location(&mut self, location: &str) {
+    pub fn location(mut self, location: &str) -> Self {
         self.locations.push(location.to_string());
+        self
     }
 
     /// Set the Directive's args.
-    pub fn arg(&mut self, arg: InputValue) {
+    pub fn arg(mut self, arg: InputValue) -> Self {
         self.args.push(arg);
+        self
+    }
+
+    /// Create a new instance of Directive.
+    pub fn build(self) -> Directive {
+        Directive {
+            name: self.name,
+            description: StringValue::Top {
+                source: self.description,
+            },
+            args: self.args,
+            locations: self.locations,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/enum_def.rs
+++ b/crates/apollo-encoder/src/enum_def.rs
@@ -50,18 +50,18 @@ pub struct EnumDef {
 
 impl EnumDef {
     /// Create a new instance of Enum Definition.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             description: StringValue::Top { source: None },
             values: Vec::new(),
         }
     }
 
     /// Set the Enum Definition's description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Top {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 

--- a/crates/apollo-encoder/src/enum_def.rs
+++ b/crates/apollo-encoder/src/enum_def.rs
@@ -8,22 +8,35 @@ use crate::{EnumValue, StringValue};
 ///     Description? **enum** Name Directives? EnumValuesDefinition?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Enums).
-///
+#[derive(Debug, PartialEq, Clone)]
+pub struct EnumDef {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: StringValue,
+    // A vector of EnumValue. There must be at least one and they must have
+    // unique names.
+    values: Vec<EnumValue>,
+}
+
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{EnumValue, EnumDef};
+/// use apollo_encoder::{EnumValueBuilder, EnumDefBuilder};
 ///
-/// let mut enum_ty_1 = EnumValue::new("CAT_TREE");
-/// enum_ty_1.description("Top bunk of a cat tree.");
-/// let enum_ty_2 = EnumValue::new("BED");
-/// let mut enum_ty_3 = EnumValue::new("CARDBOARD_BOX");
-/// enum_ty_3.deprecated("Box was recycled.");
+/// let mut enum_ty_1 = EnumValueBuilder::new("CAT_TREE")
+///     .description("Top bunk of a cat tree.")
+///     .build();
+/// let enum_ty_2 = EnumValueBuilder::new("BED").build();
+/// let mut enum_ty_3 = EnumValueBuilder::new("CARDBOARD_BOX")
+///     .deprecated("Box was recycled.")
+///     .build();
 ///
-/// let mut enum_ = EnumDef::new("NapSpots");
-/// enum_.description("Favourite cat nap spots.");
-/// enum_.value(enum_ty_1);
-/// enum_.value(enum_ty_2);
-/// enum_.value(enum_ty_3);
+/// let enum_ = EnumDefBuilder::new("NapSpots")
+///     .description("Favourite cat nap spots.")
+///     .value(enum_ty_1)
+///     .value(enum_ty_2)
+///     .value(enum_ty_3)
+///     .build();
 ///
 /// assert_eq!(
 ///     enum_.to_string(),
@@ -37,17 +50,6 @@ use crate::{EnumValue, StringValue};
 /// "#
 /// );
 /// ```
-#[derive(Debug, PartialEq, Clone)]
-pub struct EnumDef {
-    // Name must return a String.
-    name: String,
-    // Description may return a String or null.
-    description: StringValue,
-    // A vector of EnumValue. There must be at least one and they must have
-    // unique names.
-    values: Vec<EnumValue>,
-}
-
 #[derive(Debug, Clone)]
 pub struct EnumDefBuilder {
     // Name must return a String.
@@ -106,18 +108,16 @@ impl fmt::Display for EnumDef {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{EnumDefBuilder, EnumValueBuilder};
     use pretty_assertions::assert_eq;
 
     #[test]
     fn it_encodes_a_simple_enum() {
-        let enum_ = {
-            let mut enum_ = EnumDef::new("NapSpots");
-            enum_.value(EnumValue::new("CAT_TREE"));
-            enum_.value(EnumValue::new("BED"));
-            enum_.value(EnumValue::new("CARDBOARD_BOX"));
-            enum_
-        };
+        let enum_ = EnumDefBuilder::new("NapSpots")
+            .value(EnumValueBuilder::new("CAT_TREE").build())
+            .value(EnumValueBuilder::new("BED").build())
+            .value(EnumValueBuilder::new("CARDBOARD_BOX").build())
+            .build();
 
         assert_eq!(
             enum_.to_string(),
@@ -131,26 +131,19 @@ mod tests {
     }
     #[test]
     fn it_encodes_enum_with_descriptions() {
-        let enum_ = {
-            let enum_value_1 = {
-                let mut enum_value = EnumValue::new("CAT_TREE");
-                enum_value.description("Top bunk of a cat tree.");
-                enum_value
-            };
-            let enum_value_2 = EnumValue::new("BED");
-            let enum_value_3 = {
-                let mut enum_value = EnumValue::new("CARDBOARD_BOX");
-                enum_value.deprecated("Box was recycled.");
-                enum_value
-            };
-
-            let mut enum_ = EnumDef::new("NapSpots");
-            enum_.description("Favourite cat nap spots.");
-            enum_.value(enum_value_1);
-            enum_.value(enum_value_2);
-            enum_.value(enum_value_3);
-            enum_
-        };
+        let enum_value_1 = EnumValueBuilder::new("CAT_TREE")
+            .description("Top bunk of a cat tree.")
+            .build();
+        let enum_value_2 = EnumValueBuilder::new("BED").build();
+        let enum_value_3 = EnumValueBuilder::new("CARDBOARD_BOX")
+            .deprecated("Box was recycled.")
+            .build();
+        let enum_ = EnumDefBuilder::new("NapSpots")
+            .description("Favourite cat nap spots.")
+            .value(enum_value_1)
+            .value(enum_value_2)
+            .value(enum_value_3)
+            .build();
 
         assert_eq!(
             enum_.to_string(),

--- a/crates/apollo-encoder/src/enum_def.rs
+++ b/crates/apollo-encoder/src/enum_def.rs
@@ -13,14 +13,14 @@ use crate::{EnumValue, StringValue};
 /// ```rust
 /// use apollo_encoder::{EnumValue, EnumDef};
 ///
-/// let mut enum_ty_1 = EnumValue::new("CAT_TREE".to_string());
-/// enum_ty_1.description(Some("Top bunk of a cat tree.".to_string()));
-/// let enum_ty_2 = EnumValue::new("BED".to_string());
-/// let mut enum_ty_3 = EnumValue::new("CARDBOARD_BOX".to_string());
-/// enum_ty_3.deprecated(Some("Box was recycled.".to_string()));
+/// let mut enum_ty_1 = EnumValue::new("CAT_TREE");
+/// enum_ty_1.description("Top bunk of a cat tree.");
+/// let enum_ty_2 = EnumValue::new("BED");
+/// let mut enum_ty_3 = EnumValue::new("CARDBOARD_BOX");
+/// enum_ty_3.deprecated("Box was recycled.");
 ///
-/// let mut enum_ = EnumDef::new("NapSpots".to_string());
-/// enum_.description(Some("Favourite cat nap spots.".to_string()));
+/// let mut enum_ = EnumDef::new("NapSpots");
+/// enum_.description("Favourite cat nap spots.");
 /// enum_.value(enum_ty_1);
 /// enum_.value(enum_ty_2);
 /// enum_.value(enum_ty_3);
@@ -89,14 +89,13 @@ mod tests {
 
     #[test]
     fn it_encodes_a_simple_enum() {
-        let enum_ty_1 = EnumValue::new("CAT_TREE".to_string());
-        let enum_ty_2 = EnumValue::new("BED".to_string());
-        let enum_ty_3 = EnumValue::new("CARDBOARD_BOX".to_string());
-
-        let mut enum_ = EnumDef::new("NapSpots".to_string());
-        enum_.value(enum_ty_1);
-        enum_.value(enum_ty_2);
-        enum_.value(enum_ty_3);
+        let enum_ = {
+            let mut enum_ = EnumDef::new("NapSpots");
+            enum_.value(EnumValue::new("CAT_TREE"));
+            enum_.value(EnumValue::new("BED"));
+            enum_.value(EnumValue::new("CARDBOARD_BOX"));
+            enum_
+        };
 
         assert_eq!(
             enum_.to_string(),
@@ -110,17 +109,26 @@ mod tests {
     }
     #[test]
     fn it_encodes_enum_with_descriptions() {
-        let mut enum_ty_1 = EnumValue::new("CAT_TREE".to_string());
-        enum_ty_1.description(Some("Top bunk of a cat tree.".to_string()));
-        let enum_ty_2 = EnumValue::new("BED".to_string());
-        let mut enum_ty_3 = EnumValue::new("CARDBOARD_BOX".to_string());
-        enum_ty_3.deprecated(Some("Box was recycled.".to_string()));
+        let enum_ = {
+            let enum_value_1 = {
+                let mut enum_value = EnumValue::new("CAT_TREE");
+                enum_value.description("Top bunk of a cat tree.");
+                enum_value
+            };
+            let enum_value_2 = EnumValue::new("BED");
+            let enum_value_3 = {
+                let mut enum_value = EnumValue::new("CARDBOARD_BOX");
+                enum_value.deprecated("Box was recycled.");
+                enum_value
+            };
 
-        let mut enum_ = EnumDef::new("NapSpots".to_string());
-        enum_.description(Some("Favourite cat nap spots.".to_string()));
-        enum_.value(enum_ty_1);
-        enum_.value(enum_ty_2);
-        enum_.value(enum_ty_3);
+            let mut enum_ = EnumDef::new("NapSpots");
+            enum_.description("Favourite cat nap spots.");
+            enum_.value(enum_value_1);
+            enum_.value(enum_value_2);
+            enum_.value(enum_value_3);
+            enum_
+        };
 
         assert_eq!(
             enum_.to_string(),

--- a/crates/apollo-encoder/src/enum_def.rs
+++ b/crates/apollo-encoder/src/enum_def.rs
@@ -48,26 +48,48 @@ pub struct EnumDef {
     values: Vec<EnumValue>,
 }
 
-impl EnumDef {
-    /// Create a new instance of Enum Definition.
+#[derive(Debug, Clone)]
+pub struct EnumDefBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: Option<String>,
+    // A vector of EnumValue. There must be at least one and they must have
+    // unique names.
+    values: Vec<EnumValue>,
+}
+
+impl EnumDefBuilder {
+    /// Create a new instance of EnumDefBuilder.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            description: StringValue::Top { source: None },
+            description: None,
             values: Vec::new(),
         }
     }
 
     /// Set the Enum Definition's description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Top {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the Enum Definitions's values.
-    pub fn value(&mut self, value: EnumValue) {
-        self.values.push(value)
+    pub fn value(mut self, value: EnumValue) -> Self {
+        self.values.push(value);
+        self
+    }
+
+    /// Create a new instance of EnumDef.
+    pub fn build(self) -> EnumDef {
+        EnumDef {
+            name: self.name,
+            description: StringValue::Top {
+                source: self.description,
+            },
+            values: self.values,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/enum_value.rs
+++ b/crates/apollo-encoder/src/enum_value.rs
@@ -35,30 +35,50 @@ pub struct EnumValue {
     deprecation_reason: StringValue,
 }
 
-impl EnumValue {
-    /// Create a new instance of EnumValue.
+#[derive(Debug, Clone)]
+pub struct EnumValueBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: Option<String>,
+    // Deprecation reason optionally provides a reason why this enum value is deprecated.
+    deprecation_reason: Option<String>,
+}
+
+impl EnumValueBuilder {
+    /// Create a new instance of EnumValueBuilder.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            is_deprecated: false,
-            description: StringValue::Field { source: None },
-            deprecation_reason: StringValue::Reason { source: None },
+            description: None,
+            deprecation_reason: None,
         }
     }
 
     /// Set the Enum Value's description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Field {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the Enum Value's deprecation properties.
-    pub fn deprecated(&mut self, reason: &str) {
-        self.is_deprecated = true;
-        self.deprecation_reason = StringValue::Reason {
-            source: Some(reason.to_string()),
-        };
+    pub fn deprecated(mut self, reason: &str) -> Self {
+        self.deprecation_reason = Some(reason.to_string());
+        self
+    }
+
+    /// Create a new instance of EnumValue.
+    pub fn build(self) -> EnumValue {
+        EnumValue {
+            name: self.name,
+            description: StringValue::Field {
+                source: self.description,
+            },
+            is_deprecated: self.deprecation_reason.is_some(),
+            deprecation_reason: StringValue::Reason {
+                source: self.deprecation_reason,
+            },
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/enum_value.rs
+++ b/crates/apollo-encoder/src/enum_value.rs
@@ -37,9 +37,9 @@ pub struct EnumValue {
 
 impl EnumValue {
     /// Create a new instance of EnumValue.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             is_deprecated: false,
             description: StringValue::Field { source: None },
             deprecation_reason: StringValue::Reason { source: None },
@@ -47,16 +47,18 @@ impl EnumValue {
     }
 
     /// Set the Enum Value's description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Field {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 
     /// Set the Enum Value's deprecation properties.
-    pub fn deprecated(&mut self, reason: Option<String>) {
+    pub fn deprecated(&mut self, reason: &str) {
         self.is_deprecated = true;
-        self.deprecation_reason = StringValue::Reason { source: reason };
+        self.deprecation_reason = StringValue::Reason {
+            source: Some(reason.to_string()),
+        };
     }
 }
 

--- a/crates/apollo-encoder/src/enum_value.rs
+++ b/crates/apollo-encoder/src/enum_value.rs
@@ -13,12 +13,12 @@ use crate::StringValue;
 /// ```rust
 /// use apollo_encoder::{EnumValue};
 ///
-/// let mut enum_ty = EnumValue::new("CARDBOARD_BOX".to_string());
-/// enum_ty.description(Some("Box nap spot.".to_string()));
-/// enum_ty.deprecated(Some("Box was recycled.".to_string()));
+/// let mut enum_value = EnumValue::new("CARDBOARD_BOX");
+/// enum_value.description("Box nap spot.");
+/// enum_value.deprecated("Box was recycled.");
 ///
 /// assert_eq!(
-///     enum_ty.to_string(),
+///     enum_value.to_string(),
 ///     r#"  "Box nap spot."
 ///   CARDBOARD_BOX @deprecated(reason: "Box was recycled.")"#
 /// );
@@ -87,28 +87,36 @@ mod tests {
 
     #[test]
     fn it_encodes_an_enum_value() {
-        let enum_ty = EnumValue::new("CAT_TREE".to_string());
-        assert_eq!(enum_ty.to_string(), "  CAT_TREE");
+        let enum_value = EnumValue::new("CAT_TREE");
+
+        assert_eq!(enum_value.to_string(), "  CAT_TREE");
     }
 
     #[test]
     fn it_encodes_an_enum_value_with_desciption() {
-        let mut enum_ty = EnumValue::new("CAT_TREE".to_string());
-        enum_ty.description(Some("Top bunk of a cat tree.".to_string()));
+        let enum_value = {
+            let mut enum_value = EnumValue::new("CAT_TREE");
+            enum_value.description("Top bunk of a cat tree.");
+            enum_value
+        };
+
         assert_eq!(
-            enum_ty.to_string(),
+            enum_value.to_string(),
             r#"  "Top bunk of a cat tree."
   CAT_TREE"#
         );
     }
     #[test]
     fn it_encodes_an_enum_value_with_deprecated() {
-        let mut enum_ty = EnumValue::new("CARDBOARD_BOX".to_string());
-        enum_ty.description(Some("Box nap\nspot.".to_string()));
-        enum_ty.deprecated(Some("Box was recycled.".to_string()));
+        let enum_value = {
+            let mut enum_value = EnumValue::new("CARDBOARD_BOX");
+            enum_value.description("Box nap\nspot.");
+            enum_value.deprecated("Box was recycled.");
+            enum_value
+        };
 
         assert_eq!(
-            enum_ty.to_string(),
+            enum_value.to_string(),
             r#"  """
   Box nap
   spot.
@@ -119,12 +127,15 @@ mod tests {
 
     #[test]
     fn it_encodes_an_enum_value_with_deprecated_block_string_value() {
-        let mut enum_ty = EnumValue::new("CARDBOARD_BOX".to_string());
-        enum_ty.description(Some("Box nap\nspot.".to_string()));
-        enum_ty.deprecated(Some("Box was \"recycled\".".to_string()));
+        let enum_value = {
+            let mut enum_value = EnumValue::new("CARDBOARD_BOX");
+            enum_value.description("Box nap\nspot.");
+            enum_value.deprecated("Box was \"recycled\".");
+            enum_value
+        };
 
         assert_eq!(
-            enum_ty.to_string(),
+            enum_value.to_string(),
             r#"  """
   Box nap
   spot.

--- a/crates/apollo-encoder/src/enum_value.rs
+++ b/crates/apollo-encoder/src/enum_value.rs
@@ -8,21 +8,6 @@ use crate::StringValue;
 ///     Description? EnumValue Directives?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-The-__EnumValue-Type).
-///
-/// ### Example
-/// ```rust
-/// use apollo_encoder::{EnumValue};
-///
-/// let mut enum_value = EnumValue::new("CARDBOARD_BOX");
-/// enum_value.description("Box nap spot.");
-/// enum_value.deprecated("Box was recycled.");
-///
-/// assert_eq!(
-///     enum_value.to_string(),
-///     r#"  "Box nap spot."
-///   CARDBOARD_BOX @deprecated(reason: "Box was recycled.")"#
-/// );
-/// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct EnumValue {
     // Name must return a String.
@@ -35,6 +20,21 @@ pub struct EnumValue {
     deprecation_reason: StringValue,
 }
 
+/// ### Example
+/// ```rust
+/// use apollo_encoder::{EnumValueBuilder};
+///
+/// let enum_value = EnumValueBuilder::new("CARDBOARD_BOX")
+///     .description("Box nap spot.")
+///     .deprecated("Box was recycled.")
+///     .build();
+///
+/// assert_eq!(
+///     enum_value.to_string(),
+///     r#"  "Box nap spot."
+///   CARDBOARD_BOX @deprecated(reason: "Box was recycled.")"#
+/// );
+/// ```
 #[derive(Debug, Clone)]
 pub struct EnumValueBuilder {
     // Name must return a String.
@@ -102,23 +102,21 @@ impl fmt::Display for EnumValue {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::EnumValueBuilder;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn it_encodes_an_enum_value() {
-        let enum_value = EnumValue::new("CAT_TREE");
+        let enum_value = EnumValueBuilder::new("CAT_TREE").build();
 
         assert_eq!(enum_value.to_string(), "  CAT_TREE");
     }
 
     #[test]
     fn it_encodes_an_enum_value_with_desciption() {
-        let enum_value = {
-            let mut enum_value = EnumValue::new("CAT_TREE");
-            enum_value.description("Top bunk of a cat tree.");
-            enum_value
-        };
+        let enum_value = EnumValueBuilder::new("CAT_TREE")
+            .description("Top bunk of a cat tree.")
+            .build();
 
         assert_eq!(
             enum_value.to_string(),
@@ -128,12 +126,10 @@ mod tests {
     }
     #[test]
     fn it_encodes_an_enum_value_with_deprecated() {
-        let enum_value = {
-            let mut enum_value = EnumValue::new("CARDBOARD_BOX");
-            enum_value.description("Box nap\nspot.");
-            enum_value.deprecated("Box was recycled.");
-            enum_value
-        };
+        let enum_value = EnumValueBuilder::new("CARDBOARD_BOX")
+            .description("Box nap\nspot.")
+            .deprecated("Box was recycled.")
+            .build();
 
         assert_eq!(
             enum_value.to_string(),
@@ -147,12 +143,10 @@ mod tests {
 
     #[test]
     fn it_encodes_an_enum_value_with_deprecated_block_string_value() {
-        let enum_value = {
-            let mut enum_value = EnumValue::new("CARDBOARD_BOX");
-            enum_value.description("Box nap\nspot.");
-            enum_value.deprecated("Box was \"recycled\".");
-            enum_value
-        };
+        let enum_value = EnumValueBuilder::new("CARDBOARD_BOX")
+            .description("Box nap\nspot.")
+            .deprecated("Box was \"recycled\".")
+            .build();
 
         assert_eq!(
             enum_value.to_string(),

--- a/crates/apollo-encoder/src/field.rs
+++ b/crates/apollo-encoder/src/field.rs
@@ -49,10 +49,10 @@ pub struct Field {
 
 impl Field {
     /// Create a new instance of Field.
-    pub fn new(name: String, type_: Type_) -> Self {
+    pub fn new(name: &str, type_: Type_) -> Self {
         Self {
             description: StringValue::Field { source: None },
-            name,
+            name: name.to_string(),
             type_,
             args: Vec::new(),
             is_deprecated: false,
@@ -61,16 +61,18 @@ impl Field {
     }
 
     /// Set the Field's description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Field {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 
     /// Set the Field's deprecation properties.
-    pub fn deprecated(&mut self, reason: Option<String>) {
+    pub fn deprecated(&mut self, reason: &str) {
         self.is_deprecated = true;
-        self.deprecation_reason = StringValue::Reason { source: reason };
+        self.deprecation_reason = StringValue::Reason {
+            source: Some(reason.to_string()),
+        };
     }
 
     /// Set the Field's arguments.

--- a/crates/apollo-encoder/src/field.rs
+++ b/crates/apollo-encoder/src/field.rs
@@ -43,37 +43,64 @@ pub struct Field {
     deprecation_reason: StringValue,
 }
 
-impl Field {
-    /// Create a new instance of Field.
+#[derive(Debug, Clone)]
+pub struct FieldBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String.
+    description: Option<String>,
+    // Args returns a List of __InputValue representing the arguments this field accepts.
+    args: Vec<InputValue>,
+    // Type must return a __Type that represents the type of value returned by this field.
+    type_: Type_,
+    // Deprecation reason optionally provides a reason why this field is deprecated.
+    deprecation_reason: Option<String>,
+}
+
+impl FieldBuilder {
+    /// Create a new instance of FieldBuilder.
     pub fn new(name: &str, type_: Type_) -> Self {
         Self {
-            description: StringValue::Field { source: None },
             name: name.to_string(),
-            type_,
+            description: None,
             args: Vec::new(),
-            is_deprecated: false,
-            deprecation_reason: StringValue::Reason { source: None },
+            type_,
+            deprecation_reason: None,
         }
     }
 
     /// Set the Field's description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Field {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the Field's deprecation properties.
-    pub fn deprecated(&mut self, reason: &str) {
-        self.is_deprecated = true;
-        self.deprecation_reason = StringValue::Reason {
-            source: Some(reason.to_string()),
-        };
+    pub fn deprecated(mut self, reason: &str) -> Self {
+        self.deprecation_reason = Some(reason.to_string());
+        self
     }
 
     /// Set the Field's arguments.
-    pub fn arg(&mut self, arg: InputValue) {
+    pub fn arg(mut self, arg: InputValue) -> Self {
         self.args.push(arg);
+        self
+    }
+
+    /// Create a new instance of Field.
+    pub fn build(self) -> Field {
+        Field {
+            name: self.name,
+            description: StringValue::Field {
+                source: self.description,
+            },
+            args: self.args,
+            type_: self.type_,
+            is_deprecated: self.deprecation_reason.is_some(),
+            deprecation_reason: StringValue::Reason {
+                source: self.deprecation_reason,
+            },
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/field.rs
+++ b/crates/apollo-encoder/src/field.rs
@@ -27,12 +27,13 @@ pub struct Field {
 /// ```rust
 /// use apollo_encoder::{Type_, FieldBuilder, InputValueBuilder};
 ///
-/// let ty = Type_::named_type("CatBreed");
 /// let arg = {
-///     let ty = Type_::named_type("CatBreed");
+///     let ty = Type_::named("CatBreed");
 ///
 ///     InputValueBuilder::new("breed", ty).build()
 /// };
+///
+/// let ty = Type_::named("CatBreed");
 ///
 /// let field = FieldBuilder::new("cat", ty)
 ///     .arg(arg)
@@ -142,9 +143,7 @@ mod tests {
 
     #[test]
     fn it_encodes_simple_fields() {
-        let ty = Type_::named_type("SpaceProgram");
-        let ty = Type_::list(Box::new(ty));
-        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::non_null(Type_::list(Type_::named("SpaceProgram")));
 
         let field = FieldBuilder::new("spaceCat", ty).build();
 
@@ -153,8 +152,7 @@ mod tests {
 
     #[test]
     fn it_encodes_fields_with_deprecation() {
-        let ty = Type_::named_type("SpaceProgram");
-        let ty = Type_::list(Box::new(ty));
+        let ty = Type_::list(Type_::named("SpaceProgram"));
 
         let field = FieldBuilder::new("cat", ty)
             .description("Very good cats")
@@ -170,10 +168,7 @@ mod tests {
 
     #[test]
     fn it_encodes_fields_with_description() {
-        let ty = Type_::named_type("SpaceProgram");
-        let ty = Type_::non_null(Box::new(ty));
-        let ty = Type_::list(Box::new(ty));
-        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::non_null(Type_::list(Type_::non_null(Type_::named("SpaceProgram"))));
 
         let field = FieldBuilder::new("spaceCat", ty)
             .description("Very good space cats")
@@ -189,14 +184,10 @@ mod tests {
     #[test]
     fn it_encodes_fields_with_valueuments() {
         let field = {
-            let ty = Type_::named_type("SpaceProgram");
-            let ty = Type_::non_null(Box::new(ty));
-            let ty = Type_::list(Box::new(ty));
-            let ty = Type_::non_null(Box::new(ty));
+            let ty = Type_::non_null(Type_::list(Type_::non_null(Type_::named("SpaceProgram"))));
 
             let arg = {
-                let ty = Type_::named_type("SpaceProgram");
-                let ty = Type_::list(Box::new(ty));
+                let ty = Type_::list(Type_::named("SpaceProgram"));
 
                 InputValueBuilder::new("cat", ty)
                     .deprecated("Cats are no longer sent to space.")

--- a/crates/apollo-encoder/src/field_value.rs
+++ b/crates/apollo-encoder/src/field_value.rs
@@ -9,11 +9,9 @@ use std::fmt::{self, Display};
 /// ```rust
 /// use apollo_encoder::{Type_};
 ///
-/// let field_ty = Type_::named_type("String");
-/// let list = Type_::list(Box::new(field_ty));
-/// let non_null = Type_::non_null(Box::new(list));
+/// let ty = Type_::non_null(Type_::list(Type_::named("String")));
 ///
-/// assert_eq!(non_null.to_string(), "[String]!");
+/// assert_eq!(ty.to_string(), "[String]!");
 /// ```
 #[derive(Debug, PartialEq, Clone)]
 pub enum Type_ {
@@ -75,34 +73,29 @@ mod tests {
 
     #[test]
     fn encodes_simple_field_value() {
-        let ty = Type_::named_type("String");
+        let ty = Type_::named("String");
 
         assert_eq!(ty.to_string(), "String");
     }
 
     #[test]
     fn encodes_list_field_value() {
-        let ty = Type_::named_type("String");
-        let ty = Type_::list(Box::new(ty));
+        let ty = Type_::list(Type_::named("String"));
 
         assert_eq!(ty.to_string(), "[String]");
     }
 
     #[test]
     fn encodes_non_null_list_field_value() {
-        let ty = Type_::named_type("String");
-        let ty = Type_::list(Box::new(ty));
-        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::non_null(Type_::list(Type_::named("String")));
 
         assert_eq!(ty.to_string(), "[String]!");
     }
     #[test]
     fn encodes_non_null_list_non_null_list_field_value() {
-        let ty = Type_::named_type("String");
-        let ty = Type_::list(Box::new(ty));
-        let ty = Type_::non_null(Box::new(ty));
-        let ty = Type_::list(Box::new(ty));
-        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::non_null(Type_::list(Type_::non_null(Type_::list(Type_::named(
+            "String",
+        )))));
 
         assert_eq!(ty.to_string(), "[[String]!]!");
     }

--- a/crates/apollo-encoder/src/field_value.rs
+++ b/crates/apollo-encoder/src/field_value.rs
@@ -10,9 +10,7 @@ use std::fmt::{self, Display};
 /// use apollo_encoder::{Type_};
 ///
 /// let field_ty = Type_::named_type("String");
-///
 /// let list = Type_::list(Box::new(field_ty));
-///
 /// let non_null = Type_::non_null(Box::new(list));
 ///
 /// assert_eq!(non_null.to_string(), "[String]!");
@@ -72,7 +70,7 @@ impl Display for Type_ {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::Type_;
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/crates/apollo-encoder/src/field_value.rs
+++ b/crates/apollo-encoder/src/field_value.rs
@@ -28,7 +28,7 @@ pub enum Type_ {
         ty: Box<Type_>,
     },
     /// The Named field type.
-    NamedType {
+    Named {
         /// NamedType type.
         name: String,
     },
@@ -36,19 +36,19 @@ pub enum Type_ {
 
 impl Type_ {
     /// Create a new instance of Type_::NonNull.
-    pub const fn non_null(ty: Box<Type_>) -> Self {
-        Type_::NonNull { ty }
+    pub fn non_null(ty: Self) -> Self {
+        Type_::NonNull { ty: Box::new(ty) }
     }
 
     /// Create a new instance of Type_::List.
-    pub const fn list(ty: Box<Type_>) -> Self {
-        Type_::List { ty }
+    pub fn list(ty: Self) -> Self {
+        Type_::List { ty: Box::new(ty) }
     }
 
     /// Create a new instance of Type_::NamedType.
     #[inline(always)]
-    pub fn named_type(name: &str) -> Self {
-        Type_::NamedType {
+    pub fn named(name: &str) -> Self {
+        Type_::Named {
             name: name.to_string(),
         }
     }
@@ -63,7 +63,7 @@ impl Display for Type_ {
             Type_::NonNull { ty } => {
                 write!(f, "{}!", ty)
             }
-            Type_::NamedType { name } => write!(f, "{}", name),
+            Type_::Named { name } => write!(f, "{}", name),
         }
     }
 }

--- a/crates/apollo-encoder/src/field_value.rs
+++ b/crates/apollo-encoder/src/field_value.rs
@@ -40,6 +40,26 @@ pub enum Type_ {
     },
 }
 
+impl Type_ {
+    /// Create a new instance of Type_::NonNull.
+    pub const fn non_null(ty: Box<Type_>) -> Self {
+        Type_::NonNull { ty }
+    }
+
+    /// Create a new instance of Type_::List.
+    pub const fn list(ty: Box<Type_>) -> Self {
+        Type_::List { ty }
+    }
+
+    /// Create a new instance of Type_::NamedType.
+    #[inline(always)]
+    pub fn named_type(name: &str) -> Self {
+        Type_::NamedType {
+            name: name.to_string(),
+        }
+    }
+}
+
 impl Display for Type_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/apollo-encoder/src/field_value.rs
+++ b/crates/apollo-encoder/src/field_value.rs
@@ -9,15 +9,11 @@ use std::fmt::{self, Display};
 /// ```rust
 /// use apollo_encoder::{Type_};
 ///
-/// let field_ty = Type_::NamedType {
-///     name: "String".to_string(),
-/// };
+/// let field_ty = Type_::named_type("String");
 ///
-/// let list = Type_::List {
-///     ty: Box::new(field_ty),
-/// };
+/// let list = Type_::list(Box::new(field_ty));
 ///
-/// let non_null = Type_::NonNull { ty: Box::new(list) };
+/// let non_null = Type_::non_null(Box::new(list));
 ///
 /// assert_eq!(non_null.to_string(), "[String]!");
 /// ```
@@ -81,60 +77,35 @@ mod tests {
 
     #[test]
     fn encodes_simple_field_value() {
-        let field_ty = Type_::NamedType {
-            name: "String".to_string(),
-        };
+        let ty = Type_::named_type("String");
 
-        assert_eq!(field_ty.to_string(), "String");
+        assert_eq!(ty.to_string(), "String");
     }
 
     #[test]
     fn encodes_list_field_value() {
-        let field_ty = Type_::NamedType {
-            name: "String".to_string(),
-        };
+        let ty = Type_::named_type("String");
+        let ty = Type_::list(Box::new(ty));
 
-        let list = Type_::List {
-            ty: Box::new(field_ty),
-        };
-
-        assert_eq!(list.to_string(), "[String]");
+        assert_eq!(ty.to_string(), "[String]");
     }
 
     #[test]
     fn encodes_non_null_list_field_value() {
-        let field_ty = Type_::NamedType {
-            name: "String".to_string(),
-        };
+        let ty = Type_::named_type("String");
+        let ty = Type_::list(Box::new(ty));
+        let ty = Type_::non_null(Box::new(ty));
 
-        let list = Type_::List {
-            ty: Box::new(field_ty),
-        };
-
-        let non_null = Type_::NonNull { ty: Box::new(list) };
-
-        assert_eq!(non_null.to_string(), "[String]!");
+        assert_eq!(ty.to_string(), "[String]!");
     }
     #[test]
     fn encodes_non_null_list_non_null_list_field_value() {
-        let field_ty = Type_::NamedType {
-            name: "String".to_string(),
-        };
+        let ty = Type_::named_type("String");
+        let ty = Type_::list(Box::new(ty));
+        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::list(Box::new(ty));
+        let ty = Type_::non_null(Box::new(ty));
 
-        let list = Type_::List {
-            ty: Box::new(field_ty),
-        };
-
-        let non_null = Type_::NonNull { ty: Box::new(list) };
-
-        let list_2 = Type_::List {
-            ty: Box::new(non_null),
-        };
-
-        let non_null_2 = Type_::NonNull {
-            ty: Box::new(list_2),
-        };
-
-        assert_eq!(non_null_2.to_string(), "[[String]!]!");
+        assert_eq!(ty.to_string(), "[[String]!]!");
     }
 }

--- a/crates/apollo-encoder/src/input_field.rs
+++ b/crates/apollo-encoder/src/input_field.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use crate::{StringValue, Type_};
 
-#[derive(Debug, PartialEq, Clone)]
 /// Input Field in a given Input Object.
 /// A GraphQL Input Object defines a set of input fields; the input fields are
 /// either scalars, enums, or other input objects. Input fields are similar to
@@ -19,6 +18,7 @@ use crate::{StringValue, Type_};
 ///
 /// assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
 /// ```
+#[derive(Debug, PartialEq, Clone)]
 pub struct InputField {
     // Name must return a String.
     name: String,
@@ -30,27 +30,51 @@ pub struct InputField {
     default_value: Option<String>,
 }
 
-impl InputField {
-    /// Create a new instance of InputField.
+#[derive(Debug, Clone)]
+pub struct InputFieldBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String.
+    description: Option<String>,
+    // Type must return a __Type that represents the type of value returned by this field.
+    type_: Type_,
+    // Default value for this input field.
+    default_value: Option<String>,
+}
+
+impl InputFieldBuilder {
+    /// Create a new instance of InputFieldBuilder.
     pub fn new(name: &str, type_: Type_) -> Self {
         Self {
-            description: StringValue::Field { source: None },
             name: name.to_string(),
+            description: None,
             type_,
             default_value: None,
         }
     }
 
     /// Set the InputField's description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Field {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the InputField's default value.
-    pub fn default(&mut self, default: &str) {
+    pub fn default(mut self, default: &str) -> Self {
         self.default_value = Some(default.to_string());
+        self
+    }
+
+    /// Create a new instance of InputField.
+    pub fn build(self) -> InputField {
+        InputField {
+            name: self.name,
+            description: StringValue::Field {
+                source: self.description,
+            },
+            type_: self.type_,
+            default_value: self.default_value,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/input_field.rs
+++ b/crates/apollo-encoder/src/input_field.rs
@@ -34,25 +34,25 @@ pub struct InputField {
 
 impl InputField {
     /// Create a new instance of InputField.
-    pub fn new(name: String, type_: Type_) -> Self {
+    pub fn new(name: &str, type_: Type_) -> Self {
         Self {
             description: StringValue::Field { source: None },
-            name,
+            name: name.to_string(),
             type_,
             default_value: None,
         }
     }
 
     /// Set the InputField's description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Field {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 
     /// Set the InputField's default value.
-    pub fn default(&mut self, default: Option<String>) {
-        self.default_value = default;
+    pub fn default(&mut self, default: &str) {
+        self.default_value = Some(default.to_string());
     }
 }
 

--- a/crates/apollo-encoder/src/input_field.rs
+++ b/crates/apollo-encoder/src/input_field.rs
@@ -22,7 +22,7 @@ pub struct InputField {
 /// ```rust
 /// use apollo_encoder::{Type_, InputFieldBuilder};
 ///
-/// let ty = Type_::named_type("CatBreed");
+/// let ty = Type_::named("CatBreed");
 ///
 /// let field = InputFieldBuilder::new("cat", ty)
 ///     .default("\"Norwegian Forest\"")
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn it_encodes_fields_with_defaults() {
-        let ty = Type_::named_type("CatBreed");
+        let ty = Type_::named("CatBreed");
 
         let field = InputFieldBuilder::new("cat", ty)
             .default("\"Norwegian Forest\"")

--- a/crates/apollo-encoder/src/input_field.rs
+++ b/crates/apollo-encoder/src/input_field.rs
@@ -6,18 +6,6 @@ use crate::{StringValue, Type_};
 /// A GraphQL Input Object defines a set of input fields; the input fields are
 /// either scalars, enums, or other input objects. Input fields are similar to
 /// Fields, but can have a default value.
-///
-/// ### Example
-/// ```rust
-/// use apollo_encoder::{Type_, InputField};
-///
-/// let ty_1 = Type_::named_type("CatBreed");
-///
-/// let mut field = InputField::new("cat", ty_1);
-/// field.default("\"Norwegian Forest\"");
-///
-/// assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
-/// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct InputField {
     // Name must return a String.
@@ -30,6 +18,18 @@ pub struct InputField {
     default_value: Option<String>,
 }
 
+/// ### Example
+/// ```rust
+/// use apollo_encoder::{Type_, InputFieldBuilder};
+///
+/// let ty = Type_::named_type("CatBreed");
+///
+/// let field = InputFieldBuilder::new("cat", ty)
+///     .default("\"Norwegian Forest\"")
+///     .build();
+///
+/// assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
+/// ```
 #[derive(Debug, Clone)]
 pub struct InputFieldBuilder {
     // Name must return a String.
@@ -93,18 +93,16 @@ impl fmt::Display for InputField {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{InputFieldBuilder, Type_};
     use pretty_assertions::assert_eq;
 
     #[test]
     fn it_encodes_fields_with_defaults() {
-        let field = {
-            let ty = Type_::named_type("CatBreed");
+        let ty = Type_::named_type("CatBreed");
 
-            let mut field = InputField::new("cat", ty);
-            field.default("\"Norwegian Forest\"");
-            field
-        };
+        let field = InputFieldBuilder::new("cat", ty)
+            .default("\"Norwegian Forest\"")
+            .build();
 
         assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
     }

--- a/crates/apollo-encoder/src/input_field.rs
+++ b/crates/apollo-encoder/src/input_field.rs
@@ -12,12 +12,10 @@ use crate::{StringValue, Type_};
 /// ```rust
 /// use apollo_encoder::{Type_, InputField};
 ///
-/// let ty_1 = Type_::NamedType {
-///     name: "CatBreed".to_string(),
-/// };
+/// let ty_1 = Type_::named_type("CatBreed");
 ///
-/// let mut field = InputField::new("cat".to_string(), ty_1);
-/// field.default(Some("\"Norwegian Forest\"".to_string()));
+/// let mut field = InputField::new("cat", ty_1);
+/// field.default("\"Norwegian Forest\"");
 ///
 /// assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
 /// ```
@@ -76,12 +74,13 @@ mod tests {
 
     #[test]
     fn it_encodes_fields_with_defaults() {
-        let ty_1 = Type_::NamedType {
-            name: "CatBreed".to_string(),
-        };
+        let field = {
+            let ty = Type_::named_type("CatBreed");
 
-        let mut field = InputField::new("cat".to_string(), ty_1);
-        field.default(Some("\"Norwegian Forest\"".to_string()));
+            let mut field = InputField::new("cat", ty);
+            field.default("\"Norwegian Forest\"");
+            field
+        };
 
         assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
     }

--- a/crates/apollo-encoder/src/input_object_def.rs
+++ b/crates/apollo-encoder/src/input_object_def.rs
@@ -54,26 +54,47 @@ pub struct InputObjectDef {
     fields: Vec<InputField>,
 }
 
-impl InputObjectDef {
-    /// Create a new instance of ObjectDef with a name.
+#[derive(Debug, Clone)]
+pub struct InputObjectDefBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: Option<String>,
+    // A vector of fields
+    fields: Vec<InputField>,
+}
+
+impl InputObjectDefBuilder {
+    /// Create a new instance of ObjectDefBuilder.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            description: StringValue::Top { source: None },
+            description: None,
             fields: Vec::new(),
         }
     }
 
     /// Set the InputObjectDef's description field.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Top {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Push a Field to InputObjectDef's fields vector.
-    pub fn field(&mut self, field: InputField) {
-        self.fields.push(field)
+    pub fn field(mut self, field: InputField) -> Self {
+        self.fields.push(field);
+        self
+    }
+
+    /// Create a new instance of ObjectDef.
+    pub fn build(self) -> InputObjectDef {
+        InputObjectDef {
+            name: self.name,
+            description: StringValue::Top {
+                source: self.description,
+            },
+            fields: self.fields,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/input_object_def.rs
+++ b/crates/apollo-encoder/src/input_object_def.rs
@@ -12,25 +12,42 @@ use crate::{InputField, StringValue};
 /// **Note**: At the moment InputObjectTypeDefinition differs slightly from the
 /// spec. Instead of accepting InputValues as `field` parameter, we accept
 /// InputField.
-///
+#[derive(Debug, Clone)]
+pub struct InputObjectDef {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: StringValue,
+    // A vector of fields
+    fields: Vec<InputField>,
+}
+
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{Type_, InputField, InputObjectDef};
+/// use apollo_encoder::{Type_, InputFieldBuilder, InputObjectDefBuilder};
 /// use indoc::indoc;
 ///
-/// let ty_1 = Type_::named_type("DanglerPoleToys");
+/// let field_1 = {
+///     let ty = Type_::named_type("DanglerPoleToys");
+///     let ty = Type_::list(Box::new(ty));
 ///
-/// let ty_2 = Type_::list(Box::new(ty_1));
-/// let mut field = InputField::new("toys", ty_2);
-/// field.default("\"Cat Dangler Pole Bird\"");
-/// let ty_3 = Type_::named_type("FavouriteSpots");
-/// let mut field_2 = InputField::new("playSpot", ty_3);
-/// field_2.description("Best playime spots, e.g. tree, bed.");
+///     InputFieldBuilder::new("toys", ty)
+///         .default("\"Cat Dangler Pole Bird\"")
+///         .build()
+/// };
+/// let field_2 = {
+///     let ty = Type_::named_type("FavouriteSpots");
 ///
-/// let mut input_def = InputObjectDef::new("PlayTime");
-/// input_def.field(field);
-/// input_def.field(field_2);
-/// input_def.description("Cat playtime input");
+///     InputFieldBuilder::new("playSpot", ty)
+///         .description("Best playime spots, e.g. tree, bed.")
+///         .build()
+/// };
+///
+/// let input_def = InputObjectDefBuilder::new("PlayTime")
+///     .field(field_1)
+///     .field(field_2)
+///     .description("Cat playtime input")
+///     .build();
 ///
 /// assert_eq!(
 ///     input_def.to_string(),
@@ -44,16 +61,6 @@ use crate::{InputField, StringValue};
 ///     "#}
 /// );
 /// ```
-#[derive(Debug, Clone)]
-pub struct InputObjectDef {
-    // Name must return a String.
-    name: String,
-    // Description may return a String or null.
-    description: StringValue,
-    // A vector of fields
-    fields: Vec<InputField>,
-}
-
 #[derive(Debug, Clone)]
 pub struct InputObjectDefBuilder {
     // Name must return a String.
@@ -113,8 +120,7 @@ impl fmt::Display for InputObjectDef {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{InputField, Type_};
+    use crate::{InputFieldBuilder, InputObjectDefBuilder, Type_};
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -124,25 +130,23 @@ mod tests {
             let ty = Type_::named_type("DanglerPoleToys");
             let ty = Type_::list(Box::new(ty));
 
-            let mut field = InputField::new("toys", ty);
-            field.default("\"Cat Dangler Pole Bird\"");
-            field
+            InputFieldBuilder::new("toys", ty)
+                .default("\"Cat Dangler Pole Bird\"")
+                .build()
         };
 
         let field_2 = {
             let ty = Type_::named_type("FavouriteSpots");
 
-            let mut field = InputField::new("playSpot", ty);
-            field.description("Best playime spots, e.g. tree, bed.");
-            field
+            InputFieldBuilder::new("playSpot", ty)
+                .description("Best playime spots, e.g. tree, bed.")
+                .build()
         };
 
-        let input_def = {
-            let mut input_def = InputObjectDef::new("PlayTime");
-            input_def.field(field_1);
-            input_def.field(field_2);
-            input_def
-        };
+        let input_def = InputObjectDefBuilder::new("PlayTime")
+            .field(field_1)
+            .field(field_2)
+            .build();
 
         assert_eq!(
             input_def.to_string(),
@@ -162,26 +166,24 @@ mod tests {
             let ty = Type_::named_type("DanglerPoleToys");
             let ty = Type_::list(Box::new(ty));
 
-            let mut field = InputField::new("toys", ty);
-            field.default("\"Cat Dangler Pole Bird\"");
-            field
+            InputFieldBuilder::new("toys", ty)
+                .default("\"Cat Dangler Pole Bird\"")
+                .build()
         };
 
         let field_2 = {
             let ty = Type_::named_type("FavouriteSpots");
 
-            let mut field = InputField::new("playSpot", ty);
-            field.description("Best playime spots, e.g. tree, bed.");
-            field
+            InputFieldBuilder::new("playSpot", ty)
+                .description("Best playime spots, e.g. tree, bed.")
+                .build()
         };
 
-        let input_def = {
-            let mut input_def = InputObjectDef::new("PlayTime");
-            input_def.field(field_1);
-            input_def.field(field_2);
-            input_def.description("Cat playtime input");
-            input_def
-        };
+        let input_def = InputObjectDefBuilder::new("PlayTime")
+            .field(field_1)
+            .field(field_2)
+            .description("Cat playtime input")
+            .build();
 
         assert_eq!(
             input_def.to_string(),

--- a/crates/apollo-encoder/src/input_object_def.rs
+++ b/crates/apollo-encoder/src/input_object_def.rs
@@ -18,23 +18,19 @@ use crate::{InputField, StringValue};
 /// use apollo_encoder::{Type_, InputField, InputObjectDef};
 /// use indoc::indoc;
 ///
-/// let ty_1 = Type_::NamedType {
-///     name: "DanglerPoleToys".to_string(),
-/// };
+/// let ty_1 = Type_::named_type("DanglerPoleToys");
 ///
-/// let ty_2 = Type_::List { ty: Box::new(ty_1) };
-/// let mut field = InputField::new("toys".to_string(), ty_2);
-/// field.default(Some("\"Cat Dangler Pole Bird\"".to_string()));
-/// let ty_3 = Type_::NamedType {
-///     name: "FavouriteSpots".to_string(),
-/// };
-/// let mut field_2 = InputField::new("playSpot".to_string(), ty_3);
-/// field_2.description(Some("Best playime spots, e.g. tree, bed.".to_string()));
+/// let ty_2 = Type_::list(Box::new(ty_1));
+/// let mut field = InputField::new("toys", ty_2);
+/// field.default("\"Cat Dangler Pole Bird\"");
+/// let ty_3 = Type_::named_type("FavouriteSpots");
+/// let mut field_2 = InputField::new("playSpot", ty_3);
+/// field_2.description("Best playime spots, e.g. tree, bed.");
 ///
-/// let mut input_def = InputObjectDef::new("PlayTime".to_string());
+/// let mut input_def = InputObjectDef::new("PlayTime");
 /// input_def.field(field);
 /// input_def.field(field_2);
-/// input_def.description(Some("Cat playtime input".to_string()));
+/// input_def.description("Cat playtime input");
 ///
 /// assert_eq!(
 ///     input_def.to_string(),
@@ -103,22 +99,29 @@ mod tests {
 
     #[test]
     fn it_encodes_input_object() {
-        let ty_1 = Type_::NamedType {
-            name: "DanglerPoleToys".to_string(),
+        let field_1 = {
+            let ty = Type_::named_type("DanglerPoleToys");
+            let ty = Type_::list(Box::new(ty));
+
+            let mut field = InputField::new("toys", ty);
+            field.default("\"Cat Dangler Pole Bird\"");
+            field
         };
 
-        let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let mut field = InputField::new("toys".to_string(), ty_2);
-        field.default(Some("\"Cat Dangler Pole Bird\"".to_string()));
-        let ty_3 = Type_::NamedType {
-            name: "FavouriteSpots".to_string(),
-        };
-        let mut field_2 = InputField::new("playSpot".to_string(), ty_3);
-        field_2.description(Some("Best playime spots, e.g. tree, bed.".to_string()));
+        let field_2 = {
+            let ty = Type_::named_type("FavouriteSpots");
 
-        let mut input_def = InputObjectDef::new("PlayTime".to_string());
-        input_def.field(field);
-        input_def.field(field_2);
+            let mut field = InputField::new("playSpot", ty);
+            field.description("Best playime spots, e.g. tree, bed.");
+            field
+        };
+
+        let input_def = {
+            let mut input_def = InputObjectDef::new("PlayTime");
+            input_def.field(field_1);
+            input_def.field(field_2);
+            input_def
+        };
 
         assert_eq!(
             input_def.to_string(),
@@ -134,23 +137,30 @@ mod tests {
 
     #[test]
     fn it_encodes_input_object_with_description() {
-        let ty_1 = Type_::NamedType {
-            name: "DanglerPoleToys".to_string(),
+        let field_1 = {
+            let ty = Type_::named_type("DanglerPoleToys");
+            let ty = Type_::list(Box::new(ty));
+
+            let mut field = InputField::new("toys", ty);
+            field.default("\"Cat Dangler Pole Bird\"");
+            field
         };
 
-        let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let mut field = InputField::new("toys".to_string(), ty_2);
-        field.default(Some("\"Cat Dangler Pole Bird\"".to_string()));
-        let ty_3 = Type_::NamedType {
-            name: "FavouriteSpots".to_string(),
-        };
-        let mut field_2 = InputField::new("playSpot".to_string(), ty_3);
-        field_2.description(Some("Best playime spots, e.g. tree, bed.".to_string()));
+        let field_2 = {
+            let ty = Type_::named_type("FavouriteSpots");
 
-        let mut input_def = InputObjectDef::new("PlayTime".to_string());
-        input_def.field(field);
-        input_def.field(field_2);
-        input_def.description(Some("Cat playtime input".to_string()));
+            let mut field = InputField::new("playSpot", ty);
+            field.description("Best playime spots, e.g. tree, bed.");
+            field
+        };
+
+        let input_def = {
+            let mut input_def = InputObjectDef::new("PlayTime");
+            input_def.field(field_1);
+            input_def.field(field_2);
+            input_def.description("Cat playtime input");
+            input_def
+        };
 
         assert_eq!(
             input_def.to_string(),

--- a/crates/apollo-encoder/src/input_object_def.rs
+++ b/crates/apollo-encoder/src/input_object_def.rs
@@ -28,15 +28,14 @@ pub struct InputObjectDef {
 /// use indoc::indoc;
 ///
 /// let field_1 = {
-///     let ty = Type_::named_type("DanglerPoleToys");
-///     let ty = Type_::list(Box::new(ty));
+///     let ty = Type_::list(Type_::named("DanglerPoleToys"));
 ///
 ///     InputFieldBuilder::new("toys", ty)
 ///         .default("\"Cat Dangler Pole Bird\"")
 ///         .build()
 /// };
 /// let field_2 = {
-///     let ty = Type_::named_type("FavouriteSpots");
+///     let ty = Type_::named("FavouriteSpots");
 ///
 ///     InputFieldBuilder::new("playSpot", ty)
 ///         .description("Best playime spots, e.g. tree, bed.")
@@ -127,8 +126,7 @@ mod tests {
     #[test]
     fn it_encodes_input_object() {
         let field_1 = {
-            let ty = Type_::named_type("DanglerPoleToys");
-            let ty = Type_::list(Box::new(ty));
+            let ty = Type_::list(Type_::named("DanglerPoleToys"));
 
             InputFieldBuilder::new("toys", ty)
                 .default("\"Cat Dangler Pole Bird\"")
@@ -136,7 +134,7 @@ mod tests {
         };
 
         let field_2 = {
-            let ty = Type_::named_type("FavouriteSpots");
+            let ty = Type_::named("FavouriteSpots");
 
             InputFieldBuilder::new("playSpot", ty)
                 .description("Best playime spots, e.g. tree, bed.")
@@ -163,8 +161,7 @@ mod tests {
     #[test]
     fn it_encodes_input_object_with_description() {
         let field_1 = {
-            let ty = Type_::named_type("DanglerPoleToys");
-            let ty = Type_::list(Box::new(ty));
+            let ty = Type_::list(Type_::named("DanglerPoleToys"));
 
             InputFieldBuilder::new("toys", ty)
                 .default("\"Cat Dangler Pole Bird\"")
@@ -172,7 +169,7 @@ mod tests {
         };
 
         let field_2 = {
-            let ty = Type_::named_type("FavouriteSpots");
+            let ty = Type_::named("FavouriteSpots");
 
             InputFieldBuilder::new("playSpot", ty)
                 .description("Best playime spots, e.g. tree, bed.")

--- a/crates/apollo-encoder/src/input_object_def.rs
+++ b/crates/apollo-encoder/src/input_object_def.rs
@@ -60,18 +60,18 @@ pub struct InputObjectDef {
 
 impl InputObjectDef {
     /// Create a new instance of ObjectDef with a name.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             description: StringValue::Top { source: None },
             fields: Vec::new(),
         }
     }
 
     /// Set the InputObjectDef's description field.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Top {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -37,8 +37,7 @@ pub struct InputValue {
 /// ```rust
 /// use apollo_encoder::{Type_, InputValueBuilder};
 ///
-/// let ty = Type_::named_type("SpaceProgram");
-/// let ty = Type_::list(Box::new(ty));
+/// let ty = Type_::list(Type_::named("SpaceProgram"));
 /// let value = InputValueBuilder::new("cat", ty)
 ///     .description("Very good cats")
 ///     .deprecated("Cats are no longer sent to space.")
@@ -141,9 +140,7 @@ mod tests {
 
     #[test]
     fn it_encodes_simple_values() {
-        let ty = Type_::named_type("SpaceProgram");
-        let ty = Type_::list(Box::new(ty));
-        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::non_null(Type_::list(Type_::named("SpaceProgram")));
 
         let value = InputValueBuilder::new("spaceCat", ty).build();
 
@@ -152,8 +149,7 @@ mod tests {
 
     #[test]
     fn it_encodes_input_values_with_default() {
-        let ty = Type_::named_type("Breed");
-        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::non_null(Type_::named("Breed"));
 
         let value = InputValueBuilder::new("spaceCat", ty)
             .default("\"Norwegian Forest\"")
@@ -167,8 +163,7 @@ mod tests {
 
     #[test]
     fn it_encodes_value_with_deprecation() {
-        let ty = Type_::named_type("SpaceProgram");
-        let ty = Type_::list(Box::new(ty));
+        let ty = Type_::list(Type_::named("SpaceProgram"));
 
         let value = InputValueBuilder::new("cat", ty)
             .description("Very good cats")
@@ -183,10 +178,7 @@ mod tests {
 
     #[test]
     fn it_encodes_valueuments_with_description() {
-        let ty = Type_::named_type("SpaceProgram");
-        let ty = Type_::non_null(Box::new(ty));
-        let ty = Type_::list(Box::new(ty));
-        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::non_null(Type_::list(Type_::non_null(Type_::named("SpaceProgram"))));
 
         let value = InputValueBuilder::new("spaceCat", ty)
             .description("Very good space cats")

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -50,35 +50,65 @@ pub struct InputValue {
     deprecation_reason: Option<String>,
 }
 
-impl InputValue {
-    /// Create a new instance of InputValue.
+#[derive(Debug, Clone)]
+pub struct InputValueBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String.
+    description: Option<String>,
+    // Type must return a __Type that represents the type this input value expects.
+    type_: Type_,
+    // Default may return a String encoding (using the GraphQL language) of
+    // the default value used by this input value in the condition a value is
+    // not provided at runtime. If this input value has no default value,
+    // returns null.
+    default: Option<String>,
+    // Deprecation reason optionally provides a reason why this field is deprecated.
+    deprecation_reason: Option<String>,
+}
+
+impl InputValueBuilder {
+    /// Create a new instance of InputValueBuilder.
     pub fn new(name: &str, type_: Type_) -> Self {
         Self {
-            description: StringValue::Input { source: None },
+            description: None,
             name: name.to_string(),
             type_,
-            is_deprecated: false,
             deprecation_reason: None,
             default: None,
         }
     }
 
     /// Set the InputValue's description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Input {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the InputValue's default value.
-    pub fn default(&mut self, default: &str) {
+    pub fn default(mut self, default: &str) -> Self {
         self.default = Some(default.to_string());
+        self
     }
 
     /// Set the InputValue's deprecation properties.
-    pub fn deprecated(&mut self, reason: &str) {
-        self.is_deprecated = true;
+    pub fn deprecated(mut self, reason: &str) -> Self {
         self.deprecation_reason = Some(reason.to_string());
+        self
+    }
+
+    /// Create a new instance of InputValue.
+    pub fn build(self) -> InputValue {
+        InputValue {
+            name: self.name,
+            description: StringValue::Input {
+                source: self.description,
+            },
+            type_: self.type_,
+            is_deprecated: self.deprecation_reason.is_some(),
+            deprecation_reason: self.deprecation_reason,
+            default: self.default,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -54,10 +54,10 @@ pub struct InputValue {
 
 impl InputValue {
     /// Create a new instance of InputValue.
-    pub fn new(name: String, type_: Type_) -> Self {
+    pub fn new(name: &str, type_: Type_) -> Self {
         Self {
             description: StringValue::Input { source: None },
-            name,
+            name: name.to_string(),
             type_,
             is_deprecated: false,
             deprecation_reason: None,
@@ -66,21 +66,21 @@ impl InputValue {
     }
 
     /// Set the InputValue's description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Input {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 
     /// Set the InputValue's default value.
-    pub fn default(&mut self, default: Option<String>) {
-        self.default = default;
+    pub fn default(&mut self, default: &str) {
+        self.default = Some(default.to_string());
     }
 
     /// Set the InputValue's deprecation properties.
-    pub fn deprecated(&mut self, reason: Option<String>) {
+    pub fn deprecated(&mut self, reason: &str) {
         self.is_deprecated = true;
-        self.deprecation_reason = reason;
+        self.deprecation_reason = Some(reason.to_string());
     }
 }
 

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -14,23 +14,6 @@ use crate::{StringValue, Type_};
 ///     Description? Name **:** Type DefaultValue? Directives?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-The-__InputValue-Type).
-///
-/// ### Example
-/// ```rust
-/// use apollo_encoder::{Type_, InputValue};
-///
-/// let ty_1 = Type_::named_type("SpaceProgram");
-///
-/// let ty_2 = Type_::list(Box::new(ty_1));
-/// let mut value = InputValue::new("cat", ty_2);
-/// value.description("Very good cats");
-/// value.deprecated("Cats are no longer sent to space.");
-///
-/// assert_eq!(
-///     value.to_string(),
-///     r#""Very good cats" cat: [SpaceProgram] @deprecated(reason: "Cats are no longer sent to space.")"#
-/// );
-/// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct InputValue {
     // Name must return a String.
@@ -50,6 +33,22 @@ pub struct InputValue {
     deprecation_reason: Option<String>,
 }
 
+/// ### Example
+/// ```rust
+/// use apollo_encoder::{Type_, InputValueBuilder};
+///
+/// let ty = Type_::named_type("SpaceProgram");
+/// let ty = Type_::list(Box::new(ty));
+/// let value = InputValueBuilder::new("cat", ty)
+///     .description("Very good cats")
+///     .deprecated("Cats are no longer sent to space.")
+///     .build();
+///
+/// assert_eq!(
+///     value.to_string(),
+///     r#""Very good cats" cat: [SpaceProgram] @deprecated(reason: "Cats are no longer sent to space.")"#
+/// );
+/// ```
 #[derive(Debug, Clone)]
 pub struct InputValueBuilder {
     // Name must return a String.
@@ -137,32 +136,28 @@ impl fmt::Display for InputValue {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{InputValueBuilder, Type_};
     use pretty_assertions::assert_eq;
 
     #[test]
     fn it_encodes_simple_values() {
-        let value = {
-            let ty = Type_::named_type("SpaceProgram");
-            let ty = Type_::list(Box::new(ty));
-            let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::named_type("SpaceProgram");
+        let ty = Type_::list(Box::new(ty));
+        let ty = Type_::non_null(Box::new(ty));
 
-            InputValue::new("spaceCat", ty)
-        };
+        let value = InputValueBuilder::new("spaceCat", ty).build();
 
         assert_eq!(value.to_string(), r#"spaceCat: [SpaceProgram]!"#);
     }
 
     #[test]
     fn it_encodes_input_values_with_default() {
-        let value = {
-            let ty = Type_::named_type("Breed");
-            let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::named_type("Breed");
+        let ty = Type_::non_null(Box::new(ty));
 
-            let mut value = InputValue::new("spaceCat", ty);
-            value.default("\"Norwegian Forest\"");
-            value
-        };
+        let value = InputValueBuilder::new("spaceCat", ty)
+            .default("\"Norwegian Forest\"")
+            .build();
 
         assert_eq!(
             value.to_string(),
@@ -172,15 +167,13 @@ mod tests {
 
     #[test]
     fn it_encodes_value_with_deprecation() {
-        let value = {
-            let ty = Type_::named_type("SpaceProgram");
-            let ty = Type_::list(Box::new(ty));
+        let ty = Type_::named_type("SpaceProgram");
+        let ty = Type_::list(Box::new(ty));
 
-            let mut value = InputValue::new("cat", ty);
-            value.description("Very good cats");
-            value.deprecated("Cats are no longer sent to space.");
-            value
-        };
+        let value = InputValueBuilder::new("cat", ty)
+            .description("Very good cats")
+            .deprecated("Cats are no longer sent to space.")
+            .build();
 
         assert_eq!(
             value.to_string(),
@@ -190,16 +183,14 @@ mod tests {
 
     #[test]
     fn it_encodes_valueuments_with_description() {
-        let value = {
-            let ty = Type_::named_type("SpaceProgram");
-            let ty = Type_::non_null(Box::new(ty));
-            let ty = Type_::list(Box::new(ty));
-            let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::named_type("SpaceProgram");
+        let ty = Type_::non_null(Box::new(ty));
+        let ty = Type_::list(Box::new(ty));
+        let ty = Type_::non_null(Box::new(ty));
 
-            let mut value = InputValue::new("spaceCat", ty);
-            value.description("Very good space cats");
-            value
-        };
+        let value = InputValueBuilder::new("spaceCat", ty)
+            .description("Very good space cats")
+            .build();
 
         assert_eq!(
             value.to_string(),

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -19,14 +19,12 @@ use crate::{StringValue, Type_};
 /// ```rust
 /// use apollo_encoder::{Type_, InputValue};
 ///
-/// let ty_1 = Type_::NamedType {
-///     name: "SpaceProgram".to_string(),
-/// };
+/// let ty_1 = Type_::named_type("SpaceProgram");
 ///
-/// let ty_2 = Type_::List { ty: Box::new(ty_1) };
-/// let mut value = InputValue::new("cat".to_string(), ty_2);
-/// value.description(Some("Very good cats".to_string()));
-/// value.deprecated(Some("Cats are no longer sent to space.".to_string()));
+/// let ty_2 = Type_::list(Box::new(ty_1));
+/// let mut value = InputValue::new("cat", ty_2);
+/// value.description("Very good cats");
+/// value.deprecated("Cats are no longer sent to space.");
 ///
 /// assert_eq!(
 ///     value.to_string(),
@@ -114,26 +112,27 @@ mod tests {
 
     #[test]
     fn it_encodes_simple_values() {
-        let ty_1 = Type_::NamedType {
-            name: "SpaceProgram".to_string(),
-        };
+        let value = {
+            let ty = Type_::named_type("SpaceProgram");
+            let ty = Type_::list(Box::new(ty));
+            let ty = Type_::non_null(Box::new(ty));
 
-        let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let ty_3 = Type_::NonNull { ty: Box::new(ty_2) };
-        let value = InputValue::new("spaceCat".to_string(), ty_3);
+            InputValue::new("spaceCat", ty)
+        };
 
         assert_eq!(value.to_string(), r#"spaceCat: [SpaceProgram]!"#);
     }
 
     #[test]
     fn it_encodes_input_values_with_default() {
-        let ty_1 = Type_::NamedType {
-            name: "Breed".to_string(),
-        };
+        let value = {
+            let ty = Type_::named_type("Breed");
+            let ty = Type_::non_null(Box::new(ty));
 
-        let ty_2 = Type_::NonNull { ty: Box::new(ty_1) };
-        let mut value = InputValue::new("spaceCat".to_string(), ty_2);
-        value.default(Some("\"Norwegian Forest\"".to_string()));
+            let mut value = InputValue::new("spaceCat", ty);
+            value.default("\"Norwegian Forest\"");
+            value
+        };
 
         assert_eq!(
             value.to_string(),
@@ -143,14 +142,15 @@ mod tests {
 
     #[test]
     fn it_encodes_value_with_deprecation() {
-        let ty_1 = Type_::NamedType {
-            name: "SpaceProgram".to_string(),
-        };
+        let value = {
+            let ty = Type_::named_type("SpaceProgram");
+            let ty = Type_::list(Box::new(ty));
 
-        let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let mut value = InputValue::new("cat".to_string(), ty_2);
-        value.description(Some("Very good cats".to_string()));
-        value.deprecated(Some("Cats are no longer sent to space.".to_string()));
+            let mut value = InputValue::new("cat", ty);
+            value.description("Very good cats");
+            value.deprecated("Cats are no longer sent to space.");
+            value
+        };
 
         assert_eq!(
             value.to_string(),
@@ -160,15 +160,16 @@ mod tests {
 
     #[test]
     fn it_encodes_valueuments_with_description() {
-        let ty_1 = Type_::NamedType {
-            name: "SpaceProgram".to_string(),
-        };
+        let value = {
+            let ty = Type_::named_type("SpaceProgram");
+            let ty = Type_::non_null(Box::new(ty));
+            let ty = Type_::list(Box::new(ty));
+            let ty = Type_::non_null(Box::new(ty));
 
-        let ty_2 = Type_::NonNull { ty: Box::new(ty_1) };
-        let ty_3 = Type_::List { ty: Box::new(ty_2) };
-        let ty_4 = Type_::NonNull { ty: Box::new(ty_3) };
-        let mut value = InputValue::new("spaceCat".to_string(), ty_4);
-        value.description(Some("Very good space cats".to_string()));
+            let mut value = InputValue::new("spaceCat", ty);
+            value.description("Very good space cats");
+            value
+        };
 
         assert_eq!(
             value.to_string(),

--- a/crates/apollo-encoder/src/interface_def.rs
+++ b/crates/apollo-encoder/src/interface_def.rs
@@ -18,36 +18,28 @@ use crate::{Field, StringValue};
 /// use apollo_encoder::{Type_, Field, InterfaceDef};
 /// use indoc::indoc;
 ///
-/// let ty_1 = Type_::NamedType {
-///     name: "String".to_string(),
-/// };
+/// let ty_1 = Type_::named_type("String");
 ///
-/// let ty_2 = Type_::NamedType {
-///     name: "String".to_string(),
-/// };
+/// let ty_2 = Type_::named_type("String");
 ///
-/// let ty_3 = Type_::NonNull { ty: Box::new(ty_2) };
-/// let ty_4 = Type_::List { ty: Box::new(ty_3) };
-/// let ty_5 = Type_::NonNull { ty: Box::new(ty_4) };
+/// let ty_3 = Type_::non_null(Box::new(ty_2));
+/// let ty_4 = Type_::list(Box::new(ty_3));
+/// let ty_5 = Type_::non_null(Box::new(ty_4));
 ///
-/// let ty_6 = Type_::NamedType {
-///     name: "Boolean".to_string(),
-/// };
+/// let ty_6 = Type_::named_type("Boolean");
 ///
-/// let mut field_1 = Field::new("main".to_string(), ty_1);
-/// field_1.description(Some("Cat's main dish of a meal.".to_string()));
+/// let mut field_1 = Field::new("main", ty_1);
+/// field_1.description("Cat's main dish of a meal.");
 ///
-/// let mut field_2 = Field::new("snack".to_string(), ty_5);
-/// field_2.description(Some("Cat's post meal snack.".to_string()));
+/// let mut field_2 = Field::new("snack", ty_5);
+/// field_2.description("Cat's post meal snack.");
 ///
-/// let mut field_3 = Field::new("pats".to_string(), ty_6);
-/// field_3.description(Some("Does cat get a pat after meal?".to_string()));
+/// let mut field_3 = Field::new("pats", ty_6);
+/// field_3.description("Does cat get a pat after meal?");
 ///
 /// // a schema definition
-/// let mut interface = InterfaceDef::new("Meal".to_string());
-/// interface.description(Some(
-///     "Meal interface for various\nmeals during the day.".to_string(),
-/// ));
+/// let mut interface = InterfaceDef::new("Meal");
+/// interface.description("Meal interface for various\nmeals during the day.");
 /// interface.field(field_1);
 /// interface.field(field_2);
 /// interface.field(field_3);
@@ -140,39 +132,42 @@ mod tests {
 
     #[test]
     fn it_encodes_interfaces() {
-        let ty_1 = Type_::NamedType {
-            name: "String".to_string(),
+        let field_1 = {
+            let ty = Type_::named_type("String");
+
+            let mut field = Field::new("main", ty);
+            field.description("Cat's main dish of a meal.");
+            field
         };
 
-        let ty_2 = Type_::NamedType {
-            name: "String".to_string(),
+        let field_2 = {
+            let ty = Type_::named_type("String");
+            let ty = Type_::non_null(Box::new(ty));
+            let ty = Type_::list(Box::new(ty));
+            let ty = Type_::non_null(Box::new(ty));
+
+            let mut field = Field::new("snack", ty);
+            field.description("Cat's post meal snack.");
+            field
         };
 
-        let ty_3 = Type_::NonNull { ty: Box::new(ty_2) };
-        let ty_4 = Type_::List { ty: Box::new(ty_3) };
-        let ty_5 = Type_::NonNull { ty: Box::new(ty_4) };
+        let field_3 = {
+            let ty = Type_::named_type("Boolean");
 
-        let ty_6 = Type_::NamedType {
-            name: "Boolean".to_string(),
+            let mut field = Field::new("pats", ty);
+            field.description("Does cat get a pat\nafter meal?");
+            field
         };
-
-        let mut field_1 = Field::new("main".to_string(), ty_1);
-        field_1.description(Some("Cat's main dish of a meal.".to_string()));
-
-        let mut field_2 = Field::new("snack".to_string(), ty_5);
-        field_2.description(Some("Cat's post meal snack.".to_string()));
-
-        let mut field_3 = Field::new("pats".to_string(), ty_6);
-        field_3.description(Some("Does cat get a pat\nafter meal?".to_string()));
 
         // a schema definition
-        let mut interface = InterfaceDef::new("Meal".to_string());
-        interface.description(Some(
-            "Meal interface for various\nmeals during the day.".to_string(),
-        ));
-        interface.field(field_1);
-        interface.field(field_2);
-        interface.field(field_3);
+        let interface = {
+            let mut interface = InterfaceDef::new("Meal");
+            interface.description("Meal interface for various\nmeals during the day.");
+            interface.field(field_1);
+            interface.field(field_2);
+            interface.field(field_3);
+            interface
+        };
 
         assert_eq!(
             interface.to_string(),

--- a/crates/apollo-encoder/src/interface_def.rs
+++ b/crates/apollo-encoder/src/interface_def.rs
@@ -74,32 +74,57 @@ pub struct InterfaceDef {
     fields: Vec<Field>,
 }
 
-impl InterfaceDef {
-    /// Create a new instance of InterfaceDef.
+#[derive(Debug, Clone)]
+pub struct InterfaceDefBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: Option<String>,
+    // The vector of interfaces that this interface implements.
+    interfaces: Vec<String>,
+    // The vector of fields required by this interface.
+    fields: Vec<Field>,
+}
+
+impl InterfaceDefBuilder {
+    /// Create a new instance of InterfaceDefBuilder.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            description: StringValue::Top { source: None },
+            description: None,
             fields: Vec::new(),
             interfaces: Vec::new(),
         }
     }
 
     /// Set the schema def's description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Top {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the interfaces ObjectDef implements.
-    pub fn interface(&mut self, interface: &str) {
-        self.interfaces.push(interface.to_string())
+    pub fn interface(mut self, interface: &str) -> Self {
+        self.interfaces.push(interface.to_string());
+        self
     }
 
     /// Push a Field to schema def's fields vector.
-    pub fn field(&mut self, field: Field) {
-        self.fields.push(field)
+    pub fn field(mut self, field: Field) -> Self {
+        self.fields.push(field);
+        self
+    }
+
+    /// Create a new instance of InterfaceDef.
+    pub fn build(self) -> InterfaceDef {
+        InterfaceDef {
+            name: self.name,
+            description: StringValue::Top {
+                source: self.description,
+            },
+            fields: self.fields,
+            interfaces: self.interfaces,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/interface_def.rs
+++ b/crates/apollo-encoder/src/interface_def.rs
@@ -30,7 +30,7 @@ pub struct InterfaceDef {
 /// use indoc::indoc;
 ///
 /// let field_1 = {
-///     let ty = Type_::named_type("String");
+///     let ty = Type_::named("String");
 ///
 ///     FieldBuilder::new("main", ty)
 ///         .description("Cat's main dish of a meal.")
@@ -38,10 +38,7 @@ pub struct InterfaceDef {
 /// };
 ///
 /// let field_2 = {
-///     let ty = Type_::named_type("String");
-///     let ty = Type_::non_null(Box::new(ty));
-///     let ty = Type_::list(Box::new(ty));
-///     let ty = Type_::non_null(Box::new(ty));
+///     let ty = Type_::non_null(Type_::list(Type_::non_null(Type_::named("String"))));
 ///
 ///     FieldBuilder::new("snack", ty)
 ///         .description("Cat's post meal snack.")
@@ -49,7 +46,7 @@ pub struct InterfaceDef {
 /// };
 ///
 /// let field_3 = {
-///     let ty = Type_::named_type("Boolean");
+///     let ty = Type_::named("Boolean");
 ///
 ///     FieldBuilder::new("pats", ty)
 ///         .description("Does cat get a pat after meal?")
@@ -165,7 +162,7 @@ mod tests {
     #[test]
     fn it_encodes_interfaces() {
         let field_1 = {
-            let ty = Type_::named_type("String");
+            let ty = Type_::named("String");
 
             FieldBuilder::new("main", ty)
                 .description("Cat's main dish of a meal.")
@@ -173,10 +170,7 @@ mod tests {
         };
 
         let field_2 = {
-            let ty = Type_::named_type("String");
-            let ty = Type_::non_null(Box::new(ty));
-            let ty = Type_::list(Box::new(ty));
-            let ty = Type_::non_null(Box::new(ty));
+            let ty = Type_::non_null(Type_::list(Type_::non_null(Type_::named("String"))));
 
             FieldBuilder::new("snack", ty)
                 .description("Cat's post meal snack.")
@@ -184,7 +178,7 @@ mod tests {
         };
 
         let field_3 = {
-            let ty = Type_::named_type("Boolean");
+            let ty = Type_::named("Boolean");
 
             FieldBuilder::new("pats", ty)
                 .description("Does cat get a pat\nafter meal?")

--- a/crates/apollo-encoder/src/interface_def.rs
+++ b/crates/apollo-encoder/src/interface_def.rs
@@ -12,37 +12,57 @@ use crate::{Field, StringValue};
 ///     Description? **interface** Name ImplementsInterfaceDefs? Directives?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-InterfaceDef).
-///
+#[derive(Debug, Clone)]
+pub struct InterfaceDef {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: StringValue,
+    // The vector of interfaces that this interface implements.
+    interfaces: Vec<String>,
+    // The vector of fields required by this interface.
+    fields: Vec<Field>,
+}
+
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{Type_, Field, InterfaceDef};
+/// use apollo_encoder::{Type_, FieldBuilder, InterfaceDefBuilder};
 /// use indoc::indoc;
 ///
-/// let ty_1 = Type_::named_type("String");
+/// let field_1 = {
+///     let ty = Type_::named_type("String");
 ///
-/// let ty_2 = Type_::named_type("String");
+///     FieldBuilder::new("main", ty)
+///         .description("Cat's main dish of a meal.")
+///         .build()
+/// };
 ///
-/// let ty_3 = Type_::non_null(Box::new(ty_2));
-/// let ty_4 = Type_::list(Box::new(ty_3));
-/// let ty_5 = Type_::non_null(Box::new(ty_4));
+/// let field_2 = {
+///     let ty = Type_::named_type("String");
+///     let ty = Type_::non_null(Box::new(ty));
+///     let ty = Type_::list(Box::new(ty));
+///     let ty = Type_::non_null(Box::new(ty));
 ///
-/// let ty_6 = Type_::named_type("Boolean");
+///     FieldBuilder::new("snack", ty)
+///         .description("Cat's post meal snack.")
+///         .build()
+/// };
 ///
-/// let mut field_1 = Field::new("main", ty_1);
-/// field_1.description("Cat's main dish of a meal.");
+/// let field_3 = {
+///     let ty = Type_::named_type("Boolean");
 ///
-/// let mut field_2 = Field::new("snack", ty_5);
-/// field_2.description("Cat's post meal snack.");
-///
-/// let mut field_3 = Field::new("pats", ty_6);
-/// field_3.description("Does cat get a pat after meal?");
+///     FieldBuilder::new("pats", ty)
+///         .description("Does cat get a pat after meal?")
+///         .build()
+/// };
 ///
 /// // a schema definition
-/// let mut interface = InterfaceDef::new("Meal");
-/// interface.description("Meal interface for various\nmeals during the day.");
-/// interface.field(field_1);
-/// interface.field(field_2);
-/// interface.field(field_3);
+/// let interface = InterfaceDefBuilder::new("Meal")
+///     .description("Meal interface for various\nmeals during the day.")
+///     .field(field_1)
+///     .field(field_2)
+///     .field(field_3)
+///     .build();
 ///
 /// assert_eq!(
 ///     interface.to_string(),
@@ -62,18 +82,6 @@ use crate::{Field, StringValue};
 ///     "# }
 /// );
 /// ```
-#[derive(Debug, Clone)]
-pub struct InterfaceDef {
-    // Name must return a String.
-    name: String,
-    // Description may return a String or null.
-    description: StringValue,
-    // The vector of interfaces that this interface implements.
-    interfaces: Vec<String>,
-    // The vector of fields required by this interface.
-    fields: Vec<Field>,
-}
-
 #[derive(Debug, Clone)]
 pub struct InterfaceDefBuilder {
     // Name must return a String.
@@ -150,8 +158,7 @@ impl fmt::Display for InterfaceDef {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::Type_;
+    use crate::{FieldBuilder, InterfaceDefBuilder, Type_};
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -160,9 +167,9 @@ mod tests {
         let field_1 = {
             let ty = Type_::named_type("String");
 
-            let mut field = Field::new("main", ty);
-            field.description("Cat's main dish of a meal.");
-            field
+            FieldBuilder::new("main", ty)
+                .description("Cat's main dish of a meal.")
+                .build()
         };
 
         let field_2 = {
@@ -171,28 +178,26 @@ mod tests {
             let ty = Type_::list(Box::new(ty));
             let ty = Type_::non_null(Box::new(ty));
 
-            let mut field = Field::new("snack", ty);
-            field.description("Cat's post meal snack.");
-            field
+            FieldBuilder::new("snack", ty)
+                .description("Cat's post meal snack.")
+                .build()
         };
 
         let field_3 = {
             let ty = Type_::named_type("Boolean");
 
-            let mut field = Field::new("pats", ty);
-            field.description("Does cat get a pat\nafter meal?");
-            field
+            FieldBuilder::new("pats", ty)
+                .description("Does cat get a pat\nafter meal?")
+                .build()
         };
 
         // a schema definition
-        let interface = {
-            let mut interface = InterfaceDef::new("Meal");
-            interface.description("Meal interface for various\nmeals during the day.");
-            interface.field(field_1);
-            interface.field(field_2);
-            interface.field(field_3);
-            interface
-        };
+        let interface = InterfaceDefBuilder::new("Meal")
+            .description("Meal interface for various\nmeals during the day.")
+            .field(field_1)
+            .field(field_2)
+            .field(field_3)
+            .build();
 
         assert_eq!(
             interface.to_string(),

--- a/crates/apollo-encoder/src/interface_def.rs
+++ b/crates/apollo-encoder/src/interface_def.rs
@@ -84,9 +84,9 @@ pub struct InterfaceDef {
 
 impl InterfaceDef {
     /// Create a new instance of InterfaceDef.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             description: StringValue::Top { source: None },
             fields: Vec::new(),
             interfaces: Vec::new(),
@@ -94,15 +94,15 @@ impl InterfaceDef {
     }
 
     /// Set the schema def's description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Top {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 
     /// Set the interfaces ObjectDef implements.
-    pub fn interface(&mut self, interface: String) {
-        self.interfaces.push(interface)
+    pub fn interface(&mut self, interface: &str) {
+        self.interfaces.push(interface.to_string())
     }
 
     /// Push a Field to schema def's fields vector.

--- a/crates/apollo-encoder/src/lib.rs
+++ b/crates/apollo-encoder/src/lib.rs
@@ -41,33 +41,31 @@
 //! let mut schema = Schema::new();
 //!
 //! // Create a Directive Definition.
-//! let mut directive = Directive::new("provideTreat".to_string());
-//! directive.description(Some("Ensures cats get treats.".to_string()));
-//! directive.location("OBJECT".to_string());
-//! directive.location("FIELD_DEFINITION".to_string());
-//! directive.location("INPUT_FIELD_DEFINITION".to_string());
+//! let mut directive = Directive::new("provideTreat");
+//! directive.description("Ensures cats get treats.");
+//! directive.location("OBJECT");
+//! directive.location("FIELD_DEFINITION");
+//! directive.location("INPUT_FIELD_DEFINITION");
 //! schema.directive(directive);
 
 //! // Create an Enum Definition
-//! let mut enum_ty_1 = EnumValue::new("CatTree".to_string());
-//! enum_ty_1.description(Some("Top bunk of a cat tree.".to_string()));
-//! let enum_ty_2 = EnumValue::new("Bed".to_string());
-//! let mut enum_ty_3 = EnumValue::new("CardboardBox".to_string());
-//! enum_ty_3.deprecated(Some("Box was recycled.".to_string()));
+//! let mut enum_ty_1 = EnumValue::new("CatTree");
+//! enum_ty_1.description("Top bunk of a cat tree.");
+//! let enum_ty_2 = EnumValue::new("Bed");
+//! let mut enum_ty_3 = EnumValue::new("CardboardBox");
+//! enum_ty_3.deprecated("Box was recycled.");
 //!
-//! let mut enum_def = EnumDef::new("NapSpots".to_string());
-//! enum_def.description(Some("Favourite cat\nnap spots.".to_string()));
+//! let mut enum_def = EnumDef::new("NapSpots");
+//! enum_def.description("Favourite cat\nnap spots.");
 //! enum_def.value(enum_ty_1);
 //! enum_def.value(enum_ty_2);
 //! enum_def.value(enum_ty_3);
 //! schema.enum_(enum_def);
 //! // Union Definition
-//! let mut union_def = UnionDef::new("Cat".to_string());
-//! union_def.description(Some(
-//!     "A union of all cats represented within a household.".to_string(),
-//! ));
-//! union_def.member("NORI".to_string());
-//! union_def.member("CHASHU".to_string());
+//! let mut union_def = UnionDef::new("Cat");
+//! union_def.description("A union of all cats represented within a household.");
+//! union_def.member("NORI");
+//! union_def.member("CHASHU");
 //! schema.union(union_def);
 //!
 //! assert_eq!(

--- a/crates/apollo-encoder/src/lib.rs
+++ b/crates/apollo-encoder/src/lib.rs
@@ -35,41 +35,47 @@
 //!
 //! ## Example
 //! ```rust
-//! use apollo_encoder::{Schema, Field, UnionDef, EnumValue, Directive, EnumDef, Type_};
+//! use apollo_encoder::{Schema, FieldBuilder, UnionDefBuilder, EnumValueBuilder, DirectiveBuilder, EnumDefBuilder, Type_};
 //! use indoc::indoc;
 //!
-//! let mut schema = Schema::new();
+//! let directive = DirectiveBuilder::new("provideTreat")
+//!     .description("Ensures cats get treats.")
+//!     .location("OBJECT")
+//!     .location("FIELD_DEFINITION")
+//!     .location("INPUT_FIELD_DEFINITION")
+//!     .build();
 //!
-//! // Create a Directive Definition.
-//! let mut directive = Directive::new("provideTreat");
-//! directive.description("Ensures cats get treats.");
-//! directive.location("OBJECT");
-//! directive.location("FIELD_DEFINITION");
-//! directive.location("INPUT_FIELD_DEFINITION");
-//! schema.directive(directive);
-
-//! // Create an Enum Definition
-//! let mut enum_ty_1 = EnumValue::new("CatTree");
-//! enum_ty_1.description("Top bunk of a cat tree.");
-//! let enum_ty_2 = EnumValue::new("Bed");
-//! let mut enum_ty_3 = EnumValue::new("CardboardBox");
-//! enum_ty_3.deprecated("Box was recycled.");
+//! let enum_def = {
+//!     let enum_ty_1 = EnumValueBuilder::new("CatTree")
+//!         .description("Top bunk of a cat tree.")
+//!         .build();
+//!     let enum_ty_2 = EnumValueBuilder::new("Bed").build();
+//!     let enum_ty_3 = EnumValueBuilder::new("CardboardBox")
+//!         .deprecated("Box was recycled.")
+//!         .build();
 //!
-//! let mut enum_def = EnumDef::new("NapSpots");
-//! enum_def.description("Favourite cat\nnap spots.");
-//! enum_def.value(enum_ty_1);
-//! enum_def.value(enum_ty_2);
-//! enum_def.value(enum_ty_3);
-//! schema.enum_(enum_def);
-//! // Union Definition
-//! let mut union_def = UnionDef::new("Cat");
-//! union_def.description("A union of all cats represented within a household.");
-//! union_def.member("NORI");
-//! union_def.member("CHASHU");
-//! schema.union(union_def);
+//!     EnumDefBuilder::new("NapSpots")
+//!         .description("Favourite cat\nnap spots.")
+//!         .value(enum_ty_1)
+//!         .value(enum_ty_2)
+//!         .value(enum_ty_3)
+//!         .build()
+//! };
+//!
+//! let union_def = UnionDefBuilder::new("Cat")
+//!     .description("A union of all cats represented within a household.")
+//!     .member("NORI")
+//!     .member("CHASHU")
+//!     .build();
+//!
+//! let schema = Schema::new()
+//!     .directive(directive)
+//!     .enum_(enum_def)
+//!     .union(union_def)
+//!     .finish();
 //!
 //! assert_eq!(
-//!     schema.finish(),
+//!     schema,
 //!     indoc! { r#"
 //!         "Ensures cats get treats."
 //!         directive @provideTreat on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
@@ -121,18 +127,18 @@ mod schema_def;
 mod string_value;
 mod union_def;
 
-pub use directive_def::Directive;
-pub use enum_def::EnumDef;
-pub use enum_value::EnumValue;
-pub use field::Field;
+pub use directive_def::{Directive, DirectiveBuilder};
+pub use enum_def::{EnumDef, EnumDefBuilder};
+pub use enum_value::{EnumValue, EnumValueBuilder};
+pub use field::{Field, FieldBuilder};
 pub use field_value::Type_;
-pub use input_field::InputField;
-pub use input_object_def::InputObjectDef;
-pub use input_value::InputValue;
-pub use interface_def::InterfaceDef;
-pub use object_def::ObjectDef;
-pub use scalar_def::ScalarDef;
+pub use input_field::{InputField, InputFieldBuilder};
+pub use input_object_def::{InputObjectDef, InputObjectDefBuilder};
+pub use input_value::{InputValue, InputValueBuilder};
+pub use interface_def::{InterfaceDef, InterfaceDefBuilder};
+pub use object_def::{ObjectDef, ObjectDefBuilder};
+pub use scalar_def::{ScalarDef, ScalarDefBuilder};
 pub use schema::Schema;
-pub use schema_def::SchemaDef;
+pub use schema_def::{SchemaDef, SchemaDefBuilder};
 pub use string_value::StringValue;
-pub use union_def::UnionDef;
+pub use union_def::{UnionDef, UnionDefBuilder};

--- a/crates/apollo-encoder/src/object_def.rs
+++ b/crates/apollo-encoder/src/object_def.rs
@@ -58,32 +58,57 @@ pub struct ObjectDef {
     fields: Vec<Field>,
 }
 
-impl ObjectDef {
+#[derive(Debug)]
+pub struct ObjectDefBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: Option<String>,
+    // The vector of interfaces that an object implements.
+    interfaces: Vec<String>,
+    // The vector of fields query‐able on this type.
+    fields: Vec<Field>,
+}
+
+impl ObjectDefBuilder {
     /// Create a new instance of ObjectDef with a name.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            description: StringValue::Top { source: None },
+            description: None,
             interfaces: Vec::new(),
             fields: Vec::new(),
         }
     }
 
     /// Set the ObjectDef's description field.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Top {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the interfaces ObjectDef implements.
-    pub fn interface(&mut self, interface: &str) {
-        self.interfaces.push(interface.to_string())
+    pub fn interface(mut self, interface: &str) -> Self {
+        self.interfaces.push(interface.to_string());
+        self
     }
 
     /// Push a Field to ObjectDef's fields vector.
-    pub fn field(&mut self, field: Field) {
-        self.fields.push(field)
+    pub fn field(mut self, field: Field) -> Self {
+        self.fields.push(field);
+        self
+    }
+
+    /// Create a new instance of ObjectDef with a name.
+    pub fn build(self) -> ObjectDef {
+        ObjectDef {
+            name: self.name,
+            description: StringValue::Top {
+                source: self.description,
+            },
+            interfaces: self.interfaces,
+            fields: self.fields,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/object_def.rs
+++ b/crates/apollo-encoder/src/object_def.rs
@@ -10,29 +10,51 @@ use crate::{Field, StringValue};
 ///     Description? **type** Name ImplementsInterfaces? Directives? FieldsDefinition?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Object).
-///
+#[derive(Debug)]
+pub struct ObjectDef {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: StringValue,
+    // The vector of interfaces that an object implements.
+    interfaces: Vec<String>,
+    // The vector of fields query‐able on this type.
+    fields: Vec<Field>,
+}
+
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{Type_, Field, ObjectDef};
+/// use apollo_encoder::{Type_, FieldBuilder, ObjectDefBuilder};
 /// use indoc::indoc;
 ///
-/// let ty_1 = Type_::named_type("DanglerPoleToys");
+/// let field_1 = {
+///     let ty = Type_::named_type("DanglerPoleToys");
+///     let ty = Type_::list(Box::new(ty));
 ///
-/// let ty_2 = Type_::list(Box::new(ty_1));
-/// let mut field = Field::new("toys", ty_2);
-/// field.deprecated("Cats are too spoiled");
-/// let ty_3 = Type_::named_type("FoodType");
-/// let mut field_2 = Field::new("food", ty_3);
-/// field_2.description("Dry or wet food?");
+///     FieldBuilder::new("toys", ty)
+///         .deprecated("Cats are too spoiled")
+///         .build()
+/// };
+/// let field_2 = {
+///     let ty = Type_::named_type("FoodType");
 ///
-/// let ty_4 = Type_::named_type("Boolean");
-/// let field_3 = Field::new("catGrass", ty_4);
+///     FieldBuilder::new("food", ty)
+///         .description("Dry or wet food?")
+///         .build()
+/// };
 ///
-/// let mut object_def = ObjectDef::new("PetStoreTrip");
-/// object_def.field(field);
-/// object_def.field(field_2);
-/// object_def.field(field_3);
-/// object_def.interface("ShoppingTrip");
+/// let field_3 = {
+///     let ty = Type_::named_type("Boolean");
+///
+///     FieldBuilder::new("catGrass", ty).build()
+/// };
+///
+/// let object_def = ObjectDefBuilder::new("PetStoreTrip")
+///     .field(field_1)
+///     .field(field_2)
+///     .field(field_3)
+///     .interface("ShoppingTrip")
+///     .build();
 ///
 /// assert_eq!(
 ///     object_def.to_string(),
@@ -46,18 +68,6 @@ use crate::{Field, StringValue};
 ///     "#}
 /// );
 /// ```
-#[derive(Debug)]
-pub struct ObjectDef {
-    // Name must return a String.
-    name: String,
-    // Description may return a String or null.
-    description: StringValue,
-    // The vector of interfaces that an object implements.
-    interfaces: Vec<String>,
-    // The vector of fields query‐able on this type.
-    fields: Vec<Field>,
-}
-
 #[derive(Debug)]
 pub struct ObjectDefBuilder {
     // Name must return a String.
@@ -134,8 +144,7 @@ impl fmt::Display for ObjectDef {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{Field, Type_};
+    use crate::{FieldBuilder, ObjectDefBuilder, Type_};
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -145,15 +154,13 @@ mod tests {
             let ty = Type_::named_type("DanglerPoleToys");
             let ty = Type_::list(Box::new(ty));
 
-            Field::new("toys", ty)
+            FieldBuilder::new("toys", ty).build()
         };
 
-        let object_def = {
-            let mut object_def = ObjectDef::new("PetStoreTrip");
-            object_def.field(field);
-            object_def.description("What to get at Fressnapf?");
-            object_def
-        };
+        let object_def = ObjectDefBuilder::new("PetStoreTrip")
+            .field(field)
+            .description("What to get at Fressnapf?")
+            .build();
 
         assert_eq!(
             object_def.to_string(),
@@ -171,17 +178,15 @@ mod tests {
         let field = {
             let ty = Type_::named_type("DanglerPoleToys");
 
-            let mut field = Field::new("toys", ty);
-            field.deprecated("\"DanglerPoleToys\" are no longer interesting");
-            field
+            FieldBuilder::new("toys", ty)
+                .deprecated("\"DanglerPoleToys\" are no longer interesting")
+                .build()
         };
 
-        let object_def = {
-            let mut object_def = ObjectDef::new("PetStoreTrip");
-            object_def.field(field);
-            object_def.description("What to get at Fressnapf?");
-            object_def
-        };
+        let object_def = ObjectDefBuilder::new("PetStoreTrip")
+            .field(field)
+            .description("What to get at Fressnapf?")
+            .build();
 
         assert_eq!(
             object_def.to_string(),
@@ -204,33 +209,32 @@ mod tests {
             let ty = Type_::named_type("DanglerPoleToys");
             let ty = Type_::list(Box::new(ty));
 
-            let mut field = Field::new("toys", ty);
-            field.deprecated("Cats are too spoiled");
-            field
+            FieldBuilder::new("toys", ty)
+                .deprecated("Cats are too spoiled")
+                .build()
         };
 
         let field_2 = {
             let ty = Type_::named_type("FoodType");
 
-            let mut field = Field::new("food", ty);
-            field.description("Dry or wet food?");
-            field
+            FieldBuilder::new("food", ty)
+                .description("Dry or wet food?")
+                .build()
         };
 
         let field_3 = {
             let ty = Type_::named_type("Boolean");
-            Field::new("catGrass", ty)
+
+            FieldBuilder::new("catGrass", ty).build()
         };
 
-        let object_def = {
-            let mut object_def = ObjectDef::new("PetStoreTrip");
-            object_def.field(field_1);
-            object_def.field(field_2);
-            object_def.field(field_3);
-            object_def.description("Shopping list for cats at the pet store.");
-            object_def.interface("ShoppingTrip");
-            object_def
-        };
+        let object_def = ObjectDefBuilder::new("PetStoreTrip")
+            .field(field_1)
+            .field(field_2)
+            .field(field_3)
+            .description("Shopping list for cats at the pet store.")
+            .interface("ShoppingTrip")
+            .build();
 
         assert_eq!(
             object_def.to_string(),
@@ -251,17 +255,15 @@ mod tests {
         let field = {
             let ty = Type_::named_type("String");
 
-            let mut field = Field::new("name", ty);
-            field.description("multiline\ndescription");
-            field
+            FieldBuilder::new("name", ty)
+                .description("multiline\ndescription")
+                .build()
         };
 
-        let object_def = {
-            let mut object_def = ObjectDef::new("Book");
-            object_def.field(field);
-            object_def.description("Book Object\nType");
-            object_def
-        };
+        let object_def = ObjectDefBuilder::new("Book")
+            .field(field)
+            .description("Book Object\nType")
+            .build();
 
         assert_eq!(
             object_def.to_string(),

--- a/crates/apollo-encoder/src/object_def.rs
+++ b/crates/apollo-encoder/src/object_def.rs
@@ -28,15 +28,14 @@ pub struct ObjectDef {
 /// use indoc::indoc;
 ///
 /// let field_1 = {
-///     let ty = Type_::named_type("DanglerPoleToys");
-///     let ty = Type_::list(Box::new(ty));
+///     let ty = Type_::list(Type_::named("DanglerPoleToys"));
 ///
 ///     FieldBuilder::new("toys", ty)
 ///         .deprecated("Cats are too spoiled")
 ///         .build()
 /// };
 /// let field_2 = {
-///     let ty = Type_::named_type("FoodType");
+///     let ty = Type_::named("FoodType");
 ///
 ///     FieldBuilder::new("food", ty)
 ///         .description("Dry or wet food?")
@@ -44,7 +43,7 @@ pub struct ObjectDef {
 /// };
 ///
 /// let field_3 = {
-///     let ty = Type_::named_type("Boolean");
+///     let ty = Type_::named("Boolean");
 ///
 ///     FieldBuilder::new("catGrass", ty).build()
 /// };
@@ -151,8 +150,7 @@ mod tests {
     #[test]
     fn it_encodes_object_with_description() {
         let field = {
-            let ty = Type_::named_type("DanglerPoleToys");
-            let ty = Type_::list(Box::new(ty));
+            let ty = Type_::list(Type_::named("DanglerPoleToys"));
 
             FieldBuilder::new("toys", ty).build()
         };
@@ -176,7 +174,7 @@ mod tests {
     #[test]
     fn it_encodes_object_with_field_directives() {
         let field = {
-            let ty = Type_::named_type("DanglerPoleToys");
+            let ty = Type_::named("DanglerPoleToys");
 
             FieldBuilder::new("toys", ty)
                 .deprecated("\"DanglerPoleToys\" are no longer interesting")
@@ -206,8 +204,7 @@ mod tests {
     #[test]
     fn it_encodes_object_with_interface() {
         let field_1 = {
-            let ty = Type_::named_type("DanglerPoleToys");
-            let ty = Type_::list(Box::new(ty));
+            let ty = Type_::list(Type_::named("DanglerPoleToys"));
 
             FieldBuilder::new("toys", ty)
                 .deprecated("Cats are too spoiled")
@@ -215,7 +212,7 @@ mod tests {
         };
 
         let field_2 = {
-            let ty = Type_::named_type("FoodType");
+            let ty = Type_::named("FoodType");
 
             FieldBuilder::new("food", ty)
                 .description("Dry or wet food?")
@@ -223,7 +220,7 @@ mod tests {
         };
 
         let field_3 = {
-            let ty = Type_::named_type("Boolean");
+            let ty = Type_::named("Boolean");
 
             FieldBuilder::new("catGrass", ty).build()
         };
@@ -253,7 +250,7 @@ mod tests {
     #[test]
     fn it_encodes_object_with_block_string_description() {
         let field = {
-            let ty = Type_::named_type("String");
+            let ty = Type_::named("String");
 
             FieldBuilder::new("name", ty)
                 .description("multiline\ndescription")

--- a/crates/apollo-encoder/src/object_def.rs
+++ b/crates/apollo-encoder/src/object_def.rs
@@ -66,9 +66,9 @@ pub struct ObjectDef {
 
 impl ObjectDef {
     /// Create a new instance of ObjectDef with a name.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             description: StringValue::Top { source: None },
             interfaces: Vec::new(),
             fields: Vec::new(),
@@ -76,15 +76,15 @@ impl ObjectDef {
     }
 
     /// Set the ObjectDef's description field.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Top {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 
     /// Set the interfaces ObjectDef implements.
-    pub fn interface(&mut self, interface: String) {
-        self.interfaces.push(interface)
+    pub fn interface(&mut self, interface: &str) {
+        self.interfaces.push(interface.to_string())
     }
 
     /// Push a Field to ObjectDef's fields vector.

--- a/crates/apollo-encoder/src/object_def.rs
+++ b/crates/apollo-encoder/src/object_def.rs
@@ -16,29 +16,23 @@ use crate::{Field, StringValue};
 /// use apollo_encoder::{Type_, Field, ObjectDef};
 /// use indoc::indoc;
 ///
-/// let ty_1 = Type_::NamedType {
-///     name: "DanglerPoleToys".to_string(),
-/// };
+/// let ty_1 = Type_::named_type("DanglerPoleToys");
 ///
-/// let ty_2 = Type_::List { ty: Box::new(ty_1) };
-/// let mut field = Field::new("toys".to_string(), ty_2);
-/// field.deprecated(Some("Cats are too spoiled".to_string()));
-/// let ty_3 = Type_::NamedType {
-///     name: "FoodType".to_string(),
-/// };
-/// let mut field_2 = Field::new("food".to_string(), ty_3);
-/// field_2.description(Some("Dry or wet food?".to_string()));
+/// let ty_2 = Type_::list(Box::new(ty_1));
+/// let mut field = Field::new("toys", ty_2);
+/// field.deprecated("Cats are too spoiled");
+/// let ty_3 = Type_::named_type("FoodType");
+/// let mut field_2 = Field::new("food", ty_3);
+/// field_2.description("Dry or wet food?");
 ///
-/// let ty_4 = Type_::NamedType {
-///     name: "Boolean".to_string(),
-/// };
-/// let field_3 = Field::new("catGrass".to_string(), ty_4);
+/// let ty_4 = Type_::named_type("Boolean");
+/// let field_3 = Field::new("catGrass", ty_4);
 ///
-/// let mut object_def = ObjectDef::new("PetStoreTrip".to_string());
+/// let mut object_def = ObjectDef::new("PetStoreTrip");
 /// object_def.field(field);
 /// object_def.field(field_2);
 /// object_def.field(field_3);
-/// object_def.interface("ShoppingTrip".to_string());
+/// object_def.interface("ShoppingTrip");
 ///
 /// assert_eq!(
 ///     object_def.to_string(),
@@ -122,16 +116,19 @@ mod tests {
 
     #[test]
     fn it_encodes_object_with_description() {
-        let ty_1 = Type_::NamedType {
-            name: "DanglerPoleToys".to_string(),
+        let field = {
+            let ty = Type_::named_type("DanglerPoleToys");
+            let ty = Type_::list(Box::new(ty));
+
+            Field::new("toys", ty)
         };
 
-        let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let field = Field::new("toys".to_string(), ty_2);
-
-        let mut object_def = ObjectDef::new("PetStoreTrip".to_string());
-        object_def.field(field);
-        object_def.description(Some("What to get at Fressnapf?".to_string()));
+        let object_def = {
+            let mut object_def = ObjectDef::new("PetStoreTrip");
+            object_def.field(field);
+            object_def.description("What to get at Fressnapf?");
+            object_def
+        };
 
         assert_eq!(
             object_def.to_string(),
@@ -146,18 +143,20 @@ mod tests {
 
     #[test]
     fn it_encodes_object_with_field_directives() {
-        let ty_1 = Type_::NamedType {
-            name: "DanglerPoleToys".to_string(),
+        let field = {
+            let ty = Type_::named_type("DanglerPoleToys");
+
+            let mut field = Field::new("toys", ty);
+            field.deprecated("\"DanglerPoleToys\" are no longer interesting");
+            field
         };
 
-        let mut field = Field::new("toys".to_string(), ty_1);
-        field.deprecated(Some(
-            "\"DanglerPoleToys\" are no longer interesting".to_string(),
-        ));
-
-        let mut object_def = ObjectDef::new("PetStoreTrip".to_string());
-        object_def.field(field);
-        object_def.description(Some("What to get at Fressnapf?".to_string()));
+        let object_def = {
+            let mut object_def = ObjectDef::new("PetStoreTrip");
+            object_def.field(field);
+            object_def.description("What to get at Fressnapf?");
+            object_def
+        };
 
         assert_eq!(
             object_def.to_string(),
@@ -176,30 +175,37 @@ mod tests {
 
     #[test]
     fn it_encodes_object_with_interface() {
-        let ty_1 = Type_::NamedType {
-            name: "DanglerPoleToys".to_string(),
+        let field_1 = {
+            let ty = Type_::named_type("DanglerPoleToys");
+            let ty = Type_::list(Box::new(ty));
+
+            let mut field = Field::new("toys", ty);
+            field.deprecated("Cats are too spoiled");
+            field
         };
 
-        let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let mut field = Field::new("toys".to_string(), ty_2);
-        field.deprecated(Some("Cats are too spoiled".to_string()));
-        let ty_3 = Type_::NamedType {
-            name: "FoodType".to_string(),
-        };
-        let mut field_2 = Field::new("food".to_string(), ty_3);
-        field_2.description(Some("Dry or wet food?".to_string()));
+        let field_2 = {
+            let ty = Type_::named_type("FoodType");
 
-        let ty_4 = Type_::NamedType {
-            name: "Boolean".to_string(),
+            let mut field = Field::new("food", ty);
+            field.description("Dry or wet food?");
+            field
         };
-        let field_3 = Field::new("catGrass".to_string(), ty_4);
 
-        let mut object_def = ObjectDef::new("PetStoreTrip".to_string());
-        object_def.field(field);
-        object_def.field(field_2);
-        object_def.field(field_3);
-        object_def.description(Some("Shopping list for cats at the pet store.".to_string()));
-        object_def.interface("ShoppingTrip".to_string());
+        let field_3 = {
+            let ty = Type_::named_type("Boolean");
+            Field::new("catGrass", ty)
+        };
+
+        let object_def = {
+            let mut object_def = ObjectDef::new("PetStoreTrip");
+            object_def.field(field_1);
+            object_def.field(field_2);
+            object_def.field(field_3);
+            object_def.description("Shopping list for cats at the pet store.");
+            object_def.interface("ShoppingTrip");
+            object_def
+        };
 
         assert_eq!(
             object_def.to_string(),
@@ -217,16 +223,20 @@ mod tests {
 
     #[test]
     fn it_encodes_object_with_block_string_description() {
-        let ty_1 = Type_::NamedType {
-            name: "String".to_string(),
+        let field = {
+            let ty = Type_::named_type("String");
+
+            let mut field = Field::new("name", ty);
+            field.description("multiline\ndescription");
+            field
         };
 
-        let mut field = Field::new("name".to_string(), ty_1);
-        field.description(Some("multiline\ndescription".to_string()));
-
-        let mut object_def = ObjectDef::new("Book".to_string());
-        object_def.field(field);
-        object_def.description(Some("Book Object\nType".to_string()));
+        let object_def = {
+            let mut object_def = ObjectDef::new("Book");
+            object_def.field(field);
+            object_def.description("Book Object\nType");
+            object_def
+        };
 
         assert_eq!(
             object_def.to_string(),

--- a/crates/apollo-encoder/src/scalar_def.rs
+++ b/crates/apollo-encoder/src/scalar_def.rs
@@ -30,20 +30,37 @@ pub struct ScalarDef {
     description: StringValue,
 }
 
-impl ScalarDef {
-    /// Create a new instance of Scalar Definition.
+#[derive(Debug, Clone)]
+pub struct ScalarDefBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String or null.
+    description: Option<String>,
+}
+
+impl ScalarDefBuilder {
+    /// Create a new instance of ScalarDefBuilder.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            description: StringValue::Top { source: None },
+            description: None,
         }
     }
 
     /// Set the ScalarDef's description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Top {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
+    }
+
+    /// Create a new instance of ScalarDef.
+    pub fn build(self) -> ScalarDef {
+        ScalarDef {
+            name: self.name,
+            description: StringValue::Top {
+                source: self.description,
+            },
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/scalar_def.rs
+++ b/crates/apollo-encoder/src/scalar_def.rs
@@ -12,10 +12,8 @@ use crate::StringValue;
 /// ```rust
 /// use apollo_encoder::ScalarDef;
 ///
-/// let mut scalar = ScalarDef::new("NumberOfTreatsPerDay".to_string());
-/// scalar.description(Some(
-///     "Int representing number of treats received.".to_string(),
-/// ));
+/// let mut scalar = ScalarDef::new("NumberOfTreatsPerDay");
+/// scalar.description("Int representing number of treats received.");
 ///
 /// assert_eq!(
 ///     scalar.to_string(),
@@ -63,7 +61,8 @@ mod tests {
 
     #[test]
     fn it_encodes_scalar() {
-        let scalar = ScalarDef::new("NumberOfTreatsPerDay".to_string());
+        let scalar = ScalarDef::new("NumberOfTreatsPerDay");
+
         assert_eq!(
             scalar.to_string(),
             r#"scalar NumberOfTreatsPerDay
@@ -73,10 +72,11 @@ mod tests {
 
     #[test]
     fn it_encodes_scalar_with_description() {
-        let mut scalar = ScalarDef::new("NumberOfTreatsPerDay".to_string());
-        scalar.description(Some(
-            "Int representing number of treats received.".to_string(),
-        ));
+        let scalar = {
+            let mut scalar = ScalarDef::new("NumberOfTreatsPerDay");
+            scalar.description("Int representing number of treats received.");
+            scalar
+        };
 
         assert_eq!(
             scalar.to_string(),

--- a/crates/apollo-encoder/src/scalar_def.rs
+++ b/crates/apollo-encoder/src/scalar_def.rs
@@ -8,20 +8,6 @@ use crate::StringValue;
 ///     Description? **scalar** Name Directives?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Scalar).
-/// ### Example
-/// ```rust
-/// use apollo_encoder::ScalarDef;
-///
-/// let mut scalar = ScalarDef::new("NumberOfTreatsPerDay");
-/// scalar.description("Int representing number of treats received.");
-///
-/// assert_eq!(
-///     scalar.to_string(),
-///     r#""Int representing number of treats received."
-/// scalar NumberOfTreatsPerDay
-/// "#
-/// );
-/// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct ScalarDef {
     // Name must return a String.
@@ -30,6 +16,21 @@ pub struct ScalarDef {
     description: StringValue,
 }
 
+/// ### Example
+/// ```rust
+/// use apollo_encoder::ScalarDefBuilder;
+///
+/// let scalar = ScalarDefBuilder::new("NumberOfTreatsPerDay")
+///     .description("Int representing number of treats received.")
+///     .build();
+///
+/// assert_eq!(
+///     scalar.to_string(),
+///     r#""Int representing number of treats received."
+/// scalar NumberOfTreatsPerDay
+/// "#
+/// );
+/// ```
 #[derive(Debug, Clone)]
 pub struct ScalarDefBuilder {
     // Name must return a String.
@@ -73,12 +74,12 @@ impl fmt::Display for ScalarDef {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::ScalarDefBuilder;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn it_encodes_scalar() {
-        let scalar = ScalarDef::new("NumberOfTreatsPerDay");
+        let scalar = ScalarDefBuilder::new("NumberOfTreatsPerDay").build();
 
         assert_eq!(
             scalar.to_string(),
@@ -89,11 +90,9 @@ mod tests {
 
     #[test]
     fn it_encodes_scalar_with_description() {
-        let scalar = {
-            let mut scalar = ScalarDef::new("NumberOfTreatsPerDay");
-            scalar.description("Int representing number of treats received.");
-            scalar
-        };
+        let scalar = ScalarDefBuilder::new("NumberOfTreatsPerDay")
+            .description("Int representing number of treats received.")
+            .build();
 
         assert_eq!(
             scalar.to_string(),

--- a/crates/apollo-encoder/src/scalar_def.rs
+++ b/crates/apollo-encoder/src/scalar_def.rs
@@ -34,17 +34,17 @@ pub struct ScalarDef {
 
 impl ScalarDef {
     /// Create a new instance of Scalar Definition.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             description: StringValue::Top { source: None },
         }
     }
 
     /// Set the ScalarDef's description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Top {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 }

--- a/crates/apollo-encoder/src/schema.rs
+++ b/crates/apollo-encoder/src/schema.rs
@@ -30,7 +30,8 @@ use crate::{
 ///     "# }
 /// );
 /// ```
-#[derive(Debug)]
+///
+#[derive(Debug, Default)]
 pub struct Schema {
     buf: String,
 }
@@ -42,57 +43,59 @@ impl Schema {
     }
 
     /// Adds a new Directive Definition.
-    pub fn directive(&mut self, directive: Directive) {
+    pub fn directive(mut self, directive: Directive) -> Self {
         self.buf.push_str(&directive.to_string());
+        self
     }
 
     /// Adds a new Type Definition.
-    pub fn object(&mut self, object: ObjectDef) {
+    pub fn object(mut self, object: ObjectDef) -> Self {
         self.buf.push_str(&object.to_string());
+        self
     }
 
     /// Adds a new Schema Definition.
     ///
     /// The schema type is only used when the root GraphQL type is different
     /// from default GraphQL types.
-    pub fn schema(&mut self, schema: SchemaDef) {
+    pub fn schema(mut self, schema: SchemaDef) -> Self {
         self.buf.push_str(&schema.to_string());
+        self
     }
 
     /// Adds a new Input Object Definition.
-    pub fn input(&mut self, input: InputObjectDef) {
+    pub fn input(mut self, input: InputObjectDef) -> Self {
         self.buf.push_str(&input.to_string());
+        self
     }
 
     /// Adds a new Enum Definition.
-    pub fn enum_(&mut self, enum_: EnumDef) {
+    pub fn enum_(mut self, enum_: EnumDef) -> Self {
         self.buf.push_str(&enum_.to_string());
+        self
     }
 
     /// Adds a new Scalar Definition.
-    pub fn scalar(&mut self, scalar: ScalarDef) {
+    pub fn scalar(mut self, scalar: ScalarDef) -> Self {
         self.buf.push_str(&scalar.to_string());
+        self
     }
 
     /// Adds a new Union Definition.
-    pub fn union(&mut self, union_: UnionDef) {
+    pub fn union(mut self, union_: UnionDef) -> Self {
         self.buf.push_str(&union_.to_string());
+        self
     }
 
     /// Adds a new Interface Definition.
-    pub fn interface(&mut self, interface: InterfaceDef) {
+    pub fn interface(mut self, interface: InterfaceDef) -> Self {
         self.buf.push_str(&interface.to_string());
+        self
     }
 
     /// Return the encoded SDL string after all types have been processed.
     pub fn finish(self) -> String {
         self.buf
-    }
-}
-
-impl Default for Schema {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/apollo-encoder/src/schema.rs
+++ b/crates/apollo-encoder/src/schema.rs
@@ -17,12 +17,10 @@ use crate::{
 ///
 /// let mut schema = Schema::new();
 ///
-/// let mut union_def = UnionDef::new("Cat".to_string());
-/// union_def.description(Some(
-///     "A union of all cats represented within a household.".to_string(),
-/// ));
-/// union_def.member("NORI".to_string());
-/// union_def.member("CHASHU".to_string());
+/// let mut union_def = UnionDef::new("Cat");
+/// union_def.description("A union of all cats represented within a household.");
+/// union_def.member("NORI");
+/// union_def.member("CHASHU");
 /// schema.union(union_def);
 /// assert_eq!(
 ///     schema.finish(),
@@ -111,110 +109,120 @@ mod tests {
     fn smoke_test() {
         let mut schema = Schema::new();
 
-        // create a directive
-        let mut directive = Directive::new("provideTreat".to_string());
-        directive.description(Some("Ensures cats get treats.".to_string()));
-        directive.location("OBJECT".to_string());
-        directive.location("FIELD_DEFINITION".to_string());
-        directive.location("INPUT_FIELD_DEFINITION".to_string());
+        let directive = {
+            // create a directive
+            let mut directive = Directive::new("provideTreat");
+            directive.description("Ensures cats get treats.");
+            directive.location("OBJECT");
+            directive.location("FIELD_DEFINITION");
+            directive.location("INPUT_FIELD_DEFINITION");
+            directive
+        };
         schema.directive(directive);
 
-        // a schema definition
-        let mut schema_def = SchemaDef::new();
-        schema_def.query("TryingToFindCatQuery".to_string());
+        let schema_def = {
+            // a schema definition
+            let mut schema_def = SchemaDef::new();
+            schema_def.query("TryingToFindCatQuery");
+            schema_def
+        };
         schema.schema(schema_def);
 
-        // create a field
-        let field_value = Type_::NamedType {
-            name: "String".to_string(),
-        };
-
-        let null_field = Type_::NonNull {
-            ty: Box::new(field_value),
-        };
-
-        let mut field = Field::new("cat".to_string(), null_field);
-        field.description(Some("Very good cats".to_string()));
-
         // Union Definition
-        let mut union_def = UnionDef::new("Pet".to_string());
-        union_def.description(Some("A union of all animals in a household.".to_string()));
-        union_def.member("Cat".to_string());
-        union_def.member("Dog".to_string());
+        let union_def = {
+            let mut union_def = UnionDef::new("Pet");
+            union_def.description("A union of all animals in a household.");
+            union_def.member("Cat");
+            union_def.member("Dog");
+            union_def
+        };
         schema.union(union_def);
 
         // Object Definition.
-        let object_value = Type_::NamedType {
-            name: "DanglerPoleToys".to_string(),
+        let object_def = {
+            let field_1 = {
+                let ty = Type_::named_type("DanglerPoleToys");
+                let ty = Type_::list(Box::new(ty));
+
+                let mut field = Field::new("toys", ty);
+                field.deprecated("Cats are too spoiled");
+                field
+            };
+
+            let field_2 = {
+                let ty = Type_::named_type("FoodType");
+
+                let mut field = Field::new("food", ty);
+                field.description("Dry or wet food?");
+                field
+            };
+
+            let field_3 = {
+                let field = Type_::named_type("Boolean");
+
+                Field::new("catGrass", field)
+            };
+
+            let mut object_def = ObjectDef::new("PetStoreTrip");
+            object_def.field(field_1);
+            object_def.field(field_2);
+            object_def.field(field_3);
+            object_def.interface("ShoppingTrip");
+            object_def
         };
-
-        let object_value_2 = Type_::List {
-            ty: Box::new(object_value),
-        };
-
-        let mut object_field = Field::new("toys".to_string(), object_value_2);
-        object_field.deprecated(Some("Cats are too spoiled".to_string()));
-
-        let object_value_2 = Type_::NamedType {
-            name: "FoodType".to_string(),
-        };
-
-        let mut object_field_2 = Field::new("food".to_string(), object_value_2);
-        object_field_2.description(Some("Dry or wet food?".to_string()));
-
-        let object_field_3 = Type_::NamedType {
-            name: "Boolean".to_string(),
-        };
-        let object_field_3 = Field::new("catGrass".to_string(), object_field_3);
-
-        let mut object_def = ObjectDef::new("PetStoreTrip".to_string());
-        object_def.field(object_field);
-        object_def.field(object_field_2);
-        object_def.field(object_field_3);
-        object_def.interface("ShoppingTrip".to_string());
         schema.object(object_def);
 
         // Enum definition
-        let mut enum_ty_1 = EnumValue::new("CAT_TREE".to_string());
-        enum_ty_1.description(Some("Top bunk of a cat tree.".to_string()));
-        let enum_ty_2 = EnumValue::new("BED".to_string());
-        let mut enum_ty_3 = EnumValue::new("CARDBOARD_BOX".to_string());
-        enum_ty_3.deprecated(Some("Box was recycled.".to_string()));
+        let enum_def = {
+            let enum_value_1 = {
+                let mut enum_value = EnumValue::new("CAT_TREE");
+                enum_value.description("Top bunk of a cat tree.");
+                enum_value
+            };
+            let enum_value_2 = EnumValue::new("BED");
+            let enum_value_3 = {
+                let mut enum_value_3 = EnumValue::new("CARDBOARD_BOX");
+                enum_value_3.deprecated("Box was recycled.");
+                enum_value_3
+            };
 
-        let mut enum_def = EnumDef::new("NapSpots".to_string());
-        enum_def.description(Some("Favourite cat nap spots.".to_string()));
-        enum_def.value(enum_ty_1);
-        enum_def.value(enum_ty_2);
-        enum_def.value(enum_ty_3);
+            let mut enum_def = EnumDef::new("NapSpots");
+            enum_def.description("Favourite cat nap spots.");
+            enum_def.value(enum_value_1);
+            enum_def.value(enum_value_2);
+            enum_def.value(enum_value_3);
+            enum_def
+        };
         schema.enum_(enum_def);
 
-        let mut scalar = ScalarDef::new("NumberOfTreatsPerDay".to_string());
-        scalar.description(Some(
-            "Int representing number of treats received.".to_string(),
-        ));
+        let scalar = {
+            let mut scalar = ScalarDef::new("NumberOfTreatsPerDay");
+            scalar.description("Int representing number of treats received.");
+            scalar
+        };
         schema.scalar(scalar);
 
         // input definition
-        let input_value = Type_::NamedType {
-            name: "DanglerPoleToys".to_string(),
-        };
+        let input_def = {
+            let input_field = {
+                let ty = Type_::named_type("DanglerPoleToys");
+                let ty = Type_::list(Box::new(ty));
+                let mut input_field_1 = InputField::new("toys", ty);
+                input_field_1.default("\"Cat Dangler Pole Bird\"");
+                input_field_1
+            };
+            let input_value_2 = {
+                let ty = Type_::named_type("FavouriteSpots");
+                let mut input_value_2 = InputField::new("playSpot", ty);
+                input_value_2.description("Best playime spots, e.g. \"tree\", \"bed\".");
+                input_value_2
+            };
 
-        let input_value_2 = Type_::List {
-            ty: Box::new(input_value),
+            let mut input_def = InputObjectDef::new("PlayTime");
+            input_def.field(input_field);
+            input_def.field(input_value_2);
+            input_def
         };
-        let mut input_field = InputField::new("toys".to_string(), input_value_2);
-        input_field.default(Some("\"Cat Dangler Pole Bird\"".to_string()));
-        let input_value_3 = Type_::NamedType {
-            name: "FavouriteSpots".to_string(),
-        };
-        let mut input_value_2 = InputField::new("playSpot".to_string(), input_value_3);
-        input_value_2.description(Some(
-            "Best playime spots, e.g. \"tree\", \"bed\".".to_string(),
-        ));
-
-        let mut input_def = InputObjectDef::new("PlayTime".to_string());
-        input_def.field(input_field);
-        input_def.field(input_value_2);
         schema.input(input_def);
 
         assert_eq!(

--- a/crates/apollo-encoder/src/schema.rs
+++ b/crates/apollo-encoder/src/schema.rs
@@ -130,22 +130,21 @@ mod tests {
             .build();
         let object_def = {
             let field_1 = {
-                let ty = Type_::named_type("DanglerPoleToys");
-                let ty = Type_::list(Box::new(ty));
+                let ty = Type_::list(Type_::named("DanglerPoleToys"));
 
                 FieldBuilder::new("toys", ty)
                     .deprecated("Cats are too spoiled")
                     .build()
             };
             let field_2 = {
-                let ty = Type_::named_type("FoodType");
+                let ty = Type_::named("FoodType");
 
                 FieldBuilder::new("food", ty)
                     .description("Dry or wet food?")
                     .build()
             };
             let field_3 = {
-                let field = Type_::named_type("Boolean");
+                let field = Type_::named("Boolean");
 
                 FieldBuilder::new("catGrass", field).build()
             };
@@ -178,15 +177,14 @@ mod tests {
             .build();
         let input_def = {
             let input_field = {
-                let ty = Type_::named_type("DanglerPoleToys");
-                let ty = Type_::list(Box::new(ty));
+                let ty = Type_::list(Type_::named("DanglerPoleToys"));
 
                 InputFieldBuilder::new("toys", ty)
                     .default("\"Cat Dangler Pole Bird\"")
                     .build()
             };
             let input_value_2 = {
-                let ty = Type_::named_type("FavouriteSpots");
+                let ty = Type_::named("FavouriteSpots");
 
                 InputFieldBuilder::new("playSpot", ty)
                     .description("Best playime spots, e.g. \"tree\", \"bed\".")

--- a/crates/apollo-encoder/src/schema.rs
+++ b/crates/apollo-encoder/src/schema.rs
@@ -12,18 +12,21 @@ use crate::{
 ///
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{Schema, Field, UnionDef, EnumValue, Directive, EnumDef, Type_};
+/// use apollo_encoder::{Schema, FieldBuilder, UnionDefBuilder, EnumValueBuilder, DirectiveBuilder, EnumDefBuilder, Type_};
 /// use indoc::indoc;
 ///
-/// let mut schema = Schema::new();
+/// let union_def = UnionDefBuilder::new("Cat")
+///     .description("A union of all cats represented within a household.")
+///     .member("NORI")
+///     .member("CHASHU")
+///     .build();
 ///
-/// let mut union_def = UnionDef::new("Cat");
-/// union_def.description("A union of all cats represented within a household.");
-/// union_def.member("NORI");
-/// union_def.member("CHASHU");
-/// schema.union(union_def);
+/// let schema = Schema::new()
+///     .union(union_def)
+///     .finish();
+///
 /// assert_eq!(
-///     schema.finish(),
+///     schema,
 ///     indoc! { r#"
 ///         "A union of all cats represented within a household."
 ///         union Cat = NORI | CHASHU
@@ -102,134 +105,112 @@ impl Schema {
 #[cfg(test)]
 mod tests {
     use crate::{
-        Directive, EnumDef, EnumValue, Field, InputField, InputObjectDef, ObjectDef, ScalarDef,
-        Schema, SchemaDef, Type_, UnionDef,
+        DirectiveBuilder, EnumDefBuilder, EnumValueBuilder, FieldBuilder, InputFieldBuilder,
+        InputObjectDefBuilder, ObjectDefBuilder, ScalarDefBuilder, Schema, SchemaDefBuilder, Type_,
+        UnionDefBuilder,
     };
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn smoke_test() {
-        let mut schema = Schema::new();
-
-        let directive = {
-            // create a directive
-            let mut directive = Directive::new("provideTreat");
-            directive.description("Ensures cats get treats.");
-            directive.location("OBJECT");
-            directive.location("FIELD_DEFINITION");
-            directive.location("INPUT_FIELD_DEFINITION");
-            directive
-        };
-        schema.directive(directive);
-
-        let schema_def = {
-            // a schema definition
-            let mut schema_def = SchemaDef::new();
-            schema_def.query("TryingToFindCatQuery");
-            schema_def
-        };
-        schema.schema(schema_def);
-
-        // Union Definition
-        let union_def = {
-            let mut union_def = UnionDef::new("Pet");
-            union_def.description("A union of all animals in a household.");
-            union_def.member("Cat");
-            union_def.member("Dog");
-            union_def
-        };
-        schema.union(union_def);
-
-        // Object Definition.
+        let directive = DirectiveBuilder::new("provideTreat")
+            .description("Ensures cats get treats.")
+            .location("OBJECT")
+            .location("FIELD_DEFINITION")
+            .location("INPUT_FIELD_DEFINITION")
+            .build();
+        let schema_def = SchemaDefBuilder::new()
+            .query("TryingToFindCatQuery")
+            .build();
+        let union_def = UnionDefBuilder::new("Pet")
+            .description("A union of all animals in a household.")
+            .member("Cat")
+            .member("Dog")
+            .build();
         let object_def = {
             let field_1 = {
                 let ty = Type_::named_type("DanglerPoleToys");
                 let ty = Type_::list(Box::new(ty));
 
-                let mut field = Field::new("toys", ty);
-                field.deprecated("Cats are too spoiled");
-                field
+                FieldBuilder::new("toys", ty)
+                    .deprecated("Cats are too spoiled")
+                    .build()
             };
-
             let field_2 = {
                 let ty = Type_::named_type("FoodType");
 
-                let mut field = Field::new("food", ty);
-                field.description("Dry or wet food?");
-                field
+                FieldBuilder::new("food", ty)
+                    .description("Dry or wet food?")
+                    .build()
             };
-
             let field_3 = {
                 let field = Type_::named_type("Boolean");
 
-                Field::new("catGrass", field)
+                FieldBuilder::new("catGrass", field).build()
             };
 
-            let mut object_def = ObjectDef::new("PetStoreTrip");
-            object_def.field(field_1);
-            object_def.field(field_2);
-            object_def.field(field_3);
-            object_def.interface("ShoppingTrip");
-            object_def
+            ObjectDefBuilder::new("PetStoreTrip")
+                .field(field_1)
+                .field(field_2)
+                .field(field_3)
+                .interface("ShoppingTrip")
+                .build()
         };
-        schema.object(object_def);
-
-        // Enum definition
         let enum_def = {
-            let enum_value_1 = {
-                let mut enum_value = EnumValue::new("CAT_TREE");
-                enum_value.description("Top bunk of a cat tree.");
-                enum_value
-            };
-            let enum_value_2 = EnumValue::new("BED");
-            let enum_value_3 = {
-                let mut enum_value_3 = EnumValue::new("CARDBOARD_BOX");
-                enum_value_3.deprecated("Box was recycled.");
-                enum_value_3
-            };
+            let enum_value_1 = EnumValueBuilder::new("CAT_TREE")
+                .description("Top bunk of a cat tree.")
+                .build();
+            let enum_value_2 = EnumValueBuilder::new("BED").build();
+            let enum_value_3 = EnumValueBuilder::new("CARDBOARD_BOX")
+                .deprecated("Box was recycled.")
+                .build();
 
-            let mut enum_def = EnumDef::new("NapSpots");
-            enum_def.description("Favourite cat nap spots.");
-            enum_def.value(enum_value_1);
-            enum_def.value(enum_value_2);
-            enum_def.value(enum_value_3);
-            enum_def
+            EnumDefBuilder::new("NapSpots")
+                .description("Favourite cat nap spots.")
+                .value(enum_value_1)
+                .value(enum_value_2)
+                .value(enum_value_3)
+                .build()
         };
-        schema.enum_(enum_def);
-
-        let scalar = {
-            let mut scalar = ScalarDef::new("NumberOfTreatsPerDay");
-            scalar.description("Int representing number of treats received.");
-            scalar
-        };
-        schema.scalar(scalar);
-
-        // input definition
+        let scalar = ScalarDefBuilder::new("NumberOfTreatsPerDay")
+            .description("Int representing number of treats received.")
+            .build();
         let input_def = {
             let input_field = {
                 let ty = Type_::named_type("DanglerPoleToys");
                 let ty = Type_::list(Box::new(ty));
-                let mut input_field_1 = InputField::new("toys", ty);
-                input_field_1.default("\"Cat Dangler Pole Bird\"");
-                input_field_1
+
+                InputFieldBuilder::new("toys", ty)
+                    .default("\"Cat Dangler Pole Bird\"")
+                    .build()
             };
             let input_value_2 = {
                 let ty = Type_::named_type("FavouriteSpots");
-                let mut input_value_2 = InputField::new("playSpot", ty);
-                input_value_2.description("Best playime spots, e.g. \"tree\", \"bed\".");
-                input_value_2
+
+                InputFieldBuilder::new("playSpot", ty)
+                    .description("Best playime spots, e.g. \"tree\", \"bed\".")
+                    .build()
             };
 
-            let mut input_def = InputObjectDef::new("PlayTime");
-            input_def.field(input_field);
-            input_def.field(input_value_2);
-            input_def
+            InputObjectDefBuilder::new("PlayTime")
+                .field(input_field)
+                .field(input_value_2)
+                .build()
         };
-        schema.input(input_def);
+
+        let schema = Schema::new()
+            .directive(directive)
+            .schema(schema_def)
+            .union(union_def)
+            .object(object_def)
+            .enum_(enum_def)
+            .scalar(scalar)
+            .input(input_def)
+            .finish();
 
         assert_eq!(
-            schema.finish(),
+            schema,
             indoc! { r#"
                 "Ensures cats get treats."
                 directive @provideTreat on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION

--- a/crates/apollo-encoder/src/schema_def.rs
+++ b/crates/apollo-encoder/src/schema_def.rs
@@ -8,16 +8,27 @@ use crate::StringValue;
 ///     Description? **schema** Directives? **{** RootOperationTypeDefinition* **}**
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Schema).
-///
+#[derive(Debug, Clone)]
+pub struct SchemaDef {
+    // Description may be a String.
+    description: StringValue,
+    // The vector of fields in a schema to represent root operation type
+    // definition.
+    query: Option<String>,
+    mutation: Option<String>,
+    subscription: Option<String>,
+}
+
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{SchemaDef};
+/// use apollo_encoder::SchemaDefBuilder;
 /// use indoc::indoc;
 ///
-/// let mut schema_def = SchemaDef::new();
-/// schema_def.query("TryingToFindCatQuery");
-/// schema_def.mutation("MyMutation");
-/// schema_def.subscription("MySubscription");
+/// let schema_def = SchemaDefBuilder::new()
+///     .query("TryingToFindCatQuery")
+///     .mutation("MyMutation")
+///     .subscription("MySubscription")
+///     .build();
 ///
 /// assert_eq!(
 ///    schema_def.to_string(),
@@ -30,17 +41,6 @@ use crate::StringValue;
 ///    "#}
 /// );
 /// ```
-#[derive(Debug, Clone)]
-pub struct SchemaDef {
-    // Description may be a String.
-    description: StringValue,
-    // The vector of fields in a schema to represent root operation type
-    // definition.
-    query: Option<String>,
-    mutation: Option<String>,
-    subscription: Option<String>,
-}
-
 #[derive(Debug, Clone)]
 pub struct SchemaDefBuilder {
     // Description may be a String.
@@ -123,19 +123,17 @@ impl fmt::Display for SchemaDef {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::SchemaDefBuilder;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn it_encodes_schema_with_mutation_and_subscription() {
-        let schema_def = {
-            let mut schema_def = SchemaDef::new();
-            schema_def.query("TryingToFindCatQuery");
-            schema_def.mutation("MyMutation");
-            schema_def.subscription("MySubscription");
-            schema_def
-        };
+        let schema_def = SchemaDefBuilder::new()
+            .query("TryingToFindCatQuery")
+            .mutation("MyMutation")
+            .subscription("MySubscription")
+            .build();
 
         assert_eq!(
             schema_def.to_string(),

--- a/crates/apollo-encoder/src/schema_def.rs
+++ b/crates/apollo-encoder/src/schema_def.rs
@@ -30,7 +30,6 @@ use crate::StringValue;
 ///    "#}
 /// );
 /// ```
-
 #[derive(Debug, Clone)]
 pub struct SchemaDef {
     // Description may be a String.
@@ -42,11 +41,22 @@ pub struct SchemaDef {
     subscription: Option<String>,
 }
 
-impl SchemaDef {
-    /// Create a new instance of SchemaDef.
+#[derive(Debug, Clone)]
+pub struct SchemaDefBuilder {
+    // Description may be a String.
+    description: Option<String>,
+    // The vector of fields in a schema to represent root operation type
+    // definition.
+    query: Option<String>,
+    mutation: Option<String>,
+    subscription: Option<String>,
+}
+
+impl SchemaDefBuilder {
+    /// Create a new instance of SchemaDefBuilder.
     pub fn new() -> Self {
         Self {
-            description: StringValue::Top { source: None },
+            description: None,
             query: None,
             mutation: None,
             subscription: None,
@@ -54,31 +64,39 @@ impl SchemaDef {
     }
 
     /// Set the SchemaDef's description.
-    pub fn description(&mut self, description: Option<String>) {
-        self.description = StringValue::Top {
-            source: description,
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set the schema def's query type.
-    pub fn query(&mut self, query: &str) {
+    pub fn query(mut self, query: &str) -> Self {
         self.query = Some(query.to_string());
+        self
     }
 
     /// Set the schema def's mutation type.
-    pub fn mutation(&mut self, mutation: &str) {
+    pub fn mutation(mut self, mutation: &str) -> Self {
         self.mutation = Some(mutation.to_string());
+        self
     }
 
     /// Set the schema def's subscription type.
-    pub fn subscription(&mut self, subscription: &str) {
+    pub fn subscription(mut self, subscription: &str) -> Self {
         self.subscription = Some(subscription.to_string());
+        self
     }
-}
 
-impl Default for SchemaDef {
-    fn default() -> Self {
-        Self::new()
+    /// Create a new instance of SchemaDef.
+    pub fn build(self) -> SchemaDef {
+        SchemaDef {
+            description: StringValue::Top {
+                source: self.description,
+            },
+            query: self.query,
+            mutation: self.mutation,
+            subscription: self.subscription,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/schema_def.rs
+++ b/crates/apollo-encoder/src/schema_def.rs
@@ -61,18 +61,18 @@ impl SchemaDef {
     }
 
     /// Set the schema def's query type.
-    pub fn query(&mut self, query: String) {
-        self.query = Some(query);
+    pub fn query(&mut self, query: &str) {
+        self.query = Some(query.to_string());
     }
 
     /// Set the schema def's mutation type.
-    pub fn mutation(&mut self, mutation: String) {
-        self.mutation = Some(mutation);
+    pub fn mutation(&mut self, mutation: &str) {
+        self.mutation = Some(mutation.to_string());
     }
 
     /// Set the schema def's subscription type.
-    pub fn subscription(&mut self, subscription: String) {
-        self.subscription = Some(subscription);
+    pub fn subscription(&mut self, subscription: &str) {
+        self.subscription = Some(subscription.to_string());
     }
 }
 

--- a/crates/apollo-encoder/src/schema_def.rs
+++ b/crates/apollo-encoder/src/schema_def.rs
@@ -15,9 +15,9 @@ use crate::StringValue;
 /// use indoc::indoc;
 ///
 /// let mut schema_def = SchemaDef::new();
-/// schema_def.query("TryingToFindCatQuery".to_string());
-/// schema_def.mutation("MyMutation".to_string());
-/// schema_def.subscription("MySubscription".to_string());
+/// schema_def.query("TryingToFindCatQuery");
+/// schema_def.mutation("MyMutation");
+/// schema_def.subscription("MySubscription");
 ///
 /// assert_eq!(
 ///    schema_def.to_string(),
@@ -111,10 +111,13 @@ mod tests {
 
     #[test]
     fn it_encodes_schema_with_mutation_and_subscription() {
-        let mut schema_def = SchemaDef::new();
-        schema_def.query("TryingToFindCatQuery".to_string());
-        schema_def.mutation("MyMutation".to_string());
-        schema_def.subscription("MySubscription".to_string());
+        let schema_def = {
+            let mut schema_def = SchemaDef::new();
+            schema_def.query("TryingToFindCatQuery");
+            schema_def.mutation("MyMutation");
+            schema_def.subscription("MySubscription");
+            schema_def
+        };
 
         assert_eq!(
             schema_def.to_string(),

--- a/crates/apollo-encoder/src/string_value.rs
+++ b/crates/apollo-encoder/src/string_value.rs
@@ -85,9 +85,10 @@ impl fmt::Display for StringValue {
 fn is_block_string_character(s: &str) -> bool {
     s.contains('\n') || s.contains('"') || s.contains('\r')
 }
+
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::StringValue;
     use pretty_assertions::assert_eq;
 
     #[test]

--- a/crates/apollo-encoder/src/union_def.rs
+++ b/crates/apollo-encoder/src/union_def.rs
@@ -13,9 +13,9 @@ use crate::StringValue;
 /// ```rust
 /// use apollo_encoder::{UnionDef};
 ///
-/// let mut union_ = UnionDef::new("Pet".to_string());
-/// union_.member("Cat".to_string());
-/// union_.member("Dog".to_string());
+/// let mut union_ = UnionDef::new("Pet");
+/// union_.member("Cat");
+/// union_.member("Dog");
 ///
 /// assert_eq!(
 ///     union_.to_string(),
@@ -81,10 +81,13 @@ mod tests {
 
     #[test]
     fn it_encodes_union_with_description() {
-        let mut union_ = UnionDef::new("Pet".to_string());
-        union_.description(Some("A union of all animals in a household.".to_string()));
-        union_.member("Cat".to_string());
-        union_.member("Dog".to_string());
+        let union_ = {
+            let mut union_ = UnionDef::new("Pet");
+            union_.description("A union of all animals in a household.");
+            union_.member("Cat");
+            union_.member("Dog");
+            union_
+        };
 
         assert_eq!(
             union_.to_string(),

--- a/crates/apollo-encoder/src/union_def.rs
+++ b/crates/apollo-encoder/src/union_def.rs
@@ -8,21 +8,6 @@ use crate::StringValue;
 ///     Description? **union** Name Directives? UnionDefMemberTypes?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-UnionDef).
-///
-/// ### Example
-/// ```rust
-/// use apollo_encoder::{UnionDef};
-///
-/// let mut union_ = UnionDef::new("Pet");
-/// union_.member("Cat");
-/// union_.member("Dog");
-///
-/// assert_eq!(
-///     union_.to_string(),
-/// r#"union Pet = Cat | Dog
-/// "#
-/// );
-/// ```
 #[derive(Debug, PartialEq, Clone)]
 pub struct UnionDef {
     // Name must return a String.
@@ -33,6 +18,21 @@ pub struct UnionDef {
     members: Vec<String>,
 }
 
+/// ### Example
+/// ```rust
+/// use apollo_encoder::UnionDefBuilder;
+///
+/// let union_ = UnionDefBuilder::new("Pet")
+///     .member("Cat")
+///     .member("Dog")
+///     .build();
+///
+/// assert_eq!(
+///     union_.to_string(),
+/// r#"union Pet = Cat | Dog
+/// "#
+/// );
+/// ```
 #[derive(Debug, Clone)]
 pub struct UnionDefBuilder {
     // Name must return a String.
@@ -96,19 +96,17 @@ impl fmt::Display for UnionDef {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::UnionDefBuilder;
     // use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn it_encodes_union_with_description() {
-        let union_ = {
-            let mut union_ = UnionDef::new("Pet");
-            union_.description("A union of all animals in a household.");
-            union_.member("Cat");
-            union_.member("Dog");
-            union_
-        };
+        let union_ = UnionDefBuilder::new("Pet")
+            .description("A union of all animals in a household.")
+            .member("Cat")
+            .member("Dog")
+            .build();
 
         assert_eq!(
             union_.to_string(),

--- a/crates/apollo-encoder/src/union_def.rs
+++ b/crates/apollo-encoder/src/union_def.rs
@@ -33,26 +33,47 @@ pub struct UnionDef {
     members: Vec<String>,
 }
 
-impl UnionDef {
-    /// Create a new instance of a UnionDef.
+#[derive(Debug, Clone)]
+pub struct UnionDefBuilder {
+    // Name must return a String.
+    name: String,
+    // Description may return a String.
+    description: Option<String>,
+    // The vector of members that can be represented within this union.
+    members: Vec<String>,
+}
+
+impl UnionDefBuilder {
+    /// Create a new instance of a UnionDefBuilder.
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            description: StringValue::Top { source: None },
+            description: None,
             members: Vec::new(),
         }
     }
 
     /// Set the UnionDefs description.
-    pub fn description(&mut self, description: &str) {
-        self.description = StringValue::Top {
-            source: Some(description.to_string()),
-        };
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     /// Set a UnionDef member.
-    pub fn member(&mut self, member: &str) {
+    pub fn member(mut self, member: &str) -> Self {
         self.members.push(member.to_string());
+        self
+    }
+
+    /// Create a new instance of a UnionDef.
+    pub fn build(self) -> UnionDef {
+        UnionDef {
+            name: self.name,
+            description: StringValue::Top {
+                source: self.description,
+            },
+            members: self.members,
+        }
     }
 }
 

--- a/crates/apollo-encoder/src/union_def.rs
+++ b/crates/apollo-encoder/src/union_def.rs
@@ -35,24 +35,24 @@ pub struct UnionDef {
 
 impl UnionDef {
     /// Create a new instance of a UnionDef.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: &str) -> Self {
         Self {
-            name,
+            name: name.to_string(),
             description: StringValue::Top { source: None },
             members: Vec::new(),
         }
     }
 
     /// Set the UnionDefs description.
-    pub fn description(&mut self, description: Option<String>) {
+    pub fn description(&mut self, description: &str) {
         self.description = StringValue::Top {
-            source: description,
+            source: Some(description.to_string()),
         };
     }
 
     /// Set a UnionDef member.
-    pub fn member(&mut self, member: String) {
-        self.members.push(member);
+    pub fn member(&mut self, member: &str) {
+        self.members.push(member.to_string());
     }
 }
 


### PR DESCRIPTION
1. Changed String to &str for user convenience.
2. The test code has been improved to be more readable.
3. After going through the above process, the Builder Pattern looked natural, so I replaced it with the Builder Pattern.
