### PR TITLE
fix(apollo-parser): variable definition can have a LIST_TYPE

### DIFF
--- a/crates/apollo-parser/src/parser/grammar/variable.rs
+++ b/crates/apollo-parser/src/parser/grammar/variable.rs
@@ -29,7 +29,7 @@ pub(crate) fn variable_definition(p: &mut Parser, is_variable: bool) {
 
         if let Some(T![:]) = p.peek() {
             p.bump(S![:]);
-            if let Some(TokenKind::Name) = p.peek() {
+            if let Some(TokenKind::Name | TokenKind::LBracket) = p.peek() {
                 ty::ty(p);
                 if let Some(T![=]) = p.peek() {
                     value::default_value(p);

--- a/crates/apollo-parser/test_data/parser/ok/0036_parses_variable_definition_with_list_type.graphql
+++ b/crates/apollo-parser/test_data/parser/ok/0036_parses_variable_definition_with_list_type.graphql
@@ -1,0 +1,4 @@
+query ($height: [Int]) {
+    id
+    trees(height: $height)
+}

--- a/crates/apollo-parser/test_data/parser/ok/0036_parses_variable_definition_with_list_type.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0036_parses_variable_definition_with_list_type.txt
@@ -1,0 +1,46 @@
+- DOCUMENT@0..60
+    - OPERATION_DEFINITION@0..60
+        - OPERATION_TYPE@0..6
+            - query_KW@0..5 "query"
+            - WHITESPACE@5..6 " "
+        - VARIABLE_DEFINITIONS@6..23
+            - L_PAREN@6..7 "("
+            - VARIABLE_DEFINITION@7..21
+                - VARIABLE@7..14
+                    - DOLLAR@7..8 "$"
+                    - NAME@8..14
+                        - IDENT@8..14 "height"
+                - COLON@14..15 ":"
+                - WHITESPACE@15..16 " "
+                - LIST_TYPE@16..21
+                    - L_BRACK@16..17 "["
+                    - NAMED_TYPE@17..20
+                        - NAME@17..20
+                            - IDENT@17..20 "Int"
+                    - R_BRACK@20..21 "]"
+            - R_PAREN@21..22 ")"
+            - WHITESPACE@22..23 " "
+        - SELECTION_SET@23..60
+            - L_CURLY@23..24 "{"
+            - WHITESPACE@24..29 "\n    "
+            - FIELD@29..36
+                - NAME@29..36
+                    - IDENT@29..31 "id"
+                    - WHITESPACE@31..36 "\n    "
+            - FIELD@36..59
+                - NAME@36..41
+                    - IDENT@36..41 "trees"
+                - ARGUMENTS@41..59
+                    - L_PAREN@41..42 "("
+                    - ARGUMENT@42..57
+                        - NAME@42..48
+                            - IDENT@42..48 "height"
+                        - COLON@48..49 ":"
+                        - WHITESPACE@49..50 " "
+                        - VARIABLE@50..57
+                            - DOLLAR@50..51 "$"
+                            - NAME@51..57
+                                - IDENT@51..57 "height"
+                    - R_PAREN@57..58 ")"
+                    - WHITESPACE@58..59 "\n"
+            - R_CURLY@59..60 "}"


### PR DESCRIPTION
fixes #131

Variable definition was previously not accepting a LIST_TYPE, which is incorrect. This commit fixes this issue.