### PR TITLE
fix(apollo-parser): bump BANG token when creating NON_NULL_TYPE

### DIFF
--- a/crates/apollo-parser/examples/annotate_snippet.rs
+++ b/crates/apollo-parser/examples/annotate_snippet.rs
@@ -27,7 +27,7 @@ fn parse_schema() -> ast::Document {
     // each err comes with the two pieces of data you need for diagnostics:
     // - message (err.message())
     // - index (err.index())
-    for err in ast.errors().into_iter() {
+    for err in ast.errors() {
         let snippet = Snippet {
             title: Some(Annotation {
                 label: Some(err.message()),

--- a/crates/apollo-parser/test_data/parser/err/0010_input_definition_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0010_input_definition_with_missing_name.txt
@@ -1,8 +1,8 @@
-- DOCUMENT@0..34
-    - INPUT_OBJECT_TYPE_DEFINITION@0..34
+- DOCUMENT@0..35
+    - INPUT_OBJECT_TYPE_DEFINITION@0..35
         - input_KW@0..5 "input"
         - WHITESPACE@5..6 " "
-        - INPUT_FIELDS_DEFINITION@6..34
+        - INPUT_FIELDS_DEFINITION@6..35
             - L_CURLY@6..7 "{"
             - WHITESPACE@7..12 "\n    "
             - INPUT_VALUE_DEFINITION@12..26
@@ -14,15 +14,16 @@
                     - WHITESPACE@15..20 "\n    "
                     - NAME@20..26
                         - IDENT@20..26 "String"
-            - INPUT_VALUE_DEFINITION@26..33
+            - INPUT_VALUE_DEFINITION@26..34
                 - NAME@26..27
                     - IDENT@26..27 "b"
                 - COLON@27..28 ":"
                 - WHITESPACE@28..29 " "
-                - NON_NULL_TYPE@29..33
+                - NON_NULL_TYPE@29..34
                     - WHITESPACE@29..30 "\n"
                     - NAMED_TYPE@30..33
                         - NAME@30..33
                             - IDENT@30..33 "Int"
-            - R_CURLY@33..34 "}"
+                    - BANG@33..34 "!"
+            - R_CURLY@34..35 "}"
 - ERROR@6:7 "expected a Name" {

--- a/crates/apollo-parser/test_data/parser/ok/0014_input_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0014_input_definition.txt
@@ -1,11 +1,11 @@
-- DOCUMENT@0..53
-    - INPUT_OBJECT_TYPE_DEFINITION@0..53
+- DOCUMENT@0..54
+    - INPUT_OBJECT_TYPE_DEFINITION@0..54
         - input_KW@0..5 "input"
         - WHITESPACE@5..6 " "
         - NAME@6..25
             - IDENT@6..24 "ExampleInputObject"
             - WHITESPACE@24..25 " "
-        - INPUT_FIELDS_DEFINITION@25..53
+        - INPUT_FIELDS_DEFINITION@25..54
             - L_CURLY@25..26 "{"
             - WHITESPACE@26..31 "\n    "
             - INPUT_VALUE_DEFINITION@31..45
@@ -17,14 +17,15 @@
                     - WHITESPACE@34..39 "\n    "
                     - NAME@39..45
                         - IDENT@39..45 "String"
-            - INPUT_VALUE_DEFINITION@45..52
+            - INPUT_VALUE_DEFINITION@45..53
                 - NAME@45..46
                     - IDENT@45..46 "b"
                 - COLON@46..47 ":"
                 - WHITESPACE@47..48 " "
-                - NON_NULL_TYPE@48..52
+                - NON_NULL_TYPE@48..53
                     - WHITESPACE@48..49 "\n"
                     - NAMED_TYPE@49..52
                         - NAME@49..52
                             - IDENT@49..52 "Int"
-            - R_CURLY@52..53 "}"
+                    - BANG@52..53 "!"
+            - R_CURLY@53..54 "}"

--- a/crates/apollo-parser/test_data/parser/ok/0032_supergraph.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0032_supergraph.txt
@@ -1,4 +1,4 @@
-- DOCUMENT@0..7448
+- DOCUMENT@0..7494
     - SCHEMA_DEFINITION@0..155
         - schema_KW@0..6 "schema"
         - WHITESPACE@6..7 "\n"
@@ -56,3489 +56,3506 @@
                     - WHITESPACE@151..152 "\n"
         - R_CURLY@152..153 "}"
         - WHITESPACE@153..155 "\n\n"
-    - DIRECTIVE_DEFINITION@155..209
+    - DIRECTIVE_DEFINITION@155..210
         - directive_KW@155..164 "directive"
         - WHITESPACE@164..165 " "
         - AT@165..166 "@"
         - NAME@166..170
             - IDENT@166..170 "core"
-        - ARGUMENTS_DEFINITION@170..188
+        - ARGUMENTS_DEFINITION@170..189
             - L_PAREN@170..171 "("
-            - INPUT_VALUE_DEFINITION@171..186
+            - INPUT_VALUE_DEFINITION@171..187
                 - NAME@171..178
                     - IDENT@171..178 "feature"
                 - COLON@178..179 ":"
                 - WHITESPACE@179..180 " "
-                - NON_NULL_TYPE@180..186
+                - NON_NULL_TYPE@180..187
                     - NAMED_TYPE@180..186
                         - NAME@180..186
                             - IDENT@180..186 "String"
-            - R_PAREN@186..187 ")"
-            - WHITESPACE@187..188 " "
-        - repeatable_KW@188..198 "repeatable"
-        - WHITESPACE@198..199 " "
-        - on_KW@199..201 "on"
-        - WHITESPACE@201..202 " "
-        - DIRECTIVE_LOCATIONS@202..209
-            - DIRECTIVE_LOCATION@202..209
-                - SCHEMA_KW@202..208 "SCHEMA"
-                - WHITESPACE@208..209 "\n"
-    - DIRECTIVE_DEFINITION@209..324
-        - directive_KW@209..218 "directive"
-        - WHITESPACE@218..219 " "
-        - AT@219..220 "@"
-        - NAME@220..231
-            - IDENT@220..231 "join__field"
-        - ARGUMENTS_DEFINITION@231..304
-            - L_PAREN@231..232 "("
-            - INPUT_VALUE_DEFINITION@232..252
-                - NAME@232..237
-                    - IDENT@232..237 "graph"
-                - COLON@237..238 ":"
-                - WHITESPACE@238..239 " "
-                - NAMED_TYPE@239..252
-                    - COMMA@239..240 ","
-                    - WHITESPACE@240..241 " "
-                    - NAME@241..252
-                        - IDENT@241..252 "join__Graph"
-            - INPUT_VALUE_DEFINITION@252..278
-                - NAME@252..260
-                    - IDENT@252..260 "requires"
-                - COLON@260..261 ":"
-                - WHITESPACE@261..262 " "
-                - NAMED_TYPE@262..278
-                    - COMMA@262..263 ","
-                    - WHITESPACE@263..264 " "
-                    - NAME@264..278
-                        - IDENT@264..278 "join__FieldSet"
-            - INPUT_VALUE_DEFINITION@278..302
-                - NAME@278..286
-                    - IDENT@278..286 "provides"
-                - COLON@286..287 ":"
-                - WHITESPACE@287..288 " "
-                - NAMED_TYPE@288..302
-                    - NAME@288..302
-                        - IDENT@288..302 "join__FieldSet"
-            - R_PAREN@302..303 ")"
-            - WHITESPACE@303..304 " "
-        - on_KW@304..306 "on"
-        - WHITESPACE@306..307 " "
-        - DIRECTIVE_LOCATIONS@307..324
-            - DIRECTIVE_LOCATION@307..324
-                - FIELD_DEFINITION_KW@307..323 "FIELD_DEFINITION"
-                - WHITESPACE@323..324 "\n"
-    - DIRECTIVE_DEFINITION@324..420
-        - directive_KW@324..333 "directive"
-        - WHITESPACE@333..334 " "
-        - AT@334..335 "@"
-        - NAME@335..345
-            - IDENT@335..345 "join__type"
-        - ARGUMENTS_DEFINITION@345..387
-            - L_PAREN@345..346 "("
-            - INPUT_VALUE_DEFINITION@346..366
-                - NAME@346..351
-                    - IDENT@346..351 "graph"
-                - COLON@351..352 ":"
-                - WHITESPACE@352..353 " "
-                - NON_NULL_TYPE@353..366
-                    - COMMA@353..354 ","
-                    - WHITESPACE@354..355 " "
-                    - NAMED_TYPE@355..366
-                        - NAME@355..366
-                            - IDENT@355..366 "join__Graph"
-            - INPUT_VALUE_DEFINITION@366..385
-                - NAME@366..369
-                    - IDENT@366..369 "key"
-                - COLON@369..370 ":"
-                - WHITESPACE@370..371 " "
-                - NAMED_TYPE@371..385
-                    - NAME@371..385
-                        - IDENT@371..385 "join__FieldSet"
-            - R_PAREN@385..386 ")"
-            - WHITESPACE@386..387 " "
-        - repeatable_KW@387..397 "repeatable"
-        - WHITESPACE@397..398 " "
-        - on_KW@398..400 "on"
-        - WHITESPACE@400..401 " "
-        - DIRECTIVE_LOCATIONS@401..420
-            - DIRECTIVE_LOCATION@401..408
-                - OBJECT_KW@401..407 "OBJECT"
-                - WHITESPACE@407..408 " "
-            - PIPE@408..409 "|"
-            - WHITESPACE@409..410 " "
-            - DIRECTIVE_LOCATION@410..420
-                - INTERFACE_KW@410..419 "INTERFACE"
-                - WHITESPACE@419..420 "\n"
-    - DIRECTIVE_DEFINITION@420..485
-        - directive_KW@420..429 "directive"
-        - WHITESPACE@429..430 " "
-        - AT@430..431 "@"
-        - NAME@431..442
-            - IDENT@431..442 "join__owner"
-        - ARGUMENTS_DEFINITION@442..463
-            - L_PAREN@442..443 "("
-            - INPUT_VALUE_DEFINITION@443..461
-                - NAME@443..448
-                    - IDENT@443..448 "graph"
-                - COLON@448..449 ":"
-                - WHITESPACE@449..450 " "
-                - NON_NULL_TYPE@450..461
-                    - NAMED_TYPE@450..461
-                        - NAME@450..461
-                            - IDENT@450..461 "join__Graph"
-            - R_PAREN@461..462 ")"
-            - WHITESPACE@462..463 " "
-        - on_KW@463..465 "on"
-        - WHITESPACE@465..466 " "
-        - DIRECTIVE_LOCATIONS@466..485
-            - DIRECTIVE_LOCATION@466..473
-                - OBJECT_KW@466..472 "OBJECT"
-                - WHITESPACE@472..473 " "
-            - PIPE@473..474 "|"
-            - WHITESPACE@474..475 " "
-            - DIRECTIVE_LOCATION@475..485
-                - INTERFACE_KW@475..484 "INTERFACE"
-                - WHITESPACE@484..485 "\n"
-    - DIRECTIVE_DEFINITION@485..549
-        - directive_KW@485..494 "directive"
-        - WHITESPACE@494..495 " "
-        - AT@495..496 "@"
-        - NAME@496..507
-            - IDENT@496..507 "join__graph"
-        - ARGUMENTS_DEFINITION@507..535
-            - L_PAREN@507..508 "("
-            - INPUT_VALUE_DEFINITION@508..522
-                - NAME@508..512
-                    - IDENT@508..512 "name"
-                - COLON@512..513 ":"
-                - WHITESPACE@513..514 " "
-                - NON_NULL_TYPE@514..522
-                    - COMMA@514..515 ","
-                    - WHITESPACE@515..516 " "
-                    - NAMED_TYPE@516..522
-                        - NAME@516..522
-                            - IDENT@516..522 "String"
-            - INPUT_VALUE_DEFINITION@522..533
-                - NAME@522..525
-                    - IDENT@522..525 "url"
-                - COLON@525..526 ":"
-                - WHITESPACE@526..527 " "
-                - NON_NULL_TYPE@527..533
-                    - NAMED_TYPE@527..533
-                        - NAME@527..533
-                            - IDENT@527..533 "String"
-            - R_PAREN@533..534 ")"
-            - WHITESPACE@534..535 " "
-        - on_KW@535..537 "on"
-        - WHITESPACE@537..538 " "
-        - DIRECTIVE_LOCATIONS@538..549
-            - DIRECTIVE_LOCATION@538..549
-                - ENUM_VALUE_KW@538..548 "ENUM_VALUE"
-                - WHITESPACE@548..549 "\n"
-    - DIRECTIVE_DEFINITION@549..576
-        - directive_KW@549..558 "directive"
-        - WHITESPACE@558..559 " "
-        - AT@559..560 "@"
-        - NAME@560..567
-            - IDENT@560..566 "stream"
-            - WHITESPACE@566..567 " "
-        - on_KW@567..569 "on"
-        - WHITESPACE@569..570 " "
-        - DIRECTIVE_LOCATIONS@570..576
-            - DIRECTIVE_LOCATION@570..576
-                - FIELD_KW@570..575 "FIELD"
-                - WHITESPACE@575..576 "\n"
-    - DIRECTIVE_DEFINITION@576..621
-        - directive_KW@576..585 "directive"
-        - WHITESPACE@585..586 " "
-        - AT@586..587 "@"
-        - NAME@587..596
-            - IDENT@587..596 "transform"
-        - ARGUMENTS_DEFINITION@596..611
-            - L_PAREN@596..597 "("
-            - INPUT_VALUE_DEFINITION@597..609
-                - NAME@597..601
-                    - IDENT@597..601 "from"
-                - COLON@601..602 ":"
-                - WHITESPACE@602..603 " "
-                - NON_NULL_TYPE@603..609
-                    - NAMED_TYPE@603..609
-                        - NAME@603..609
-                            - IDENT@603..609 "String"
-            - R_PAREN@609..610 ")"
-            - WHITESPACE@610..611 " "
-        - on_KW@611..613 "on"
-        - WHITESPACE@613..614 " "
-        - DIRECTIVE_LOCATIONS@614..621
-            - DIRECTIVE_LOCATION@614..621
-                - FIELD_KW@614..619 "FIELD"
-                - WHITESPACE@619..621 "\n\n"
-    - UNION_TYPE_DEFINITION@621..671
-        - union_KW@621..626 "union"
-        - WHITESPACE@626..627 " "
-        - NAME@627..639
-            - IDENT@627..638 "AccountType"
-            - WHITESPACE@638..639 " "
-        - UNION_MEMBER_TYPES@639..671
-            - EQ@639..640 "="
-            - WHITESPACE@640..641 " "
-            - NAMED_TYPE@641..657
-                - NAME@641..657
-                    - IDENT@641..656 "PasswordAccount"
-                    - WHITESPACE@656..657 " "
-            - PIPE@657..658 "|"
-            - WHITESPACE@658..659 " "
-            - NAMED_TYPE@659..671
-                - NAME@659..671
-                    - IDENT@659..669 "SMSAccount"
-                    - WHITESPACE@669..671 "\n\n"
-    - OBJECT_TYPE_DEFINITION@671..707
-        - type_KW@671..675 "type"
-        - WHITESPACE@675..676 " "
-        - NAME@676..683
-            - IDENT@676..682 "Amazon"
-            - WHITESPACE@682..683 " "
-        - FIELDS_DEFINITION@683..707
-            - L_CURLY@683..684 "{"
-            - WHITESPACE@684..687 "\n  "
-            - FIELD_DEFINITION@687..704
-                - NAME@687..695
-                    - IDENT@687..695 "referrer"
-                - COLON@695..696 ":"
-                - WHITESPACE@696..697 " "
-                - NAMED_TYPE@697..704
-                    - WHITESPACE@697..698 "\n"
-                    - NAME@698..704
-                        - IDENT@698..704 "String"
-            - R_CURLY@704..705 "}"
-            - WHITESPACE@705..707 "\n\n"
-    - UNION_TYPE_DEFINITION@707..734
-        - union_KW@707..712 "union"
-        - WHITESPACE@712..713 " "
-        - NAME@713..718
-            - IDENT@713..717 "Body"
-            - WHITESPACE@717..718 " "
-        - UNION_MEMBER_TYPES@718..734
-            - EQ@718..719 "="
-            - WHITESPACE@719..720 " "
-            - NAMED_TYPE@720..726
-                - NAME@720..726
-                    - IDENT@720..725 "Image"
-                    - WHITESPACE@725..726 " "
-            - PIPE@726..727 "|"
-            - WHITESPACE@727..728 " "
-            - NAMED_TYPE@728..734
-                - NAME@728..734
-                    - IDENT@728..732 "Text"
-                    - WHITESPACE@732..734 "\n\n"
-    - OBJECT_TYPE_DEFINITION@734..1715
-        - type_KW@734..738 "type"
-        - WHITESPACE@738..739 " "
-        - NAME@739..744
-            - IDENT@739..743 "Book"
-            - WHITESPACE@743..744 " "
-        - IMPLEMENTS_INTERFACES@744..763
-            - implements_KW@744..754 "implements"
-            - WHITESPACE@754..755 " "
-            - NAMED_TYPE@755..763
-                - NAME@755..763
-                    - IDENT@755..762 "Product"
-                    - WHITESPACE@762..763 "\n"
-        - DIRECTIVES@763..954
-            - DIRECTIVE@763..790
-                - AT@763..764 "@"
-                - NAME@764..775
-                    - IDENT@764..775 "join__owner"
-                - ARGUMENTS@775..790
-                    - L_PAREN@775..776 "("
-                    - ARGUMENT@776..788
-                        - NAME@776..781
-                            - IDENT@776..781 "graph"
-                        - COLON@781..782 ":"
-                        - WHITESPACE@782..783 " "
-                        - ENUM_VALUE@783..788
-                            - NAME@783..788
-                                - IDENT@783..788 "BOOKS"
-                    - R_PAREN@788..789 ")"
-                    - WHITESPACE@789..790 "\n"
-            - DIRECTIVE@790..829
-                - AT@790..791 "@"
-                - NAME@791..801
-                    - IDENT@791..801 "join__type"
-                - ARGUMENTS@801..829
-                    - L_PAREN@801..802 "("
-                    - ARGUMENT@802..816
-                        - NAME@802..807
-                            - IDENT@802..807 "graph"
-                        - COLON@807..808 ":"
-                        - WHITESPACE@808..809 " "
-                        - ENUM_VALUE@809..816
-                            - NAME@809..816
-                                - IDENT@809..814 "BOOKS"
-                                - COMMA@814..815 ","
-                                - WHITESPACE@815..816 " "
-                    - ARGUMENT@816..827
-                        - NAME@816..819
-                            - IDENT@816..819 "key"
-                        - COLON@819..820 ":"
-                        - WHITESPACE@820..821 " "
-                        - STRING_VALUE@821..827
-                            - STRING@821..827 "\"isbn\""
-                    - R_PAREN@827..828 ")"
-                    - WHITESPACE@828..829 "\n"
-            - DIRECTIVE@829..872
-                - AT@829..830 "@"
-                - NAME@830..840
-                    - IDENT@830..840 "join__type"
-                - ARGUMENTS@840..872
-                    - L_PAREN@840..841 "("
-                    - ARGUMENT@841..859
-                        - NAME@841..846
-                            - IDENT@841..846 "graph"
-                        - COLON@846..847 ":"
-                        - WHITESPACE@847..848 " "
-                        - ENUM_VALUE@848..859
-                            - NAME@848..859
-                                - IDENT@848..857 "INVENTORY"
-                                - COMMA@857..858 ","
-                                - WHITESPACE@858..859 " "
-                    - ARGUMENT@859..870
-                        - NAME@859..862
-                            - IDENT@859..862 "key"
-                        - COLON@862..863 ":"
-                        - WHITESPACE@863..864 " "
-                        - STRING_VALUE@864..870
-                            - STRING@864..870 "\"isbn\""
-                    - R_PAREN@870..871 ")"
-                    - WHITESPACE@871..872 "\n"
-            - DIRECTIVE@872..913
-                - AT@872..873 "@"
-                - NAME@873..883
-                    - IDENT@873..883 "join__type"
-                - ARGUMENTS@883..913
-                    - L_PAREN@883..884 "("
-                    - ARGUMENT@884..900
-                        - NAME@884..889
-                            - IDENT@884..889 "graph"
-                        - COLON@889..890 ":"
-                        - WHITESPACE@890..891 " "
-                        - ENUM_VALUE@891..900
-                            - NAME@891..900
-                                - IDENT@891..898 "PRODUCT"
-                                - COMMA@898..899 ","
-                                - WHITESPACE@899..900 " "
-                    - ARGUMENT@900..911
-                        - NAME@900..903
-                            - IDENT@900..903 "key"
-                        - COLON@903..904 ":"
-                        - WHITESPACE@904..905 " "
-                        - STRING_VALUE@905..911
-                            - STRING@905..911 "\"isbn\""
-                    - R_PAREN@911..912 ")"
-                    - WHITESPACE@912..913 "\n"
-            - DIRECTIVE@913..954
-                - AT@913..914 "@"
-                - NAME@914..924
-                    - IDENT@914..924 "join__type"
-                - ARGUMENTS@924..954
-                    - L_PAREN@924..925 "("
-                    - ARGUMENT@925..941
-                        - NAME@925..930
-                            - IDENT@925..930 "graph"
-                        - COLON@930..931 ":"
-                        - WHITESPACE@931..932 " "
-                        - ENUM_VALUE@932..941
-                            - NAME@932..941
-                                - IDENT@932..939 "REVIEWS"
-                                - COMMA@939..940 ","
-                                - WHITESPACE@940..941 " "
-                    - ARGUMENT@941..952
-                        - NAME@941..944
-                            - IDENT@941..944 "key"
-                        - COLON@944..945 ":"
-                        - WHITESPACE@945..946 " "
-                        - STRING_VALUE@946..952
-                            - STRING@946..952 "\"isbn\""
-                    - R_PAREN@952..953 ")"
-                    - WHITESPACE@953..954 "\n"
-        - FIELDS_DEFINITION@954..1715
-            - L_CURLY@954..955 "{"
-            - WHITESPACE@955..958 "\n  "
-            - FIELD_DEFINITION@958..1000
-                - NAME@958..962
-                    - IDENT@958..962 "isbn"
-                - COLON@962..963 ":"
-                - WHITESPACE@963..964 " "
-                - NON_NULL_TYPE@964..971
-                    - WHITESPACE@964..965 " "
-                    - NAMED_TYPE@965..971
-                        - NAME@965..971
-                            - IDENT@965..971 "String"
-                - DIRECTIVES@971..1000
-                    - DIRECTIVE@971..1000
-                        - AT@971..972 "@"
-                        - NAME@972..983
-                            - IDENT@972..983 "join__field"
-                        - ARGUMENTS@983..1000
-                            - L_PAREN@983..984 "("
-                            - ARGUMENT@984..996
-                                - NAME@984..989
-                                    - IDENT@984..989 "graph"
-                                - COLON@989..990 ":"
-                                - WHITESPACE@990..991 " "
-                                - ENUM_VALUE@991..996
-                                    - NAME@991..996
-                                        - IDENT@991..996 "BOOKS"
-                            - R_PAREN@996..997 ")"
-                            - WHITESPACE@997..1000 "\n  "
-            - FIELD_DEFINITION@1000..1043
-                - NAME@1000..1005
-                    - IDENT@1000..1005 "title"
-                - COLON@1005..1006 ":"
-                - WHITESPACE@1006..1007 " "
-                - NAMED_TYPE@1007..1014
-                    - WHITESPACE@1007..1008 " "
-                    - NAME@1008..1014
-                        - IDENT@1008..1014 "String"
-                - DIRECTIVES@1014..1043
-                    - DIRECTIVE@1014..1043
-                        - AT@1014..1015 "@"
-                        - NAME@1015..1026
-                            - IDENT@1015..1026 "join__field"
-                        - ARGUMENTS@1026..1043
-                            - L_PAREN@1026..1027 "("
-                            - ARGUMENT@1027..1039
-                                - NAME@1027..1032
-                                    - IDENT@1027..1032 "graph"
-                                - COLON@1032..1033 ":"
-                                - WHITESPACE@1033..1034 " "
-                                - ENUM_VALUE@1034..1039
-                                    - NAME@1034..1039
-                                        - IDENT@1034..1039 "BOOKS"
-                            - R_PAREN@1039..1040 ")"
-                            - WHITESPACE@1040..1043 "\n  "
-            - FIELD_DEFINITION@1043..1082
-                - NAME@1043..1047
-                    - IDENT@1043..1047 "year"
-                - COLON@1047..1048 ":"
-                - WHITESPACE@1048..1049 " "
-                - NAMED_TYPE@1049..1053
-                    - WHITESPACE@1049..1050 " "
-                    - NAME@1050..1053
-                        - IDENT@1050..1053 "Int"
-                - DIRECTIVES@1053..1082
-                    - DIRECTIVE@1053..1082
-                        - AT@1053..1054 "@"
-                        - NAME@1054..1065
-                            - IDENT@1054..1065 "join__field"
-                        - ARGUMENTS@1065..1082
-                            - L_PAREN@1065..1066 "("
-                            - ARGUMENT@1066..1078
-                                - NAME@1066..1071
-                                    - IDENT@1066..1071 "graph"
-                                - COLON@1071..1072 ":"
-                                - WHITESPACE@1072..1073 " "
-                                - ENUM_VALUE@1073..1078
-                                    - NAME@1073..1078
-                                        - IDENT@1073..1078 "BOOKS"
-                            - R_PAREN@1078..1079 ")"
-                            - WHITESPACE@1079..1082 "\n  "
-            - FIELD_DEFINITION@1082..1132
-                - NAME@1082..1094
-                    - IDENT@1082..1094 "similarBooks"
-                - COLON@1094..1095 ":"
-                - WHITESPACE@1095..1096 " "
-                - NON_NULL_TYPE@1096..1103
-                    - WHITESPACE@1096..1097 " "
-                    - LIST_TYPE@1097..1103
-                        - L_BRACK@1097..1098 "["
-                        - NAMED_TYPE@1098..1102
-                            - NAME@1098..1102
-                                - IDENT@1098..1102 "Book"
-                        - R_BRACK@1102..1103 "]"
-                - DIRECTIVES@1103..1132
-                    - DIRECTIVE@1103..1132
-                        - AT@1103..1104 "@"
-                        - NAME@1104..1115
-                            - IDENT@1104..1115 "join__field"
-                        - ARGUMENTS@1115..1132
-                            - L_PAREN@1115..1116 "("
-                            - ARGUMENT@1116..1128
-                                - NAME@1116..1121
-                                    - IDENT@1116..1121 "graph"
-                                - COLON@1121..1122 ":"
-                                - WHITESPACE@1122..1123 " "
-                                - ENUM_VALUE@1123..1128
-                                    - NAME@1123..1128
-                                        - IDENT@1123..1128 "BOOKS"
-                            - R_PAREN@1128..1129 ")"
-                            - WHITESPACE@1129..1132 "\n  "
-            - FIELD_DEFINITION@1132..1189
-                - NAME@1132..1140
-                    - IDENT@1132..1140 "metadata"
-                - COLON@1140..1141 ":"
-                - WHITESPACE@1141..1142 " "
-                - LIST_TYPE@1142..1160
-                    - WHITESPACE@1142..1143 " "
-                    - L_BRACK@1143..1144 "["
-                    - NAMED_TYPE@1144..1159
-                        - NAME@1144..1159
-                            - IDENT@1144..1159 "MetadataOrError"
-                    - R_BRACK@1159..1160 "]"
-                - DIRECTIVES@1160..1189
-                    - DIRECTIVE@1160..1189
-                        - AT@1160..1161 "@"
-                        - NAME@1161..1172
-                            - IDENT@1161..1172 "join__field"
-                        - ARGUMENTS@1172..1189
-                            - L_PAREN@1172..1173 "("
-                            - ARGUMENT@1173..1185
-                                - NAME@1173..1178
-                                    - IDENT@1173..1178 "graph"
-                                - COLON@1178..1179 ":"
-                                - WHITESPACE@1179..1180 " "
-                                - ENUM_VALUE@1180..1185
-                                    - NAME@1180..1185
-                                        - IDENT@1180..1185 "BOOKS"
-                            - R_PAREN@1185..1186 ")"
-                            - WHITESPACE@1186..1189 "\n  "
-            - FIELD_DEFINITION@1189..1239
-                - NAME@1189..1196
-                    - IDENT@1189..1196 "inStock"
-                - COLON@1196..1197 ":"
-                - WHITESPACE@1197..1198 " "
-                - NAMED_TYPE@1198..1206
-                    - WHITESPACE@1198..1199 " "
-                    - NAME@1199..1206
-                        - IDENT@1199..1206 "Boolean"
-                - DIRECTIVES@1206..1239
-                    - DIRECTIVE@1206..1239
-                        - AT@1206..1207 "@"
-                        - NAME@1207..1218
-                            - IDENT@1207..1218 "join__field"
-                        - ARGUMENTS@1218..1239
-                            - L_PAREN@1218..1219 "("
-                            - ARGUMENT@1219..1235
-                                - NAME@1219..1224
-                                    - IDENT@1219..1224 "graph"
-                                - COLON@1224..1225 ":"
-                                - WHITESPACE@1225..1226 " "
-                                - ENUM_VALUE@1226..1235
-                                    - NAME@1226..1235
-                                        - IDENT@1226..1235 "INVENTORY"
-                            - R_PAREN@1235..1236 ")"
-                            - WHITESPACE@1236..1239 "\n  "
-            - FIELD_DEFINITION@1239..1294
-                - NAME@1239..1251
-                    - IDENT@1239..1251 "isCheckedOut"
-                - COLON@1251..1252 ":"
-                - WHITESPACE@1252..1253 " "
-                - NAMED_TYPE@1253..1261
-                    - WHITESPACE@1253..1254 " "
-                    - NAME@1254..1261
-                        - IDENT@1254..1261 "Boolean"
-                - DIRECTIVES@1261..1294
-                    - DIRECTIVE@1261..1294
-                        - AT@1261..1262 "@"
-                        - NAME@1262..1273
-                            - IDENT@1262..1273 "join__field"
-                        - ARGUMENTS@1273..1294
-                            - L_PAREN@1273..1274 "("
-                            - ARGUMENT@1274..1290
-                                - NAME@1274..1279
-                                    - IDENT@1274..1279 "graph"
-                                - COLON@1279..1280 ":"
-                                - WHITESPACE@1280..1281 " "
-                                - ENUM_VALUE@1281..1290
-                                    - NAME@1281..1290
-                                        - IDENT@1281..1290 "INVENTORY"
-                            - R_PAREN@1290..1291 ")"
-                            - WHITESPACE@1291..1294 "\n  "
-            - FIELD_DEFINITION@1294..1337
-                - NAME@1294..1297
-                    - IDENT@1294..1297 "upc"
-                - COLON@1297..1298 ":"
-                - WHITESPACE@1298..1299 " "
-                - NON_NULL_TYPE@1299..1306
-                    - WHITESPACE@1299..1300 " "
-                    - NAMED_TYPE@1300..1306
-                        - NAME@1300..1306
-                            - IDENT@1300..1306 "String"
-                - DIRECTIVES@1306..1337
-                    - DIRECTIVE@1306..1337
-                        - AT@1306..1307 "@"
-                        - NAME@1307..1318
-                            - IDENT@1307..1318 "join__field"
-                        - ARGUMENTS@1318..1337
-                            - L_PAREN@1318..1319 "("
-                            - ARGUMENT@1319..1333
-                                - NAME@1319..1324
-                                    - IDENT@1319..1324 "graph"
-                                - COLON@1324..1325 ":"
-                                - WHITESPACE@1325..1326 " "
-                                - ENUM_VALUE@1326..1333
-                                    - NAME@1326..1333
-                                        - IDENT@1326..1333 "PRODUCT"
-                            - R_PAREN@1333..1334 ")"
-                            - WHITESPACE@1334..1337 "\n  "
-            - FIELD_DEFINITION@1337..1380
-                - NAME@1337..1340
-                    - IDENT@1337..1340 "sku"
-                - COLON@1340..1341 ":"
-                - WHITESPACE@1341..1342 " "
-                - NON_NULL_TYPE@1342..1349
-                    - WHITESPACE@1342..1343 " "
-                    - NAMED_TYPE@1343..1349
-                        - NAME@1343..1349
-                            - IDENT@1343..1349 "String"
-                - DIRECTIVES@1349..1380
-                    - DIRECTIVE@1349..1380
-                        - AT@1349..1350 "@"
-                        - NAME@1350..1361
-                            - IDENT@1350..1361 "join__field"
-                        - ARGUMENTS@1361..1380
-                            - L_PAREN@1361..1362 "("
-                            - ARGUMENT@1362..1376
-                                - NAME@1362..1367
-                                    - IDENT@1362..1367 "graph"
-                                - COLON@1367..1368 ":"
-                                - WHITESPACE@1368..1369 " "
-                                - ENUM_VALUE@1369..1376
-                                    - NAME@1369..1376
-                                        - IDENT@1369..1376 "PRODUCT"
-                            - R_PAREN@1376..1377 ")"
-                            - WHITESPACE@1377..1380 "\n  "
-            - FIELD_DEFINITION@1380..1473
-                - NAME@1380..1384
-                    - IDENT@1380..1384 "name"
-                - ARGUMENTS@1384..1409
-                    - L_PAREN@1384..1385 "("
-                    - INPUT_VALUE_DEFINITION@1385..1408
-                        - NAME@1385..1394
-                            - IDENT@1385..1394 "delimeter"
-                        - COLON@1394..1395 ":"
-                        - WHITESPACE@1395..1396 " "
-                        - NAMED_TYPE@1396..1403
-                            - WHITESPACE@1396..1397 " "
-                            - NAME@1397..1403
-                                - IDENT@1397..1403 "String"
-                        - DEFAULT_VALUE@1403..1408
-                            - EQ@1403..1404 "="
-                            - WHITESPACE@1404..1405 " "
-                            - STRING_VALUE@1405..1408
-                                - STRING@1405..1408 "\" \""
-                    - R_PAREN@1408..1409 ")"
-                - COLON@1409..1410 ":"
-                - WHITESPACE@1410..1411 " "
-                - NAMED_TYPE@1411..1418
-                    - WHITESPACE@1411..1412 " "
-                    - NAME@1412..1418
-                        - IDENT@1412..1418 "String"
-                - DIRECTIVES@1418..1473
-                    - DIRECTIVE@1418..1473
-                        - AT@1418..1419 "@"
-                        - NAME@1419..1430
-                            - IDENT@1419..1430 "join__field"
-                        - ARGUMENTS@1430..1473
-                            - L_PAREN@1430..1431 "("
-                            - ARGUMENT@1431..1447
-                                - NAME@1431..1436
-                                    - IDENT@1431..1436 "graph"
-                                - COLON@1436..1437 ":"
-                                - WHITESPACE@1437..1438 " "
-                                - ENUM_VALUE@1438..1447
-                                    - NAME@1438..1447
-                                        - IDENT@1438..1445 "PRODUCT"
-                                        - COMMA@1445..1446 ","
-                                        - WHITESPACE@1446..1447 " "
-                            - ARGUMENT@1447..1469
-                                - NAME@1447..1455
-                                    - IDENT@1447..1455 "requires"
-                                - COLON@1455..1456 ":"
-                                - WHITESPACE@1456..1457 " "
-                                - STRING_VALUE@1457..1469
-                                    - STRING@1457..1469 "\"title year\""
-                            - R_PAREN@1469..1470 ")"
-                            - WHITESPACE@1470..1473 "\n  "
-            - FIELD_DEFINITION@1473..1518
-                - NAME@1473..1478
-                    - IDENT@1473..1478 "price"
-                - COLON@1478..1479 ":"
-                - WHITESPACE@1479..1480 " "
-                - NAMED_TYPE@1480..1487
-                    - WHITESPACE@1480..1481 " "
-                    - NAME@1481..1487
-                        - IDENT@1481..1487 "String"
-                - DIRECTIVES@1487..1518
-                    - DIRECTIVE@1487..1518
-                        - AT@1487..1488 "@"
-                        - NAME@1488..1499
-                            - IDENT@1488..1499 "join__field"
-                        - ARGUMENTS@1499..1518
-                            - L_PAREN@1499..1500 "("
-                            - ARGUMENT@1500..1514
-                                - NAME@1500..1505
-                                    - IDENT@1500..1505 "graph"
-                                - COLON@1505..1506 ":"
-                                - WHITESPACE@1506..1507 " "
-                                - ENUM_VALUE@1507..1514
-                                    - NAME@1507..1514
-                                        - IDENT@1507..1514 "PRODUCT"
-                            - R_PAREN@1514..1515 ")"
-                            - WHITESPACE@1515..1518 "\n  "
-            - FIELD_DEFINITION@1518..1577
-                - NAME@1518..1525
-                    - IDENT@1518..1525 "details"
-                - COLON@1525..1526 ":"
-                - WHITESPACE@1526..1527 " "
-                - NAMED_TYPE@1527..1546
-                    - WHITESPACE@1527..1528 " "
-                    - NAME@1528..1546
-                        - IDENT@1528..1546 "ProductDetailsBook"
-                - DIRECTIVES@1546..1577
-                    - DIRECTIVE@1546..1577
-                        - AT@1546..1547 "@"
-                        - NAME@1547..1558
-                            - IDENT@1547..1558 "join__field"
-                        - ARGUMENTS@1558..1577
-                            - L_PAREN@1558..1559 "("
-                            - ARGUMENT@1559..1573
-                                - NAME@1559..1564
-                                    - IDENT@1559..1564 "graph"
-                                - COLON@1564..1565 ":"
-                                - WHITESPACE@1565..1566 " "
-                                - ENUM_VALUE@1566..1573
-                                    - NAME@1566..1573
-                                        - IDENT@1566..1573 "PRODUCT"
-                            - R_PAREN@1573..1574 ")"
-                            - WHITESPACE@1574..1577 "\n  "
-            - FIELD_DEFINITION@1577..1626
-                - NAME@1577..1584
-                    - IDENT@1577..1584 "reviews"
-                - COLON@1584..1585 ":"
-                - WHITESPACE@1585..1586 " "
-                - LIST_TYPE@1586..1595
-                    - WHITESPACE@1586..1587 " "
-                    - L_BRACK@1587..1588 "["
-                    - NAMED_TYPE@1588..1594
-                        - NAME@1588..1594
-                            - IDENT@1588..1594 "Review"
-                    - R_BRACK@1594..1595 "]"
-                - DIRECTIVES@1595..1626
-                    - DIRECTIVE@1595..1626
-                        - AT@1595..1596 "@"
-                        - NAME@1596..1607
-                            - IDENT@1596..1607 "join__field"
-                        - ARGUMENTS@1607..1626
-                            - L_PAREN@1607..1608 "("
-                            - ARGUMENT@1608..1622
-                                - NAME@1608..1613
-                                    - IDENT@1608..1613 "graph"
-                                - COLON@1613..1614 ":"
-                                - WHITESPACE@1614..1615 " "
-                                - ENUM_VALUE@1615..1622
-                                    - NAME@1615..1622
-                                        - IDENT@1615..1622 "REVIEWS"
-                            - R_PAREN@1622..1623 ")"
-                            - WHITESPACE@1623..1626 "\n  "
-            - FIELD_DEFINITION@1626..1712
-                - NAME@1626..1640
-                    - IDENT@1626..1640 "relatedReviews"
-                - COLON@1640..1641 ":"
-                - WHITESPACE@1641..1642 " "
-                - NON_NULL_TYPE@1642..1651
-                    - WHITESPACE@1642..1643 " "
-                    - LIST_TYPE@1643..1651
-                        - L_BRACK@1643..1644 "["
-                        - NON_NULL_TYPE@1644..1650
-                            - NAMED_TYPE@1644..1650
-                                - NAME@1644..1650
-                                    - IDENT@1644..1650 "Review"
-                        - R_BRACK@1650..1651 "]"
-                - DIRECTIVES@1651..1712
-                    - DIRECTIVE@1651..1712
-                        - AT@1651..1652 "@"
-                        - NAME@1652..1663
-                            - IDENT@1652..1663 "join__field"
-                        - ARGUMENTS@1663..1712
-                            - L_PAREN@1663..1664 "("
-                            - ARGUMENT@1664..1680
-                                - NAME@1664..1669
-                                    - IDENT@1664..1669 "graph"
-                                - COLON@1669..1670 ":"
-                                - WHITESPACE@1670..1671 " "
-                                - ENUM_VALUE@1671..1680
-                                    - NAME@1671..1680
-                                        - IDENT@1671..1678 "REVIEWS"
-                                        - COMMA@1678..1679 ","
-                                        - WHITESPACE@1679..1680 " "
-                            - ARGUMENT@1680..1710
-                                - NAME@1680..1688
-                                    - IDENT@1680..1688 "requires"
-                                - COLON@1688..1689 ":"
-                                - WHITESPACE@1689..1690 " "
-                                - STRING_VALUE@1690..1710
-                                    - STRING@1690..1710 "\"similarBooks{isbn}\""
-                            - R_PAREN@1710..1711 ")"
-                            - WHITESPACE@1711..1712 "\n"
-            - R_CURLY@1712..1713 "}"
-            - WHITESPACE@1713..1715 "\n\n"
-    - UNION_TYPE_DEFINITION@1715..1744
-        - union_KW@1715..1720 "union"
-        - WHITESPACE@1720..1721 " "
-        - NAME@1721..1727
-            - IDENT@1721..1726 "Brand"
-            - WHITESPACE@1726..1727 " "
-        - UNION_MEMBER_TYPES@1727..1744
-            - EQ@1727..1728 "="
-            - WHITESPACE@1728..1729 " "
-            - NAMED_TYPE@1729..1734
-                - NAME@1729..1734
-                    - IDENT@1729..1733 "Ikea"
-                    - WHITESPACE@1733..1734 " "
-            - PIPE@1734..1735 "|"
-            - WHITESPACE@1735..1736 " "
-            - NAMED_TYPE@1736..1744
-                - NAME@1736..1744
-                    - IDENT@1736..1742 "Amazon"
-                    - WHITESPACE@1742..1744 "\n\n"
-    - OBJECT_TYPE_DEFINITION@1744..2092
-        - type_KW@1744..1748 "type"
-        - WHITESPACE@1748..1749 " "
-        - NAME@1749..1753
-            - IDENT@1749..1752 "Car"
-            - WHITESPACE@1752..1753 " "
-        - IMPLEMENTS_INTERFACES@1753..1772
-            - implements_KW@1753..1763 "implements"
-            - WHITESPACE@1763..1764 " "
-            - NAMED_TYPE@1764..1772
-                - NAME@1764..1772
-                    - IDENT@1764..1771 "Vehicle"
-                    - WHITESPACE@1771..1772 "\n"
-        - DIRECTIVES@1772..1879
-            - DIRECTIVE@1772..1801
-                - AT@1772..1773 "@"
-                - NAME@1773..1784
-                    - IDENT@1773..1784 "join__owner"
-                - ARGUMENTS@1784..1801
-                    - L_PAREN@1784..1785 "("
-                    - ARGUMENT@1785..1799
-                        - NAME@1785..1790
-                            - IDENT@1785..1790 "graph"
-                        - COLON@1790..1791 ":"
-                        - WHITESPACE@1791..1792 " "
-                        - ENUM_VALUE@1792..1799
-                            - NAME@1792..1799
-                                - IDENT@1792..1799 "PRODUCT"
-                    - R_PAREN@1799..1800 ")"
-                    - WHITESPACE@1800..1801 "\n"
-            - DIRECTIVE@1801..1840
-                - AT@1801..1802 "@"
-                - NAME@1802..1812
-                    - IDENT@1802..1812 "join__type"
-                - ARGUMENTS@1812..1840
-                    - L_PAREN@1812..1813 "("
-                    - ARGUMENT@1813..1829
-                        - NAME@1813..1818
-                            - IDENT@1813..1818 "graph"
-                        - COLON@1818..1819 ":"
-                        - WHITESPACE@1819..1820 " "
-                        - ENUM_VALUE@1820..1829
-                            - NAME@1820..1829
-                                - IDENT@1820..1827 "PRODUCT"
-                                - COMMA@1827..1828 ","
-                                - WHITESPACE@1828..1829 " "
-                    - ARGUMENT@1829..1838
-                        - NAME@1829..1832
-                            - IDENT@1829..1832 "key"
-                        - COLON@1832..1833 ":"
-                        - WHITESPACE@1833..1834 " "
-                        - STRING_VALUE@1834..1838
-                            - STRING@1834..1838 "\"id\""
-                    - R_PAREN@1838..1839 ")"
-                    - WHITESPACE@1839..1840 "\n"
-            - DIRECTIVE@1840..1879
-                - AT@1840..1841 "@"
-                - NAME@1841..1851
-                    - IDENT@1841..1851 "join__type"
-                - ARGUMENTS@1851..1879
-                    - L_PAREN@1851..1852 "("
-                    - ARGUMENT@1852..1868
-                        - NAME@1852..1857
-                            - IDENT@1852..1857 "graph"
-                        - COLON@1857..1858 ":"
-                        - WHITESPACE@1858..1859 " "
-                        - ENUM_VALUE@1859..1868
-                            - NAME@1859..1868
-                                - IDENT@1859..1866 "REVIEWS"
-                                - COMMA@1866..1867 ","
-                                - WHITESPACE@1867..1868 " "
-                    - ARGUMENT@1868..1877
-                        - NAME@1868..1871
-                            - IDENT@1868..1871 "key"
-                        - COLON@1871..1872 ":"
-                        - WHITESPACE@1872..1873 " "
-                        - STRING_VALUE@1873..1877
-                            - STRING@1873..1877 "\"id\""
-                    - R_PAREN@1877..1878 ")"
-                    - WHITESPACE@1878..1879 "\n"
-        - FIELDS_DEFINITION@1879..2092
-            - L_CURLY@1879..1880 "{"
-            - WHITESPACE@1880..1883 "\n  "
-            - FIELD_DEFINITION@1883..1925
-                - NAME@1883..1885
-                    - IDENT@1883..1885 "id"
-                - COLON@1885..1886 ":"
-                - WHITESPACE@1886..1887 " "
-                - NON_NULL_TYPE@1887..1894
-                    - WHITESPACE@1887..1888 " "
-                    - NAMED_TYPE@1888..1894
-                        - NAME@1888..1894
-                            - IDENT@1888..1894 "String"
-                - DIRECTIVES@1894..1925
-                    - DIRECTIVE@1894..1925
-                        - AT@1894..1895 "@"
-                        - NAME@1895..1906
-                            - IDENT@1895..1906 "join__field"
-                        - ARGUMENTS@1906..1925
-                            - L_PAREN@1906..1907 "("
-                            - ARGUMENT@1907..1921
-                                - NAME@1907..1912
-                                    - IDENT@1907..1912 "graph"
-                                - COLON@1912..1913 ":"
-                                - WHITESPACE@1913..1914 " "
-                                - ENUM_VALUE@1914..1921
-                                    - NAME@1914..1921
-                                        - IDENT@1914..1921 "PRODUCT"
-                            - R_PAREN@1921..1922 ")"
-                            - WHITESPACE@1922..1925 "\n  "
-            - FIELD_DEFINITION@1925..1976
-                - NAME@1925..1936
-                    - IDENT@1925..1936 "description"
-                - COLON@1936..1937 ":"
-                - WHITESPACE@1937..1938 " "
-                - NAMED_TYPE@1938..1945
-                    - WHITESPACE@1938..1939 " "
-                    - NAME@1939..1945
-                        - IDENT@1939..1945 "String"
-                - DIRECTIVES@1945..1976
-                    - DIRECTIVE@1945..1976
-                        - AT@1945..1946 "@"
-                        - NAME@1946..1957
-                            - IDENT@1946..1957 "join__field"
-                        - ARGUMENTS@1957..1976
-                            - L_PAREN@1957..1958 "("
-                            - ARGUMENT@1958..1972
-                                - NAME@1958..1963
-                                    - IDENT@1958..1963 "graph"
-                                - COLON@1963..1964 ":"
-                                - WHITESPACE@1964..1965 " "
-                                - ENUM_VALUE@1965..1972
-                                    - NAME@1965..1972
-                                        - IDENT@1965..1972 "PRODUCT"
-                            - R_PAREN@1972..1973 ")"
-                            - WHITESPACE@1973..1976 "\n  "
-            - FIELD_DEFINITION@1976..2021
-                - NAME@1976..1981
-                    - IDENT@1976..1981 "price"
-                - COLON@1981..1982 ":"
-                - WHITESPACE@1982..1983 " "
-                - NAMED_TYPE@1983..1990
-                    - WHITESPACE@1983..1984 " "
-                    - NAME@1984..1990
-                        - IDENT@1984..1990 "String"
-                - DIRECTIVES@1990..2021
-                    - DIRECTIVE@1990..2021
-                        - AT@1990..1991 "@"
-                        - NAME@1991..2002
-                            - IDENT@1991..2002 "join__field"
-                        - ARGUMENTS@2002..2021
-                            - L_PAREN@2002..2003 "("
-                            - ARGUMENT@2003..2017
-                                - NAME@2003..2008
-                                    - IDENT@2003..2008 "graph"
-                                - COLON@2008..2009 ":"
-                                - WHITESPACE@2009..2010 " "
-                                - ENUM_VALUE@2010..2017
-                                    - NAME@2010..2017
-                                        - IDENT@2010..2017 "PRODUCT"
-                            - R_PAREN@2017..2018 ")"
-                            - WHITESPACE@2018..2021 "\n  "
-            - FIELD_DEFINITION@2021..2089
-                - NAME@2021..2032
-                    - IDENT@2021..2032 "retailPrice"
-                - COLON@2032..2033 ":"
-                - WHITESPACE@2033..2034 " "
-                - NAMED_TYPE@2034..2041
-                    - WHITESPACE@2034..2035 " "
-                    - NAME@2035..2041
-                        - IDENT@2035..2041 "String"
-                - DIRECTIVES@2041..2089
-                    - DIRECTIVE@2041..2089
-                        - AT@2041..2042 "@"
-                        - NAME@2042..2053
-                            - IDENT@2042..2053 "join__field"
-                        - ARGUMENTS@2053..2089
-                            - L_PAREN@2053..2054 "("
-                            - ARGUMENT@2054..2070
-                                - NAME@2054..2059
-                                    - IDENT@2054..2059 "graph"
-                                - COLON@2059..2060 ":"
-                                - WHITESPACE@2060..2061 " "
-                                - ENUM_VALUE@2061..2070
-                                    - NAME@2061..2070
-                                        - IDENT@2061..2068 "REVIEWS"
-                                        - COMMA@2068..2069 ","
-                                        - WHITESPACE@2069..2070 " "
-                            - ARGUMENT@2070..2087
-                                - NAME@2070..2078
-                                    - IDENT@2070..2078 "requires"
-                                - COLON@2078..2079 ":"
-                                - WHITESPACE@2079..2080 " "
-                                - STRING_VALUE@2080..2087
-                                    - STRING@2080..2087 "\"price\""
-                            - R_PAREN@2087..2088 ")"
-                            - WHITESPACE@2088..2089 "\n"
-            - R_CURLY@2089..2090 "}"
-            - WHITESPACE@2090..2092 "\n\n"
-    - OBJECT_TYPE_DEFINITION@2092..2138
-        - type_KW@2092..2096 "type"
-        - WHITESPACE@2096..2097 " "
-        - NAME@2097..2103
-            - IDENT@2097..2102 "Error"
-            - WHITESPACE@2102..2103 " "
-        - FIELDS_DEFINITION@2103..2138
-            - L_CURLY@2103..2104 "{"
-            - WHITESPACE@2104..2107 "\n  "
-            - FIELD_DEFINITION@2107..2119
-                - NAME@2107..2111
-                    - IDENT@2107..2111 "code"
-                - COLON@2111..2112 ":"
-                - WHITESPACE@2112..2113 " "
-                - NAMED_TYPE@2113..2119
-                    - WHITESPACE@2113..2116 "\n  "
-                    - NAME@2116..2119
-                        - IDENT@2116..2119 "Int"
-            - FIELD_DEFINITION@2119..2135
-                - NAME@2119..2126
-                    - IDENT@2119..2126 "message"
-                - COLON@2126..2127 ":"
-                - WHITESPACE@2127..2128 " "
-                - NAMED_TYPE@2128..2135
-                    - WHITESPACE@2128..2129 "\n"
-                    - NAME@2129..2135
-                        - IDENT@2129..2135 "String"
-            - R_CURLY@2135..2136 "}"
-            - WHITESPACE@2136..2138 "\n\n"
-    - OBJECT_TYPE_DEFINITION@2138..2859
-        - type_KW@2138..2142 "type"
-        - WHITESPACE@2142..2143 " "
-        - NAME@2143..2153
-            - IDENT@2143..2152 "Furniture"
-            - WHITESPACE@2152..2153 " "
-        - IMPLEMENTS_INTERFACES@2153..2172
-            - implements_KW@2153..2163 "implements"
-            - WHITESPACE@2163..2164 " "
-            - NAMED_TYPE@2164..2172
-                - NAME@2164..2172
-                    - IDENT@2164..2171 "Product"
-                    - WHITESPACE@2171..2172 "\n"
-        - DIRECTIVES@2172..2363
-            - DIRECTIVE@2172..2201
-                - AT@2172..2173 "@"
-                - NAME@2173..2184
-                    - IDENT@2173..2184 "join__owner"
-                - ARGUMENTS@2184..2201
-                    - L_PAREN@2184..2185 "("
-                    - ARGUMENT@2185..2199
-                        - NAME@2185..2190
-                            - IDENT@2185..2190 "graph"
-                        - COLON@2190..2191 ":"
-                        - WHITESPACE@2191..2192 " "
-                        - ENUM_VALUE@2192..2199
-                            - NAME@2192..2199
-                                - IDENT@2192..2199 "PRODUCT"
-                    - R_PAREN@2199..2200 ")"
-                    - WHITESPACE@2200..2201 "\n"
-            - DIRECTIVE@2201..2241
-                - AT@2201..2202 "@"
-                - NAME@2202..2212
-                    - IDENT@2202..2212 "join__type"
-                - ARGUMENTS@2212..2241
-                    - L_PAREN@2212..2213 "("
-                    - ARGUMENT@2213..2229
-                        - NAME@2213..2218
-                            - IDENT@2213..2218 "graph"
-                        - COLON@2218..2219 ":"
-                        - WHITESPACE@2219..2220 " "
-                        - ENUM_VALUE@2220..2229
-                            - NAME@2220..2229
-                                - IDENT@2220..2227 "PRODUCT"
-                                - COMMA@2227..2228 ","
-                                - WHITESPACE@2228..2229 " "
-                    - ARGUMENT@2229..2239
-                        - NAME@2229..2232
-                            - IDENT@2229..2232 "key"
-                        - COLON@2232..2233 ":"
-                        - WHITESPACE@2233..2234 " "
-                        - STRING_VALUE@2234..2239
-                            - STRING@2234..2239 "\"upc\""
-                    - R_PAREN@2239..2240 ")"
-                    - WHITESPACE@2240..2241 "\n"
-            - DIRECTIVE@2241..2281
-                - AT@2241..2242 "@"
-                - NAME@2242..2252
-                    - IDENT@2242..2252 "join__type"
-                - ARGUMENTS@2252..2281
-                    - L_PAREN@2252..2253 "("
-                    - ARGUMENT@2253..2269
-                        - NAME@2253..2258
-                            - IDENT@2253..2258 "graph"
-                        - COLON@2258..2259 ":"
-                        - WHITESPACE@2259..2260 " "
-                        - ENUM_VALUE@2260..2269
-                            - NAME@2260..2269
-                                - IDENT@2260..2267 "PRODUCT"
-                                - COMMA@2267..2268 ","
-                                - WHITESPACE@2268..2269 " "
-                    - ARGUMENT@2269..2279
-                        - NAME@2269..2272
-                            - IDENT@2269..2272 "key"
-                        - COLON@2272..2273 ":"
-                        - WHITESPACE@2273..2274 " "
-                        - STRING_VALUE@2274..2279
-                            - STRING@2274..2279 "\"sku\""
-                    - R_PAREN@2279..2280 ")"
-                    - WHITESPACE@2280..2281 "\n"
-            - DIRECTIVE@2281..2323
-                - AT@2281..2282 "@"
-                - NAME@2282..2292
-                    - IDENT@2282..2292 "join__type"
-                - ARGUMENTS@2292..2323
-                    - L_PAREN@2292..2293 "("
-                    - ARGUMENT@2293..2311
-                        - NAME@2293..2298
-                            - IDENT@2293..2298 "graph"
-                        - COLON@2298..2299 ":"
-                        - WHITESPACE@2299..2300 " "
-                        - ENUM_VALUE@2300..2311
-                            - NAME@2300..2311
-                                - IDENT@2300..2309 "INVENTORY"
-                                - COMMA@2309..2310 ","
-                                - WHITESPACE@2310..2311 " "
-                    - ARGUMENT@2311..2321
-                        - NAME@2311..2314
-                            - IDENT@2311..2314 "key"
-                        - COLON@2314..2315 ":"
-                        - WHITESPACE@2315..2316 " "
-                        - STRING_VALUE@2316..2321
-                            - STRING@2316..2321 "\"sku\""
-                    - R_PAREN@2321..2322 ")"
-                    - WHITESPACE@2322..2323 "\n"
-            - DIRECTIVE@2323..2363
-                - AT@2323..2324 "@"
-                - NAME@2324..2334
-                    - IDENT@2324..2334 "join__type"
-                - ARGUMENTS@2334..2363
-                    - L_PAREN@2334..2335 "("
-                    - ARGUMENT@2335..2351
-                        - NAME@2335..2340
-                            - IDENT@2335..2340 "graph"
-                        - COLON@2340..2341 ":"
-                        - WHITESPACE@2341..2342 " "
-                        - ENUM_VALUE@2342..2351
-                            - NAME@2342..2351
-                                - IDENT@2342..2349 "REVIEWS"
-                                - COMMA@2349..2350 ","
-                                - WHITESPACE@2350..2351 " "
-                    - ARGUMENT@2351..2361
-                        - NAME@2351..2354
-                            - IDENT@2351..2354 "key"
-                        - COLON@2354..2355 ":"
-                        - WHITESPACE@2355..2356 " "
-                        - STRING_VALUE@2356..2361
-                            - STRING@2356..2361 "\"upc\""
-                    - R_PAREN@2361..2362 ")"
-                    - WHITESPACE@2362..2363 "\n"
-        - FIELDS_DEFINITION@2363..2859
-            - L_CURLY@2363..2364 "{"
-            - WHITESPACE@2364..2367 "\n  "
-            - FIELD_DEFINITION@2367..2410
-                - NAME@2367..2370
-                    - IDENT@2367..2370 "upc"
-                - COLON@2370..2371 ":"
-                - WHITESPACE@2371..2372 " "
-                - NON_NULL_TYPE@2372..2379
-                    - WHITESPACE@2372..2373 " "
-                    - NAMED_TYPE@2373..2379
-                        - NAME@2373..2379
-                            - IDENT@2373..2379 "String"
-                - DIRECTIVES@2379..2410
-                    - DIRECTIVE@2379..2410
-                        - AT@2379..2380 "@"
-                        - NAME@2380..2391
-                            - IDENT@2380..2391 "join__field"
-                        - ARGUMENTS@2391..2410
-                            - L_PAREN@2391..2392 "("
-                            - ARGUMENT@2392..2406
-                                - NAME@2392..2397
-                                    - IDENT@2392..2397 "graph"
-                                - COLON@2397..2398 ":"
-                                - WHITESPACE@2398..2399 " "
-                                - ENUM_VALUE@2399..2406
-                                    - NAME@2399..2406
-                                        - IDENT@2399..2406 "PRODUCT"
-                            - R_PAREN@2406..2407 ")"
-                            - WHITESPACE@2407..2410 "\n  "
-            - FIELD_DEFINITION@2410..2453
-                - NAME@2410..2413
-                    - IDENT@2410..2413 "sku"
-                - COLON@2413..2414 ":"
-                - WHITESPACE@2414..2415 " "
-                - NON_NULL_TYPE@2415..2422
-                    - WHITESPACE@2415..2416 " "
-                    - NAMED_TYPE@2416..2422
-                        - NAME@2416..2422
-                            - IDENT@2416..2422 "String"
-                - DIRECTIVES@2422..2453
-                    - DIRECTIVE@2422..2453
-                        - AT@2422..2423 "@"
-                        - NAME@2423..2434
-                            - IDENT@2423..2434 "join__field"
-                        - ARGUMENTS@2434..2453
-                            - L_PAREN@2434..2435 "("
-                            - ARGUMENT@2435..2449
-                                - NAME@2435..2440
-                                    - IDENT@2435..2440 "graph"
-                                - COLON@2440..2441 ":"
-                                - WHITESPACE@2441..2442 " "
-                                - ENUM_VALUE@2442..2449
-                                    - NAME@2442..2449
-                                        - IDENT@2442..2449 "PRODUCT"
-                            - R_PAREN@2449..2450 ")"
-                            - WHITESPACE@2450..2453 "\n  "
-            - FIELD_DEFINITION@2453..2497
-                - NAME@2453..2457
-                    - IDENT@2453..2457 "name"
-                - COLON@2457..2458 ":"
-                - WHITESPACE@2458..2459 " "
-                - NAMED_TYPE@2459..2466
-                    - WHITESPACE@2459..2460 " "
-                    - NAME@2460..2466
-                        - IDENT@2460..2466 "String"
-                - DIRECTIVES@2466..2497
-                    - DIRECTIVE@2466..2497
-                        - AT@2466..2467 "@"
-                        - NAME@2467..2478
-                            - IDENT@2467..2478 "join__field"
-                        - ARGUMENTS@2478..2497
-                            - L_PAREN@2478..2479 "("
-                            - ARGUMENT@2479..2493
-                                - NAME@2479..2484
-                                    - IDENT@2479..2484 "graph"
-                                - COLON@2484..2485 ":"
-                                - WHITESPACE@2485..2486 " "
-                                - ENUM_VALUE@2486..2493
-                                    - NAME@2486..2493
-                                        - IDENT@2486..2493 "PRODUCT"
-                            - R_PAREN@2493..2494 ")"
-                            - WHITESPACE@2494..2497 "\n  "
-            - FIELD_DEFINITION@2497..2542
-                - NAME@2497..2502
-                    - IDENT@2497..2502 "price"
-                - COLON@2502..2503 ":"
-                - WHITESPACE@2503..2504 " "
-                - NAMED_TYPE@2504..2511
-                    - WHITESPACE@2504..2505 " "
-                    - NAME@2505..2511
-                        - IDENT@2505..2511 "String"
-                - DIRECTIVES@2511..2542
-                    - DIRECTIVE@2511..2542
-                        - AT@2511..2512 "@"
-                        - NAME@2512..2523
-                            - IDENT@2512..2523 "join__field"
-                        - ARGUMENTS@2523..2542
-                            - L_PAREN@2523..2524 "("
-                            - ARGUMENT@2524..2538
-                                - NAME@2524..2529
-                                    - IDENT@2524..2529 "graph"
-                                - COLON@2529..2530 ":"
-                                - WHITESPACE@2530..2531 " "
-                                - ENUM_VALUE@2531..2538
-                                    - NAME@2531..2538
-                                        - IDENT@2531..2538 "PRODUCT"
-                            - R_PAREN@2538..2539 ")"
-                            - WHITESPACE@2539..2542 "\n  "
-            - FIELD_DEFINITION@2542..2586
-                - NAME@2542..2547
-                    - IDENT@2542..2547 "brand"
-                - COLON@2547..2548 ":"
-                - WHITESPACE@2548..2549 " "
-                - NAMED_TYPE@2549..2555
-                    - WHITESPACE@2549..2550 " "
-                    - NAME@2550..2555
-                        - IDENT@2550..2555 "Brand"
-                - DIRECTIVES@2555..2586
-                    - DIRECTIVE@2555..2586
-                        - AT@2555..2556 "@"
-                        - NAME@2556..2567
-                            - IDENT@2556..2567 "join__field"
-                        - ARGUMENTS@2567..2586
-                            - L_PAREN@2567..2568 "("
-                            - ARGUMENT@2568..2582
-                                - NAME@2568..2573
-                                    - IDENT@2568..2573 "graph"
-                                - COLON@2573..2574 ":"
-                                - WHITESPACE@2574..2575 " "
-                                - ENUM_VALUE@2575..2582
-                                    - NAME@2575..2582
-                                        - IDENT@2575..2582 "PRODUCT"
-                            - R_PAREN@2582..2583 ")"
-                            - WHITESPACE@2583..2586 "\n  "
-            - FIELD_DEFINITION@2586..2645
-                - NAME@2586..2594
-                    - IDENT@2586..2594 "metadata"
-                - COLON@2594..2595 ":"
-                - WHITESPACE@2595..2596 " "
-                - LIST_TYPE@2596..2614
-                    - WHITESPACE@2596..2597 " "
-                    - L_BRACK@2597..2598 "["
-                    - NAMED_TYPE@2598..2613
-                        - NAME@2598..2613
-                            - IDENT@2598..2613 "MetadataOrError"
-                    - R_BRACK@2613..2614 "]"
-                - DIRECTIVES@2614..2645
-                    - DIRECTIVE@2614..2645
-                        - AT@2614..2615 "@"
-                        - NAME@2615..2626
-                            - IDENT@2615..2626 "join__field"
-                        - ARGUMENTS@2626..2645
-                            - L_PAREN@2626..2627 "("
-                            - ARGUMENT@2627..2641
-                                - NAME@2627..2632
-                                    - IDENT@2627..2632 "graph"
-                                - COLON@2632..2633 ":"
-                                - WHITESPACE@2633..2634 " "
-                                - ENUM_VALUE@2634..2641
-                                    - NAME@2634..2641
-                                        - IDENT@2634..2641 "PRODUCT"
-                            - R_PAREN@2641..2642 ")"
-                            - WHITESPACE@2642..2645 "\n  "
-            - FIELD_DEFINITION@2645..2709
-                - NAME@2645..2652
-                    - IDENT@2645..2652 "details"
-                - COLON@2652..2653 ":"
-                - WHITESPACE@2653..2654 " "
-                - NAMED_TYPE@2654..2678
-                    - WHITESPACE@2654..2655 " "
-                    - NAME@2655..2678
-                        - IDENT@2655..2678 "ProductDetailsFurniture"
-                - DIRECTIVES@2678..2709
-                    - DIRECTIVE@2678..2709
-                        - AT@2678..2679 "@"
-                        - NAME@2679..2690
-                            - IDENT@2679..2690 "join__field"
-                        - ARGUMENTS@2690..2709
-                            - L_PAREN@2690..2691 "("
-                            - ARGUMENT@2691..2705
-                                - NAME@2691..2696
-                                    - IDENT@2691..2696 "graph"
-                                - COLON@2696..2697 ":"
-                                - WHITESPACE@2697..2698 " "
-                                - ENUM_VALUE@2698..2705
-                                    - NAME@2698..2705
-                                        - IDENT@2698..2705 "PRODUCT"
-                            - R_PAREN@2705..2706 ")"
-                            - WHITESPACE@2706..2709 "\n  "
-            - FIELD_DEFINITION@2709..2759
-                - NAME@2709..2716
-                    - IDENT@2709..2716 "inStock"
-                - COLON@2716..2717 ":"
-                - WHITESPACE@2717..2718 " "
-                - NAMED_TYPE@2718..2726
-                    - WHITESPACE@2718..2719 " "
-                    - NAME@2719..2726
-                        - IDENT@2719..2726 "Boolean"
-                - DIRECTIVES@2726..2759
-                    - DIRECTIVE@2726..2759
-                        - AT@2726..2727 "@"
-                        - NAME@2727..2738
-                            - IDENT@2727..2738 "join__field"
-                        - ARGUMENTS@2738..2759
-                            - L_PAREN@2738..2739 "("
-                            - ARGUMENT@2739..2755
-                                - NAME@2739..2744
-                                    - IDENT@2739..2744 "graph"
-                                - COLON@2744..2745 ":"
-                                - WHITESPACE@2745..2746 " "
-                                - ENUM_VALUE@2746..2755
-                                    - NAME@2746..2755
-                                        - IDENT@2746..2755 "INVENTORY"
-                            - R_PAREN@2755..2756 ")"
-                            - WHITESPACE@2756..2759 "\n  "
-            - FIELD_DEFINITION@2759..2809
-                - NAME@2759..2766
-                    - IDENT@2759..2766 "isHeavy"
-                - COLON@2766..2767 ":"
-                - WHITESPACE@2767..2768 " "
-                - NAMED_TYPE@2768..2776
-                    - WHITESPACE@2768..2769 " "
-                    - NAME@2769..2776
-                        - IDENT@2769..2776 "Boolean"
-                - DIRECTIVES@2776..2809
-                    - DIRECTIVE@2776..2809
-                        - AT@2776..2777 "@"
-                        - NAME@2777..2788
-                            - IDENT@2777..2788 "join__field"
-                        - ARGUMENTS@2788..2809
-                            - L_PAREN@2788..2789 "("
-                            - ARGUMENT@2789..2805
-                                - NAME@2789..2794
-                                    - IDENT@2789..2794 "graph"
-                                - COLON@2794..2795 ":"
-                                - WHITESPACE@2795..2796 " "
-                                - ENUM_VALUE@2796..2805
-                                    - NAME@2796..2805
-                                        - IDENT@2796..2805 "INVENTORY"
-                            - R_PAREN@2805..2806 ")"
-                            - WHITESPACE@2806..2809 "\n  "
-            - FIELD_DEFINITION@2809..2856
-                - NAME@2809..2816
-                    - IDENT@2809..2816 "reviews"
-                - COLON@2816..2817 ":"
-                - WHITESPACE@2817..2818 " "
-                - LIST_TYPE@2818..2827
-                    - WHITESPACE@2818..2819 " "
-                    - L_BRACK@2819..2820 "["
-                    - NAMED_TYPE@2820..2826
-                        - NAME@2820..2826
-                            - IDENT@2820..2826 "Review"
-                    - R_BRACK@2826..2827 "]"
-                - DIRECTIVES@2827..2856
-                    - DIRECTIVE@2827..2856
-                        - AT@2827..2828 "@"
-                        - NAME@2828..2839
-                            - IDENT@2828..2839 "join__field"
-                        - ARGUMENTS@2839..2856
-                            - L_PAREN@2839..2840 "("
-                            - ARGUMENT@2840..2854
-                                - NAME@2840..2845
-                                    - IDENT@2840..2845 "graph"
-                                - COLON@2845..2846 ":"
-                                - WHITESPACE@2846..2847 " "
-                                - ENUM_VALUE@2847..2854
-                                    - NAME@2847..2854
-                                        - IDENT@2847..2854 "REVIEWS"
-                            - R_PAREN@2854..2855 ")"
-                            - WHITESPACE@2855..2856 "\n"
-            - R_CURLY@2856..2857 "}"
-            - WHITESPACE@2857..2859 "\n\n"
-    - OBJECT_TYPE_DEFINITION@2859..2887
-        - type_KW@2859..2863 "type"
-        - WHITESPACE@2863..2864 " "
-        - NAME@2864..2869
-            - IDENT@2864..2868 "Ikea"
-            - WHITESPACE@2868..2869 " "
-        - FIELDS_DEFINITION@2869..2887
-            - L_CURLY@2869..2870 "{"
-            - WHITESPACE@2870..2873 "\n  "
-            - FIELD_DEFINITION@2873..2884
-                - NAME@2873..2878
-                    - IDENT@2873..2878 "asile"
-                - COLON@2878..2879 ":"
-                - WHITESPACE@2879..2880 " "
-                - NAMED_TYPE@2880..2884
-                    - WHITESPACE@2880..2881 "\n"
-                    - NAME@2881..2884
-                        - IDENT@2881..2884 "Int"
-            - R_CURLY@2884..2885 "}"
-            - WHITESPACE@2885..2887 "\n\n"
-    - OBJECT_TYPE_DEFINITION@2887..2971
-        - type_KW@2887..2891 "type"
-        - WHITESPACE@2891..2892 " "
-        - NAME@2892..2898
-            - IDENT@2892..2897 "Image"
-            - WHITESPACE@2897..2898 " "
-        - IMPLEMENTS_INTERFACES@2898..2921
-            - implements_KW@2898..2908 "implements"
-            - WHITESPACE@2908..2909 " "
-            - NAMED_TYPE@2909..2921
-                - NAME@2909..2921
-                    - IDENT@2909..2920 "NamedObject"
-                    - WHITESPACE@2920..2921 " "
-        - FIELDS_DEFINITION@2921..2971
-            - L_CURLY@2921..2922 "{"
-            - WHITESPACE@2922..2925 "\n  "
-            - FIELD_DEFINITION@2925..2940
-                - NAME@2925..2929
-                    - IDENT@2925..2929 "name"
-                - COLON@2929..2930 ":"
-                - WHITESPACE@2930..2931 " "
-                - NON_NULL_TYPE@2931..2940
-                    - WHITESPACE@2931..2934 "\n  "
-                    - NAMED_TYPE@2934..2940
-                        - NAME@2934..2940
-                            - IDENT@2934..2940 "String"
-            - FIELD_DEFINITION@2940..2968
-                - NAME@2940..2950
-                    - IDENT@2940..2950 "attributes"
-                - COLON@2950..2951 ":"
-                - WHITESPACE@2951..2952 " "
-                - NON_NULL_TYPE@2952..2968
-                    - WHITESPACE@2952..2953 "\n"
-                    - NAMED_TYPE@2953..2968
-                        - NAME@2953..2968
-                            - IDENT@2953..2968 "ImageAttributes"
-            - R_CURLY@2968..2969 "}"
-            - WHITESPACE@2969..2971 "\n\n"
-    - OBJECT_TYPE_DEFINITION@2971..3011
-        - type_KW@2971..2975 "type"
-        - WHITESPACE@2975..2976 " "
-        - NAME@2976..2992
-            - IDENT@2976..2991 "ImageAttributes"
-            - WHITESPACE@2991..2992 " "
-        - FIELDS_DEFINITION@2992..3011
-            - L_CURLY@2992..2993 "{"
-            - WHITESPACE@2993..2996 "\n  "
-            - FIELD_DEFINITION@2996..3008
-                - NAME@2996..2999
-                    - IDENT@2996..2999 "url"
-                - COLON@2999..3000 ":"
-                - WHITESPACE@3000..3001 " "
-                - NON_NULL_TYPE@3001..3008
-                    - WHITESPACE@3001..3002 "\n"
-                    - NAMED_TYPE@3002..3008
-                        - NAME@3002..3008
-                            - IDENT@3002..3008 "String"
-            - R_CURLY@3008..3009 "}"
-            - WHITESPACE@3009..3011 "\n\n"
-    - SCALAR_TYPE_DEFINITION@3011..3034
-        - scalar_KW@3011..3017 "scalar"
-        - WHITESPACE@3017..3018 " "
-        - NAME@3018..3034
-            - IDENT@3018..3032 "join__FieldSet"
-            - WHITESPACE@3032..3034 "\n\n"
-    - ENUM_TYPE_DEFINITION@3034..3338
-        - enum_KW@3034..3038 "enum"
-        - WHITESPACE@3038..3039 " "
-        - NAME@3039..3051
-            - IDENT@3039..3050 "join__Graph"
-            - WHITESPACE@3050..3051 " "
-        - ENUM_VALUES_DEFINITION@3051..3338
-            - L_CURLY@3051..3052 "{"
-            - WHITESPACE@3052..3053 "\n"
-            - ENUM_VALUE_DEFINITION@3053..3101
-                - ENUM_VALUE@3053..3062
-                    - NAME@3053..3062
-                        - IDENT@3053..3061 "ACCOUNTS"
-                        - WHITESPACE@3061..3062 " "
-                - DIRECTIVES@3062..3101
-                    - DIRECTIVE@3062..3101
-                        - AT@3062..3063 "@"
-                        - NAME@3063..3074
-                            - IDENT@3063..3074 "join__graph"
-                        - ARGUMENTS@3074..3101
-                            - L_PAREN@3074..3075 "("
-                            - ARGUMENT@3075..3092
-                                - NAME@3075..3079
-                                    - IDENT@3075..3079 "name"
-                                - COLON@3079..3080 ":"
-                                - WHITESPACE@3080..3081 " "
-                                - STRING_VALUE@3081..3092
-                                    - STRING@3081..3091 "\"accounts\""
-                                    - WHITESPACE@3091..3092 " "
-                            - ARGUMENT@3092..3099
-                                - NAME@3092..3095
-                                    - IDENT@3092..3095 "url"
-                                - COLON@3095..3096 ":"
-                                - WHITESPACE@3096..3097 " "
-                                - STRING_VALUE@3097..3099
-                                    - STRING@3097..3099 "\"\""
-                            - R_PAREN@3099..3100 ")"
-                            - WHITESPACE@3100..3101 "\n"
-            - ENUM_VALUE_DEFINITION@3101..3143
-                - ENUM_VALUE@3101..3107
-                    - NAME@3101..3107
-                        - IDENT@3101..3106 "BOOKS"
-                        - WHITESPACE@3106..3107 " "
-                - DIRECTIVES@3107..3143
-                    - DIRECTIVE@3107..3143
-                        - AT@3107..3108 "@"
-                        - NAME@3108..3119
-                            - IDENT@3108..3119 "join__graph"
-                        - ARGUMENTS@3119..3143
-                            - L_PAREN@3119..3120 "("
-                            - ARGUMENT@3120..3134
-                                - NAME@3120..3124
-                                    - IDENT@3120..3124 "name"
-                                - COLON@3124..3125 ":"
-                                - WHITESPACE@3125..3126 " "
-                                - STRING_VALUE@3126..3134
-                                    - STRING@3126..3133 "\"books\""
-                                    - WHITESPACE@3133..3134 " "
-                            - ARGUMENT@3134..3141
-                                - NAME@3134..3137
-                                    - IDENT@3134..3137 "url"
-                                - COLON@3137..3138 ":"
-                                - WHITESPACE@3138..3139 " "
-                                - STRING_VALUE@3139..3141
-                                    - STRING@3139..3141 "\"\""
-                            - R_PAREN@3141..3142 ")"
-                            - WHITESPACE@3142..3143 "\n"
-            - ENUM_VALUE_DEFINITION@3143..3193
-                - ENUM_VALUE@3143..3153
-                    - NAME@3143..3153
-                        - IDENT@3143..3152 "DOCUMENTS"
-                        - WHITESPACE@3152..3153 " "
-                - DIRECTIVES@3153..3193
-                    - DIRECTIVE@3153..3193
-                        - AT@3153..3154 "@"
-                        - NAME@3154..3165
-                            - IDENT@3154..3165 "join__graph"
-                        - ARGUMENTS@3165..3193
-                            - L_PAREN@3165..3166 "("
-                            - ARGUMENT@3166..3184
-                                - NAME@3166..3170
-                                    - IDENT@3166..3170 "name"
-                                - COLON@3170..3171 ":"
-                                - WHITESPACE@3171..3172 " "
-                                - STRING_VALUE@3172..3184
-                                    - STRING@3172..3183 "\"documents\""
-                                    - WHITESPACE@3183..3184 " "
-                            - ARGUMENT@3184..3191
-                                - NAME@3184..3187
-                                    - IDENT@3184..3187 "url"
-                                - COLON@3187..3188 ":"
-                                - WHITESPACE@3188..3189 " "
-                                - STRING_VALUE@3189..3191
-                                    - STRING@3189..3191 "\"\""
-                            - R_PAREN@3191..3192 ")"
-                            - WHITESPACE@3192..3193 "\n"
-            - ENUM_VALUE_DEFINITION@3193..3243
-                - ENUM_VALUE@3193..3203
-                    - NAME@3193..3203
-                        - IDENT@3193..3202 "INVENTORY"
-                        - WHITESPACE@3202..3203 " "
-                - DIRECTIVES@3203..3243
-                    - DIRECTIVE@3203..3243
-                        - AT@3203..3204 "@"
-                        - NAME@3204..3215
-                            - IDENT@3204..3215 "join__graph"
-                        - ARGUMENTS@3215..3243
-                            - L_PAREN@3215..3216 "("
-                            - ARGUMENT@3216..3234
-                                - NAME@3216..3220
-                                    - IDENT@3216..3220 "name"
-                                - COLON@3220..3221 ":"
-                                - WHITESPACE@3221..3222 " "
-                                - STRING_VALUE@3222..3234
-                                    - STRING@3222..3233 "\"inventory\""
-                                    - WHITESPACE@3233..3234 " "
-                            - ARGUMENT@3234..3241
-                                - NAME@3234..3237
-                                    - IDENT@3234..3237 "url"
-                                - COLON@3237..3238 ":"
-                                - WHITESPACE@3238..3239 " "
-                                - STRING_VALUE@3239..3241
-                                    - STRING@3239..3241 "\"\""
-                            - R_PAREN@3241..3242 ")"
-                            - WHITESPACE@3242..3243 "\n"
-            - ENUM_VALUE_DEFINITION@3243..3289
-                - ENUM_VALUE@3243..3251
-                    - NAME@3243..3251
-                        - IDENT@3243..3250 "PRODUCT"
-                        - WHITESPACE@3250..3251 " "
-                - DIRECTIVES@3251..3289
-                    - DIRECTIVE@3251..3289
-                        - AT@3251..3252 "@"
-                        - NAME@3252..3263
-                            - IDENT@3252..3263 "join__graph"
-                        - ARGUMENTS@3263..3289
-                            - L_PAREN@3263..3264 "("
-                            - ARGUMENT@3264..3280
-                                - NAME@3264..3268
-                                    - IDENT@3264..3268 "name"
-                                - COLON@3268..3269 ":"
-                                - WHITESPACE@3269..3270 " "
-                                - STRING_VALUE@3270..3280
-                                    - STRING@3270..3279 "\"product\""
-                                    - WHITESPACE@3279..3280 " "
-                            - ARGUMENT@3280..3287
-                                - NAME@3280..3283
-                                    - IDENT@3280..3283 "url"
-                                - COLON@3283..3284 ":"
-                                - WHITESPACE@3284..3285 " "
-                                - STRING_VALUE@3285..3287
-                                    - STRING@3285..3287 "\"\""
-                            - R_PAREN@3287..3288 ")"
-                            - WHITESPACE@3288..3289 "\n"
-            - ENUM_VALUE_DEFINITION@3289..3335
-                - ENUM_VALUE@3289..3297
-                    - NAME@3289..3297
-                        - IDENT@3289..3296 "REVIEWS"
-                        - WHITESPACE@3296..3297 " "
-                - DIRECTIVES@3297..3335
-                    - DIRECTIVE@3297..3335
-                        - AT@3297..3298 "@"
-                        - NAME@3298..3309
-                            - IDENT@3298..3309 "join__graph"
-                        - ARGUMENTS@3309..3335
-                            - L_PAREN@3309..3310 "("
-                            - ARGUMENT@3310..3326
-                                - NAME@3310..3314
-                                    - IDENT@3310..3314 "name"
-                                - COLON@3314..3315 ":"
-                                - WHITESPACE@3315..3316 " "
-                                - STRING_VALUE@3316..3326
-                                    - STRING@3316..3325 "\"reviews\""
-                                    - WHITESPACE@3325..3326 " "
-                            - ARGUMENT@3326..3333
-                                - NAME@3326..3329
-                                    - IDENT@3326..3329 "url"
-                                - COLON@3329..3330 ":"
-                                - WHITESPACE@3330..3331 " "
-                                - STRING_VALUE@3331..3333
-                                    - STRING@3331..3333 "\"\""
-                            - R_PAREN@3333..3334 ")"
-                            - WHITESPACE@3334..3335 "\n"
-            - R_CURLY@3335..3336 "}"
-            - WHITESPACE@3336..3338 "\n\n"
-    - OBJECT_TYPE_DEFINITION@3338..3387
-        - type_KW@3338..3342 "type"
-        - WHITESPACE@3342..3343 " "
-        - NAME@3343..3352
-            - IDENT@3343..3351 "KeyValue"
-            - WHITESPACE@3351..3352 " "
-        - FIELDS_DEFINITION@3352..3387
-            - L_CURLY@3352..3353 "{"
-            - WHITESPACE@3353..3356 "\n  "
-            - FIELD_DEFINITION@3356..3370
-                - NAME@3356..3359
-                    - IDENT@3356..3359 "key"
-                - COLON@3359..3360 ":"
-                - WHITESPACE@3360..3361 " "
-                - NON_NULL_TYPE@3361..3370
-                    - WHITESPACE@3361..3364 "\n  "
-                    - NAMED_TYPE@3364..3370
-                        - NAME@3364..3370
-                            - IDENT@3364..3370 "String"
-            - FIELD_DEFINITION@3370..3384
-                - NAME@3370..3375
-                    - IDENT@3370..3375 "value"
-                - COLON@3375..3376 ":"
-                - WHITESPACE@3376..3377 " "
-                - NON_NULL_TYPE@3377..3384
-                    - WHITESPACE@3377..3378 "\n"
-                    - NAMED_TYPE@3378..3384
-                        - NAME@3378..3384
-                            - IDENT@3378..3384 "String"
-            - R_CURLY@3384..3385 "}"
-            - WHITESPACE@3385..3387 "\n\n"
-    - OBJECT_TYPE_DEFINITION@3387..3667
-        - type_KW@3387..3391 "type"
-        - WHITESPACE@3391..3392 " "
-        - NAME@3392..3400
-            - IDENT@3392..3399 "Library"
-            - WHITESPACE@3399..3400 "\n"
-        - DIRECTIVES@3400..3504
-            - DIRECTIVE@3400..3427
-                - AT@3400..3401 "@"
-                - NAME@3401..3412
-                    - IDENT@3401..3412 "join__owner"
-                - ARGUMENTS@3412..3427
-                    - L_PAREN@3412..3413 "("
-                    - ARGUMENT@3413..3425
-                        - NAME@3413..3418
-                            - IDENT@3413..3418 "graph"
-                        - COLON@3418..3419 ":"
-                        - WHITESPACE@3419..3420 " "
-                        - ENUM_VALUE@3420..3425
-                            - NAME@3420..3425
-                                - IDENT@3420..3425 "BOOKS"
-                    - R_PAREN@3425..3426 ")"
-                    - WHITESPACE@3426..3427 "\n"
-            - DIRECTIVE@3427..3464
-                - AT@3427..3428 "@"
-                - NAME@3428..3438
-                    - IDENT@3428..3438 "join__type"
-                - ARGUMENTS@3438..3464
-                    - L_PAREN@3438..3439 "("
-                    - ARGUMENT@3439..3453
-                        - NAME@3439..3444
-                            - IDENT@3439..3444 "graph"
-                        - COLON@3444..3445 ":"
-                        - WHITESPACE@3445..3446 " "
-                        - ENUM_VALUE@3446..3453
-                            - NAME@3446..3453
-                                - IDENT@3446..3451 "BOOKS"
-                                - COMMA@3451..3452 ","
-                                - WHITESPACE@3452..3453 " "
-                    - ARGUMENT@3453..3462
-                        - NAME@3453..3456
-                            - IDENT@3453..3456 "key"
-                        - COLON@3456..3457 ":"
-                        - WHITESPACE@3457..3458 " "
-                        - STRING_VALUE@3458..3462
-                            - STRING@3458..3462 "\"id\""
-                    - R_PAREN@3462..3463 ")"
-                    - WHITESPACE@3463..3464 "\n"
-            - DIRECTIVE@3464..3504
-                - AT@3464..3465 "@"
-                - NAME@3465..3475
-                    - IDENT@3465..3475 "join__type"
-                - ARGUMENTS@3475..3504
-                    - L_PAREN@3475..3476 "("
-                    - ARGUMENT@3476..3493
-                        - NAME@3476..3481
-                            - IDENT@3476..3481 "graph"
-                        - COLON@3481..3482 ":"
-                        - WHITESPACE@3482..3483 " "
-                        - ENUM_VALUE@3483..3493
-                            - NAME@3483..3493
-                                - IDENT@3483..3491 "ACCOUNTS"
-                                - COMMA@3491..3492 ","
-                                - WHITESPACE@3492..3493 " "
-                    - ARGUMENT@3493..3502
-                        - NAME@3493..3496
-                            - IDENT@3493..3496 "key"
-                        - COLON@3496..3497 ":"
-                        - WHITESPACE@3497..3498 " "
-                        - STRING_VALUE@3498..3502
-                            - STRING@3498..3502 "\"id\""
-                    - R_PAREN@3502..3503 ")"
-                    - WHITESPACE@3503..3504 "\n"
-        - FIELDS_DEFINITION@3504..3667
-            - L_CURLY@3504..3505 "{"
-            - WHITESPACE@3505..3508 "\n  "
-            - FIELD_DEFINITION@3508..3544
-                - NAME@3508..3510
-                    - IDENT@3508..3510 "id"
-                - COLON@3510..3511 ":"
-                - WHITESPACE@3511..3512 " "
-                - NON_NULL_TYPE@3512..3515
-                    - WHITESPACE@3512..3513 " "
-                    - NAMED_TYPE@3513..3515
-                        - NAME@3513..3515
-                            - IDENT@3513..3515 "ID"
-                - DIRECTIVES@3515..3544
-                    - DIRECTIVE@3515..3544
-                        - AT@3515..3516 "@"
-                        - NAME@3516..3527
-                            - IDENT@3516..3527 "join__field"
-                        - ARGUMENTS@3527..3544
-                            - L_PAREN@3527..3528 "("
-                            - ARGUMENT@3528..3540
-                                - NAME@3528..3533
-                                    - IDENT@3528..3533 "graph"
-                                - COLON@3533..3534 ":"
-                                - WHITESPACE@3534..3535 " "
-                                - ENUM_VALUE@3535..3540
-                                    - NAME@3535..3540
-                                        - IDENT@3535..3540 "BOOKS"
-                            - R_PAREN@3540..3541 ")"
-                            - WHITESPACE@3541..3544 "\n  "
-            - FIELD_DEFINITION@3544..3586
-                - NAME@3544..3548
-                    - IDENT@3544..3548 "name"
-                - COLON@3548..3549 ":"
-                - WHITESPACE@3549..3550 " "
-                - NAMED_TYPE@3550..3557
-                    - WHITESPACE@3550..3551 " "
-                    - NAME@3551..3557
-                        - IDENT@3551..3557 "String"
-                - DIRECTIVES@3557..3586
-                    - DIRECTIVE@3557..3586
-                        - AT@3557..3558 "@"
-                        - NAME@3558..3569
-                            - IDENT@3558..3569 "join__field"
-                        - ARGUMENTS@3569..3586
-                            - L_PAREN@3569..3570 "("
-                            - ARGUMENT@3570..3582
-                                - NAME@3570..3575
-                                    - IDENT@3570..3575 "graph"
-                                - COLON@3575..3576 ":"
-                                - WHITESPACE@3576..3577 " "
-                                - ENUM_VALUE@3577..3582
-                                    - NAME@3577..3582
-                                        - IDENT@3577..3582 "BOOKS"
-                            - R_PAREN@3582..3583 ")"
-                            - WHITESPACE@3583..3586 "\n  "
-            - FIELD_DEFINITION@3586..3664
-                - NAME@3586..3597
-                    - IDENT@3586..3597 "userAccount"
-                - ARGUMENTS@3597..3609
-                    - L_PAREN@3597..3598 "("
-                    - INPUT_VALUE_DEFINITION@3598..3608
-                        - NAME@3598..3600
-                            - IDENT@3598..3600 "id"
-                        - COLON@3600..3601 ":"
-                        - WHITESPACE@3601..3602 " "
-                        - NON_NULL_TYPE@3602..3605
-                            - WHITESPACE@3602..3603 " "
-                            - NAMED_TYPE@3603..3605
-                                - NAME@3603..3605
-                                    - IDENT@3603..3605 "ID"
-                        - DEFAULT_VALUE@3605..3608
-                            - EQ@3605..3606 "="
-                            - WHITESPACE@3606..3607 " "
-                            - INT_VALUE@3607..3608
-                                - INT@3607..3608 "1"
-                    - R_PAREN@3608..3609 ")"
-                - COLON@3609..3610 ":"
-                - WHITESPACE@3610..3611 " "
-                - NAMED_TYPE@3611..3616
-                    - WHITESPACE@3611..3612 " "
-                    - NAME@3612..3616
-                        - IDENT@3612..3616 "User"
-                - DIRECTIVES@3616..3664
-                    - DIRECTIVE@3616..3664
-                        - AT@3616..3617 "@"
-                        - NAME@3617..3628
-                            - IDENT@3617..3628 "join__field"
-                        - ARGUMENTS@3628..3664
-                            - L_PAREN@3628..3629 "("
-                            - ARGUMENT@3629..3646
-                                - NAME@3629..3634
-                                    - IDENT@3629..3634 "graph"
-                                - COLON@3634..3635 ":"
-                                - WHITESPACE@3635..3636 " "
-                                - ENUM_VALUE@3636..3646
-                                    - NAME@3636..3646
-                                        - IDENT@3636..3644 "ACCOUNTS"
-                                        - COMMA@3644..3645 ","
-                                        - WHITESPACE@3645..3646 " "
-                            - ARGUMENT@3646..3662
-                                - NAME@3646..3654
-                                    - IDENT@3646..3654 "requires"
-                                - COLON@3654..3655 ":"
-                                - WHITESPACE@3655..3656 " "
-                                - STRING_VALUE@3656..3662
-                                    - STRING@3656..3662 "\"name\""
-                            - R_PAREN@3662..3663 ")"
-                            - WHITESPACE@3663..3664 "\n"
-            - R_CURLY@3664..3665 "}"
-            - WHITESPACE@3665..3667 "\n\n"
-    - UNION_TYPE_DEFINITION@3667..3709
-        - union_KW@3667..3672 "union"
-        - WHITESPACE@3672..3673 " "
-        - NAME@3673..3689
-            - IDENT@3673..3688 "MetadataOrError"
-            - WHITESPACE@3688..3689 " "
-        - UNION_MEMBER_TYPES@3689..3709
-            - EQ@3689..3690 "="
-            - WHITESPACE@3690..3691 " "
-            - NAMED_TYPE@3691..3700
-                - NAME@3691..3700
-                    - IDENT@3691..3699 "KeyValue"
-                    - WHITESPACE@3699..3700 " "
-            - PIPE@3700..3701 "|"
-            - WHITESPACE@3701..3702 " "
-            - NAMED_TYPE@3702..3709
-                - NAME@3702..3709
-                    - IDENT@3702..3707 "Error"
-                    - WHITESPACE@3707..3709 "\n\n"
-    - OBJECT_TYPE_DEFINITION@3709..4029
-        - type_KW@3709..3713 "type"
-        - WHITESPACE@3713..3714 " "
-        - NAME@3714..3723
-            - IDENT@3714..3722 "Mutation"
-            - WHITESPACE@3722..3723 " "
-        - FIELDS_DEFINITION@3723..4029
-            - L_CURLY@3723..3724 "{"
-            - WHITESPACE@3724..3727 "\n  "
-            - FIELD_DEFINITION@3727..3807
-                - NAME@3727..3732
-                    - IDENT@3727..3732 "login"
-                - ARGUMENTS@3732..3768
-                    - L_PAREN@3732..3733 "("
-                    - INPUT_VALUE_DEFINITION@3733..3751
-                        - NAME@3733..3741
-                            - IDENT@3733..3741 "username"
-                        - COLON@3741..3742 ":"
-                        - WHITESPACE@3742..3743 " "
-                        - NON_NULL_TYPE@3743..3751
-                            - COMMA@3743..3744 ","
-                            - WHITESPACE@3744..3745 " "
-                            - NAMED_TYPE@3745..3751
-                                - NAME@3745..3751
-                                    - IDENT@3745..3751 "String"
-                    - INPUT_VALUE_DEFINITION@3751..3767
-                        - NAME@3751..3759
-                            - IDENT@3751..3759 "password"
-                        - COLON@3759..3760 ":"
-                        - WHITESPACE@3760..3761 " "
-                        - NON_NULL_TYPE@3761..3767
-                            - NAMED_TYPE@3761..3767
-                                - NAME@3761..3767
-                                    - IDENT@3761..3767 "String"
-                    - R_PAREN@3767..3768 ")"
-                - COLON@3768..3769 ":"
-                - WHITESPACE@3769..3770 " "
-                - NAMED_TYPE@3770..3775
-                    - WHITESPACE@3770..3771 " "
-                    - NAME@3771..3775
-                        - IDENT@3771..3775 "User"
-                - DIRECTIVES@3775..3807
-                    - DIRECTIVE@3775..3807
-                        - AT@3775..3776 "@"
-                        - NAME@3776..3787
-                            - IDENT@3776..3787 "join__field"
-                        - ARGUMENTS@3787..3807
-                            - L_PAREN@3787..3788 "("
-                            - ARGUMENT@3788..3803
-                                - NAME@3788..3793
-                                    - IDENT@3788..3793 "graph"
-                                - COLON@3793..3794 ":"
-                                - WHITESPACE@3794..3795 " "
-                                - ENUM_VALUE@3795..3803
-                                    - NAME@3795..3803
-                                        - IDENT@3795..3803 "ACCOUNTS"
-                            - R_PAREN@3803..3804 ")"
-                            - WHITESPACE@3804..3807 "\n  "
-            - FIELD_DEFINITION@3807..3888
-                - NAME@3807..3820
-                    - IDENT@3807..3820 "reviewProduct"
-                - ARGUMENTS@3820..3847
-                    - L_PAREN@3820..3821 "("
-                    - INPUT_VALUE_DEFINITION@3821..3834
-                        - NAME@3821..3824
-                            - IDENT@3821..3824 "upc"
-                        - COLON@3824..3825 ":"
-                        - WHITESPACE@3825..3826 " "
-                        - NON_NULL_TYPE@3826..3834
-                            - COMMA@3826..3827 ","
-                            - WHITESPACE@3827..3828 " "
-                            - NAMED_TYPE@3828..3834
-                                - NAME@3828..3834
-                                    - IDENT@3828..3834 "String"
-                    - INPUT_VALUE_DEFINITION@3834..3846
-                        - NAME@3834..3838
-                            - IDENT@3834..3838 "body"
-                        - COLON@3838..3839 ":"
-                        - WHITESPACE@3839..3840 " "
-                        - NON_NULL_TYPE@3840..3846
-                            - NAMED_TYPE@3840..3846
-                                - NAME@3840..3846
-                                    - IDENT@3840..3846 "String"
-                    - R_PAREN@3846..3847 ")"
-                - COLON@3847..3848 ":"
-                - WHITESPACE@3848..3849 " "
-                - NAMED_TYPE@3849..3857
-                    - WHITESPACE@3849..3850 " "
-                    - NAME@3850..3857
-                        - IDENT@3850..3857 "Product"
-                - DIRECTIVES@3857..3888
-                    - DIRECTIVE@3857..3888
-                        - AT@3857..3858 "@"
-                        - NAME@3858..3869
-                            - IDENT@3858..3869 "join__field"
-                        - ARGUMENTS@3869..3888
-                            - L_PAREN@3869..3870 "("
-                            - ARGUMENT@3870..3884
-                                - NAME@3870..3875
-                                    - IDENT@3870..3875 "graph"
-                                - COLON@3875..3876 ":"
-                                - WHITESPACE@3876..3877 " "
-                                - ENUM_VALUE@3877..3884
-                                    - NAME@3877..3884
-                                        - IDENT@3877..3884 "REVIEWS"
-                            - R_PAREN@3884..3885 ")"
-                            - WHITESPACE@3885..3888 "\n  "
-            - FIELD_DEFINITION@3888..3967
-                - NAME@3888..3900
-                    - IDENT@3888..3900 "updateReview"
-                - ARGUMENTS@3900..3927
-                    - L_PAREN@3900..3901 "("
-                    - INPUT_VALUE_DEFINITION@3901..3926
-                        - NAME@3901..3907
-                            - IDENT@3901..3907 "review"
-                        - COLON@3907..3908 ":"
-                        - WHITESPACE@3908..3909 " "
-                        - NON_NULL_TYPE@3909..3926
-                            - NAMED_TYPE@3909..3926
-                                - NAME@3909..3926
-                                    - IDENT@3909..3926 "UpdateReviewInput"
-                    - R_PAREN@3926..3927 ")"
-                - COLON@3927..3928 ":"
-                - WHITESPACE@3928..3929 " "
-                - NAMED_TYPE@3929..3936
-                    - WHITESPACE@3929..3930 " "
-                    - NAME@3930..3936
-                        - IDENT@3930..3936 "Review"
-                - DIRECTIVES@3936..3967
-                    - DIRECTIVE@3936..3967
-                        - AT@3936..3937 "@"
-                        - NAME@3937..3948
-                            - IDENT@3937..3948 "join__field"
-                        - ARGUMENTS@3948..3967
-                            - L_PAREN@3948..3949 "("
-                            - ARGUMENT@3949..3963
-                                - NAME@3949..3954
-                                    - IDENT@3949..3954 "graph"
-                                - COLON@3954..3955 ":"
-                                - WHITESPACE@3955..3956 " "
-                                - ENUM_VALUE@3956..3963
-                                    - NAME@3956..3963
-                                        - IDENT@3956..3963 "REVIEWS"
-                            - R_PAREN@3963..3964 ")"
-                            - WHITESPACE@3964..3967 "\n  "
-            - FIELD_DEFINITION@3967..4026
-                - NAME@3967..3979
-                    - IDENT@3967..3979 "deleteReview"
-                - ARGUMENTS@3979..3987
-                    - L_PAREN@3979..3980 "("
-                    - INPUT_VALUE_DEFINITION@3980..3986
-                        - NAME@3980..3982
-                            - IDENT@3980..3982 "id"
-                        - COLON@3982..3983 ":"
-                        - WHITESPACE@3983..3984 " "
-                        - NON_NULL_TYPE@3984..3986
-                            - NAMED_TYPE@3984..3986
-                                - NAME@3984..3986
-                                    - IDENT@3984..3986 "ID"
-                    - R_PAREN@3986..3987 ")"
-                - COLON@3987..3988 ":"
-                - WHITESPACE@3988..3989 " "
-                - NAMED_TYPE@3989..3997
-                    - WHITESPACE@3989..3990 " "
-                    - NAME@3990..3997
-                        - IDENT@3990..3997 "Boolean"
-                - DIRECTIVES@3997..4026
-                    - DIRECTIVE@3997..4026
-                        - AT@3997..3998 "@"
-                        - NAME@3998..4009
-                            - IDENT@3998..4009 "join__field"
-                        - ARGUMENTS@4009..4026
-                            - L_PAREN@4009..4010 "("
-                            - ARGUMENT@4010..4024
-                                - NAME@4010..4015
-                                    - IDENT@4010..4015 "graph"
-                                - COLON@4015..4016 ":"
-                                - WHITESPACE@4016..4017 " "
-                                - ENUM_VALUE@4017..4024
-                                    - NAME@4017..4024
-                                        - IDENT@4017..4024 "REVIEWS"
-                            - R_PAREN@4024..4025 ")"
-                            - WHITESPACE@4025..4026 "\n"
-            - R_CURLY@4026..4027 "}"
-            - WHITESPACE@4027..4029 "\n\n"
-    - OBJECT_TYPE_DEFINITION@4029..4075
-        - type_KW@4029..4033 "type"
-        - WHITESPACE@4033..4034 " "
-        - NAME@4034..4039
-            - IDENT@4034..4038 "Name"
-            - WHITESPACE@4038..4039 " "
-        - FIELDS_DEFINITION@4039..4075
-            - L_CURLY@4039..4040 "{"
-            - WHITESPACE@4040..4043 "\n  "
-            - FIELD_DEFINITION@4043..4059
-                - NAME@4043..4048
-                    - IDENT@4043..4048 "first"
-                - COLON@4048..4049 ":"
-                - WHITESPACE@4049..4050 " "
-                - NAMED_TYPE@4050..4059
-                    - WHITESPACE@4050..4053 "\n  "
-                    - NAME@4053..4059
-                        - IDENT@4053..4059 "String"
-            - FIELD_DEFINITION@4059..4072
-                - NAME@4059..4063
-                    - IDENT@4059..4063 "last"
-                - COLON@4063..4064 ":"
-                - WHITESPACE@4064..4065 " "
-                - NAMED_TYPE@4065..4072
-                    - WHITESPACE@4065..4066 "\n"
-                    - NAME@4066..4072
-                        - IDENT@4066..4072 "String"
-            - R_CURLY@4072..4073 "}"
-            - WHITESPACE@4073..4075 "\n\n"
-    - INTERFACE_TYPE_DEFINITION@4075..4117
-        - interface_KW@4075..4084 "interface"
-        - WHITESPACE@4084..4085 " "
-        - NAME@4085..4097
-            - IDENT@4085..4096 "NamedObject"
-            - WHITESPACE@4096..4097 " "
-        - FIELDS_DEFINITION@4097..4117
-            - L_CURLY@4097..4098 "{"
-            - WHITESPACE@4098..4101 "\n  "
-            - FIELD_DEFINITION@4101..4114
-                - NAME@4101..4105
-                    - IDENT@4101..4105 "name"
-                - COLON@4105..4106 ":"
-                - WHITESPACE@4106..4107 " "
-                - NON_NULL_TYPE@4107..4114
-                    - WHITESPACE@4107..4108 "\n"
-                    - NAMED_TYPE@4108..4114
-                        - NAME@4108..4114
-                            - IDENT@4108..4114 "String"
-            - R_CURLY@4114..4115 "}"
-            - WHITESPACE@4115..4117 "\n\n"
-    - OBJECT_TYPE_DEFINITION@4117..4262
-        - type_KW@4117..4121 "type"
-        - WHITESPACE@4121..4122 " "
-        - NAME@4122..4138
-            - IDENT@4122..4137 "PasswordAccount"
-            - WHITESPACE@4137..4138 "\n"
-        - DIRECTIVES@4138..4211
-            - DIRECTIVE@4138..4168
-                - AT@4138..4139 "@"
-                - NAME@4139..4150
-                    - IDENT@4139..4150 "join__owner"
-                - ARGUMENTS@4150..4168
-                    - L_PAREN@4150..4151 "("
-                    - ARGUMENT@4151..4166
-                        - NAME@4151..4156
-                            - IDENT@4151..4156 "graph"
-                        - COLON@4156..4157 ":"
-                        - WHITESPACE@4157..4158 " "
-                        - ENUM_VALUE@4158..4166
-                            - NAME@4158..4166
-                                - IDENT@4158..4166 "ACCOUNTS"
-                    - R_PAREN@4166..4167 ")"
-                    - WHITESPACE@4167..4168 "\n"
-            - DIRECTIVE@4168..4211
-                - AT@4168..4169 "@"
-                - NAME@4169..4179
-                    - IDENT@4169..4179 "join__type"
-                - ARGUMENTS@4179..4211
+                    - BANG@186..187 "!"
+            - R_PAREN@187..188 ")"
+            - WHITESPACE@188..189 " "
+        - repeatable_KW@189..199 "repeatable"
+        - WHITESPACE@199..200 " "
+        - on_KW@200..202 "on"
+        - WHITESPACE@202..203 " "
+        - DIRECTIVE_LOCATIONS@203..210
+            - DIRECTIVE_LOCATION@203..210
+                - SCHEMA_KW@203..209 "SCHEMA"
+                - WHITESPACE@209..210 "\n"
+    - DIRECTIVE_DEFINITION@210..325
+        - directive_KW@210..219 "directive"
+        - WHITESPACE@219..220 " "
+        - AT@220..221 "@"
+        - NAME@221..232
+            - IDENT@221..232 "join__field"
+        - ARGUMENTS_DEFINITION@232..305
+            - L_PAREN@232..233 "("
+            - INPUT_VALUE_DEFINITION@233..253
+                - NAME@233..238
+                    - IDENT@233..238 "graph"
+                - COLON@238..239 ":"
+                - WHITESPACE@239..240 " "
+                - NAMED_TYPE@240..253
+                    - COMMA@240..241 ","
+                    - WHITESPACE@241..242 " "
+                    - NAME@242..253
+                        - IDENT@242..253 "join__Graph"
+            - INPUT_VALUE_DEFINITION@253..279
+                - NAME@253..261
+                    - IDENT@253..261 "requires"
+                - COLON@261..262 ":"
+                - WHITESPACE@262..263 " "
+                - NAMED_TYPE@263..279
+                    - COMMA@263..264 ","
+                    - WHITESPACE@264..265 " "
+                    - NAME@265..279
+                        - IDENT@265..279 "join__FieldSet"
+            - INPUT_VALUE_DEFINITION@279..303
+                - NAME@279..287
+                    - IDENT@279..287 "provides"
+                - COLON@287..288 ":"
+                - WHITESPACE@288..289 " "
+                - NAMED_TYPE@289..303
+                    - NAME@289..303
+                        - IDENT@289..303 "join__FieldSet"
+            - R_PAREN@303..304 ")"
+            - WHITESPACE@304..305 " "
+        - on_KW@305..307 "on"
+        - WHITESPACE@307..308 " "
+        - DIRECTIVE_LOCATIONS@308..325
+            - DIRECTIVE_LOCATION@308..325
+                - FIELD_DEFINITION_KW@308..324 "FIELD_DEFINITION"
+                - WHITESPACE@324..325 "\n"
+    - DIRECTIVE_DEFINITION@325..422
+        - directive_KW@325..334 "directive"
+        - WHITESPACE@334..335 " "
+        - AT@335..336 "@"
+        - NAME@336..346
+            - IDENT@336..346 "join__type"
+        - ARGUMENTS_DEFINITION@346..389
+            - L_PAREN@346..347 "("
+            - INPUT_VALUE_DEFINITION@347..368
+                - NAME@347..352
+                    - IDENT@347..352 "graph"
+                - COLON@352..353 ":"
+                - WHITESPACE@353..354 " "
+                - NON_NULL_TYPE@354..368
+                    - COMMA@354..355 ","
+                    - WHITESPACE@355..356 " "
+                    - NAMED_TYPE@356..367
+                        - NAME@356..367
+                            - IDENT@356..367 "join__Graph"
+                    - BANG@367..368 "!"
+            - INPUT_VALUE_DEFINITION@368..387
+                - NAME@368..371
+                    - IDENT@368..371 "key"
+                - COLON@371..372 ":"
+                - WHITESPACE@372..373 " "
+                - NAMED_TYPE@373..387
+                    - NAME@373..387
+                        - IDENT@373..387 "join__FieldSet"
+            - R_PAREN@387..388 ")"
+            - WHITESPACE@388..389 " "
+        - repeatable_KW@389..399 "repeatable"
+        - WHITESPACE@399..400 " "
+        - on_KW@400..402 "on"
+        - WHITESPACE@402..403 " "
+        - DIRECTIVE_LOCATIONS@403..422
+            - DIRECTIVE_LOCATION@403..410
+                - OBJECT_KW@403..409 "OBJECT"
+                - WHITESPACE@409..410 " "
+            - PIPE@410..411 "|"
+            - WHITESPACE@411..412 " "
+            - DIRECTIVE_LOCATION@412..422
+                - INTERFACE_KW@412..421 "INTERFACE"
+                - WHITESPACE@421..422 "\n"
+    - DIRECTIVE_DEFINITION@422..488
+        - directive_KW@422..431 "directive"
+        - WHITESPACE@431..432 " "
+        - AT@432..433 "@"
+        - NAME@433..444
+            - IDENT@433..444 "join__owner"
+        - ARGUMENTS_DEFINITION@444..466
+            - L_PAREN@444..445 "("
+            - INPUT_VALUE_DEFINITION@445..464
+                - NAME@445..450
+                    - IDENT@445..450 "graph"
+                - COLON@450..451 ":"
+                - WHITESPACE@451..452 " "
+                - NON_NULL_TYPE@452..464
+                    - NAMED_TYPE@452..463
+                        - NAME@452..463
+                            - IDENT@452..463 "join__Graph"
+                    - BANG@463..464 "!"
+            - R_PAREN@464..465 ")"
+            - WHITESPACE@465..466 " "
+        - on_KW@466..468 "on"
+        - WHITESPACE@468..469 " "
+        - DIRECTIVE_LOCATIONS@469..488
+            - DIRECTIVE_LOCATION@469..476
+                - OBJECT_KW@469..475 "OBJECT"
+                - WHITESPACE@475..476 " "
+            - PIPE@476..477 "|"
+            - WHITESPACE@477..478 " "
+            - DIRECTIVE_LOCATION@478..488
+                - INTERFACE_KW@478..487 "INTERFACE"
+                - WHITESPACE@487..488 "\n"
+    - DIRECTIVE_DEFINITION@488..554
+        - directive_KW@488..497 "directive"
+        - WHITESPACE@497..498 " "
+        - AT@498..499 "@"
+        - NAME@499..510
+            - IDENT@499..510 "join__graph"
+        - ARGUMENTS_DEFINITION@510..540
+            - L_PAREN@510..511 "("
+            - INPUT_VALUE_DEFINITION@511..526
+                - NAME@511..515
+                    - IDENT@511..515 "name"
+                - COLON@515..516 ":"
+                - WHITESPACE@516..517 " "
+                - NON_NULL_TYPE@517..526
+                    - COMMA@517..518 ","
+                    - WHITESPACE@518..519 " "
+                    - NAMED_TYPE@519..525
+                        - NAME@519..525
+                            - IDENT@519..525 "String"
+                    - BANG@525..526 "!"
+            - INPUT_VALUE_DEFINITION@526..538
+                - NAME@526..529
+                    - IDENT@526..529 "url"
+                - COLON@529..530 ":"
+                - WHITESPACE@530..531 " "
+                - NON_NULL_TYPE@531..538
+                    - NAMED_TYPE@531..537
+                        - NAME@531..537
+                            - IDENT@531..537 "String"
+                    - BANG@537..538 "!"
+            - R_PAREN@538..539 ")"
+            - WHITESPACE@539..540 " "
+        - on_KW@540..542 "on"
+        - WHITESPACE@542..543 " "
+        - DIRECTIVE_LOCATIONS@543..554
+            - DIRECTIVE_LOCATION@543..554
+                - ENUM_VALUE_KW@543..553 "ENUM_VALUE"
+                - WHITESPACE@553..554 "\n"
+    - DIRECTIVE_DEFINITION@554..581
+        - directive_KW@554..563 "directive"
+        - WHITESPACE@563..564 " "
+        - AT@564..565 "@"
+        - NAME@565..572
+            - IDENT@565..571 "stream"
+            - WHITESPACE@571..572 " "
+        - on_KW@572..574 "on"
+        - WHITESPACE@574..575 " "
+        - DIRECTIVE_LOCATIONS@575..581
+            - DIRECTIVE_LOCATION@575..581
+                - FIELD_KW@575..580 "FIELD"
+                - WHITESPACE@580..581 "\n"
+    - DIRECTIVE_DEFINITION@581..627
+        - directive_KW@581..590 "directive"
+        - WHITESPACE@590..591 " "
+        - AT@591..592 "@"
+        - NAME@592..601
+            - IDENT@592..601 "transform"
+        - ARGUMENTS_DEFINITION@601..617
+            - L_PAREN@601..602 "("
+            - INPUT_VALUE_DEFINITION@602..615
+                - NAME@602..606
+                    - IDENT@602..606 "from"
+                - COLON@606..607 ":"
+                - WHITESPACE@607..608 " "
+                - NON_NULL_TYPE@608..615
+                    - NAMED_TYPE@608..614
+                        - NAME@608..614
+                            - IDENT@608..614 "String"
+                    - BANG@614..615 "!"
+            - R_PAREN@615..616 ")"
+            - WHITESPACE@616..617 " "
+        - on_KW@617..619 "on"
+        - WHITESPACE@619..620 " "
+        - DIRECTIVE_LOCATIONS@620..627
+            - DIRECTIVE_LOCATION@620..627
+                - FIELD_KW@620..625 "FIELD"
+                - WHITESPACE@625..627 "\n\n"
+    - UNION_TYPE_DEFINITION@627..677
+        - union_KW@627..632 "union"
+        - WHITESPACE@632..633 " "
+        - NAME@633..645
+            - IDENT@633..644 "AccountType"
+            - WHITESPACE@644..645 " "
+        - UNION_MEMBER_TYPES@645..677
+            - EQ@645..646 "="
+            - WHITESPACE@646..647 " "
+            - NAMED_TYPE@647..663
+                - NAME@647..663
+                    - IDENT@647..662 "PasswordAccount"
+                    - WHITESPACE@662..663 " "
+            - PIPE@663..664 "|"
+            - WHITESPACE@664..665 " "
+            - NAMED_TYPE@665..677
+                - NAME@665..677
+                    - IDENT@665..675 "SMSAccount"
+                    - WHITESPACE@675..677 "\n\n"
+    - OBJECT_TYPE_DEFINITION@677..713
+        - type_KW@677..681 "type"
+        - WHITESPACE@681..682 " "
+        - NAME@682..689
+            - IDENT@682..688 "Amazon"
+            - WHITESPACE@688..689 " "
+        - FIELDS_DEFINITION@689..713
+            - L_CURLY@689..690 "{"
+            - WHITESPACE@690..693 "\n  "
+            - FIELD_DEFINITION@693..710
+                - NAME@693..701
+                    - IDENT@693..701 "referrer"
+                - COLON@701..702 ":"
+                - WHITESPACE@702..703 " "
+                - NAMED_TYPE@703..710
+                    - WHITESPACE@703..704 "\n"
+                    - NAME@704..710
+                        - IDENT@704..710 "String"
+            - R_CURLY@710..711 "}"
+            - WHITESPACE@711..713 "\n\n"
+    - UNION_TYPE_DEFINITION@713..740
+        - union_KW@713..718 "union"
+        - WHITESPACE@718..719 " "
+        - NAME@719..724
+            - IDENT@719..723 "Body"
+            - WHITESPACE@723..724 " "
+        - UNION_MEMBER_TYPES@724..740
+            - EQ@724..725 "="
+            - WHITESPACE@725..726 " "
+            - NAMED_TYPE@726..732
+                - NAME@726..732
+                    - IDENT@726..731 "Image"
+                    - WHITESPACE@731..732 " "
+            - PIPE@732..733 "|"
+            - WHITESPACE@733..734 " "
+            - NAMED_TYPE@734..740
+                - NAME@734..740
+                    - IDENT@734..738 "Text"
+                    - WHITESPACE@738..740 "\n\n"
+    - OBJECT_TYPE_DEFINITION@740..1727
+        - type_KW@740..744 "type"
+        - WHITESPACE@744..745 " "
+        - NAME@745..750
+            - IDENT@745..749 "Book"
+            - WHITESPACE@749..750 " "
+        - IMPLEMENTS_INTERFACES@750..769
+            - implements_KW@750..760 "implements"
+            - WHITESPACE@760..761 " "
+            - NAMED_TYPE@761..769
+                - NAME@761..769
+                    - IDENT@761..768 "Product"
+                    - WHITESPACE@768..769 "\n"
+        - DIRECTIVES@769..960
+            - DIRECTIVE@769..796
+                - AT@769..770 "@"
+                - NAME@770..781
+                    - IDENT@770..781 "join__owner"
+                - ARGUMENTS@781..796
+                    - L_PAREN@781..782 "("
+                    - ARGUMENT@782..794
+                        - NAME@782..787
+                            - IDENT@782..787 "graph"
+                        - COLON@787..788 ":"
+                        - WHITESPACE@788..789 " "
+                        - ENUM_VALUE@789..794
+                            - NAME@789..794
+                                - IDENT@789..794 "BOOKS"
+                    - R_PAREN@794..795 ")"
+                    - WHITESPACE@795..796 "\n"
+            - DIRECTIVE@796..835
+                - AT@796..797 "@"
+                - NAME@797..807
+                    - IDENT@797..807 "join__type"
+                - ARGUMENTS@807..835
+                    - L_PAREN@807..808 "("
+                    - ARGUMENT@808..822
+                        - NAME@808..813
+                            - IDENT@808..813 "graph"
+                        - COLON@813..814 ":"
+                        - WHITESPACE@814..815 " "
+                        - ENUM_VALUE@815..822
+                            - NAME@815..822
+                                - IDENT@815..820 "BOOKS"
+                                - COMMA@820..821 ","
+                                - WHITESPACE@821..822 " "
+                    - ARGUMENT@822..833
+                        - NAME@822..825
+                            - IDENT@822..825 "key"
+                        - COLON@825..826 ":"
+                        - WHITESPACE@826..827 " "
+                        - STRING_VALUE@827..833
+                            - STRING@827..833 "\"isbn\""
+                    - R_PAREN@833..834 ")"
+                    - WHITESPACE@834..835 "\n"
+            - DIRECTIVE@835..878
+                - AT@835..836 "@"
+                - NAME@836..846
+                    - IDENT@836..846 "join__type"
+                - ARGUMENTS@846..878
+                    - L_PAREN@846..847 "("
+                    - ARGUMENT@847..865
+                        - NAME@847..852
+                            - IDENT@847..852 "graph"
+                        - COLON@852..853 ":"
+                        - WHITESPACE@853..854 " "
+                        - ENUM_VALUE@854..865
+                            - NAME@854..865
+                                - IDENT@854..863 "INVENTORY"
+                                - COMMA@863..864 ","
+                                - WHITESPACE@864..865 " "
+                    - ARGUMENT@865..876
+                        - NAME@865..868
+                            - IDENT@865..868 "key"
+                        - COLON@868..869 ":"
+                        - WHITESPACE@869..870 " "
+                        - STRING_VALUE@870..876
+                            - STRING@870..876 "\"isbn\""
+                    - R_PAREN@876..877 ")"
+                    - WHITESPACE@877..878 "\n"
+            - DIRECTIVE@878..919
+                - AT@878..879 "@"
+                - NAME@879..889
+                    - IDENT@879..889 "join__type"
+                - ARGUMENTS@889..919
+                    - L_PAREN@889..890 "("
+                    - ARGUMENT@890..906
+                        - NAME@890..895
+                            - IDENT@890..895 "graph"
+                        - COLON@895..896 ":"
+                        - WHITESPACE@896..897 " "
+                        - ENUM_VALUE@897..906
+                            - NAME@897..906
+                                - IDENT@897..904 "PRODUCT"
+                                - COMMA@904..905 ","
+                                - WHITESPACE@905..906 " "
+                    - ARGUMENT@906..917
+                        - NAME@906..909
+                            - IDENT@906..909 "key"
+                        - COLON@909..910 ":"
+                        - WHITESPACE@910..911 " "
+                        - STRING_VALUE@911..917
+                            - STRING@911..917 "\"isbn\""
+                    - R_PAREN@917..918 ")"
+                    - WHITESPACE@918..919 "\n"
+            - DIRECTIVE@919..960
+                - AT@919..920 "@"
+                - NAME@920..930
+                    - IDENT@920..930 "join__type"
+                - ARGUMENTS@930..960
+                    - L_PAREN@930..931 "("
+                    - ARGUMENT@931..947
+                        - NAME@931..936
+                            - IDENT@931..936 "graph"
+                        - COLON@936..937 ":"
+                        - WHITESPACE@937..938 " "
+                        - ENUM_VALUE@938..947
+                            - NAME@938..947
+                                - IDENT@938..945 "REVIEWS"
+                                - COMMA@945..946 ","
+                                - WHITESPACE@946..947 " "
+                    - ARGUMENT@947..958
+                        - NAME@947..950
+                            - IDENT@947..950 "key"
+                        - COLON@950..951 ":"
+                        - WHITESPACE@951..952 " "
+                        - STRING_VALUE@952..958
+                            - STRING@952..958 "\"isbn\""
+                    - R_PAREN@958..959 ")"
+                    - WHITESPACE@959..960 "\n"
+        - FIELDS_DEFINITION@960..1727
+            - L_CURLY@960..961 "{"
+            - WHITESPACE@961..964 "\n  "
+            - FIELD_DEFINITION@964..1007
+                - NAME@964..968
+                    - IDENT@964..968 "isbn"
+                - COLON@968..969 ":"
+                - WHITESPACE@969..970 " "
+                - NON_NULL_TYPE@970..978
+                    - WHITESPACE@970..971 " "
+                    - NAMED_TYPE@971..977
+                        - NAME@971..977
+                            - IDENT@971..977 "String"
+                    - BANG@977..978 "!"
+                - DIRECTIVES@978..1007
+                    - DIRECTIVE@978..1007
+                        - AT@978..979 "@"
+                        - NAME@979..990
+                            - IDENT@979..990 "join__field"
+                        - ARGUMENTS@990..1007
+                            - L_PAREN@990..991 "("
+                            - ARGUMENT@991..1003
+                                - NAME@991..996
+                                    - IDENT@991..996 "graph"
+                                - COLON@996..997 ":"
+                                - WHITESPACE@997..998 " "
+                                - ENUM_VALUE@998..1003
+                                    - NAME@998..1003
+                                        - IDENT@998..1003 "BOOKS"
+                            - R_PAREN@1003..1004 ")"
+                            - WHITESPACE@1004..1007 "\n  "
+            - FIELD_DEFINITION@1007..1050
+                - NAME@1007..1012
+                    - IDENT@1007..1012 "title"
+                - COLON@1012..1013 ":"
+                - WHITESPACE@1013..1014 " "
+                - NAMED_TYPE@1014..1021
+                    - WHITESPACE@1014..1015 " "
+                    - NAME@1015..1021
+                        - IDENT@1015..1021 "String"
+                - DIRECTIVES@1021..1050
+                    - DIRECTIVE@1021..1050
+                        - AT@1021..1022 "@"
+                        - NAME@1022..1033
+                            - IDENT@1022..1033 "join__field"
+                        - ARGUMENTS@1033..1050
+                            - L_PAREN@1033..1034 "("
+                            - ARGUMENT@1034..1046
+                                - NAME@1034..1039
+                                    - IDENT@1034..1039 "graph"
+                                - COLON@1039..1040 ":"
+                                - WHITESPACE@1040..1041 " "
+                                - ENUM_VALUE@1041..1046
+                                    - NAME@1041..1046
+                                        - IDENT@1041..1046 "BOOKS"
+                            - R_PAREN@1046..1047 ")"
+                            - WHITESPACE@1047..1050 "\n  "
+            - FIELD_DEFINITION@1050..1089
+                - NAME@1050..1054
+                    - IDENT@1050..1054 "year"
+                - COLON@1054..1055 ":"
+                - WHITESPACE@1055..1056 " "
+                - NAMED_TYPE@1056..1060
+                    - WHITESPACE@1056..1057 " "
+                    - NAME@1057..1060
+                        - IDENT@1057..1060 "Int"
+                - DIRECTIVES@1060..1089
+                    - DIRECTIVE@1060..1089
+                        - AT@1060..1061 "@"
+                        - NAME@1061..1072
+                            - IDENT@1061..1072 "join__field"
+                        - ARGUMENTS@1072..1089
+                            - L_PAREN@1072..1073 "("
+                            - ARGUMENT@1073..1085
+                                - NAME@1073..1078
+                                    - IDENT@1073..1078 "graph"
+                                - COLON@1078..1079 ":"
+                                - WHITESPACE@1079..1080 " "
+                                - ENUM_VALUE@1080..1085
+                                    - NAME@1080..1085
+                                        - IDENT@1080..1085 "BOOKS"
+                            - R_PAREN@1085..1086 ")"
+                            - WHITESPACE@1086..1089 "\n  "
+            - FIELD_DEFINITION@1089..1140
+                - NAME@1089..1101
+                    - IDENT@1089..1101 "similarBooks"
+                - COLON@1101..1102 ":"
+                - WHITESPACE@1102..1103 " "
+                - NON_NULL_TYPE@1103..1111
+                    - WHITESPACE@1103..1104 " "
+                    - LIST_TYPE@1104..1110
+                        - L_BRACK@1104..1105 "["
+                        - NAMED_TYPE@1105..1109
+                            - NAME@1105..1109
+                                - IDENT@1105..1109 "Book"
+                        - R_BRACK@1109..1110 "]"
+                    - BANG@1110..1111 "!"
+                - DIRECTIVES@1111..1140
+                    - DIRECTIVE@1111..1140
+                        - AT@1111..1112 "@"
+                        - NAME@1112..1123
+                            - IDENT@1112..1123 "join__field"
+                        - ARGUMENTS@1123..1140
+                            - L_PAREN@1123..1124 "("
+                            - ARGUMENT@1124..1136
+                                - NAME@1124..1129
+                                    - IDENT@1124..1129 "graph"
+                                - COLON@1129..1130 ":"
+                                - WHITESPACE@1130..1131 " "
+                                - ENUM_VALUE@1131..1136
+                                    - NAME@1131..1136
+                                        - IDENT@1131..1136 "BOOKS"
+                            - R_PAREN@1136..1137 ")"
+                            - WHITESPACE@1137..1140 "\n  "
+            - FIELD_DEFINITION@1140..1197
+                - NAME@1140..1148
+                    - IDENT@1140..1148 "metadata"
+                - COLON@1148..1149 ":"
+                - WHITESPACE@1149..1150 " "
+                - LIST_TYPE@1150..1168
+                    - WHITESPACE@1150..1151 " "
+                    - L_BRACK@1151..1152 "["
+                    - NAMED_TYPE@1152..1167
+                        - NAME@1152..1167
+                            - IDENT@1152..1167 "MetadataOrError"
+                    - R_BRACK@1167..1168 "]"
+                - DIRECTIVES@1168..1197
+                    - DIRECTIVE@1168..1197
+                        - AT@1168..1169 "@"
+                        - NAME@1169..1180
+                            - IDENT@1169..1180 "join__field"
+                        - ARGUMENTS@1180..1197
+                            - L_PAREN@1180..1181 "("
+                            - ARGUMENT@1181..1193
+                                - NAME@1181..1186
+                                    - IDENT@1181..1186 "graph"
+                                - COLON@1186..1187 ":"
+                                - WHITESPACE@1187..1188 " "
+                                - ENUM_VALUE@1188..1193
+                                    - NAME@1188..1193
+                                        - IDENT@1188..1193 "BOOKS"
+                            - R_PAREN@1193..1194 ")"
+                            - WHITESPACE@1194..1197 "\n  "
+            - FIELD_DEFINITION@1197..1247
+                - NAME@1197..1204
+                    - IDENT@1197..1204 "inStock"
+                - COLON@1204..1205 ":"
+                - WHITESPACE@1205..1206 " "
+                - NAMED_TYPE@1206..1214
+                    - WHITESPACE@1206..1207 " "
+                    - NAME@1207..1214
+                        - IDENT@1207..1214 "Boolean"
+                - DIRECTIVES@1214..1247
+                    - DIRECTIVE@1214..1247
+                        - AT@1214..1215 "@"
+                        - NAME@1215..1226
+                            - IDENT@1215..1226 "join__field"
+                        - ARGUMENTS@1226..1247
+                            - L_PAREN@1226..1227 "("
+                            - ARGUMENT@1227..1243
+                                - NAME@1227..1232
+                                    - IDENT@1227..1232 "graph"
+                                - COLON@1232..1233 ":"
+                                - WHITESPACE@1233..1234 " "
+                                - ENUM_VALUE@1234..1243
+                                    - NAME@1234..1243
+                                        - IDENT@1234..1243 "INVENTORY"
+                            - R_PAREN@1243..1244 ")"
+                            - WHITESPACE@1244..1247 "\n  "
+            - FIELD_DEFINITION@1247..1302
+                - NAME@1247..1259
+                    - IDENT@1247..1259 "isCheckedOut"
+                - COLON@1259..1260 ":"
+                - WHITESPACE@1260..1261 " "
+                - NAMED_TYPE@1261..1269
+                    - WHITESPACE@1261..1262 " "
+                    - NAME@1262..1269
+                        - IDENT@1262..1269 "Boolean"
+                - DIRECTIVES@1269..1302
+                    - DIRECTIVE@1269..1302
+                        - AT@1269..1270 "@"
+                        - NAME@1270..1281
+                            - IDENT@1270..1281 "join__field"
+                        - ARGUMENTS@1281..1302
+                            - L_PAREN@1281..1282 "("
+                            - ARGUMENT@1282..1298
+                                - NAME@1282..1287
+                                    - IDENT@1282..1287 "graph"
+                                - COLON@1287..1288 ":"
+                                - WHITESPACE@1288..1289 " "
+                                - ENUM_VALUE@1289..1298
+                                    - NAME@1289..1298
+                                        - IDENT@1289..1298 "INVENTORY"
+                            - R_PAREN@1298..1299 ")"
+                            - WHITESPACE@1299..1302 "\n  "
+            - FIELD_DEFINITION@1302..1346
+                - NAME@1302..1305
+                    - IDENT@1302..1305 "upc"
+                - COLON@1305..1306 ":"
+                - WHITESPACE@1306..1307 " "
+                - NON_NULL_TYPE@1307..1315
+                    - WHITESPACE@1307..1308 " "
+                    - NAMED_TYPE@1308..1314
+                        - NAME@1308..1314
+                            - IDENT@1308..1314 "String"
+                    - BANG@1314..1315 "!"
+                - DIRECTIVES@1315..1346
+                    - DIRECTIVE@1315..1346
+                        - AT@1315..1316 "@"
+                        - NAME@1316..1327
+                            - IDENT@1316..1327 "join__field"
+                        - ARGUMENTS@1327..1346
+                            - L_PAREN@1327..1328 "("
+                            - ARGUMENT@1328..1342
+                                - NAME@1328..1333
+                                    - IDENT@1328..1333 "graph"
+                                - COLON@1333..1334 ":"
+                                - WHITESPACE@1334..1335 " "
+                                - ENUM_VALUE@1335..1342
+                                    - NAME@1335..1342
+                                        - IDENT@1335..1342 "PRODUCT"
+                            - R_PAREN@1342..1343 ")"
+                            - WHITESPACE@1343..1346 "\n  "
+            - FIELD_DEFINITION@1346..1390
+                - NAME@1346..1349
+                    - IDENT@1346..1349 "sku"
+                - COLON@1349..1350 ":"
+                - WHITESPACE@1350..1351 " "
+                - NON_NULL_TYPE@1351..1359
+                    - WHITESPACE@1351..1352 " "
+                    - NAMED_TYPE@1352..1358
+                        - NAME@1352..1358
+                            - IDENT@1352..1358 "String"
+                    - BANG@1358..1359 "!"
+                - DIRECTIVES@1359..1390
+                    - DIRECTIVE@1359..1390
+                        - AT@1359..1360 "@"
+                        - NAME@1360..1371
+                            - IDENT@1360..1371 "join__field"
+                        - ARGUMENTS@1371..1390
+                            - L_PAREN@1371..1372 "("
+                            - ARGUMENT@1372..1386
+                                - NAME@1372..1377
+                                    - IDENT@1372..1377 "graph"
+                                - COLON@1377..1378 ":"
+                                - WHITESPACE@1378..1379 " "
+                                - ENUM_VALUE@1379..1386
+                                    - NAME@1379..1386
+                                        - IDENT@1379..1386 "PRODUCT"
+                            - R_PAREN@1386..1387 ")"
+                            - WHITESPACE@1387..1390 "\n  "
+            - FIELD_DEFINITION@1390..1483
+                - NAME@1390..1394
+                    - IDENT@1390..1394 "name"
+                - ARGUMENTS@1394..1419
+                    - L_PAREN@1394..1395 "("
+                    - INPUT_VALUE_DEFINITION@1395..1418
+                        - NAME@1395..1404
+                            - IDENT@1395..1404 "delimeter"
+                        - COLON@1404..1405 ":"
+                        - WHITESPACE@1405..1406 " "
+                        - NAMED_TYPE@1406..1413
+                            - WHITESPACE@1406..1407 " "
+                            - NAME@1407..1413
+                                - IDENT@1407..1413 "String"
+                        - DEFAULT_VALUE@1413..1418
+                            - EQ@1413..1414 "="
+                            - WHITESPACE@1414..1415 " "
+                            - STRING_VALUE@1415..1418
+                                - STRING@1415..1418 "\" \""
+                    - R_PAREN@1418..1419 ")"
+                - COLON@1419..1420 ":"
+                - WHITESPACE@1420..1421 " "
+                - NAMED_TYPE@1421..1428
+                    - WHITESPACE@1421..1422 " "
+                    - NAME@1422..1428
+                        - IDENT@1422..1428 "String"
+                - DIRECTIVES@1428..1483
+                    - DIRECTIVE@1428..1483
+                        - AT@1428..1429 "@"
+                        - NAME@1429..1440
+                            - IDENT@1429..1440 "join__field"
+                        - ARGUMENTS@1440..1483
+                            - L_PAREN@1440..1441 "("
+                            - ARGUMENT@1441..1457
+                                - NAME@1441..1446
+                                    - IDENT@1441..1446 "graph"
+                                - COLON@1446..1447 ":"
+                                - WHITESPACE@1447..1448 " "
+                                - ENUM_VALUE@1448..1457
+                                    - NAME@1448..1457
+                                        - IDENT@1448..1455 "PRODUCT"
+                                        - COMMA@1455..1456 ","
+                                        - WHITESPACE@1456..1457 " "
+                            - ARGUMENT@1457..1479
+                                - NAME@1457..1465
+                                    - IDENT@1457..1465 "requires"
+                                - COLON@1465..1466 ":"
+                                - WHITESPACE@1466..1467 " "
+                                - STRING_VALUE@1467..1479
+                                    - STRING@1467..1479 "\"title year\""
+                            - R_PAREN@1479..1480 ")"
+                            - WHITESPACE@1480..1483 "\n  "
+            - FIELD_DEFINITION@1483..1528
+                - NAME@1483..1488
+                    - IDENT@1483..1488 "price"
+                - COLON@1488..1489 ":"
+                - WHITESPACE@1489..1490 " "
+                - NAMED_TYPE@1490..1497
+                    - WHITESPACE@1490..1491 " "
+                    - NAME@1491..1497
+                        - IDENT@1491..1497 "String"
+                - DIRECTIVES@1497..1528
+                    - DIRECTIVE@1497..1528
+                        - AT@1497..1498 "@"
+                        - NAME@1498..1509
+                            - IDENT@1498..1509 "join__field"
+                        - ARGUMENTS@1509..1528
+                            - L_PAREN@1509..1510 "("
+                            - ARGUMENT@1510..1524
+                                - NAME@1510..1515
+                                    - IDENT@1510..1515 "graph"
+                                - COLON@1515..1516 ":"
+                                - WHITESPACE@1516..1517 " "
+                                - ENUM_VALUE@1517..1524
+                                    - NAME@1517..1524
+                                        - IDENT@1517..1524 "PRODUCT"
+                            - R_PAREN@1524..1525 ")"
+                            - WHITESPACE@1525..1528 "\n  "
+            - FIELD_DEFINITION@1528..1587
+                - NAME@1528..1535
+                    - IDENT@1528..1535 "details"
+                - COLON@1535..1536 ":"
+                - WHITESPACE@1536..1537 " "
+                - NAMED_TYPE@1537..1556
+                    - WHITESPACE@1537..1538 " "
+                    - NAME@1538..1556
+                        - IDENT@1538..1556 "ProductDetailsBook"
+                - DIRECTIVES@1556..1587
+                    - DIRECTIVE@1556..1587
+                        - AT@1556..1557 "@"
+                        - NAME@1557..1568
+                            - IDENT@1557..1568 "join__field"
+                        - ARGUMENTS@1568..1587
+                            - L_PAREN@1568..1569 "("
+                            - ARGUMENT@1569..1583
+                                - NAME@1569..1574
+                                    - IDENT@1569..1574 "graph"
+                                - COLON@1574..1575 ":"
+                                - WHITESPACE@1575..1576 " "
+                                - ENUM_VALUE@1576..1583
+                                    - NAME@1576..1583
+                                        - IDENT@1576..1583 "PRODUCT"
+                            - R_PAREN@1583..1584 ")"
+                            - WHITESPACE@1584..1587 "\n  "
+            - FIELD_DEFINITION@1587..1636
+                - NAME@1587..1594
+                    - IDENT@1587..1594 "reviews"
+                - COLON@1594..1595 ":"
+                - WHITESPACE@1595..1596 " "
+                - LIST_TYPE@1596..1605
+                    - WHITESPACE@1596..1597 " "
+                    - L_BRACK@1597..1598 "["
+                    - NAMED_TYPE@1598..1604
+                        - NAME@1598..1604
+                            - IDENT@1598..1604 "Review"
+                    - R_BRACK@1604..1605 "]"
+                - DIRECTIVES@1605..1636
+                    - DIRECTIVE@1605..1636
+                        - AT@1605..1606 "@"
+                        - NAME@1606..1617
+                            - IDENT@1606..1617 "join__field"
+                        - ARGUMENTS@1617..1636
+                            - L_PAREN@1617..1618 "("
+                            - ARGUMENT@1618..1632
+                                - NAME@1618..1623
+                                    - IDENT@1618..1623 "graph"
+                                - COLON@1623..1624 ":"
+                                - WHITESPACE@1624..1625 " "
+                                - ENUM_VALUE@1625..1632
+                                    - NAME@1625..1632
+                                        - IDENT@1625..1632 "REVIEWS"
+                            - R_PAREN@1632..1633 ")"
+                            - WHITESPACE@1633..1636 "\n  "
+            - FIELD_DEFINITION@1636..1724
+                - NAME@1636..1650
+                    - IDENT@1636..1650 "relatedReviews"
+                - COLON@1650..1651 ":"
+                - WHITESPACE@1651..1652 " "
+                - NON_NULL_TYPE@1652..1663
+                    - WHITESPACE@1652..1653 " "
+                    - LIST_TYPE@1653..1662
+                        - L_BRACK@1653..1654 "["
+                        - NON_NULL_TYPE@1654..1661
+                            - NAMED_TYPE@1654..1660
+                                - NAME@1654..1660
+                                    - IDENT@1654..1660 "Review"
+                            - BANG@1660..1661 "!"
+                        - R_BRACK@1661..1662 "]"
+                    - BANG@1662..1663 "!"
+                - DIRECTIVES@1663..1724
+                    - DIRECTIVE@1663..1724
+                        - AT@1663..1664 "@"
+                        - NAME@1664..1675
+                            - IDENT@1664..1675 "join__field"
+                        - ARGUMENTS@1675..1724
+                            - L_PAREN@1675..1676 "("
+                            - ARGUMENT@1676..1692
+                                - NAME@1676..1681
+                                    - IDENT@1676..1681 "graph"
+                                - COLON@1681..1682 ":"
+                                - WHITESPACE@1682..1683 " "
+                                - ENUM_VALUE@1683..1692
+                                    - NAME@1683..1692
+                                        - IDENT@1683..1690 "REVIEWS"
+                                        - COMMA@1690..1691 ","
+                                        - WHITESPACE@1691..1692 " "
+                            - ARGUMENT@1692..1722
+                                - NAME@1692..1700
+                                    - IDENT@1692..1700 "requires"
+                                - COLON@1700..1701 ":"
+                                - WHITESPACE@1701..1702 " "
+                                - STRING_VALUE@1702..1722
+                                    - STRING@1702..1722 "\"similarBooks{isbn}\""
+                            - R_PAREN@1722..1723 ")"
+                            - WHITESPACE@1723..1724 "\n"
+            - R_CURLY@1724..1725 "}"
+            - WHITESPACE@1725..1727 "\n\n"
+    - UNION_TYPE_DEFINITION@1727..1756
+        - union_KW@1727..1732 "union"
+        - WHITESPACE@1732..1733 " "
+        - NAME@1733..1739
+            - IDENT@1733..1738 "Brand"
+            - WHITESPACE@1738..1739 " "
+        - UNION_MEMBER_TYPES@1739..1756
+            - EQ@1739..1740 "="
+            - WHITESPACE@1740..1741 " "
+            - NAMED_TYPE@1741..1746
+                - NAME@1741..1746
+                    - IDENT@1741..1745 "Ikea"
+                    - WHITESPACE@1745..1746 " "
+            - PIPE@1746..1747 "|"
+            - WHITESPACE@1747..1748 " "
+            - NAMED_TYPE@1748..1756
+                - NAME@1748..1756
+                    - IDENT@1748..1754 "Amazon"
+                    - WHITESPACE@1754..1756 "\n\n"
+    - OBJECT_TYPE_DEFINITION@1756..2105
+        - type_KW@1756..1760 "type"
+        - WHITESPACE@1760..1761 " "
+        - NAME@1761..1765
+            - IDENT@1761..1764 "Car"
+            - WHITESPACE@1764..1765 " "
+        - IMPLEMENTS_INTERFACES@1765..1784
+            - implements_KW@1765..1775 "implements"
+            - WHITESPACE@1775..1776 " "
+            - NAMED_TYPE@1776..1784
+                - NAME@1776..1784
+                    - IDENT@1776..1783 "Vehicle"
+                    - WHITESPACE@1783..1784 "\n"
+        - DIRECTIVES@1784..1891
+            - DIRECTIVE@1784..1813
+                - AT@1784..1785 "@"
+                - NAME@1785..1796
+                    - IDENT@1785..1796 "join__owner"
+                - ARGUMENTS@1796..1813
+                    - L_PAREN@1796..1797 "("
+                    - ARGUMENT@1797..1811
+                        - NAME@1797..1802
+                            - IDENT@1797..1802 "graph"
+                        - COLON@1802..1803 ":"
+                        - WHITESPACE@1803..1804 " "
+                        - ENUM_VALUE@1804..1811
+                            - NAME@1804..1811
+                                - IDENT@1804..1811 "PRODUCT"
+                    - R_PAREN@1811..1812 ")"
+                    - WHITESPACE@1812..1813 "\n"
+            - DIRECTIVE@1813..1852
+                - AT@1813..1814 "@"
+                - NAME@1814..1824
+                    - IDENT@1814..1824 "join__type"
+                - ARGUMENTS@1824..1852
+                    - L_PAREN@1824..1825 "("
+                    - ARGUMENT@1825..1841
+                        - NAME@1825..1830
+                            - IDENT@1825..1830 "graph"
+                        - COLON@1830..1831 ":"
+                        - WHITESPACE@1831..1832 " "
+                        - ENUM_VALUE@1832..1841
+                            - NAME@1832..1841
+                                - IDENT@1832..1839 "PRODUCT"
+                                - COMMA@1839..1840 ","
+                                - WHITESPACE@1840..1841 " "
+                    - ARGUMENT@1841..1850
+                        - NAME@1841..1844
+                            - IDENT@1841..1844 "key"
+                        - COLON@1844..1845 ":"
+                        - WHITESPACE@1845..1846 " "
+                        - STRING_VALUE@1846..1850
+                            - STRING@1846..1850 "\"id\""
+                    - R_PAREN@1850..1851 ")"
+                    - WHITESPACE@1851..1852 "\n"
+            - DIRECTIVE@1852..1891
+                - AT@1852..1853 "@"
+                - NAME@1853..1863
+                    - IDENT@1853..1863 "join__type"
+                - ARGUMENTS@1863..1891
+                    - L_PAREN@1863..1864 "("
+                    - ARGUMENT@1864..1880
+                        - NAME@1864..1869
+                            - IDENT@1864..1869 "graph"
+                        - COLON@1869..1870 ":"
+                        - WHITESPACE@1870..1871 " "
+                        - ENUM_VALUE@1871..1880
+                            - NAME@1871..1880
+                                - IDENT@1871..1878 "REVIEWS"
+                                - COMMA@1878..1879 ","
+                                - WHITESPACE@1879..1880 " "
+                    - ARGUMENT@1880..1889
+                        - NAME@1880..1883
+                            - IDENT@1880..1883 "key"
+                        - COLON@1883..1884 ":"
+                        - WHITESPACE@1884..1885 " "
+                        - STRING_VALUE@1885..1889
+                            - STRING@1885..1889 "\"id\""
+                    - R_PAREN@1889..1890 ")"
+                    - WHITESPACE@1890..1891 "\n"
+        - FIELDS_DEFINITION@1891..2105
+            - L_CURLY@1891..1892 "{"
+            - WHITESPACE@1892..1895 "\n  "
+            - FIELD_DEFINITION@1895..1938
+                - NAME@1895..1897
+                    - IDENT@1895..1897 "id"
+                - COLON@1897..1898 ":"
+                - WHITESPACE@1898..1899 " "
+                - NON_NULL_TYPE@1899..1907
+                    - WHITESPACE@1899..1900 " "
+                    - NAMED_TYPE@1900..1906
+                        - NAME@1900..1906
+                            - IDENT@1900..1906 "String"
+                    - BANG@1906..1907 "!"
+                - DIRECTIVES@1907..1938
+                    - DIRECTIVE@1907..1938
+                        - AT@1907..1908 "@"
+                        - NAME@1908..1919
+                            - IDENT@1908..1919 "join__field"
+                        - ARGUMENTS@1919..1938
+                            - L_PAREN@1919..1920 "("
+                            - ARGUMENT@1920..1934
+                                - NAME@1920..1925
+                                    - IDENT@1920..1925 "graph"
+                                - COLON@1925..1926 ":"
+                                - WHITESPACE@1926..1927 " "
+                                - ENUM_VALUE@1927..1934
+                                    - NAME@1927..1934
+                                        - IDENT@1927..1934 "PRODUCT"
+                            - R_PAREN@1934..1935 ")"
+                            - WHITESPACE@1935..1938 "\n  "
+            - FIELD_DEFINITION@1938..1989
+                - NAME@1938..1949
+                    - IDENT@1938..1949 "description"
+                - COLON@1949..1950 ":"
+                - WHITESPACE@1950..1951 " "
+                - NAMED_TYPE@1951..1958
+                    - WHITESPACE@1951..1952 " "
+                    - NAME@1952..1958
+                        - IDENT@1952..1958 "String"
+                - DIRECTIVES@1958..1989
+                    - DIRECTIVE@1958..1989
+                        - AT@1958..1959 "@"
+                        - NAME@1959..1970
+                            - IDENT@1959..1970 "join__field"
+                        - ARGUMENTS@1970..1989
+                            - L_PAREN@1970..1971 "("
+                            - ARGUMENT@1971..1985
+                                - NAME@1971..1976
+                                    - IDENT@1971..1976 "graph"
+                                - COLON@1976..1977 ":"
+                                - WHITESPACE@1977..1978 " "
+                                - ENUM_VALUE@1978..1985
+                                    - NAME@1978..1985
+                                        - IDENT@1978..1985 "PRODUCT"
+                            - R_PAREN@1985..1986 ")"
+                            - WHITESPACE@1986..1989 "\n  "
+            - FIELD_DEFINITION@1989..2034
+                - NAME@1989..1994
+                    - IDENT@1989..1994 "price"
+                - COLON@1994..1995 ":"
+                - WHITESPACE@1995..1996 " "
+                - NAMED_TYPE@1996..2003
+                    - WHITESPACE@1996..1997 " "
+                    - NAME@1997..2003
+                        - IDENT@1997..2003 "String"
+                - DIRECTIVES@2003..2034
+                    - DIRECTIVE@2003..2034
+                        - AT@2003..2004 "@"
+                        - NAME@2004..2015
+                            - IDENT@2004..2015 "join__field"
+                        - ARGUMENTS@2015..2034
+                            - L_PAREN@2015..2016 "("
+                            - ARGUMENT@2016..2030
+                                - NAME@2016..2021
+                                    - IDENT@2016..2021 "graph"
+                                - COLON@2021..2022 ":"
+                                - WHITESPACE@2022..2023 " "
+                                - ENUM_VALUE@2023..2030
+                                    - NAME@2023..2030
+                                        - IDENT@2023..2030 "PRODUCT"
+                            - R_PAREN@2030..2031 ")"
+                            - WHITESPACE@2031..2034 "\n  "
+            - FIELD_DEFINITION@2034..2102
+                - NAME@2034..2045
+                    - IDENT@2034..2045 "retailPrice"
+                - COLON@2045..2046 ":"
+                - WHITESPACE@2046..2047 " "
+                - NAMED_TYPE@2047..2054
+                    - WHITESPACE@2047..2048 " "
+                    - NAME@2048..2054
+                        - IDENT@2048..2054 "String"
+                - DIRECTIVES@2054..2102
+                    - DIRECTIVE@2054..2102
+                        - AT@2054..2055 "@"
+                        - NAME@2055..2066
+                            - IDENT@2055..2066 "join__field"
+                        - ARGUMENTS@2066..2102
+                            - L_PAREN@2066..2067 "("
+                            - ARGUMENT@2067..2083
+                                - NAME@2067..2072
+                                    - IDENT@2067..2072 "graph"
+                                - COLON@2072..2073 ":"
+                                - WHITESPACE@2073..2074 " "
+                                - ENUM_VALUE@2074..2083
+                                    - NAME@2074..2083
+                                        - IDENT@2074..2081 "REVIEWS"
+                                        - COMMA@2081..2082 ","
+                                        - WHITESPACE@2082..2083 " "
+                            - ARGUMENT@2083..2100
+                                - NAME@2083..2091
+                                    - IDENT@2083..2091 "requires"
+                                - COLON@2091..2092 ":"
+                                - WHITESPACE@2092..2093 " "
+                                - STRING_VALUE@2093..2100
+                                    - STRING@2093..2100 "\"price\""
+                            - R_PAREN@2100..2101 ")"
+                            - WHITESPACE@2101..2102 "\n"
+            - R_CURLY@2102..2103 "}"
+            - WHITESPACE@2103..2105 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2105..2151
+        - type_KW@2105..2109 "type"
+        - WHITESPACE@2109..2110 " "
+        - NAME@2110..2116
+            - IDENT@2110..2115 "Error"
+            - WHITESPACE@2115..2116 " "
+        - FIELDS_DEFINITION@2116..2151
+            - L_CURLY@2116..2117 "{"
+            - WHITESPACE@2117..2120 "\n  "
+            - FIELD_DEFINITION@2120..2132
+                - NAME@2120..2124
+                    - IDENT@2120..2124 "code"
+                - COLON@2124..2125 ":"
+                - WHITESPACE@2125..2126 " "
+                - NAMED_TYPE@2126..2132
+                    - WHITESPACE@2126..2129 "\n  "
+                    - NAME@2129..2132
+                        - IDENT@2129..2132 "Int"
+            - FIELD_DEFINITION@2132..2148
+                - NAME@2132..2139
+                    - IDENT@2132..2139 "message"
+                - COLON@2139..2140 ":"
+                - WHITESPACE@2140..2141 " "
+                - NAMED_TYPE@2141..2148
+                    - WHITESPACE@2141..2142 "\n"
+                    - NAME@2142..2148
+                        - IDENT@2142..2148 "String"
+            - R_CURLY@2148..2149 "}"
+            - WHITESPACE@2149..2151 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2151..2874
+        - type_KW@2151..2155 "type"
+        - WHITESPACE@2155..2156 " "
+        - NAME@2156..2166
+            - IDENT@2156..2165 "Furniture"
+            - WHITESPACE@2165..2166 " "
+        - IMPLEMENTS_INTERFACES@2166..2185
+            - implements_KW@2166..2176 "implements"
+            - WHITESPACE@2176..2177 " "
+            - NAMED_TYPE@2177..2185
+                - NAME@2177..2185
+                    - IDENT@2177..2184 "Product"
+                    - WHITESPACE@2184..2185 "\n"
+        - DIRECTIVES@2185..2376
+            - DIRECTIVE@2185..2214
+                - AT@2185..2186 "@"
+                - NAME@2186..2197
+                    - IDENT@2186..2197 "join__owner"
+                - ARGUMENTS@2197..2214
+                    - L_PAREN@2197..2198 "("
+                    - ARGUMENT@2198..2212
+                        - NAME@2198..2203
+                            - IDENT@2198..2203 "graph"
+                        - COLON@2203..2204 ":"
+                        - WHITESPACE@2204..2205 " "
+                        - ENUM_VALUE@2205..2212
+                            - NAME@2205..2212
+                                - IDENT@2205..2212 "PRODUCT"
+                    - R_PAREN@2212..2213 ")"
+                    - WHITESPACE@2213..2214 "\n"
+            - DIRECTIVE@2214..2254
+                - AT@2214..2215 "@"
+                - NAME@2215..2225
+                    - IDENT@2215..2225 "join__type"
+                - ARGUMENTS@2225..2254
+                    - L_PAREN@2225..2226 "("
+                    - ARGUMENT@2226..2242
+                        - NAME@2226..2231
+                            - IDENT@2226..2231 "graph"
+                        - COLON@2231..2232 ":"
+                        - WHITESPACE@2232..2233 " "
+                        - ENUM_VALUE@2233..2242
+                            - NAME@2233..2242
+                                - IDENT@2233..2240 "PRODUCT"
+                                - COMMA@2240..2241 ","
+                                - WHITESPACE@2241..2242 " "
+                    - ARGUMENT@2242..2252
+                        - NAME@2242..2245
+                            - IDENT@2242..2245 "key"
+                        - COLON@2245..2246 ":"
+                        - WHITESPACE@2246..2247 " "
+                        - STRING_VALUE@2247..2252
+                            - STRING@2247..2252 "\"upc\""
+                    - R_PAREN@2252..2253 ")"
+                    - WHITESPACE@2253..2254 "\n"
+            - DIRECTIVE@2254..2294
+                - AT@2254..2255 "@"
+                - NAME@2255..2265
+                    - IDENT@2255..2265 "join__type"
+                - ARGUMENTS@2265..2294
+                    - L_PAREN@2265..2266 "("
+                    - ARGUMENT@2266..2282
+                        - NAME@2266..2271
+                            - IDENT@2266..2271 "graph"
+                        - COLON@2271..2272 ":"
+                        - WHITESPACE@2272..2273 " "
+                        - ENUM_VALUE@2273..2282
+                            - NAME@2273..2282
+                                - IDENT@2273..2280 "PRODUCT"
+                                - COMMA@2280..2281 ","
+                                - WHITESPACE@2281..2282 " "
+                    - ARGUMENT@2282..2292
+                        - NAME@2282..2285
+                            - IDENT@2282..2285 "key"
+                        - COLON@2285..2286 ":"
+                        - WHITESPACE@2286..2287 " "
+                        - STRING_VALUE@2287..2292
+                            - STRING@2287..2292 "\"sku\""
+                    - R_PAREN@2292..2293 ")"
+                    - WHITESPACE@2293..2294 "\n"
+            - DIRECTIVE@2294..2336
+                - AT@2294..2295 "@"
+                - NAME@2295..2305
+                    - IDENT@2295..2305 "join__type"
+                - ARGUMENTS@2305..2336
+                    - L_PAREN@2305..2306 "("
+                    - ARGUMENT@2306..2324
+                        - NAME@2306..2311
+                            - IDENT@2306..2311 "graph"
+                        - COLON@2311..2312 ":"
+                        - WHITESPACE@2312..2313 " "
+                        - ENUM_VALUE@2313..2324
+                            - NAME@2313..2324
+                                - IDENT@2313..2322 "INVENTORY"
+                                - COMMA@2322..2323 ","
+                                - WHITESPACE@2323..2324 " "
+                    - ARGUMENT@2324..2334
+                        - NAME@2324..2327
+                            - IDENT@2324..2327 "key"
+                        - COLON@2327..2328 ":"
+                        - WHITESPACE@2328..2329 " "
+                        - STRING_VALUE@2329..2334
+                            - STRING@2329..2334 "\"sku\""
+                    - R_PAREN@2334..2335 ")"
+                    - WHITESPACE@2335..2336 "\n"
+            - DIRECTIVE@2336..2376
+                - AT@2336..2337 "@"
+                - NAME@2337..2347
+                    - IDENT@2337..2347 "join__type"
+                - ARGUMENTS@2347..2376
+                    - L_PAREN@2347..2348 "("
+                    - ARGUMENT@2348..2364
+                        - NAME@2348..2353
+                            - IDENT@2348..2353 "graph"
+                        - COLON@2353..2354 ":"
+                        - WHITESPACE@2354..2355 " "
+                        - ENUM_VALUE@2355..2364
+                            - NAME@2355..2364
+                                - IDENT@2355..2362 "REVIEWS"
+                                - COMMA@2362..2363 ","
+                                - WHITESPACE@2363..2364 " "
+                    - ARGUMENT@2364..2374
+                        - NAME@2364..2367
+                            - IDENT@2364..2367 "key"
+                        - COLON@2367..2368 ":"
+                        - WHITESPACE@2368..2369 " "
+                        - STRING_VALUE@2369..2374
+                            - STRING@2369..2374 "\"upc\""
+                    - R_PAREN@2374..2375 ")"
+                    - WHITESPACE@2375..2376 "\n"
+        - FIELDS_DEFINITION@2376..2874
+            - L_CURLY@2376..2377 "{"
+            - WHITESPACE@2377..2380 "\n  "
+            - FIELD_DEFINITION@2380..2424
+                - NAME@2380..2383
+                    - IDENT@2380..2383 "upc"
+                - COLON@2383..2384 ":"
+                - WHITESPACE@2384..2385 " "
+                - NON_NULL_TYPE@2385..2393
+                    - WHITESPACE@2385..2386 " "
+                    - NAMED_TYPE@2386..2392
+                        - NAME@2386..2392
+                            - IDENT@2386..2392 "String"
+                    - BANG@2392..2393 "!"
+                - DIRECTIVES@2393..2424
+                    - DIRECTIVE@2393..2424
+                        - AT@2393..2394 "@"
+                        - NAME@2394..2405
+                            - IDENT@2394..2405 "join__field"
+                        - ARGUMENTS@2405..2424
+                            - L_PAREN@2405..2406 "("
+                            - ARGUMENT@2406..2420
+                                - NAME@2406..2411
+                                    - IDENT@2406..2411 "graph"
+                                - COLON@2411..2412 ":"
+                                - WHITESPACE@2412..2413 " "
+                                - ENUM_VALUE@2413..2420
+                                    - NAME@2413..2420
+                                        - IDENT@2413..2420 "PRODUCT"
+                            - R_PAREN@2420..2421 ")"
+                            - WHITESPACE@2421..2424 "\n  "
+            - FIELD_DEFINITION@2424..2468
+                - NAME@2424..2427
+                    - IDENT@2424..2427 "sku"
+                - COLON@2427..2428 ":"
+                - WHITESPACE@2428..2429 " "
+                - NON_NULL_TYPE@2429..2437
+                    - WHITESPACE@2429..2430 " "
+                    - NAMED_TYPE@2430..2436
+                        - NAME@2430..2436
+                            - IDENT@2430..2436 "String"
+                    - BANG@2436..2437 "!"
+                - DIRECTIVES@2437..2468
+                    - DIRECTIVE@2437..2468
+                        - AT@2437..2438 "@"
+                        - NAME@2438..2449
+                            - IDENT@2438..2449 "join__field"
+                        - ARGUMENTS@2449..2468
+                            - L_PAREN@2449..2450 "("
+                            - ARGUMENT@2450..2464
+                                - NAME@2450..2455
+                                    - IDENT@2450..2455 "graph"
+                                - COLON@2455..2456 ":"
+                                - WHITESPACE@2456..2457 " "
+                                - ENUM_VALUE@2457..2464
+                                    - NAME@2457..2464
+                                        - IDENT@2457..2464 "PRODUCT"
+                            - R_PAREN@2464..2465 ")"
+                            - WHITESPACE@2465..2468 "\n  "
+            - FIELD_DEFINITION@2468..2512
+                - NAME@2468..2472
+                    - IDENT@2468..2472 "name"
+                - COLON@2472..2473 ":"
+                - WHITESPACE@2473..2474 " "
+                - NAMED_TYPE@2474..2481
+                    - WHITESPACE@2474..2475 " "
+                    - NAME@2475..2481
+                        - IDENT@2475..2481 "String"
+                - DIRECTIVES@2481..2512
+                    - DIRECTIVE@2481..2512
+                        - AT@2481..2482 "@"
+                        - NAME@2482..2493
+                            - IDENT@2482..2493 "join__field"
+                        - ARGUMENTS@2493..2512
+                            - L_PAREN@2493..2494 "("
+                            - ARGUMENT@2494..2508
+                                - NAME@2494..2499
+                                    - IDENT@2494..2499 "graph"
+                                - COLON@2499..2500 ":"
+                                - WHITESPACE@2500..2501 " "
+                                - ENUM_VALUE@2501..2508
+                                    - NAME@2501..2508
+                                        - IDENT@2501..2508 "PRODUCT"
+                            - R_PAREN@2508..2509 ")"
+                            - WHITESPACE@2509..2512 "\n  "
+            - FIELD_DEFINITION@2512..2557
+                - NAME@2512..2517
+                    - IDENT@2512..2517 "price"
+                - COLON@2517..2518 ":"
+                - WHITESPACE@2518..2519 " "
+                - NAMED_TYPE@2519..2526
+                    - WHITESPACE@2519..2520 " "
+                    - NAME@2520..2526
+                        - IDENT@2520..2526 "String"
+                - DIRECTIVES@2526..2557
+                    - DIRECTIVE@2526..2557
+                        - AT@2526..2527 "@"
+                        - NAME@2527..2538
+                            - IDENT@2527..2538 "join__field"
+                        - ARGUMENTS@2538..2557
+                            - L_PAREN@2538..2539 "("
+                            - ARGUMENT@2539..2553
+                                - NAME@2539..2544
+                                    - IDENT@2539..2544 "graph"
+                                - COLON@2544..2545 ":"
+                                - WHITESPACE@2545..2546 " "
+                                - ENUM_VALUE@2546..2553
+                                    - NAME@2546..2553
+                                        - IDENT@2546..2553 "PRODUCT"
+                            - R_PAREN@2553..2554 ")"
+                            - WHITESPACE@2554..2557 "\n  "
+            - FIELD_DEFINITION@2557..2601
+                - NAME@2557..2562
+                    - IDENT@2557..2562 "brand"
+                - COLON@2562..2563 ":"
+                - WHITESPACE@2563..2564 " "
+                - NAMED_TYPE@2564..2570
+                    - WHITESPACE@2564..2565 " "
+                    - NAME@2565..2570
+                        - IDENT@2565..2570 "Brand"
+                - DIRECTIVES@2570..2601
+                    - DIRECTIVE@2570..2601
+                        - AT@2570..2571 "@"
+                        - NAME@2571..2582
+                            - IDENT@2571..2582 "join__field"
+                        - ARGUMENTS@2582..2601
+                            - L_PAREN@2582..2583 "("
+                            - ARGUMENT@2583..2597
+                                - NAME@2583..2588
+                                    - IDENT@2583..2588 "graph"
+                                - COLON@2588..2589 ":"
+                                - WHITESPACE@2589..2590 " "
+                                - ENUM_VALUE@2590..2597
+                                    - NAME@2590..2597
+                                        - IDENT@2590..2597 "PRODUCT"
+                            - R_PAREN@2597..2598 ")"
+                            - WHITESPACE@2598..2601 "\n  "
+            - FIELD_DEFINITION@2601..2660
+                - NAME@2601..2609
+                    - IDENT@2601..2609 "metadata"
+                - COLON@2609..2610 ":"
+                - WHITESPACE@2610..2611 " "
+                - LIST_TYPE@2611..2629
+                    - WHITESPACE@2611..2612 " "
+                    - L_BRACK@2612..2613 "["
+                    - NAMED_TYPE@2613..2628
+                        - NAME@2613..2628
+                            - IDENT@2613..2628 "MetadataOrError"
+                    - R_BRACK@2628..2629 "]"
+                - DIRECTIVES@2629..2660
+                    - DIRECTIVE@2629..2660
+                        - AT@2629..2630 "@"
+                        - NAME@2630..2641
+                            - IDENT@2630..2641 "join__field"
+                        - ARGUMENTS@2641..2660
+                            - L_PAREN@2641..2642 "("
+                            - ARGUMENT@2642..2656
+                                - NAME@2642..2647
+                                    - IDENT@2642..2647 "graph"
+                                - COLON@2647..2648 ":"
+                                - WHITESPACE@2648..2649 " "
+                                - ENUM_VALUE@2649..2656
+                                    - NAME@2649..2656
+                                        - IDENT@2649..2656 "PRODUCT"
+                            - R_PAREN@2656..2657 ")"
+                            - WHITESPACE@2657..2660 "\n  "
+            - FIELD_DEFINITION@2660..2724
+                - NAME@2660..2667
+                    - IDENT@2660..2667 "details"
+                - COLON@2667..2668 ":"
+                - WHITESPACE@2668..2669 " "
+                - NAMED_TYPE@2669..2693
+                    - WHITESPACE@2669..2670 " "
+                    - NAME@2670..2693
+                        - IDENT@2670..2693 "ProductDetailsFurniture"
+                - DIRECTIVES@2693..2724
+                    - DIRECTIVE@2693..2724
+                        - AT@2693..2694 "@"
+                        - NAME@2694..2705
+                            - IDENT@2694..2705 "join__field"
+                        - ARGUMENTS@2705..2724
+                            - L_PAREN@2705..2706 "("
+                            - ARGUMENT@2706..2720
+                                - NAME@2706..2711
+                                    - IDENT@2706..2711 "graph"
+                                - COLON@2711..2712 ":"
+                                - WHITESPACE@2712..2713 " "
+                                - ENUM_VALUE@2713..2720
+                                    - NAME@2713..2720
+                                        - IDENT@2713..2720 "PRODUCT"
+                            - R_PAREN@2720..2721 ")"
+                            - WHITESPACE@2721..2724 "\n  "
+            - FIELD_DEFINITION@2724..2774
+                - NAME@2724..2731
+                    - IDENT@2724..2731 "inStock"
+                - COLON@2731..2732 ":"
+                - WHITESPACE@2732..2733 " "
+                - NAMED_TYPE@2733..2741
+                    - WHITESPACE@2733..2734 " "
+                    - NAME@2734..2741
+                        - IDENT@2734..2741 "Boolean"
+                - DIRECTIVES@2741..2774
+                    - DIRECTIVE@2741..2774
+                        - AT@2741..2742 "@"
+                        - NAME@2742..2753
+                            - IDENT@2742..2753 "join__field"
+                        - ARGUMENTS@2753..2774
+                            - L_PAREN@2753..2754 "("
+                            - ARGUMENT@2754..2770
+                                - NAME@2754..2759
+                                    - IDENT@2754..2759 "graph"
+                                - COLON@2759..2760 ":"
+                                - WHITESPACE@2760..2761 " "
+                                - ENUM_VALUE@2761..2770
+                                    - NAME@2761..2770
+                                        - IDENT@2761..2770 "INVENTORY"
+                            - R_PAREN@2770..2771 ")"
+                            - WHITESPACE@2771..2774 "\n  "
+            - FIELD_DEFINITION@2774..2824
+                - NAME@2774..2781
+                    - IDENT@2774..2781 "isHeavy"
+                - COLON@2781..2782 ":"
+                - WHITESPACE@2782..2783 " "
+                - NAMED_TYPE@2783..2791
+                    - WHITESPACE@2783..2784 " "
+                    - NAME@2784..2791
+                        - IDENT@2784..2791 "Boolean"
+                - DIRECTIVES@2791..2824
+                    - DIRECTIVE@2791..2824
+                        - AT@2791..2792 "@"
+                        - NAME@2792..2803
+                            - IDENT@2792..2803 "join__field"
+                        - ARGUMENTS@2803..2824
+                            - L_PAREN@2803..2804 "("
+                            - ARGUMENT@2804..2820
+                                - NAME@2804..2809
+                                    - IDENT@2804..2809 "graph"
+                                - COLON@2809..2810 ":"
+                                - WHITESPACE@2810..2811 " "
+                                - ENUM_VALUE@2811..2820
+                                    - NAME@2811..2820
+                                        - IDENT@2811..2820 "INVENTORY"
+                            - R_PAREN@2820..2821 ")"
+                            - WHITESPACE@2821..2824 "\n  "
+            - FIELD_DEFINITION@2824..2871
+                - NAME@2824..2831
+                    - IDENT@2824..2831 "reviews"
+                - COLON@2831..2832 ":"
+                - WHITESPACE@2832..2833 " "
+                - LIST_TYPE@2833..2842
+                    - WHITESPACE@2833..2834 " "
+                    - L_BRACK@2834..2835 "["
+                    - NAMED_TYPE@2835..2841
+                        - NAME@2835..2841
+                            - IDENT@2835..2841 "Review"
+                    - R_BRACK@2841..2842 "]"
+                - DIRECTIVES@2842..2871
+                    - DIRECTIVE@2842..2871
+                        - AT@2842..2843 "@"
+                        - NAME@2843..2854
+                            - IDENT@2843..2854 "join__field"
+                        - ARGUMENTS@2854..2871
+                            - L_PAREN@2854..2855 "("
+                            - ARGUMENT@2855..2869
+                                - NAME@2855..2860
+                                    - IDENT@2855..2860 "graph"
+                                - COLON@2860..2861 ":"
+                                - WHITESPACE@2861..2862 " "
+                                - ENUM_VALUE@2862..2869
+                                    - NAME@2862..2869
+                                        - IDENT@2862..2869 "REVIEWS"
+                            - R_PAREN@2869..2870 ")"
+                            - WHITESPACE@2870..2871 "\n"
+            - R_CURLY@2871..2872 "}"
+            - WHITESPACE@2872..2874 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2874..2902
+        - type_KW@2874..2878 "type"
+        - WHITESPACE@2878..2879 " "
+        - NAME@2879..2884
+            - IDENT@2879..2883 "Ikea"
+            - WHITESPACE@2883..2884 " "
+        - FIELDS_DEFINITION@2884..2902
+            - L_CURLY@2884..2885 "{"
+            - WHITESPACE@2885..2888 "\n  "
+            - FIELD_DEFINITION@2888..2899
+                - NAME@2888..2893
+                    - IDENT@2888..2893 "asile"
+                - COLON@2893..2894 ":"
+                - WHITESPACE@2894..2895 " "
+                - NAMED_TYPE@2895..2899
+                    - WHITESPACE@2895..2896 "\n"
+                    - NAME@2896..2899
+                        - IDENT@2896..2899 "Int"
+            - R_CURLY@2899..2900 "}"
+            - WHITESPACE@2900..2902 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2902..2988
+        - type_KW@2902..2906 "type"
+        - WHITESPACE@2906..2907 " "
+        - NAME@2907..2913
+            - IDENT@2907..2912 "Image"
+            - WHITESPACE@2912..2913 " "
+        - IMPLEMENTS_INTERFACES@2913..2936
+            - implements_KW@2913..2923 "implements"
+            - WHITESPACE@2923..2924 " "
+            - NAMED_TYPE@2924..2936
+                - NAME@2924..2936
+                    - IDENT@2924..2935 "NamedObject"
+                    - WHITESPACE@2935..2936 " "
+        - FIELDS_DEFINITION@2936..2988
+            - L_CURLY@2936..2937 "{"
+            - WHITESPACE@2937..2940 "\n  "
+            - FIELD_DEFINITION@2940..2956
+                - NAME@2940..2944
+                    - IDENT@2940..2944 "name"
+                - COLON@2944..2945 ":"
+                - WHITESPACE@2945..2946 " "
+                - NON_NULL_TYPE@2946..2956
+                    - WHITESPACE@2946..2949 "\n  "
+                    - NAMED_TYPE@2949..2955
+                        - NAME@2949..2955
+                            - IDENT@2949..2955 "String"
+                    - BANG@2955..2956 "!"
+            - FIELD_DEFINITION@2956..2985
+                - NAME@2956..2966
+                    - IDENT@2956..2966 "attributes"
+                - COLON@2966..2967 ":"
+                - WHITESPACE@2967..2968 " "
+                - NON_NULL_TYPE@2968..2985
+                    - WHITESPACE@2968..2969 "\n"
+                    - NAMED_TYPE@2969..2984
+                        - NAME@2969..2984
+                            - IDENT@2969..2984 "ImageAttributes"
+                    - BANG@2984..2985 "!"
+            - R_CURLY@2985..2986 "}"
+            - WHITESPACE@2986..2988 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2988..3029
+        - type_KW@2988..2992 "type"
+        - WHITESPACE@2992..2993 " "
+        - NAME@2993..3009
+            - IDENT@2993..3008 "ImageAttributes"
+            - WHITESPACE@3008..3009 " "
+        - FIELDS_DEFINITION@3009..3029
+            - L_CURLY@3009..3010 "{"
+            - WHITESPACE@3010..3013 "\n  "
+            - FIELD_DEFINITION@3013..3026
+                - NAME@3013..3016
+                    - IDENT@3013..3016 "url"
+                - COLON@3016..3017 ":"
+                - WHITESPACE@3017..3018 " "
+                - NON_NULL_TYPE@3018..3026
+                    - WHITESPACE@3018..3019 "\n"
+                    - NAMED_TYPE@3019..3025
+                        - NAME@3019..3025
+                            - IDENT@3019..3025 "String"
+                    - BANG@3025..3026 "!"
+            - R_CURLY@3026..3027 "}"
+            - WHITESPACE@3027..3029 "\n\n"
+    - SCALAR_TYPE_DEFINITION@3029..3052
+        - scalar_KW@3029..3035 "scalar"
+        - WHITESPACE@3035..3036 " "
+        - NAME@3036..3052
+            - IDENT@3036..3050 "join__FieldSet"
+            - WHITESPACE@3050..3052 "\n\n"
+    - ENUM_TYPE_DEFINITION@3052..3356
+        - enum_KW@3052..3056 "enum"
+        - WHITESPACE@3056..3057 " "
+        - NAME@3057..3069
+            - IDENT@3057..3068 "join__Graph"
+            - WHITESPACE@3068..3069 " "
+        - ENUM_VALUES_DEFINITION@3069..3356
+            - L_CURLY@3069..3070 "{"
+            - WHITESPACE@3070..3071 "\n"
+            - ENUM_VALUE_DEFINITION@3071..3119
+                - ENUM_VALUE@3071..3080
+                    - NAME@3071..3080
+                        - IDENT@3071..3079 "ACCOUNTS"
+                        - WHITESPACE@3079..3080 " "
+                - DIRECTIVES@3080..3119
+                    - DIRECTIVE@3080..3119
+                        - AT@3080..3081 "@"
+                        - NAME@3081..3092
+                            - IDENT@3081..3092 "join__graph"
+                        - ARGUMENTS@3092..3119
+                            - L_PAREN@3092..3093 "("
+                            - ARGUMENT@3093..3110
+                                - NAME@3093..3097
+                                    - IDENT@3093..3097 "name"
+                                - COLON@3097..3098 ":"
+                                - WHITESPACE@3098..3099 " "
+                                - STRING_VALUE@3099..3110
+                                    - STRING@3099..3109 "\"accounts\""
+                                    - WHITESPACE@3109..3110 " "
+                            - ARGUMENT@3110..3117
+                                - NAME@3110..3113
+                                    - IDENT@3110..3113 "url"
+                                - COLON@3113..3114 ":"
+                                - WHITESPACE@3114..3115 " "
+                                - STRING_VALUE@3115..3117
+                                    - STRING@3115..3117 "\"\""
+                            - R_PAREN@3117..3118 ")"
+                            - WHITESPACE@3118..3119 "\n"
+            - ENUM_VALUE_DEFINITION@3119..3161
+                - ENUM_VALUE@3119..3125
+                    - NAME@3119..3125
+                        - IDENT@3119..3124 "BOOKS"
+                        - WHITESPACE@3124..3125 " "
+                - DIRECTIVES@3125..3161
+                    - DIRECTIVE@3125..3161
+                        - AT@3125..3126 "@"
+                        - NAME@3126..3137
+                            - IDENT@3126..3137 "join__graph"
+                        - ARGUMENTS@3137..3161
+                            - L_PAREN@3137..3138 "("
+                            - ARGUMENT@3138..3152
+                                - NAME@3138..3142
+                                    - IDENT@3138..3142 "name"
+                                - COLON@3142..3143 ":"
+                                - WHITESPACE@3143..3144 " "
+                                - STRING_VALUE@3144..3152
+                                    - STRING@3144..3151 "\"books\""
+                                    - WHITESPACE@3151..3152 " "
+                            - ARGUMENT@3152..3159
+                                - NAME@3152..3155
+                                    - IDENT@3152..3155 "url"
+                                - COLON@3155..3156 ":"
+                                - WHITESPACE@3156..3157 " "
+                                - STRING_VALUE@3157..3159
+                                    - STRING@3157..3159 "\"\""
+                            - R_PAREN@3159..3160 ")"
+                            - WHITESPACE@3160..3161 "\n"
+            - ENUM_VALUE_DEFINITION@3161..3211
+                - ENUM_VALUE@3161..3171
+                    - NAME@3161..3171
+                        - IDENT@3161..3170 "DOCUMENTS"
+                        - WHITESPACE@3170..3171 " "
+                - DIRECTIVES@3171..3211
+                    - DIRECTIVE@3171..3211
+                        - AT@3171..3172 "@"
+                        - NAME@3172..3183
+                            - IDENT@3172..3183 "join__graph"
+                        - ARGUMENTS@3183..3211
+                            - L_PAREN@3183..3184 "("
+                            - ARGUMENT@3184..3202
+                                - NAME@3184..3188
+                                    - IDENT@3184..3188 "name"
+                                - COLON@3188..3189 ":"
+                                - WHITESPACE@3189..3190 " "
+                                - STRING_VALUE@3190..3202
+                                    - STRING@3190..3201 "\"documents\""
+                                    - WHITESPACE@3201..3202 " "
+                            - ARGUMENT@3202..3209
+                                - NAME@3202..3205
+                                    - IDENT@3202..3205 "url"
+                                - COLON@3205..3206 ":"
+                                - WHITESPACE@3206..3207 " "
+                                - STRING_VALUE@3207..3209
+                                    - STRING@3207..3209 "\"\""
+                            - R_PAREN@3209..3210 ")"
+                            - WHITESPACE@3210..3211 "\n"
+            - ENUM_VALUE_DEFINITION@3211..3261
+                - ENUM_VALUE@3211..3221
+                    - NAME@3211..3221
+                        - IDENT@3211..3220 "INVENTORY"
+                        - WHITESPACE@3220..3221 " "
+                - DIRECTIVES@3221..3261
+                    - DIRECTIVE@3221..3261
+                        - AT@3221..3222 "@"
+                        - NAME@3222..3233
+                            - IDENT@3222..3233 "join__graph"
+                        - ARGUMENTS@3233..3261
+                            - L_PAREN@3233..3234 "("
+                            - ARGUMENT@3234..3252
+                                - NAME@3234..3238
+                                    - IDENT@3234..3238 "name"
+                                - COLON@3238..3239 ":"
+                                - WHITESPACE@3239..3240 " "
+                                - STRING_VALUE@3240..3252
+                                    - STRING@3240..3251 "\"inventory\""
+                                    - WHITESPACE@3251..3252 " "
+                            - ARGUMENT@3252..3259
+                                - NAME@3252..3255
+                                    - IDENT@3252..3255 "url"
+                                - COLON@3255..3256 ":"
+                                - WHITESPACE@3256..3257 " "
+                                - STRING_VALUE@3257..3259
+                                    - STRING@3257..3259 "\"\""
+                            - R_PAREN@3259..3260 ")"
+                            - WHITESPACE@3260..3261 "\n"
+            - ENUM_VALUE_DEFINITION@3261..3307
+                - ENUM_VALUE@3261..3269
+                    - NAME@3261..3269
+                        - IDENT@3261..3268 "PRODUCT"
+                        - WHITESPACE@3268..3269 " "
+                - DIRECTIVES@3269..3307
+                    - DIRECTIVE@3269..3307
+                        - AT@3269..3270 "@"
+                        - NAME@3270..3281
+                            - IDENT@3270..3281 "join__graph"
+                        - ARGUMENTS@3281..3307
+                            - L_PAREN@3281..3282 "("
+                            - ARGUMENT@3282..3298
+                                - NAME@3282..3286
+                                    - IDENT@3282..3286 "name"
+                                - COLON@3286..3287 ":"
+                                - WHITESPACE@3287..3288 " "
+                                - STRING_VALUE@3288..3298
+                                    - STRING@3288..3297 "\"product\""
+                                    - WHITESPACE@3297..3298 " "
+                            - ARGUMENT@3298..3305
+                                - NAME@3298..3301
+                                    - IDENT@3298..3301 "url"
+                                - COLON@3301..3302 ":"
+                                - WHITESPACE@3302..3303 " "
+                                - STRING_VALUE@3303..3305
+                                    - STRING@3303..3305 "\"\""
+                            - R_PAREN@3305..3306 ")"
+                            - WHITESPACE@3306..3307 "\n"
+            - ENUM_VALUE_DEFINITION@3307..3353
+                - ENUM_VALUE@3307..3315
+                    - NAME@3307..3315
+                        - IDENT@3307..3314 "REVIEWS"
+                        - WHITESPACE@3314..3315 " "
+                - DIRECTIVES@3315..3353
+                    - DIRECTIVE@3315..3353
+                        - AT@3315..3316 "@"
+                        - NAME@3316..3327
+                            - IDENT@3316..3327 "join__graph"
+                        - ARGUMENTS@3327..3353
+                            - L_PAREN@3327..3328 "("
+                            - ARGUMENT@3328..3344
+                                - NAME@3328..3332
+                                    - IDENT@3328..3332 "name"
+                                - COLON@3332..3333 ":"
+                                - WHITESPACE@3333..3334 " "
+                                - STRING_VALUE@3334..3344
+                                    - STRING@3334..3343 "\"reviews\""
+                                    - WHITESPACE@3343..3344 " "
+                            - ARGUMENT@3344..3351
+                                - NAME@3344..3347
+                                    - IDENT@3344..3347 "url"
+                                - COLON@3347..3348 ":"
+                                - WHITESPACE@3348..3349 " "
+                                - STRING_VALUE@3349..3351
+                                    - STRING@3349..3351 "\"\""
+                            - R_PAREN@3351..3352 ")"
+                            - WHITESPACE@3352..3353 "\n"
+            - R_CURLY@3353..3354 "}"
+            - WHITESPACE@3354..3356 "\n\n"
+    - OBJECT_TYPE_DEFINITION@3356..3407
+        - type_KW@3356..3360 "type"
+        - WHITESPACE@3360..3361 " "
+        - NAME@3361..3370
+            - IDENT@3361..3369 "KeyValue"
+            - WHITESPACE@3369..3370 " "
+        - FIELDS_DEFINITION@3370..3407
+            - L_CURLY@3370..3371 "{"
+            - WHITESPACE@3371..3374 "\n  "
+            - FIELD_DEFINITION@3374..3389
+                - NAME@3374..3377
+                    - IDENT@3374..3377 "key"
+                - COLON@3377..3378 ":"
+                - WHITESPACE@3378..3379 " "
+                - NON_NULL_TYPE@3379..3389
+                    - WHITESPACE@3379..3382 "\n  "
+                    - NAMED_TYPE@3382..3388
+                        - NAME@3382..3388
+                            - IDENT@3382..3388 "String"
+                    - BANG@3388..3389 "!"
+            - FIELD_DEFINITION@3389..3404
+                - NAME@3389..3394
+                    - IDENT@3389..3394 "value"
+                - COLON@3394..3395 ":"
+                - WHITESPACE@3395..3396 " "
+                - NON_NULL_TYPE@3396..3404
+                    - WHITESPACE@3396..3397 "\n"
+                    - NAMED_TYPE@3397..3403
+                        - NAME@3397..3403
+                            - IDENT@3397..3403 "String"
+                    - BANG@3403..3404 "!"
+            - R_CURLY@3404..3405 "}"
+            - WHITESPACE@3405..3407 "\n\n"
+    - OBJECT_TYPE_DEFINITION@3407..3689
+        - type_KW@3407..3411 "type"
+        - WHITESPACE@3411..3412 " "
+        - NAME@3412..3420
+            - IDENT@3412..3419 "Library"
+            - WHITESPACE@3419..3420 "\n"
+        - DIRECTIVES@3420..3524
+            - DIRECTIVE@3420..3447
+                - AT@3420..3421 "@"
+                - NAME@3421..3432
+                    - IDENT@3421..3432 "join__owner"
+                - ARGUMENTS@3432..3447
+                    - L_PAREN@3432..3433 "("
+                    - ARGUMENT@3433..3445
+                        - NAME@3433..3438
+                            - IDENT@3433..3438 "graph"
+                        - COLON@3438..3439 ":"
+                        - WHITESPACE@3439..3440 " "
+                        - ENUM_VALUE@3440..3445
+                            - NAME@3440..3445
+                                - IDENT@3440..3445 "BOOKS"
+                    - R_PAREN@3445..3446 ")"
+                    - WHITESPACE@3446..3447 "\n"
+            - DIRECTIVE@3447..3484
+                - AT@3447..3448 "@"
+                - NAME@3448..3458
+                    - IDENT@3448..3458 "join__type"
+                - ARGUMENTS@3458..3484
+                    - L_PAREN@3458..3459 "("
+                    - ARGUMENT@3459..3473
+                        - NAME@3459..3464
+                            - IDENT@3459..3464 "graph"
+                        - COLON@3464..3465 ":"
+                        - WHITESPACE@3465..3466 " "
+                        - ENUM_VALUE@3466..3473
+                            - NAME@3466..3473
+                                - IDENT@3466..3471 "BOOKS"
+                                - COMMA@3471..3472 ","
+                                - WHITESPACE@3472..3473 " "
+                    - ARGUMENT@3473..3482
+                        - NAME@3473..3476
+                            - IDENT@3473..3476 "key"
+                        - COLON@3476..3477 ":"
+                        - WHITESPACE@3477..3478 " "
+                        - STRING_VALUE@3478..3482
+                            - STRING@3478..3482 "\"id\""
+                    - R_PAREN@3482..3483 ")"
+                    - WHITESPACE@3483..3484 "\n"
+            - DIRECTIVE@3484..3524
+                - AT@3484..3485 "@"
+                - NAME@3485..3495
+                    - IDENT@3485..3495 "join__type"
+                - ARGUMENTS@3495..3524
+                    - L_PAREN@3495..3496 "("
+                    - ARGUMENT@3496..3513
+                        - NAME@3496..3501
+                            - IDENT@3496..3501 "graph"
+                        - COLON@3501..3502 ":"
+                        - WHITESPACE@3502..3503 " "
+                        - ENUM_VALUE@3503..3513
+                            - NAME@3503..3513
+                                - IDENT@3503..3511 "ACCOUNTS"
+                                - COMMA@3511..3512 ","
+                                - WHITESPACE@3512..3513 " "
+                    - ARGUMENT@3513..3522
+                        - NAME@3513..3516
+                            - IDENT@3513..3516 "key"
+                        - COLON@3516..3517 ":"
+                        - WHITESPACE@3517..3518 " "
+                        - STRING_VALUE@3518..3522
+                            - STRING@3518..3522 "\"id\""
+                    - R_PAREN@3522..3523 ")"
+                    - WHITESPACE@3523..3524 "\n"
+        - FIELDS_DEFINITION@3524..3689
+            - L_CURLY@3524..3525 "{"
+            - WHITESPACE@3525..3528 "\n  "
+            - FIELD_DEFINITION@3528..3565
+                - NAME@3528..3530
+                    - IDENT@3528..3530 "id"
+                - COLON@3530..3531 ":"
+                - WHITESPACE@3531..3532 " "
+                - NON_NULL_TYPE@3532..3536
+                    - WHITESPACE@3532..3533 " "
+                    - NAMED_TYPE@3533..3535
+                        - NAME@3533..3535
+                            - IDENT@3533..3535 "ID"
+                    - BANG@3535..3536 "!"
+                - DIRECTIVES@3536..3565
+                    - DIRECTIVE@3536..3565
+                        - AT@3536..3537 "@"
+                        - NAME@3537..3548
+                            - IDENT@3537..3548 "join__field"
+                        - ARGUMENTS@3548..3565
+                            - L_PAREN@3548..3549 "("
+                            - ARGUMENT@3549..3561
+                                - NAME@3549..3554
+                                    - IDENT@3549..3554 "graph"
+                                - COLON@3554..3555 ":"
+                                - WHITESPACE@3555..3556 " "
+                                - ENUM_VALUE@3556..3561
+                                    - NAME@3556..3561
+                                        - IDENT@3556..3561 "BOOKS"
+                            - R_PAREN@3561..3562 ")"
+                            - WHITESPACE@3562..3565 "\n  "
+            - FIELD_DEFINITION@3565..3607
+                - NAME@3565..3569
+                    - IDENT@3565..3569 "name"
+                - COLON@3569..3570 ":"
+                - WHITESPACE@3570..3571 " "
+                - NAMED_TYPE@3571..3578
+                    - WHITESPACE@3571..3572 " "
+                    - NAME@3572..3578
+                        - IDENT@3572..3578 "String"
+                - DIRECTIVES@3578..3607
+                    - DIRECTIVE@3578..3607
+                        - AT@3578..3579 "@"
+                        - NAME@3579..3590
+                            - IDENT@3579..3590 "join__field"
+                        - ARGUMENTS@3590..3607
+                            - L_PAREN@3590..3591 "("
+                            - ARGUMENT@3591..3603
+                                - NAME@3591..3596
+                                    - IDENT@3591..3596 "graph"
+                                - COLON@3596..3597 ":"
+                                - WHITESPACE@3597..3598 " "
+                                - ENUM_VALUE@3598..3603
+                                    - NAME@3598..3603
+                                        - IDENT@3598..3603 "BOOKS"
+                            - R_PAREN@3603..3604 ")"
+                            - WHITESPACE@3604..3607 "\n  "
+            - FIELD_DEFINITION@3607..3686
+                - NAME@3607..3618
+                    - IDENT@3607..3618 "userAccount"
+                - ARGUMENTS@3618..3631
+                    - L_PAREN@3618..3619 "("
+                    - INPUT_VALUE_DEFINITION@3619..3630
+                        - NAME@3619..3621
+                            - IDENT@3619..3621 "id"
+                        - COLON@3621..3622 ":"
+                        - WHITESPACE@3622..3623 " "
+                        - NON_NULL_TYPE@3623..3627
+                            - WHITESPACE@3623..3624 " "
+                            - NAMED_TYPE@3624..3626
+                                - NAME@3624..3626
+                                    - IDENT@3624..3626 "ID"
+                            - BANG@3626..3627 "!"
+                        - DEFAULT_VALUE@3627..3630
+                            - EQ@3627..3628 "="
+                            - WHITESPACE@3628..3629 " "
+                            - INT_VALUE@3629..3630
+                                - INT@3629..3630 "1"
+                    - R_PAREN@3630..3631 ")"
+                - COLON@3631..3632 ":"
+                - WHITESPACE@3632..3633 " "
+                - NAMED_TYPE@3633..3638
+                    - WHITESPACE@3633..3634 " "
+                    - NAME@3634..3638
+                        - IDENT@3634..3638 "User"
+                - DIRECTIVES@3638..3686
+                    - DIRECTIVE@3638..3686
+                        - AT@3638..3639 "@"
+                        - NAME@3639..3650
+                            - IDENT@3639..3650 "join__field"
+                        - ARGUMENTS@3650..3686
+                            - L_PAREN@3650..3651 "("
+                            - ARGUMENT@3651..3668
+                                - NAME@3651..3656
+                                    - IDENT@3651..3656 "graph"
+                                - COLON@3656..3657 ":"
+                                - WHITESPACE@3657..3658 " "
+                                - ENUM_VALUE@3658..3668
+                                    - NAME@3658..3668
+                                        - IDENT@3658..3666 "ACCOUNTS"
+                                        - COMMA@3666..3667 ","
+                                        - WHITESPACE@3667..3668 " "
+                            - ARGUMENT@3668..3684
+                                - NAME@3668..3676
+                                    - IDENT@3668..3676 "requires"
+                                - COLON@3676..3677 ":"
+                                - WHITESPACE@3677..3678 " "
+                                - STRING_VALUE@3678..3684
+                                    - STRING@3678..3684 "\"name\""
+                            - R_PAREN@3684..3685 ")"
+                            - WHITESPACE@3685..3686 "\n"
+            - R_CURLY@3686..3687 "}"
+            - WHITESPACE@3687..3689 "\n\n"
+    - UNION_TYPE_DEFINITION@3689..3731
+        - union_KW@3689..3694 "union"
+        - WHITESPACE@3694..3695 " "
+        - NAME@3695..3711
+            - IDENT@3695..3710 "MetadataOrError"
+            - WHITESPACE@3710..3711 " "
+        - UNION_MEMBER_TYPES@3711..3731
+            - EQ@3711..3712 "="
+            - WHITESPACE@3712..3713 " "
+            - NAMED_TYPE@3713..3722
+                - NAME@3713..3722
+                    - IDENT@3713..3721 "KeyValue"
+                    - WHITESPACE@3721..3722 " "
+            - PIPE@3722..3723 "|"
+            - WHITESPACE@3723..3724 " "
+            - NAMED_TYPE@3724..3731
+                - NAME@3724..3731
+                    - IDENT@3724..3729 "Error"
+                    - WHITESPACE@3729..3731 "\n\n"
+    - OBJECT_TYPE_DEFINITION@3731..4057
+        - type_KW@3731..3735 "type"
+        - WHITESPACE@3735..3736 " "
+        - NAME@3736..3745
+            - IDENT@3736..3744 "Mutation"
+            - WHITESPACE@3744..3745 " "
+        - FIELDS_DEFINITION@3745..4057
+            - L_CURLY@3745..3746 "{"
+            - WHITESPACE@3746..3749 "\n  "
+            - FIELD_DEFINITION@3749..3831
+                - NAME@3749..3754
+                    - IDENT@3749..3754 "login"
+                - ARGUMENTS@3754..3792
+                    - L_PAREN@3754..3755 "("
+                    - INPUT_VALUE_DEFINITION@3755..3774
+                        - NAME@3755..3763
+                            - IDENT@3755..3763 "username"
+                        - COLON@3763..3764 ":"
+                        - WHITESPACE@3764..3765 " "
+                        - NON_NULL_TYPE@3765..3774
+                            - COMMA@3765..3766 ","
+                            - WHITESPACE@3766..3767 " "
+                            - NAMED_TYPE@3767..3773
+                                - NAME@3767..3773
+                                    - IDENT@3767..3773 "String"
+                            - BANG@3773..3774 "!"
+                    - INPUT_VALUE_DEFINITION@3774..3791
+                        - NAME@3774..3782
+                            - IDENT@3774..3782 "password"
+                        - COLON@3782..3783 ":"
+                        - WHITESPACE@3783..3784 " "
+                        - NON_NULL_TYPE@3784..3791
+                            - NAMED_TYPE@3784..3790
+                                - NAME@3784..3790
+                                    - IDENT@3784..3790 "String"
+                            - BANG@3790..3791 "!"
+                    - R_PAREN@3791..3792 ")"
+                - COLON@3792..3793 ":"
+                - WHITESPACE@3793..3794 " "
+                - NAMED_TYPE@3794..3799
+                    - WHITESPACE@3794..3795 " "
+                    - NAME@3795..3799
+                        - IDENT@3795..3799 "User"
+                - DIRECTIVES@3799..3831
+                    - DIRECTIVE@3799..3831
+                        - AT@3799..3800 "@"
+                        - NAME@3800..3811
+                            - IDENT@3800..3811 "join__field"
+                        - ARGUMENTS@3811..3831
+                            - L_PAREN@3811..3812 "("
+                            - ARGUMENT@3812..3827
+                                - NAME@3812..3817
+                                    - IDENT@3812..3817 "graph"
+                                - COLON@3817..3818 ":"
+                                - WHITESPACE@3818..3819 " "
+                                - ENUM_VALUE@3819..3827
+                                    - NAME@3819..3827
+                                        - IDENT@3819..3827 "ACCOUNTS"
+                            - R_PAREN@3827..3828 ")"
+                            - WHITESPACE@3828..3831 "\n  "
+            - FIELD_DEFINITION@3831..3914
+                - NAME@3831..3844
+                    - IDENT@3831..3844 "reviewProduct"
+                - ARGUMENTS@3844..3873
+                    - L_PAREN@3844..3845 "("
+                    - INPUT_VALUE_DEFINITION@3845..3859
+                        - NAME@3845..3848
+                            - IDENT@3845..3848 "upc"
+                        - COLON@3848..3849 ":"
+                        - WHITESPACE@3849..3850 " "
+                        - NON_NULL_TYPE@3850..3859
+                            - COMMA@3850..3851 ","
+                            - WHITESPACE@3851..3852 " "
+                            - NAMED_TYPE@3852..3858
+                                - NAME@3852..3858
+                                    - IDENT@3852..3858 "String"
+                            - BANG@3858..3859 "!"
+                    - INPUT_VALUE_DEFINITION@3859..3872
+                        - NAME@3859..3863
+                            - IDENT@3859..3863 "body"
+                        - COLON@3863..3864 ":"
+                        - WHITESPACE@3864..3865 " "
+                        - NON_NULL_TYPE@3865..3872
+                            - NAMED_TYPE@3865..3871
+                                - NAME@3865..3871
+                                    - IDENT@3865..3871 "String"
+                            - BANG@3871..3872 "!"
+                    - R_PAREN@3872..3873 ")"
+                - COLON@3873..3874 ":"
+                - WHITESPACE@3874..3875 " "
+                - NAMED_TYPE@3875..3883
+                    - WHITESPACE@3875..3876 " "
+                    - NAME@3876..3883
+                        - IDENT@3876..3883 "Product"
+                - DIRECTIVES@3883..3914
+                    - DIRECTIVE@3883..3914
+                        - AT@3883..3884 "@"
+                        - NAME@3884..3895
+                            - IDENT@3884..3895 "join__field"
+                        - ARGUMENTS@3895..3914
+                            - L_PAREN@3895..3896 "("
+                            - ARGUMENT@3896..3910
+                                - NAME@3896..3901
+                                    - IDENT@3896..3901 "graph"
+                                - COLON@3901..3902 ":"
+                                - WHITESPACE@3902..3903 " "
+                                - ENUM_VALUE@3903..3910
+                                    - NAME@3903..3910
+                                        - IDENT@3903..3910 "REVIEWS"
+                            - R_PAREN@3910..3911 ")"
+                            - WHITESPACE@3911..3914 "\n  "
+            - FIELD_DEFINITION@3914..3994
+                - NAME@3914..3926
+                    - IDENT@3914..3926 "updateReview"
+                - ARGUMENTS@3926..3954
+                    - L_PAREN@3926..3927 "("
+                    - INPUT_VALUE_DEFINITION@3927..3953
+                        - NAME@3927..3933
+                            - IDENT@3927..3933 "review"
+                        - COLON@3933..3934 ":"
+                        - WHITESPACE@3934..3935 " "
+                        - NON_NULL_TYPE@3935..3953
+                            - NAMED_TYPE@3935..3952
+                                - NAME@3935..3952
+                                    - IDENT@3935..3952 "UpdateReviewInput"
+                            - BANG@3952..3953 "!"
+                    - R_PAREN@3953..3954 ")"
+                - COLON@3954..3955 ":"
+                - WHITESPACE@3955..3956 " "
+                - NAMED_TYPE@3956..3963
+                    - WHITESPACE@3956..3957 " "
+                    - NAME@3957..3963
+                        - IDENT@3957..3963 "Review"
+                - DIRECTIVES@3963..3994
+                    - DIRECTIVE@3963..3994
+                        - AT@3963..3964 "@"
+                        - NAME@3964..3975
+                            - IDENT@3964..3975 "join__field"
+                        - ARGUMENTS@3975..3994
+                            - L_PAREN@3975..3976 "("
+                            - ARGUMENT@3976..3990
+                                - NAME@3976..3981
+                                    - IDENT@3976..3981 "graph"
+                                - COLON@3981..3982 ":"
+                                - WHITESPACE@3982..3983 " "
+                                - ENUM_VALUE@3983..3990
+                                    - NAME@3983..3990
+                                        - IDENT@3983..3990 "REVIEWS"
+                            - R_PAREN@3990..3991 ")"
+                            - WHITESPACE@3991..3994 "\n  "
+            - FIELD_DEFINITION@3994..4054
+                - NAME@3994..4006
+                    - IDENT@3994..4006 "deleteReview"
+                - ARGUMENTS@4006..4015
+                    - L_PAREN@4006..4007 "("
+                    - INPUT_VALUE_DEFINITION@4007..4014
+                        - NAME@4007..4009
+                            - IDENT@4007..4009 "id"
+                        - COLON@4009..4010 ":"
+                        - WHITESPACE@4010..4011 " "
+                        - NON_NULL_TYPE@4011..4014
+                            - NAMED_TYPE@4011..4013
+                                - NAME@4011..4013
+                                    - IDENT@4011..4013 "ID"
+                            - BANG@4013..4014 "!"
+                    - R_PAREN@4014..4015 ")"
+                - COLON@4015..4016 ":"
+                - WHITESPACE@4016..4017 " "
+                - NAMED_TYPE@4017..4025
+                    - WHITESPACE@4017..4018 " "
+                    - NAME@4018..4025
+                        - IDENT@4018..4025 "Boolean"
+                - DIRECTIVES@4025..4054
+                    - DIRECTIVE@4025..4054
+                        - AT@4025..4026 "@"
+                        - NAME@4026..4037
+                            - IDENT@4026..4037 "join__field"
+                        - ARGUMENTS@4037..4054
+                            - L_PAREN@4037..4038 "("
+                            - ARGUMENT@4038..4052
+                                - NAME@4038..4043
+                                    - IDENT@4038..4043 "graph"
+                                - COLON@4043..4044 ":"
+                                - WHITESPACE@4044..4045 " "
+                                - ENUM_VALUE@4045..4052
+                                    - NAME@4045..4052
+                                        - IDENT@4045..4052 "REVIEWS"
+                            - R_PAREN@4052..4053 ")"
+                            - WHITESPACE@4053..4054 "\n"
+            - R_CURLY@4054..4055 "}"
+            - WHITESPACE@4055..4057 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4057..4103
+        - type_KW@4057..4061 "type"
+        - WHITESPACE@4061..4062 " "
+        - NAME@4062..4067
+            - IDENT@4062..4066 "Name"
+            - WHITESPACE@4066..4067 " "
+        - FIELDS_DEFINITION@4067..4103
+            - L_CURLY@4067..4068 "{"
+            - WHITESPACE@4068..4071 "\n  "
+            - FIELD_DEFINITION@4071..4087
+                - NAME@4071..4076
+                    - IDENT@4071..4076 "first"
+                - COLON@4076..4077 ":"
+                - WHITESPACE@4077..4078 " "
+                - NAMED_TYPE@4078..4087
+                    - WHITESPACE@4078..4081 "\n  "
+                    - NAME@4081..4087
+                        - IDENT@4081..4087 "String"
+            - FIELD_DEFINITION@4087..4100
+                - NAME@4087..4091
+                    - IDENT@4087..4091 "last"
+                - COLON@4091..4092 ":"
+                - WHITESPACE@4092..4093 " "
+                - NAMED_TYPE@4093..4100
+                    - WHITESPACE@4093..4094 "\n"
+                    - NAME@4094..4100
+                        - IDENT@4094..4100 "String"
+            - R_CURLY@4100..4101 "}"
+            - WHITESPACE@4101..4103 "\n\n"
+    - INTERFACE_TYPE_DEFINITION@4103..4146
+        - interface_KW@4103..4112 "interface"
+        - WHITESPACE@4112..4113 " "
+        - NAME@4113..4125
+            - IDENT@4113..4124 "NamedObject"
+            - WHITESPACE@4124..4125 " "
+        - FIELDS_DEFINITION@4125..4146
+            - L_CURLY@4125..4126 "{"
+            - WHITESPACE@4126..4129 "\n  "
+            - FIELD_DEFINITION@4129..4143
+                - NAME@4129..4133
+                    - IDENT@4129..4133 "name"
+                - COLON@4133..4134 ":"
+                - WHITESPACE@4134..4135 " "
+                - NON_NULL_TYPE@4135..4143
+                    - WHITESPACE@4135..4136 "\n"
+                    - NAMED_TYPE@4136..4142
+                        - NAME@4136..4142
+                            - IDENT@4136..4142 "String"
+                    - BANG@4142..4143 "!"
+            - R_CURLY@4143..4144 "}"
+            - WHITESPACE@4144..4146 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4146..4292
+        - type_KW@4146..4150 "type"
+        - WHITESPACE@4150..4151 " "
+        - NAME@4151..4167
+            - IDENT@4151..4166 "PasswordAccount"
+            - WHITESPACE@4166..4167 "\n"
+        - DIRECTIVES@4167..4240
+            - DIRECTIVE@4167..4197
+                - AT@4167..4168 "@"
+                - NAME@4168..4179
+                    - IDENT@4168..4179 "join__owner"
+                - ARGUMENTS@4179..4197
                     - L_PAREN@4179..4180 "("
-                    - ARGUMENT@4180..4197
+                    - ARGUMENT@4180..4195
                         - NAME@4180..4185
                             - IDENT@4180..4185 "graph"
                         - COLON@4185..4186 ":"
                         - WHITESPACE@4186..4187 " "
-                        - ENUM_VALUE@4187..4197
-                            - NAME@4187..4197
+                        - ENUM_VALUE@4187..4195
+                            - NAME@4187..4195
                                 - IDENT@4187..4195 "ACCOUNTS"
-                                - COMMA@4195..4196 ","
-                                - WHITESPACE@4196..4197 " "
-                    - ARGUMENT@4197..4209
-                        - NAME@4197..4200
-                            - IDENT@4197..4200 "key"
-                        - COLON@4200..4201 ":"
-                        - WHITESPACE@4201..4202 " "
-                        - STRING_VALUE@4202..4209
-                            - STRING@4202..4209 "\"email\""
-                    - R_PAREN@4209..4210 ")"
-                    - WHITESPACE@4210..4211 "\n"
-        - FIELDS_DEFINITION@4211..4262
-            - L_CURLY@4211..4212 "{"
-            - WHITESPACE@4212..4215 "\n  "
-            - FIELD_DEFINITION@4215..4259
-                - NAME@4215..4220
-                    - IDENT@4215..4220 "email"
-                - COLON@4220..4221 ":"
-                - WHITESPACE@4221..4222 " "
-                - NON_NULL_TYPE@4222..4229
-                    - WHITESPACE@4222..4223 " "
-                    - NAMED_TYPE@4223..4229
-                        - NAME@4223..4229
-                            - IDENT@4223..4229 "String"
-                - DIRECTIVES@4229..4259
-                    - DIRECTIVE@4229..4259
-                        - AT@4229..4230 "@"
-                        - NAME@4230..4241
-                            - IDENT@4230..4241 "join__field"
-                        - ARGUMENTS@4241..4259
-                            - L_PAREN@4241..4242 "("
-                            - ARGUMENT@4242..4257
-                                - NAME@4242..4247
-                                    - IDENT@4242..4247 "graph"
-                                - COLON@4247..4248 ":"
-                                - WHITESPACE@4248..4249 " "
-                                - ENUM_VALUE@4249..4257
-                                    - NAME@4249..4257
-                                        - IDENT@4249..4257 "ACCOUNTS"
-                            - R_PAREN@4257..4258 ")"
-                            - WHITESPACE@4258..4259 "\n"
-            - R_CURLY@4259..4260 "}"
-            - WHITESPACE@4260..4262 "\n\n"
-    - INTERFACE_TYPE_DEFINITION@4262..4409
-        - interface_KW@4262..4271 "interface"
-        - WHITESPACE@4271..4272 " "
-        - NAME@4272..4280
-            - IDENT@4272..4279 "Product"
-            - WHITESPACE@4279..4280 " "
-        - FIELDS_DEFINITION@4280..4409
-            - L_CURLY@4280..4281 "{"
-            - WHITESPACE@4281..4284 "\n  "
-            - FIELD_DEFINITION@4284..4298
-                - NAME@4284..4287
-                    - IDENT@4284..4287 "upc"
-                - COLON@4287..4288 ":"
-                - WHITESPACE@4288..4289 " "
-                - NON_NULL_TYPE@4289..4298
-                    - WHITESPACE@4289..4292 "\n  "
-                    - NAMED_TYPE@4292..4298
-                        - NAME@4292..4298
-                            - IDENT@4292..4298 "String"
-            - FIELD_DEFINITION@4298..4312
-                - NAME@4298..4301
-                    - IDENT@4298..4301 "sku"
-                - COLON@4301..4302 ":"
-                - WHITESPACE@4302..4303 " "
-                - NON_NULL_TYPE@4303..4312
-                    - WHITESPACE@4303..4306 "\n  "
-                    - NAMED_TYPE@4306..4312
-                        - NAME@4306..4312
-                            - IDENT@4306..4312 "String"
-            - FIELD_DEFINITION@4312..4327
-                - NAME@4312..4316
-                    - IDENT@4312..4316 "name"
-                - COLON@4316..4317 ":"
-                - WHITESPACE@4317..4318 " "
-                - NAMED_TYPE@4318..4327
-                    - WHITESPACE@4318..4321 "\n  "
-                    - NAME@4321..4327
-                        - IDENT@4321..4327 "String"
-            - FIELD_DEFINITION@4327..4343
-                - NAME@4327..4332
-                    - IDENT@4327..4332 "price"
+                    - R_PAREN@4195..4196 ")"
+                    - WHITESPACE@4196..4197 "\n"
+            - DIRECTIVE@4197..4240
+                - AT@4197..4198 "@"
+                - NAME@4198..4208
+                    - IDENT@4198..4208 "join__type"
+                - ARGUMENTS@4208..4240
+                    - L_PAREN@4208..4209 "("
+                    - ARGUMENT@4209..4226
+                        - NAME@4209..4214
+                            - IDENT@4209..4214 "graph"
+                        - COLON@4214..4215 ":"
+                        - WHITESPACE@4215..4216 " "
+                        - ENUM_VALUE@4216..4226
+                            - NAME@4216..4226
+                                - IDENT@4216..4224 "ACCOUNTS"
+                                - COMMA@4224..4225 ","
+                                - WHITESPACE@4225..4226 " "
+                    - ARGUMENT@4226..4238
+                        - NAME@4226..4229
+                            - IDENT@4226..4229 "key"
+                        - COLON@4229..4230 ":"
+                        - WHITESPACE@4230..4231 " "
+                        - STRING_VALUE@4231..4238
+                            - STRING@4231..4238 "\"email\""
+                    - R_PAREN@4238..4239 ")"
+                    - WHITESPACE@4239..4240 "\n"
+        - FIELDS_DEFINITION@4240..4292
+            - L_CURLY@4240..4241 "{"
+            - WHITESPACE@4241..4244 "\n  "
+            - FIELD_DEFINITION@4244..4289
+                - NAME@4244..4249
+                    - IDENT@4244..4249 "email"
+                - COLON@4249..4250 ":"
+                - WHITESPACE@4250..4251 " "
+                - NON_NULL_TYPE@4251..4259
+                    - WHITESPACE@4251..4252 " "
+                    - NAMED_TYPE@4252..4258
+                        - NAME@4252..4258
+                            - IDENT@4252..4258 "String"
+                    - BANG@4258..4259 "!"
+                - DIRECTIVES@4259..4289
+                    - DIRECTIVE@4259..4289
+                        - AT@4259..4260 "@"
+                        - NAME@4260..4271
+                            - IDENT@4260..4271 "join__field"
+                        - ARGUMENTS@4271..4289
+                            - L_PAREN@4271..4272 "("
+                            - ARGUMENT@4272..4287
+                                - NAME@4272..4277
+                                    - IDENT@4272..4277 "graph"
+                                - COLON@4277..4278 ":"
+                                - WHITESPACE@4278..4279 " "
+                                - ENUM_VALUE@4279..4287
+                                    - NAME@4279..4287
+                                        - IDENT@4279..4287 "ACCOUNTS"
+                            - R_PAREN@4287..4288 ")"
+                            - WHITESPACE@4288..4289 "\n"
+            - R_CURLY@4289..4290 "}"
+            - WHITESPACE@4290..4292 "\n\n"
+    - INTERFACE_TYPE_DEFINITION@4292..4441
+        - interface_KW@4292..4301 "interface"
+        - WHITESPACE@4301..4302 " "
+        - NAME@4302..4310
+            - IDENT@4302..4309 "Product"
+            - WHITESPACE@4309..4310 " "
+        - FIELDS_DEFINITION@4310..4441
+            - L_CURLY@4310..4311 "{"
+            - WHITESPACE@4311..4314 "\n  "
+            - FIELD_DEFINITION@4314..4329
+                - NAME@4314..4317
+                    - IDENT@4314..4317 "upc"
+                - COLON@4317..4318 ":"
+                - WHITESPACE@4318..4319 " "
+                - NON_NULL_TYPE@4319..4329
+                    - WHITESPACE@4319..4322 "\n  "
+                    - NAMED_TYPE@4322..4328
+                        - NAME@4322..4328
+                            - IDENT@4322..4328 "String"
+                    - BANG@4328..4329 "!"
+            - FIELD_DEFINITION@4329..4344
+                - NAME@4329..4332
+                    - IDENT@4329..4332 "sku"
                 - COLON@4332..4333 ":"
                 - WHITESPACE@4333..4334 " "
-                - NAMED_TYPE@4334..4343
+                - NON_NULL_TYPE@4334..4344
                     - WHITESPACE@4334..4337 "\n  "
-                    - NAME@4337..4343
-                        - IDENT@4337..4343 "String"
-            - FIELD_DEFINITION@4343..4369
-                - NAME@4343..4350
-                    - IDENT@4343..4350 "details"
-                - COLON@4350..4351 ":"
-                - WHITESPACE@4351..4352 " "
-                - NAMED_TYPE@4352..4369
-                    - WHITESPACE@4352..4355 "\n  "
-                    - NAME@4355..4369
-                        - IDENT@4355..4369 "ProductDetails"
-            - FIELD_DEFINITION@4369..4388
-                - NAME@4369..4376
-                    - IDENT@4369..4376 "inStock"
-                - COLON@4376..4377 ":"
-                - WHITESPACE@4377..4378 " "
-                - NAMED_TYPE@4378..4388
-                    - WHITESPACE@4378..4381 "\n  "
-                    - NAME@4381..4388
-                        - IDENT@4381..4388 "Boolean"
-            - FIELD_DEFINITION@4388..4406
-                - NAME@4388..4395
-                    - IDENT@4388..4395 "reviews"
-                - COLON@4395..4396 ":"
-                - WHITESPACE@4396..4397 " "
-                - LIST_TYPE@4397..4406
-                    - WHITESPACE@4397..4398 "\n"
-                    - L_BRACK@4398..4399 "["
-                    - NAMED_TYPE@4399..4405
-                        - NAME@4399..4405
-                            - IDENT@4399..4405 "Review"
-                    - R_BRACK@4405..4406 "]"
-            - R_CURLY@4406..4407 "}"
-            - WHITESPACE@4407..4409 "\n\n"
-    - INTERFACE_TYPE_DEFINITION@4409..4457
-        - interface_KW@4409..4418 "interface"
-        - WHITESPACE@4418..4419 " "
-        - NAME@4419..4434
-            - IDENT@4419..4433 "ProductDetails"
-            - WHITESPACE@4433..4434 " "
-        - FIELDS_DEFINITION@4434..4457
-            - L_CURLY@4434..4435 "{"
-            - WHITESPACE@4435..4438 "\n  "
-            - FIELD_DEFINITION@4438..4454
-                - NAME@4438..4445
-                    - IDENT@4438..4445 "country"
-                - COLON@4445..4446 ":"
-                - WHITESPACE@4446..4447 " "
-                - NAMED_TYPE@4447..4454
-                    - WHITESPACE@4447..4448 "\n"
-                    - NAME@4448..4454
-                        - IDENT@4448..4454 "String"
-            - R_CURLY@4454..4455 "}"
-            - WHITESPACE@4455..4457 "\n\n"
-    - OBJECT_TYPE_DEFINITION@4457..4543
-        - type_KW@4457..4461 "type"
-        - WHITESPACE@4461..4462 " "
-        - NAME@4462..4481
-            - IDENT@4462..4480 "ProductDetailsBook"
-            - WHITESPACE@4480..4481 " "
-        - IMPLEMENTS_INTERFACES@4481..4507
-            - implements_KW@4481..4491 "implements"
-            - WHITESPACE@4491..4492 " "
-            - NAMED_TYPE@4492..4507
-                - NAME@4492..4507
-                    - IDENT@4492..4506 "ProductDetails"
-                    - WHITESPACE@4506..4507 " "
-        - FIELDS_DEFINITION@4507..4543
-            - L_CURLY@4507..4508 "{"
-            - WHITESPACE@4508..4511 "\n  "
-            - FIELD_DEFINITION@4511..4529
-                - NAME@4511..4518
-                    - IDENT@4511..4518 "country"
-                - COLON@4518..4519 ":"
-                - WHITESPACE@4519..4520 " "
-                - NAMED_TYPE@4520..4529
-                    - WHITESPACE@4520..4523 "\n  "
-                    - NAME@4523..4529
-                        - IDENT@4523..4529 "String"
-            - FIELD_DEFINITION@4529..4540
-                - NAME@4529..4534
-                    - IDENT@4529..4534 "pages"
-                - COLON@4534..4535 ":"
-                - WHITESPACE@4535..4536 " "
-                - NAMED_TYPE@4536..4540
-                    - WHITESPACE@4536..4537 "\n"
-                    - NAME@4537..4540
-                        - IDENT@4537..4540 "Int"
-            - R_CURLY@4540..4541 "}"
-            - WHITESPACE@4541..4543 "\n\n"
-    - OBJECT_TYPE_DEFINITION@4543..4637
-        - type_KW@4543..4547 "type"
-        - WHITESPACE@4547..4548 " "
-        - NAME@4548..4572
-            - IDENT@4548..4571 "ProductDetailsFurniture"
-            - WHITESPACE@4571..4572 " "
-        - IMPLEMENTS_INTERFACES@4572..4598
-            - implements_KW@4572..4582 "implements"
-            - WHITESPACE@4582..4583 " "
-            - NAMED_TYPE@4583..4598
-                - NAME@4583..4598
-                    - IDENT@4583..4597 "ProductDetails"
-                    - WHITESPACE@4597..4598 " "
-        - FIELDS_DEFINITION@4598..4637
-            - L_CURLY@4598..4599 "{"
-            - WHITESPACE@4599..4602 "\n  "
-            - FIELD_DEFINITION@4602..4620
-                - NAME@4602..4609
-                    - IDENT@4602..4609 "country"
-                - COLON@4609..4610 ":"
-                - WHITESPACE@4610..4611 " "
-                - NAMED_TYPE@4611..4620
-                    - WHITESPACE@4611..4614 "\n  "
-                    - NAME@4614..4620
-                        - IDENT@4614..4620 "String"
-            - FIELD_DEFINITION@4620..4634
-                - NAME@4620..4625
-                    - IDENT@4620..4625 "color"
-                - COLON@4625..4626 ":"
-                - WHITESPACE@4626..4627 " "
-                - NAMED_TYPE@4627..4634
-                    - WHITESPACE@4627..4628 "\n"
-                    - NAME@4628..4634
-                        - IDENT@4628..4634 "String"
-            - R_CURLY@4634..4635 "}"
-            - WHITESPACE@4635..4637 "\n\n"
-    - OBJECT_TYPE_DEFINITION@4637..5261
-        - type_KW@4637..4641 "type"
-        - WHITESPACE@4641..4642 " "
-        - NAME@4642..4648
-            - IDENT@4642..4647 "Query"
-            - WHITESPACE@4647..4648 " "
-        - FIELDS_DEFINITION@4648..5261
-            - L_CURLY@4648..4649 "{"
-            - WHITESPACE@4649..4652 "\n  "
-            - FIELD_DEFINITION@4652..4703
-                - NAME@4652..4656
-                    - IDENT@4652..4656 "user"
-                - ARGUMENTS@4656..4664
-                    - L_PAREN@4656..4657 "("
-                    - INPUT_VALUE_DEFINITION@4657..4663
-                        - NAME@4657..4659
-                            - IDENT@4657..4659 "id"
-                        - COLON@4659..4660 ":"
-                        - WHITESPACE@4660..4661 " "
-                        - NON_NULL_TYPE@4661..4663
-                            - NAMED_TYPE@4661..4663
-                                - NAME@4661..4663
-                                    - IDENT@4661..4663 "ID"
-                    - R_PAREN@4663..4664 ")"
-                - COLON@4664..4665 ":"
-                - WHITESPACE@4665..4666 " "
-                - NAMED_TYPE@4666..4671
-                    - WHITESPACE@4666..4667 " "
-                    - NAME@4667..4671
-                        - IDENT@4667..4671 "User"
-                - DIRECTIVES@4671..4703
-                    - DIRECTIVE@4671..4703
-                        - AT@4671..4672 "@"
-                        - NAME@4672..4683
-                            - IDENT@4672..4683 "join__field"
-                        - ARGUMENTS@4683..4703
-                            - L_PAREN@4683..4684 "("
-                            - ARGUMENT@4684..4699
-                                - NAME@4684..4689
-                                    - IDENT@4684..4689 "graph"
-                                - COLON@4689..4690 ":"
-                                - WHITESPACE@4690..4691 " "
-                                - ENUM_VALUE@4691..4699
-                                    - NAME@4691..4699
-                                        - IDENT@4691..4699 "ACCOUNTS"
-                            - R_PAREN@4699..4700 ")"
-                            - WHITESPACE@4700..4703 "\n  "
-            - FIELD_DEFINITION@4703..4744
-                - NAME@4703..4705
-                    - IDENT@4703..4705 "me"
-                - COLON@4705..4706 ":"
-                - WHITESPACE@4706..4707 " "
-                - NAMED_TYPE@4707..4712
-                    - WHITESPACE@4707..4708 " "
-                    - NAME@4708..4712
-                        - IDENT@4708..4712 "User"
-                - DIRECTIVES@4712..4744
-                    - DIRECTIVE@4712..4744
-                        - AT@4712..4713 "@"
-                        - NAME@4713..4724
-                            - IDENT@4713..4724 "join__field"
-                        - ARGUMENTS@4724..4744
-                            - L_PAREN@4724..4725 "("
-                            - ARGUMENT@4725..4740
-                                - NAME@4725..4730
-                                    - IDENT@4725..4730 "graph"
-                                - COLON@4730..4731 ":"
-                                - WHITESPACE@4731..4732 " "
-                                - ENUM_VALUE@4732..4740
-                                    - NAME@4732..4740
-                                        - IDENT@4732..4740 "ACCOUNTS"
-                            - R_PAREN@4740..4741 ")"
-                            - WHITESPACE@4741..4744 "\n  "
-            - FIELD_DEFINITION@4744..4798
-                - NAME@4744..4748
-                    - IDENT@4744..4748 "book"
-                - ARGUMENTS@4748..4762
-                    - L_PAREN@4748..4749 "("
-                    - INPUT_VALUE_DEFINITION@4749..4761
-                        - NAME@4749..4753
-                            - IDENT@4749..4753 "isbn"
-                        - COLON@4753..4754 ":"
-                        - WHITESPACE@4754..4755 " "
-                        - NON_NULL_TYPE@4755..4761
-                            - NAMED_TYPE@4755..4761
-                                - NAME@4755..4761
-                                    - IDENT@4755..4761 "String"
-                    - R_PAREN@4761..4762 ")"
-                - COLON@4762..4763 ":"
-                - WHITESPACE@4763..4764 " "
-                - NAMED_TYPE@4764..4769
-                    - WHITESPACE@4764..4765 " "
-                    - NAME@4765..4769
-                        - IDENT@4765..4769 "Book"
-                - DIRECTIVES@4769..4798
-                    - DIRECTIVE@4769..4798
-                        - AT@4769..4770 "@"
-                        - NAME@4770..4781
-                            - IDENT@4770..4781 "join__field"
-                        - ARGUMENTS@4781..4798
-                            - L_PAREN@4781..4782 "("
-                            - ARGUMENT@4782..4794
-                                - NAME@4782..4787
-                                    - IDENT@4782..4787 "graph"
-                                - COLON@4787..4788 ":"
-                                - WHITESPACE@4788..4789 " "
-                                - ENUM_VALUE@4789..4794
-                                    - NAME@4789..4794
-                                        - IDENT@4789..4794 "BOOKS"
-                            - R_PAREN@4794..4795 ")"
-                            - WHITESPACE@4795..4798 "\n  "
-            - FIELD_DEFINITION@4798..4841
-                - NAME@4798..4803
-                    - IDENT@4798..4803 "books"
-                - COLON@4803..4804 ":"
-                - WHITESPACE@4804..4805 " "
-                - LIST_TYPE@4805..4812
-                    - WHITESPACE@4805..4806 " "
-                    - L_BRACK@4806..4807 "["
-                    - NAMED_TYPE@4807..4811
-                        - NAME@4807..4811
-                            - IDENT@4807..4811 "Book"
-                    - R_BRACK@4811..4812 "]"
-                - DIRECTIVES@4812..4841
-                    - DIRECTIVE@4812..4841
-                        - AT@4812..4813 "@"
-                        - NAME@4813..4824
-                            - IDENT@4813..4824 "join__field"
-                        - ARGUMENTS@4824..4841
-                            - L_PAREN@4824..4825 "("
-                            - ARGUMENT@4825..4837
-                                - NAME@4825..4830
-                                    - IDENT@4825..4830 "graph"
-                                - COLON@4830..4831 ":"
-                                - WHITESPACE@4831..4832 " "
-                                - ENUM_VALUE@4832..4837
-                                    - NAME@4832..4837
-                                        - IDENT@4832..4837 "BOOKS"
-                            - R_PAREN@4837..4838 ")"
-                            - WHITESPACE@4838..4841 "\n  "
-            - FIELD_DEFINITION@4841..4895
-                - NAME@4841..4848
-                    - IDENT@4841..4848 "library"
-                - ARGUMENTS@4848..4856
-                    - L_PAREN@4848..4849 "("
-                    - INPUT_VALUE_DEFINITION@4849..4855
-                        - NAME@4849..4851
-                            - IDENT@4849..4851 "id"
-                        - COLON@4851..4852 ":"
-                        - WHITESPACE@4852..4853 " "
-                        - NON_NULL_TYPE@4853..4855
-                            - NAMED_TYPE@4853..4855
-                                - NAME@4853..4855
-                                    - IDENT@4853..4855 "ID"
-                    - R_PAREN@4855..4856 ")"
-                - COLON@4856..4857 ":"
-                - WHITESPACE@4857..4858 " "
-                - NAMED_TYPE@4858..4866
-                    - WHITESPACE@4858..4859 " "
-                    - NAME@4859..4866
-                        - IDENT@4859..4866 "Library"
-                - DIRECTIVES@4866..4895
-                    - DIRECTIVE@4866..4895
-                        - AT@4866..4867 "@"
-                        - NAME@4867..4878
-                            - IDENT@4867..4878 "join__field"
-                        - ARGUMENTS@4878..4895
-                            - L_PAREN@4878..4879 "("
-                            - ARGUMENT@4879..4891
-                                - NAME@4879..4884
-                                    - IDENT@4879..4884 "graph"
-                                - COLON@4884..4885 ":"
-                                - WHITESPACE@4885..4886 " "
-                                - ENUM_VALUE@4886..4891
-                                    - NAME@4886..4891
-                                        - IDENT@4886..4891 "BOOKS"
-                            - R_PAREN@4891..4892 ")"
-                            - WHITESPACE@4892..4895 "\n  "
-            - FIELD_DEFINITION@4895..4939
-                - NAME@4895..4899
-                    - IDENT@4895..4899 "body"
-                - COLON@4899..4900 ":"
-                - WHITESPACE@4900..4901 " "
-                - NON_NULL_TYPE@4901..4906
-                    - WHITESPACE@4901..4902 " "
-                    - NAMED_TYPE@4902..4906
-                        - NAME@4902..4906
-                            - IDENT@4902..4906 "Body"
-                - DIRECTIVES@4906..4939
-                    - DIRECTIVE@4906..4939
-                        - AT@4906..4907 "@"
-                        - NAME@4907..4918
-                            - IDENT@4907..4918 "join__field"
-                        - ARGUMENTS@4918..4939
-                            - L_PAREN@4918..4919 "("
-                            - ARGUMENT@4919..4935
-                                - NAME@4919..4924
-                                    - IDENT@4919..4924 "graph"
-                                - COLON@4924..4925 ":"
-                                - WHITESPACE@4925..4926 " "
-                                - ENUM_VALUE@4926..4935
-                                    - NAME@4926..4935
-                                        - IDENT@4926..4935 "DOCUMENTS"
-                            - R_PAREN@4935..4936 ")"
-                            - WHITESPACE@4936..4939 "\n  "
-            - FIELD_DEFINITION@4939..5000
-                - NAME@4939..4946
-                    - IDENT@4939..4946 "product"
-                - ARGUMENTS@4946..4959
-                    - L_PAREN@4946..4947 "("
-                    - INPUT_VALUE_DEFINITION@4947..4958
-                        - NAME@4947..4950
-                            - IDENT@4947..4950 "upc"
-                        - COLON@4950..4951 ":"
-                        - WHITESPACE@4951..4952 " "
-                        - NON_NULL_TYPE@4952..4958
-                            - NAMED_TYPE@4952..4958
-                                - NAME@4952..4958
-                                    - IDENT@4952..4958 "String"
-                    - R_PAREN@4958..4959 ")"
-                - COLON@4959..4960 ":"
-                - WHITESPACE@4960..4961 " "
-                - NAMED_TYPE@4961..4969
-                    - WHITESPACE@4961..4962 " "
-                    - NAME@4962..4969
-                        - IDENT@4962..4969 "Product"
-                - DIRECTIVES@4969..5000
-                    - DIRECTIVE@4969..5000
-                        - AT@4969..4970 "@"
-                        - NAME@4970..4981
-                            - IDENT@4970..4981 "join__field"
-                        - ARGUMENTS@4981..5000
-                            - L_PAREN@4981..4982 "("
-                            - ARGUMENT@4982..4996
-                                - NAME@4982..4987
-                                    - IDENT@4982..4987 "graph"
-                                - COLON@4987..4988 ":"
-                                - WHITESPACE@4988..4989 " "
-                                - ENUM_VALUE@4989..4996
-                                    - NAME@4989..4996
-                                        - IDENT@4989..4996 "PRODUCT"
-                            - R_PAREN@4996..4997 ")"
-                            - WHITESPACE@4997..5000 "\n  "
-            - FIELD_DEFINITION@5000..5060
-                - NAME@5000..5007
-                    - IDENT@5000..5007 "vehicle"
-                - ARGUMENTS@5007..5019
-                    - L_PAREN@5007..5008 "("
-                    - INPUT_VALUE_DEFINITION@5008..5018
-                        - NAME@5008..5010
-                            - IDENT@5008..5010 "id"
-                        - COLON@5010..5011 ":"
-                        - WHITESPACE@5011..5012 " "
-                        - NON_NULL_TYPE@5012..5018
-                            - NAMED_TYPE@5012..5018
-                                - NAME@5012..5018
-                                    - IDENT@5012..5018 "String"
-                    - R_PAREN@5018..5019 ")"
-                - COLON@5019..5020 ":"
-                - WHITESPACE@5020..5021 " "
-                - NAMED_TYPE@5021..5029
-                    - WHITESPACE@5021..5022 " "
-                    - NAME@5022..5029
-                        - IDENT@5022..5029 "Vehicle"
-                - DIRECTIVES@5029..5060
-                    - DIRECTIVE@5029..5060
-                        - AT@5029..5030 "@"
-                        - NAME@5030..5041
-                            - IDENT@5030..5041 "join__field"
-                        - ARGUMENTS@5041..5060
-                            - L_PAREN@5041..5042 "("
-                            - ARGUMENT@5042..5056
-                                - NAME@5042..5047
-                                    - IDENT@5042..5047 "graph"
-                                - COLON@5047..5048 ":"
-                                - WHITESPACE@5048..5049 " "
-                                - ENUM_VALUE@5049..5056
-                                    - NAME@5049..5056
-                                        - IDENT@5049..5056 "PRODUCT"
-                            - R_PAREN@5056..5057 ")"
-                            - WHITESPACE@5057..5060 "\n  "
-            - FIELD_DEFINITION@5060..5130
-                - NAME@5060..5071
-                    - IDENT@5060..5071 "topProducts"
-                - ARGUMENTS@5071..5087
-                    - L_PAREN@5071..5072 "("
-                    - INPUT_VALUE_DEFINITION@5072..5086
-                        - NAME@5072..5077
-                            - IDENT@5072..5077 "first"
-                        - COLON@5077..5078 ":"
-                        - WHITESPACE@5078..5079 " "
-                        - NAMED_TYPE@5079..5083
-                            - WHITESPACE@5079..5080 " "
-                            - NAME@5080..5083
-                                - IDENT@5080..5083 "Int"
-                        - DEFAULT_VALUE@5083..5086
-                            - EQ@5083..5084 "="
-                            - WHITESPACE@5084..5085 " "
-                            - INT_VALUE@5085..5086
-                                - INT@5085..5086 "5"
-                    - R_PAREN@5086..5087 ")"
-                - COLON@5087..5088 ":"
-                - WHITESPACE@5088..5089 " "
-                - LIST_TYPE@5089..5099
-                    - WHITESPACE@5089..5090 " "
-                    - L_BRACK@5090..5091 "["
-                    - NAMED_TYPE@5091..5098
-                        - NAME@5091..5098
-                            - IDENT@5091..5098 "Product"
-                    - R_BRACK@5098..5099 "]"
-                - DIRECTIVES@5099..5130
-                    - DIRECTIVE@5099..5130
-                        - AT@5099..5100 "@"
-                        - NAME@5100..5111
-                            - IDENT@5100..5111 "join__field"
-                        - ARGUMENTS@5111..5130
-                            - L_PAREN@5111..5112 "("
-                            - ARGUMENT@5112..5126
-                                - NAME@5112..5117
-                                    - IDENT@5112..5117 "graph"
-                                - COLON@5117..5118 ":"
-                                - WHITESPACE@5118..5119 " "
-                                - ENUM_VALUE@5119..5126
-                                    - NAME@5119..5126
-                                        - IDENT@5119..5126 "PRODUCT"
-                            - R_PAREN@5126..5127 ")"
-                            - WHITESPACE@5127..5130 "\n  "
-            - FIELD_DEFINITION@5130..5192
-                - NAME@5130..5137
-                    - IDENT@5130..5137 "topCars"
-                - ARGUMENTS@5137..5153
-                    - L_PAREN@5137..5138 "("
-                    - INPUT_VALUE_DEFINITION@5138..5152
-                        - NAME@5138..5143
-                            - IDENT@5138..5143 "first"
-                        - COLON@5143..5144 ":"
-                        - WHITESPACE@5144..5145 " "
-                        - NAMED_TYPE@5145..5149
-                            - WHITESPACE@5145..5146 " "
-                            - NAME@5146..5149
-                                - IDENT@5146..5149 "Int"
-                        - DEFAULT_VALUE@5149..5152
-                            - EQ@5149..5150 "="
-                            - WHITESPACE@5150..5151 " "
-                            - INT_VALUE@5151..5152
-                                - INT@5151..5152 "5"
-                    - R_PAREN@5152..5153 ")"
-                - COLON@5153..5154 ":"
-                - WHITESPACE@5154..5155 " "
-                - LIST_TYPE@5155..5161
-                    - WHITESPACE@5155..5156 " "
-                    - L_BRACK@5156..5157 "["
-                    - NAMED_TYPE@5157..5160
-                        - NAME@5157..5160
-                            - IDENT@5157..5160 "Car"
-                    - R_BRACK@5160..5161 "]"
-                - DIRECTIVES@5161..5192
-                    - DIRECTIVE@5161..5192
-                        - AT@5161..5162 "@"
-                        - NAME@5162..5173
-                            - IDENT@5162..5173 "join__field"
-                        - ARGUMENTS@5173..5192
-                            - L_PAREN@5173..5174 "("
-                            - ARGUMENT@5174..5188
-                                - NAME@5174..5179
-                                    - IDENT@5174..5179 "graph"
-                                - COLON@5179..5180 ":"
-                                - WHITESPACE@5180..5181 " "
-                                - ENUM_VALUE@5181..5188
-                                    - NAME@5181..5188
-                                        - IDENT@5181..5188 "PRODUCT"
-                            - R_PAREN@5188..5189 ")"
-                            - WHITESPACE@5189..5192 "\n  "
-            - FIELD_DEFINITION@5192..5258
-                - NAME@5192..5202
-                    - IDENT@5192..5202 "topReviews"
-                - ARGUMENTS@5202..5218
-                    - L_PAREN@5202..5203 "("
-                    - INPUT_VALUE_DEFINITION@5203..5217
-                        - NAME@5203..5208
-                            - IDENT@5203..5208 "first"
-                        - COLON@5208..5209 ":"
-                        - WHITESPACE@5209..5210 " "
-                        - NAMED_TYPE@5210..5214
-                            - WHITESPACE@5210..5211 " "
-                            - NAME@5211..5214
-                                - IDENT@5211..5214 "Int"
-                        - DEFAULT_VALUE@5214..5217
-                            - EQ@5214..5215 "="
-                            - WHITESPACE@5215..5216 " "
-                            - INT_VALUE@5216..5217
-                                - INT@5216..5217 "5"
-                    - R_PAREN@5217..5218 ")"
-                - COLON@5218..5219 ":"
-                - WHITESPACE@5219..5220 " "
-                - LIST_TYPE@5220..5229
-                    - WHITESPACE@5220..5221 " "
-                    - L_BRACK@5221..5222 "["
-                    - NAMED_TYPE@5222..5228
-                        - NAME@5222..5228
-                            - IDENT@5222..5228 "Review"
-                    - R_BRACK@5228..5229 "]"
-                - DIRECTIVES@5229..5258
-                    - DIRECTIVE@5229..5258
-                        - AT@5229..5230 "@"
-                        - NAME@5230..5241
-                            - IDENT@5230..5241 "join__field"
-                        - ARGUMENTS@5241..5258
-                            - L_PAREN@5241..5242 "("
-                            - ARGUMENT@5242..5256
-                                - NAME@5242..5247
-                                    - IDENT@5242..5247 "graph"
-                                - COLON@5247..5248 ":"
-                                - WHITESPACE@5248..5249 " "
-                                - ENUM_VALUE@5249..5256
-                                    - NAME@5249..5256
-                                        - IDENT@5249..5256 "REVIEWS"
-                            - R_PAREN@5256..5257 ")"
-                            - WHITESPACE@5257..5258 "\n"
-            - R_CURLY@5258..5259 "}"
-            - WHITESPACE@5259..5261 "\n\n"
-    - OBJECT_TYPE_DEFINITION@5261..5626
-        - type_KW@5261..5265 "type"
-        - WHITESPACE@5265..5266 " "
-        - NAME@5266..5273
-            - IDENT@5266..5272 "Review"
-            - WHITESPACE@5272..5273 "\n"
-        - DIRECTIVES@5273..5341
-            - DIRECTIVE@5273..5302
-                - AT@5273..5274 "@"
-                - NAME@5274..5285
-                    - IDENT@5274..5285 "join__owner"
-                - ARGUMENTS@5285..5302
-                    - L_PAREN@5285..5286 "("
-                    - ARGUMENT@5286..5300
-                        - NAME@5286..5291
-                            - IDENT@5286..5291 "graph"
-                        - COLON@5291..5292 ":"
-                        - WHITESPACE@5292..5293 " "
-                        - ENUM_VALUE@5293..5300
-                            - NAME@5293..5300
-                                - IDENT@5293..5300 "REVIEWS"
-                    - R_PAREN@5300..5301 ")"
-                    - WHITESPACE@5301..5302 "\n"
-            - DIRECTIVE@5302..5341
-                - AT@5302..5303 "@"
-                - NAME@5303..5313
-                    - IDENT@5303..5313 "join__type"
-                - ARGUMENTS@5313..5341
-                    - L_PAREN@5313..5314 "("
-                    - ARGUMENT@5314..5330
-                        - NAME@5314..5319
-                            - IDENT@5314..5319 "graph"
-                        - COLON@5319..5320 ":"
-                        - WHITESPACE@5320..5321 " "
-                        - ENUM_VALUE@5321..5330
-                            - NAME@5321..5330
-                                - IDENT@5321..5328 "REVIEWS"
-                                - COMMA@5328..5329 ","
-                                - WHITESPACE@5329..5330 " "
-                    - ARGUMENT@5330..5339
-                        - NAME@5330..5333
-                            - IDENT@5330..5333 "key"
-                        - COLON@5333..5334 ":"
-                        - WHITESPACE@5334..5335 " "
-                        - STRING_VALUE@5335..5339
-                            - STRING@5335..5339 "\"id\""
-                    - R_PAREN@5339..5340 ")"
-                    - WHITESPACE@5340..5341 "\n"
-        - FIELDS_DEFINITION@5341..5626
-            - L_CURLY@5341..5342 "{"
-            - WHITESPACE@5342..5345 "\n  "
-            - FIELD_DEFINITION@5345..5383
-                - NAME@5345..5347
-                    - IDENT@5345..5347 "id"
-                - COLON@5347..5348 ":"
-                - WHITESPACE@5348..5349 " "
-                - NON_NULL_TYPE@5349..5352
-                    - WHITESPACE@5349..5350 " "
-                    - NAMED_TYPE@5350..5352
-                        - NAME@5350..5352
-                            - IDENT@5350..5352 "ID"
-                - DIRECTIVES@5352..5383
-                    - DIRECTIVE@5352..5383
-                        - AT@5352..5353 "@"
-                        - NAME@5353..5364
-                            - IDENT@5353..5364 "join__field"
-                        - ARGUMENTS@5364..5383
-                            - L_PAREN@5364..5365 "("
-                            - ARGUMENT@5365..5379
-                                - NAME@5365..5370
-                                    - IDENT@5365..5370 "graph"
-                                - COLON@5370..5371 ":"
-                                - WHITESPACE@5371..5372 " "
-                                - ENUM_VALUE@5372..5379
-                                    - NAME@5372..5379
-                                        - IDENT@5372..5379 "REVIEWS"
-                            - R_PAREN@5379..5380 ")"
-                            - WHITESPACE@5380..5383 "\n  "
-            - FIELD_DEFINITION@5383..5452
-                - NAME@5383..5387
-                    - IDENT@5383..5387 "body"
-                - ARGUMENTS@5387..5412
-                    - L_PAREN@5387..5388 "("
-                    - INPUT_VALUE_DEFINITION@5388..5411
-                        - NAME@5388..5394
-                            - IDENT@5388..5394 "format"
-                        - COLON@5394..5395 ":"
-                        - WHITESPACE@5395..5396 " "
-                        - NAMED_TYPE@5396..5404
-                            - WHITESPACE@5396..5397 " "
-                            - NAME@5397..5404
-                                - IDENT@5397..5404 "Boolean"
-                        - DEFAULT_VALUE@5404..5411
-                            - EQ@5404..5405 "="
-                            - WHITESPACE@5405..5406 " "
-                            - BOOLEAN_VALUE@5406..5411
-                                - false_KW@5406..5411 "false"
-                    - R_PAREN@5411..5412 ")"
-                - COLON@5412..5413 ":"
-                - WHITESPACE@5413..5414 " "
-                - NAMED_TYPE@5414..5421
-                    - WHITESPACE@5414..5415 " "
-                    - NAME@5415..5421
-                        - IDENT@5415..5421 "String"
-                - DIRECTIVES@5421..5452
-                    - DIRECTIVE@5421..5452
-                        - AT@5421..5422 "@"
-                        - NAME@5422..5433
-                            - IDENT@5422..5433 "join__field"
-                        - ARGUMENTS@5433..5452
-                            - L_PAREN@5433..5434 "("
-                            - ARGUMENT@5434..5448
-                                - NAME@5434..5439
-                                    - IDENT@5434..5439 "graph"
-                                - COLON@5439..5440 ":"
-                                - WHITESPACE@5440..5441 " "
-                                - ENUM_VALUE@5441..5448
-                                    - NAME@5441..5448
-                                        - IDENT@5441..5448 "REVIEWS"
-                            - R_PAREN@5448..5449 ")"
-                            - WHITESPACE@5449..5452 "\n  "
-            - FIELD_DEFINITION@5452..5518
-                - NAME@5452..5458
-                    - IDENT@5452..5458 "author"
-                - COLON@5458..5459 ":"
-                - WHITESPACE@5459..5460 " "
-                - NAMED_TYPE@5460..5465
-                    - WHITESPACE@5460..5461 " "
-                    - NAME@5461..5465
-                        - IDENT@5461..5465 "User"
-                - DIRECTIVES@5465..5518
-                    - DIRECTIVE@5465..5518
-                        - AT@5465..5466 "@"
-                        - NAME@5466..5477
-                            - IDENT@5466..5477 "join__field"
-                        - ARGUMENTS@5477..5518
-                            - L_PAREN@5477..5478 "("
-                            - ARGUMENT@5478..5494
-                                - NAME@5478..5483
-                                    - IDENT@5478..5483 "graph"
-                                - COLON@5483..5484 ":"
-                                - WHITESPACE@5484..5485 " "
-                                - ENUM_VALUE@5485..5494
-                                    - NAME@5485..5494
-                                        - IDENT@5485..5492 "REVIEWS"
-                                        - COMMA@5492..5493 ","
-                                        - WHITESPACE@5493..5494 " "
-                            - ARGUMENT@5494..5514
-                                - NAME@5494..5502
-                                    - IDENT@5494..5502 "provides"
-                                - COLON@5502..5503 ":"
-                                - WHITESPACE@5503..5504 " "
-                                - STRING_VALUE@5504..5514
-                                    - STRING@5504..5514 "\"username\""
-                            - R_PAREN@5514..5515 ")"
-                            - WHITESPACE@5515..5518 "\n  "
-            - FIELD_DEFINITION@5518..5566
-                - NAME@5518..5525
-                    - IDENT@5518..5525 "product"
-                - COLON@5525..5526 ":"
-                - WHITESPACE@5526..5527 " "
-                - NAMED_TYPE@5527..5535
-                    - WHITESPACE@5527..5528 " "
-                    - NAME@5528..5535
-                        - IDENT@5528..5535 "Product"
-                - DIRECTIVES@5535..5566
-                    - DIRECTIVE@5535..5566
-                        - AT@5535..5536 "@"
-                        - NAME@5536..5547
-                            - IDENT@5536..5547 "join__field"
-                        - ARGUMENTS@5547..5566
-                            - L_PAREN@5547..5548 "("
-                            - ARGUMENT@5548..5562
-                                - NAME@5548..5553
-                                    - IDENT@5548..5553 "graph"
-                                - COLON@5553..5554 ":"
-                                - WHITESPACE@5554..5555 " "
-                                - ENUM_VALUE@5555..5562
-                                    - NAME@5555..5562
-                                        - IDENT@5555..5562 "REVIEWS"
-                            - R_PAREN@5562..5563 ")"
-                            - WHITESPACE@5563..5566 "\n  "
-            - FIELD_DEFINITION@5566..5623
-                - NAME@5566..5574
-                    - IDENT@5566..5574 "metadata"
-                - COLON@5574..5575 ":"
-                - WHITESPACE@5575..5576 " "
-                - LIST_TYPE@5576..5594
-                    - WHITESPACE@5576..5577 " "
-                    - L_BRACK@5577..5578 "["
-                    - NAMED_TYPE@5578..5593
-                        - NAME@5578..5593
-                            - IDENT@5578..5593 "MetadataOrError"
-                    - R_BRACK@5593..5594 "]"
-                - DIRECTIVES@5594..5623
-                    - DIRECTIVE@5594..5623
-                        - AT@5594..5595 "@"
-                        - NAME@5595..5606
-                            - IDENT@5595..5606 "join__field"
-                        - ARGUMENTS@5606..5623
-                            - L_PAREN@5606..5607 "("
-                            - ARGUMENT@5607..5621
-                                - NAME@5607..5612
-                                    - IDENT@5607..5612 "graph"
-                                - COLON@5612..5613 ":"
-                                - WHITESPACE@5613..5614 " "
-                                - ENUM_VALUE@5614..5621
-                                    - NAME@5614..5621
-                                        - IDENT@5614..5621 "REVIEWS"
-                            - R_PAREN@5621..5622 ")"
-                            - WHITESPACE@5622..5623 "\n"
-            - R_CURLY@5623..5624 "}"
-            - WHITESPACE@5624..5626 "\n\n"
-    - OBJECT_TYPE_DEFINITION@5626..5768
-        - type_KW@5626..5630 "type"
-        - WHITESPACE@5630..5631 " "
-        - NAME@5631..5642
-            - IDENT@5631..5641 "SMSAccount"
-            - WHITESPACE@5641..5642 "\n"
-        - DIRECTIVES@5642..5716
-            - DIRECTIVE@5642..5672
-                - AT@5642..5643 "@"
-                - NAME@5643..5654
-                    - IDENT@5643..5654 "join__owner"
-                - ARGUMENTS@5654..5672
-                    - L_PAREN@5654..5655 "("
-                    - ARGUMENT@5655..5670
-                        - NAME@5655..5660
-                            - IDENT@5655..5660 "graph"
-                        - COLON@5660..5661 ":"
-                        - WHITESPACE@5661..5662 " "
-                        - ENUM_VALUE@5662..5670
-                            - NAME@5662..5670
-                                - IDENT@5662..5670 "ACCOUNTS"
-                    - R_PAREN@5670..5671 ")"
-                    - WHITESPACE@5671..5672 "\n"
-            - DIRECTIVE@5672..5716
-                - AT@5672..5673 "@"
-                - NAME@5673..5683
-                    - IDENT@5673..5683 "join__type"
-                - ARGUMENTS@5683..5716
-                    - L_PAREN@5683..5684 "("
-                    - ARGUMENT@5684..5701
-                        - NAME@5684..5689
-                            - IDENT@5684..5689 "graph"
-                        - COLON@5689..5690 ":"
-                        - WHITESPACE@5690..5691 " "
-                        - ENUM_VALUE@5691..5701
-                            - NAME@5691..5701
-                                - IDENT@5691..5699 "ACCOUNTS"
-                                - COMMA@5699..5700 ","
-                                - WHITESPACE@5700..5701 " "
-                    - ARGUMENT@5701..5714
-                        - NAME@5701..5704
-                            - IDENT@5701..5704 "key"
-                        - COLON@5704..5705 ":"
-                        - WHITESPACE@5705..5706 " "
-                        - STRING_VALUE@5706..5714
-                            - STRING@5706..5714 "\"number\""
-                    - R_PAREN@5714..5715 ")"
-                    - WHITESPACE@5715..5716 "\n"
-        - FIELDS_DEFINITION@5716..5768
-            - L_CURLY@5716..5717 "{"
-            - WHITESPACE@5717..5720 "\n  "
-            - FIELD_DEFINITION@5720..5765
-                - NAME@5720..5726
-                    - IDENT@5720..5726 "number"
-                - COLON@5726..5727 ":"
-                - WHITESPACE@5727..5728 " "
-                - NAMED_TYPE@5728..5735
-                    - WHITESPACE@5728..5729 " "
-                    - NAME@5729..5735
-                        - IDENT@5729..5735 "String"
-                - DIRECTIVES@5735..5765
-                    - DIRECTIVE@5735..5765
-                        - AT@5735..5736 "@"
-                        - NAME@5736..5747
-                            - IDENT@5736..5747 "join__field"
-                        - ARGUMENTS@5747..5765
-                            - L_PAREN@5747..5748 "("
-                            - ARGUMENT@5748..5763
-                                - NAME@5748..5753
-                                    - IDENT@5748..5753 "graph"
-                                - COLON@5753..5754 ":"
-                                - WHITESPACE@5754..5755 " "
-                                - ENUM_VALUE@5755..5763
-                                    - NAME@5755..5763
-                                        - IDENT@5755..5763 "ACCOUNTS"
-                            - R_PAREN@5763..5764 ")"
-                            - WHITESPACE@5764..5765 "\n"
-            - R_CURLY@5765..5766 "}"
-            - WHITESPACE@5766..5768 "\n\n"
-    - OBJECT_TYPE_DEFINITION@5768..5850
-        - type_KW@5768..5772 "type"
-        - WHITESPACE@5772..5773 " "
-        - NAME@5773..5778
-            - IDENT@5773..5777 "Text"
-            - WHITESPACE@5777..5778 " "
-        - IMPLEMENTS_INTERFACES@5778..5801
-            - implements_KW@5778..5788 "implements"
-            - WHITESPACE@5788..5789 " "
-            - NAMED_TYPE@5789..5801
-                - NAME@5789..5801
-                    - IDENT@5789..5800 "NamedObject"
-                    - WHITESPACE@5800..5801 " "
-        - FIELDS_DEFINITION@5801..5850
-            - L_CURLY@5801..5802 "{"
-            - WHITESPACE@5802..5805 "\n  "
-            - FIELD_DEFINITION@5805..5820
-                - NAME@5805..5809
-                    - IDENT@5805..5809 "name"
-                - COLON@5809..5810 ":"
-                - WHITESPACE@5810..5811 " "
-                - NON_NULL_TYPE@5811..5820
-                    - WHITESPACE@5811..5814 "\n  "
-                    - NAMED_TYPE@5814..5820
-                        - NAME@5814..5820
-                            - IDENT@5814..5820 "String"
-            - FIELD_DEFINITION@5820..5847
-                - NAME@5820..5830
-                    - IDENT@5820..5830 "attributes"
-                - COLON@5830..5831 ":"
-                - WHITESPACE@5831..5832 " "
-                - NON_NULL_TYPE@5832..5847
-                    - WHITESPACE@5832..5833 "\n"
-                    - NAMED_TYPE@5833..5847
-                        - NAME@5833..5847
-                            - IDENT@5833..5847 "TextAttributes"
-            - R_CURLY@5847..5848 "}"
-            - WHITESPACE@5848..5850 "\n\n"
-    - OBJECT_TYPE_DEFINITION@5850..5906
-        - type_KW@5850..5854 "type"
-        - WHITESPACE@5854..5855 " "
-        - NAME@5855..5870
-            - IDENT@5855..5869 "TextAttributes"
-            - WHITESPACE@5869..5870 " "
-        - FIELDS_DEFINITION@5870..5906
-            - L_CURLY@5870..5871 "{"
-            - WHITESPACE@5871..5874 "\n  "
-            - FIELD_DEFINITION@5874..5890
-                - NAME@5874..5878
-                    - IDENT@5874..5878 "bold"
-                - COLON@5878..5879 ":"
-                - WHITESPACE@5879..5880 " "
-                - NAMED_TYPE@5880..5890
-                    - WHITESPACE@5880..5883 "\n  "
-                    - NAME@5883..5890
-                        - IDENT@5883..5890 "Boolean"
-            - FIELD_DEFINITION@5890..5903
-                - NAME@5890..5894
-                    - IDENT@5890..5894 "text"
-                - COLON@5894..5895 ":"
-                - WHITESPACE@5895..5896 " "
-                - NAMED_TYPE@5896..5903
-                    - WHITESPACE@5896..5897 "\n"
-                    - NAME@5897..5903
-                        - IDENT@5897..5903 "String"
-            - R_CURLY@5903..5904 "}"
-            - WHITESPACE@5904..5906 "\n\n"
-    - UNION_TYPE_DEFINITION@5906..5932
-        - union_KW@5906..5911 "union"
-        - WHITESPACE@5911..5912 " "
-        - NAME@5912..5918
-            - IDENT@5912..5917 "Thing"
-            - WHITESPACE@5917..5918 " "
-        - UNION_MEMBER_TYPES@5918..5932
-            - EQ@5918..5919 "="
-            - WHITESPACE@5919..5920 " "
-            - NAMED_TYPE@5920..5924
-                - NAME@5920..5924
-                    - IDENT@5920..5923 "Car"
-                    - WHITESPACE@5923..5924 " "
-            - PIPE@5924..5925 "|"
-            - WHITESPACE@5925..5926 " "
-            - NAMED_TYPE@5926..5932
-                - NAME@5926..5932
-                    - IDENT@5926..5930 "Ikea"
-                    - WHITESPACE@5930..5932 "\n\n"
-    - INPUT_OBJECT_TYPE_DEFINITION@5932..5985
-        - input_KW@5932..5937 "input"
-        - WHITESPACE@5937..5938 " "
-        - NAME@5938..5956
-            - IDENT@5938..5955 "UpdateReviewInput"
-            - WHITESPACE@5955..5956 " "
-        - INPUT_FIELDS_DEFINITION@5956..5985
-            - L_CURLY@5956..5957 "{"
-            - WHITESPACE@5957..5960 "\n  "
-            - INPUT_VALUE_DEFINITION@5960..5969
-                - NAME@5960..5962
-                    - IDENT@5960..5962 "id"
-                - COLON@5962..5963 ":"
-                - WHITESPACE@5963..5964 " "
-                - NON_NULL_TYPE@5964..5969
-                    - WHITESPACE@5964..5967 "\n  "
-                    - NAMED_TYPE@5967..5969
-                        - NAME@5967..5969
-                            - IDENT@5967..5969 "ID"
-            - INPUT_VALUE_DEFINITION@5969..5982
-                - NAME@5969..5973
-                    - IDENT@5969..5973 "body"
-                - COLON@5973..5974 ":"
-                - WHITESPACE@5974..5975 " "
-                - NAMED_TYPE@5975..5982
-                    - WHITESPACE@5975..5976 "\n"
-                    - NAME@5976..5982
-                        - IDENT@5976..5982 "String"
-            - R_CURLY@5982..5983 "}"
-            - WHITESPACE@5983..5985 "\n\n"
-    - OBJECT_TYPE_DEFINITION@5985..6928
-        - type_KW@5985..5989 "type"
-        - WHITESPACE@5989..5990 " "
-        - NAME@5990..5995
-            - IDENT@5990..5994 "User"
-            - WHITESPACE@5994..5995 "\n"
-        - DIRECTIVES@5995..6247
-            - DIRECTIVE@5995..6025
-                - AT@5995..5996 "@"
-                - NAME@5996..6007
-                    - IDENT@5996..6007 "join__owner"
-                - ARGUMENTS@6007..6025
-                    - L_PAREN@6007..6008 "("
-                    - ARGUMENT@6008..6023
-                        - NAME@6008..6013
-                            - IDENT@6008..6013 "graph"
-                        - COLON@6013..6014 ":"
-                        - WHITESPACE@6014..6015 " "
-                        - ENUM_VALUE@6015..6023
-                            - NAME@6015..6023
-                                - IDENT@6015..6023 "ACCOUNTS"
-                    - R_PAREN@6023..6024 ")"
-                    - WHITESPACE@6024..6025 "\n"
-            - DIRECTIVE@6025..6065
-                - AT@6025..6026 "@"
-                - NAME@6026..6036
-                    - IDENT@6026..6036 "join__type"
-                - ARGUMENTS@6036..6065
-                    - L_PAREN@6036..6037 "("
-                    - ARGUMENT@6037..6054
-                        - NAME@6037..6042
-                            - IDENT@6037..6042 "graph"
-                        - COLON@6042..6043 ":"
-                        - WHITESPACE@6043..6044 " "
-                        - ENUM_VALUE@6044..6054
-                            - NAME@6044..6054
-                                - IDENT@6044..6052 "ACCOUNTS"
-                                - COMMA@6052..6053 ","
-                                - WHITESPACE@6053..6054 " "
-                    - ARGUMENT@6054..6063
-                        - NAME@6054..6057
-                            - IDENT@6054..6057 "key"
-                        - COLON@6057..6058 ":"
-                        - WHITESPACE@6058..6059 " "
-                        - STRING_VALUE@6059..6063
-                            - STRING@6059..6063 "\"id\""
-                    - R_PAREN@6063..6064 ")"
-                    - WHITESPACE@6064..6065 "\n"
-            - DIRECTIVE@6065..6128
-                - AT@6065..6066 "@"
-                - NAME@6066..6076
-                    - IDENT@6066..6076 "join__type"
-                - ARGUMENTS@6076..6128
-                    - L_PAREN@6076..6077 "("
-                    - ARGUMENT@6077..6094
-                        - NAME@6077..6082
-                            - IDENT@6077..6082 "graph"
-                        - COLON@6082..6083 ":"
-                        - WHITESPACE@6083..6084 " "
-                        - ENUM_VALUE@6084..6094
-                            - NAME@6084..6094
-                                - IDENT@6084..6092 "ACCOUNTS"
-                                - COMMA@6092..6093 ","
-                                - WHITESPACE@6093..6094 " "
-                    - ARGUMENT@6094..6126
-                        - NAME@6094..6097
-                            - IDENT@6094..6097 "key"
-                        - COLON@6097..6098 ":"
-                        - WHITESPACE@6098..6099 " "
-                        - STRING_VALUE@6099..6126
-                            - STRING@6099..6126 "\"username name{first last}\""
-                    - R_PAREN@6126..6127 ")"
-                    - WHITESPACE@6127..6128 "\n"
-            - DIRECTIVE@6128..6169
-                - AT@6128..6129 "@"
-                - NAME@6129..6139
-                    - IDENT@6129..6139 "join__type"
-                - ARGUMENTS@6139..6169
-                    - L_PAREN@6139..6140 "("
-                    - ARGUMENT@6140..6158
-                        - NAME@6140..6145
-                            - IDENT@6140..6145 "graph"
-                        - COLON@6145..6146 ":"
-                        - WHITESPACE@6146..6147 " "
-                        - ENUM_VALUE@6147..6158
-                            - NAME@6147..6158
-                                - IDENT@6147..6156 "INVENTORY"
-                                - COMMA@6156..6157 ","
-                                - WHITESPACE@6157..6158 " "
-                    - ARGUMENT@6158..6167
-                        - NAME@6158..6161
-                            - IDENT@6158..6161 "key"
-                        - COLON@6161..6162 ":"
-                        - WHITESPACE@6162..6163 " "
-                        - STRING_VALUE@6163..6167
-                            - STRING@6163..6167 "\"id\""
-                    - R_PAREN@6167..6168 ")"
-                    - WHITESPACE@6168..6169 "\n"
-            - DIRECTIVE@6169..6208
-                - AT@6169..6170 "@"
-                - NAME@6170..6180
-                    - IDENT@6170..6180 "join__type"
-                - ARGUMENTS@6180..6208
-                    - L_PAREN@6180..6181 "("
-                    - ARGUMENT@6181..6197
-                        - NAME@6181..6186
-                            - IDENT@6181..6186 "graph"
-                        - COLON@6186..6187 ":"
-                        - WHITESPACE@6187..6188 " "
-                        - ENUM_VALUE@6188..6197
-                            - NAME@6188..6197
-                                - IDENT@6188..6195 "PRODUCT"
-                                - COMMA@6195..6196 ","
-                                - WHITESPACE@6196..6197 " "
-                    - ARGUMENT@6197..6206
-                        - NAME@6197..6200
-                            - IDENT@6197..6200 "key"
-                        - COLON@6200..6201 ":"
-                        - WHITESPACE@6201..6202 " "
-                        - STRING_VALUE@6202..6206
-                            - STRING@6202..6206 "\"id\""
-                    - R_PAREN@6206..6207 ")"
-                    - WHITESPACE@6207..6208 "\n"
-            - DIRECTIVE@6208..6247
-                - AT@6208..6209 "@"
-                - NAME@6209..6219
-                    - IDENT@6209..6219 "join__type"
-                - ARGUMENTS@6219..6247
-                    - L_PAREN@6219..6220 "("
-                    - ARGUMENT@6220..6236
-                        - NAME@6220..6225
-                            - IDENT@6220..6225 "graph"
-                        - COLON@6225..6226 ":"
-                        - WHITESPACE@6226..6227 " "
-                        - ENUM_VALUE@6227..6236
-                            - NAME@6227..6236
-                                - IDENT@6227..6234 "REVIEWS"
-                                - COMMA@6234..6235 ","
-                                - WHITESPACE@6235..6236 " "
-                    - ARGUMENT@6236..6245
-                        - NAME@6236..6239
-                            - IDENT@6236..6239 "key"
-                        - COLON@6239..6240 ":"
-                        - WHITESPACE@6240..6241 " "
-                        - STRING_VALUE@6241..6245
-                            - STRING@6241..6245 "\"id\""
-                    - R_PAREN@6245..6246 ")"
-                    - WHITESPACE@6246..6247 "\n"
-        - FIELDS_DEFINITION@6247..6928
-            - L_CURLY@6247..6248 "{"
-            - WHITESPACE@6248..6251 "\n  "
-            - FIELD_DEFINITION@6251..6290
-                - NAME@6251..6253
-                    - IDENT@6251..6253 "id"
-                - COLON@6253..6254 ":"
-                - WHITESPACE@6254..6255 " "
-                - NON_NULL_TYPE@6255..6258
-                    - WHITESPACE@6255..6256 " "
-                    - NAMED_TYPE@6256..6258
-                        - NAME@6256..6258
-                            - IDENT@6256..6258 "ID"
-                - DIRECTIVES@6258..6290
-                    - DIRECTIVE@6258..6290
-                        - AT@6258..6259 "@"
-                        - NAME@6259..6270
-                            - IDENT@6259..6270 "join__field"
-                        - ARGUMENTS@6270..6290
-                            - L_PAREN@6270..6271 "("
-                            - ARGUMENT@6271..6286
-                                - NAME@6271..6276
-                                    - IDENT@6271..6276 "graph"
-                                - COLON@6276..6277 ":"
+                    - NAMED_TYPE@4337..4343
+                        - NAME@4337..4343
+                            - IDENT@4337..4343 "String"
+                    - BANG@4343..4344 "!"
+            - FIELD_DEFINITION@4344..4359
+                - NAME@4344..4348
+                    - IDENT@4344..4348 "name"
+                - COLON@4348..4349 ":"
+                - WHITESPACE@4349..4350 " "
+                - NAMED_TYPE@4350..4359
+                    - WHITESPACE@4350..4353 "\n  "
+                    - NAME@4353..4359
+                        - IDENT@4353..4359 "String"
+            - FIELD_DEFINITION@4359..4375
+                - NAME@4359..4364
+                    - IDENT@4359..4364 "price"
+                - COLON@4364..4365 ":"
+                - WHITESPACE@4365..4366 " "
+                - NAMED_TYPE@4366..4375
+                    - WHITESPACE@4366..4369 "\n  "
+                    - NAME@4369..4375
+                        - IDENT@4369..4375 "String"
+            - FIELD_DEFINITION@4375..4401
+                - NAME@4375..4382
+                    - IDENT@4375..4382 "details"
+                - COLON@4382..4383 ":"
+                - WHITESPACE@4383..4384 " "
+                - NAMED_TYPE@4384..4401
+                    - WHITESPACE@4384..4387 "\n  "
+                    - NAME@4387..4401
+                        - IDENT@4387..4401 "ProductDetails"
+            - FIELD_DEFINITION@4401..4420
+                - NAME@4401..4408
+                    - IDENT@4401..4408 "inStock"
+                - COLON@4408..4409 ":"
+                - WHITESPACE@4409..4410 " "
+                - NAMED_TYPE@4410..4420
+                    - WHITESPACE@4410..4413 "\n  "
+                    - NAME@4413..4420
+                        - IDENT@4413..4420 "Boolean"
+            - FIELD_DEFINITION@4420..4438
+                - NAME@4420..4427
+                    - IDENT@4420..4427 "reviews"
+                - COLON@4427..4428 ":"
+                - WHITESPACE@4428..4429 " "
+                - LIST_TYPE@4429..4438
+                    - WHITESPACE@4429..4430 "\n"
+                    - L_BRACK@4430..4431 "["
+                    - NAMED_TYPE@4431..4437
+                        - NAME@4431..4437
+                            - IDENT@4431..4437 "Review"
+                    - R_BRACK@4437..4438 "]"
+            - R_CURLY@4438..4439 "}"
+            - WHITESPACE@4439..4441 "\n\n"
+    - INTERFACE_TYPE_DEFINITION@4441..4489
+        - interface_KW@4441..4450 "interface"
+        - WHITESPACE@4450..4451 " "
+        - NAME@4451..4466
+            - IDENT@4451..4465 "ProductDetails"
+            - WHITESPACE@4465..4466 " "
+        - FIELDS_DEFINITION@4466..4489
+            - L_CURLY@4466..4467 "{"
+            - WHITESPACE@4467..4470 "\n  "
+            - FIELD_DEFINITION@4470..4486
+                - NAME@4470..4477
+                    - IDENT@4470..4477 "country"
+                - COLON@4477..4478 ":"
+                - WHITESPACE@4478..4479 " "
+                - NAMED_TYPE@4479..4486
+                    - WHITESPACE@4479..4480 "\n"
+                    - NAME@4480..4486
+                        - IDENT@4480..4486 "String"
+            - R_CURLY@4486..4487 "}"
+            - WHITESPACE@4487..4489 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4489..4575
+        - type_KW@4489..4493 "type"
+        - WHITESPACE@4493..4494 " "
+        - NAME@4494..4513
+            - IDENT@4494..4512 "ProductDetailsBook"
+            - WHITESPACE@4512..4513 " "
+        - IMPLEMENTS_INTERFACES@4513..4539
+            - implements_KW@4513..4523 "implements"
+            - WHITESPACE@4523..4524 " "
+            - NAMED_TYPE@4524..4539
+                - NAME@4524..4539
+                    - IDENT@4524..4538 "ProductDetails"
+                    - WHITESPACE@4538..4539 " "
+        - FIELDS_DEFINITION@4539..4575
+            - L_CURLY@4539..4540 "{"
+            - WHITESPACE@4540..4543 "\n  "
+            - FIELD_DEFINITION@4543..4561
+                - NAME@4543..4550
+                    - IDENT@4543..4550 "country"
+                - COLON@4550..4551 ":"
+                - WHITESPACE@4551..4552 " "
+                - NAMED_TYPE@4552..4561
+                    - WHITESPACE@4552..4555 "\n  "
+                    - NAME@4555..4561
+                        - IDENT@4555..4561 "String"
+            - FIELD_DEFINITION@4561..4572
+                - NAME@4561..4566
+                    - IDENT@4561..4566 "pages"
+                - COLON@4566..4567 ":"
+                - WHITESPACE@4567..4568 " "
+                - NAMED_TYPE@4568..4572
+                    - WHITESPACE@4568..4569 "\n"
+                    - NAME@4569..4572
+                        - IDENT@4569..4572 "Int"
+            - R_CURLY@4572..4573 "}"
+            - WHITESPACE@4573..4575 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4575..4669
+        - type_KW@4575..4579 "type"
+        - WHITESPACE@4579..4580 " "
+        - NAME@4580..4604
+            - IDENT@4580..4603 "ProductDetailsFurniture"
+            - WHITESPACE@4603..4604 " "
+        - IMPLEMENTS_INTERFACES@4604..4630
+            - implements_KW@4604..4614 "implements"
+            - WHITESPACE@4614..4615 " "
+            - NAMED_TYPE@4615..4630
+                - NAME@4615..4630
+                    - IDENT@4615..4629 "ProductDetails"
+                    - WHITESPACE@4629..4630 " "
+        - FIELDS_DEFINITION@4630..4669
+            - L_CURLY@4630..4631 "{"
+            - WHITESPACE@4631..4634 "\n  "
+            - FIELD_DEFINITION@4634..4652
+                - NAME@4634..4641
+                    - IDENT@4634..4641 "country"
+                - COLON@4641..4642 ":"
+                - WHITESPACE@4642..4643 " "
+                - NAMED_TYPE@4643..4652
+                    - WHITESPACE@4643..4646 "\n  "
+                    - NAME@4646..4652
+                        - IDENT@4646..4652 "String"
+            - FIELD_DEFINITION@4652..4666
+                - NAME@4652..4657
+                    - IDENT@4652..4657 "color"
+                - COLON@4657..4658 ":"
+                - WHITESPACE@4658..4659 " "
+                - NAMED_TYPE@4659..4666
+                    - WHITESPACE@4659..4660 "\n"
+                    - NAME@4660..4666
+                        - IDENT@4660..4666 "String"
+            - R_CURLY@4666..4667 "}"
+            - WHITESPACE@4667..4669 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4669..5299
+        - type_KW@4669..4673 "type"
+        - WHITESPACE@4673..4674 " "
+        - NAME@4674..4680
+            - IDENT@4674..4679 "Query"
+            - WHITESPACE@4679..4680 " "
+        - FIELDS_DEFINITION@4680..5299
+            - L_CURLY@4680..4681 "{"
+            - WHITESPACE@4681..4684 "\n  "
+            - FIELD_DEFINITION@4684..4736
+                - NAME@4684..4688
+                    - IDENT@4684..4688 "user"
+                - ARGUMENTS@4688..4697
+                    - L_PAREN@4688..4689 "("
+                    - INPUT_VALUE_DEFINITION@4689..4696
+                        - NAME@4689..4691
+                            - IDENT@4689..4691 "id"
+                        - COLON@4691..4692 ":"
+                        - WHITESPACE@4692..4693 " "
+                        - NON_NULL_TYPE@4693..4696
+                            - NAMED_TYPE@4693..4695
+                                - NAME@4693..4695
+                                    - IDENT@4693..4695 "ID"
+                            - BANG@4695..4696 "!"
+                    - R_PAREN@4696..4697 ")"
+                - COLON@4697..4698 ":"
+                - WHITESPACE@4698..4699 " "
+                - NAMED_TYPE@4699..4704
+                    - WHITESPACE@4699..4700 " "
+                    - NAME@4700..4704
+                        - IDENT@4700..4704 "User"
+                - DIRECTIVES@4704..4736
+                    - DIRECTIVE@4704..4736
+                        - AT@4704..4705 "@"
+                        - NAME@4705..4716
+                            - IDENT@4705..4716 "join__field"
+                        - ARGUMENTS@4716..4736
+                            - L_PAREN@4716..4717 "("
+                            - ARGUMENT@4717..4732
+                                - NAME@4717..4722
+                                    - IDENT@4717..4722 "graph"
+                                - COLON@4722..4723 ":"
+                                - WHITESPACE@4723..4724 " "
+                                - ENUM_VALUE@4724..4732
+                                    - NAME@4724..4732
+                                        - IDENT@4724..4732 "ACCOUNTS"
+                            - R_PAREN@4732..4733 ")"
+                            - WHITESPACE@4733..4736 "\n  "
+            - FIELD_DEFINITION@4736..4777
+                - NAME@4736..4738
+                    - IDENT@4736..4738 "me"
+                - COLON@4738..4739 ":"
+                - WHITESPACE@4739..4740 " "
+                - NAMED_TYPE@4740..4745
+                    - WHITESPACE@4740..4741 " "
+                    - NAME@4741..4745
+                        - IDENT@4741..4745 "User"
+                - DIRECTIVES@4745..4777
+                    - DIRECTIVE@4745..4777
+                        - AT@4745..4746 "@"
+                        - NAME@4746..4757
+                            - IDENT@4746..4757 "join__field"
+                        - ARGUMENTS@4757..4777
+                            - L_PAREN@4757..4758 "("
+                            - ARGUMENT@4758..4773
+                                - NAME@4758..4763
+                                    - IDENT@4758..4763 "graph"
+                                - COLON@4763..4764 ":"
+                                - WHITESPACE@4764..4765 " "
+                                - ENUM_VALUE@4765..4773
+                                    - NAME@4765..4773
+                                        - IDENT@4765..4773 "ACCOUNTS"
+                            - R_PAREN@4773..4774 ")"
+                            - WHITESPACE@4774..4777 "\n  "
+            - FIELD_DEFINITION@4777..4832
+                - NAME@4777..4781
+                    - IDENT@4777..4781 "book"
+                - ARGUMENTS@4781..4796
+                    - L_PAREN@4781..4782 "("
+                    - INPUT_VALUE_DEFINITION@4782..4795
+                        - NAME@4782..4786
+                            - IDENT@4782..4786 "isbn"
+                        - COLON@4786..4787 ":"
+                        - WHITESPACE@4787..4788 " "
+                        - NON_NULL_TYPE@4788..4795
+                            - NAMED_TYPE@4788..4794
+                                - NAME@4788..4794
+                                    - IDENT@4788..4794 "String"
+                            - BANG@4794..4795 "!"
+                    - R_PAREN@4795..4796 ")"
+                - COLON@4796..4797 ":"
+                - WHITESPACE@4797..4798 " "
+                - NAMED_TYPE@4798..4803
+                    - WHITESPACE@4798..4799 " "
+                    - NAME@4799..4803
+                        - IDENT@4799..4803 "Book"
+                - DIRECTIVES@4803..4832
+                    - DIRECTIVE@4803..4832
+                        - AT@4803..4804 "@"
+                        - NAME@4804..4815
+                            - IDENT@4804..4815 "join__field"
+                        - ARGUMENTS@4815..4832
+                            - L_PAREN@4815..4816 "("
+                            - ARGUMENT@4816..4828
+                                - NAME@4816..4821
+                                    - IDENT@4816..4821 "graph"
+                                - COLON@4821..4822 ":"
+                                - WHITESPACE@4822..4823 " "
+                                - ENUM_VALUE@4823..4828
+                                    - NAME@4823..4828
+                                        - IDENT@4823..4828 "BOOKS"
+                            - R_PAREN@4828..4829 ")"
+                            - WHITESPACE@4829..4832 "\n  "
+            - FIELD_DEFINITION@4832..4875
+                - NAME@4832..4837
+                    - IDENT@4832..4837 "books"
+                - COLON@4837..4838 ":"
+                - WHITESPACE@4838..4839 " "
+                - LIST_TYPE@4839..4846
+                    - WHITESPACE@4839..4840 " "
+                    - L_BRACK@4840..4841 "["
+                    - NAMED_TYPE@4841..4845
+                        - NAME@4841..4845
+                            - IDENT@4841..4845 "Book"
+                    - R_BRACK@4845..4846 "]"
+                - DIRECTIVES@4846..4875
+                    - DIRECTIVE@4846..4875
+                        - AT@4846..4847 "@"
+                        - NAME@4847..4858
+                            - IDENT@4847..4858 "join__field"
+                        - ARGUMENTS@4858..4875
+                            - L_PAREN@4858..4859 "("
+                            - ARGUMENT@4859..4871
+                                - NAME@4859..4864
+                                    - IDENT@4859..4864 "graph"
+                                - COLON@4864..4865 ":"
+                                - WHITESPACE@4865..4866 " "
+                                - ENUM_VALUE@4866..4871
+                                    - NAME@4866..4871
+                                        - IDENT@4866..4871 "BOOKS"
+                            - R_PAREN@4871..4872 ")"
+                            - WHITESPACE@4872..4875 "\n  "
+            - FIELD_DEFINITION@4875..4930
+                - NAME@4875..4882
+                    - IDENT@4875..4882 "library"
+                - ARGUMENTS@4882..4891
+                    - L_PAREN@4882..4883 "("
+                    - INPUT_VALUE_DEFINITION@4883..4890
+                        - NAME@4883..4885
+                            - IDENT@4883..4885 "id"
+                        - COLON@4885..4886 ":"
+                        - WHITESPACE@4886..4887 " "
+                        - NON_NULL_TYPE@4887..4890
+                            - NAMED_TYPE@4887..4889
+                                - NAME@4887..4889
+                                    - IDENT@4887..4889 "ID"
+                            - BANG@4889..4890 "!"
+                    - R_PAREN@4890..4891 ")"
+                - COLON@4891..4892 ":"
+                - WHITESPACE@4892..4893 " "
+                - NAMED_TYPE@4893..4901
+                    - WHITESPACE@4893..4894 " "
+                    - NAME@4894..4901
+                        - IDENT@4894..4901 "Library"
+                - DIRECTIVES@4901..4930
+                    - DIRECTIVE@4901..4930
+                        - AT@4901..4902 "@"
+                        - NAME@4902..4913
+                            - IDENT@4902..4913 "join__field"
+                        - ARGUMENTS@4913..4930
+                            - L_PAREN@4913..4914 "("
+                            - ARGUMENT@4914..4926
+                                - NAME@4914..4919
+                                    - IDENT@4914..4919 "graph"
+                                - COLON@4919..4920 ":"
+                                - WHITESPACE@4920..4921 " "
+                                - ENUM_VALUE@4921..4926
+                                    - NAME@4921..4926
+                                        - IDENT@4921..4926 "BOOKS"
+                            - R_PAREN@4926..4927 ")"
+                            - WHITESPACE@4927..4930 "\n  "
+            - FIELD_DEFINITION@4930..4975
+                - NAME@4930..4934
+                    - IDENT@4930..4934 "body"
+                - COLON@4934..4935 ":"
+                - WHITESPACE@4935..4936 " "
+                - NON_NULL_TYPE@4936..4942
+                    - WHITESPACE@4936..4937 " "
+                    - NAMED_TYPE@4937..4941
+                        - NAME@4937..4941
+                            - IDENT@4937..4941 "Body"
+                    - BANG@4941..4942 "!"
+                - DIRECTIVES@4942..4975
+                    - DIRECTIVE@4942..4975
+                        - AT@4942..4943 "@"
+                        - NAME@4943..4954
+                            - IDENT@4943..4954 "join__field"
+                        - ARGUMENTS@4954..4975
+                            - L_PAREN@4954..4955 "("
+                            - ARGUMENT@4955..4971
+                                - NAME@4955..4960
+                                    - IDENT@4955..4960 "graph"
+                                - COLON@4960..4961 ":"
+                                - WHITESPACE@4961..4962 " "
+                                - ENUM_VALUE@4962..4971
+                                    - NAME@4962..4971
+                                        - IDENT@4962..4971 "DOCUMENTS"
+                            - R_PAREN@4971..4972 ")"
+                            - WHITESPACE@4972..4975 "\n  "
+            - FIELD_DEFINITION@4975..5037
+                - NAME@4975..4982
+                    - IDENT@4975..4982 "product"
+                - ARGUMENTS@4982..4996
+                    - L_PAREN@4982..4983 "("
+                    - INPUT_VALUE_DEFINITION@4983..4995
+                        - NAME@4983..4986
+                            - IDENT@4983..4986 "upc"
+                        - COLON@4986..4987 ":"
+                        - WHITESPACE@4987..4988 " "
+                        - NON_NULL_TYPE@4988..4995
+                            - NAMED_TYPE@4988..4994
+                                - NAME@4988..4994
+                                    - IDENT@4988..4994 "String"
+                            - BANG@4994..4995 "!"
+                    - R_PAREN@4995..4996 ")"
+                - COLON@4996..4997 ":"
+                - WHITESPACE@4997..4998 " "
+                - NAMED_TYPE@4998..5006
+                    - WHITESPACE@4998..4999 " "
+                    - NAME@4999..5006
+                        - IDENT@4999..5006 "Product"
+                - DIRECTIVES@5006..5037
+                    - DIRECTIVE@5006..5037
+                        - AT@5006..5007 "@"
+                        - NAME@5007..5018
+                            - IDENT@5007..5018 "join__field"
+                        - ARGUMENTS@5018..5037
+                            - L_PAREN@5018..5019 "("
+                            - ARGUMENT@5019..5033
+                                - NAME@5019..5024
+                                    - IDENT@5019..5024 "graph"
+                                - COLON@5024..5025 ":"
+                                - WHITESPACE@5025..5026 " "
+                                - ENUM_VALUE@5026..5033
+                                    - NAME@5026..5033
+                                        - IDENT@5026..5033 "PRODUCT"
+                            - R_PAREN@5033..5034 ")"
+                            - WHITESPACE@5034..5037 "\n  "
+            - FIELD_DEFINITION@5037..5098
+                - NAME@5037..5044
+                    - IDENT@5037..5044 "vehicle"
+                - ARGUMENTS@5044..5057
+                    - L_PAREN@5044..5045 "("
+                    - INPUT_VALUE_DEFINITION@5045..5056
+                        - NAME@5045..5047
+                            - IDENT@5045..5047 "id"
+                        - COLON@5047..5048 ":"
+                        - WHITESPACE@5048..5049 " "
+                        - NON_NULL_TYPE@5049..5056
+                            - NAMED_TYPE@5049..5055
+                                - NAME@5049..5055
+                                    - IDENT@5049..5055 "String"
+                            - BANG@5055..5056 "!"
+                    - R_PAREN@5056..5057 ")"
+                - COLON@5057..5058 ":"
+                - WHITESPACE@5058..5059 " "
+                - NAMED_TYPE@5059..5067
+                    - WHITESPACE@5059..5060 " "
+                    - NAME@5060..5067
+                        - IDENT@5060..5067 "Vehicle"
+                - DIRECTIVES@5067..5098
+                    - DIRECTIVE@5067..5098
+                        - AT@5067..5068 "@"
+                        - NAME@5068..5079
+                            - IDENT@5068..5079 "join__field"
+                        - ARGUMENTS@5079..5098
+                            - L_PAREN@5079..5080 "("
+                            - ARGUMENT@5080..5094
+                                - NAME@5080..5085
+                                    - IDENT@5080..5085 "graph"
+                                - COLON@5085..5086 ":"
+                                - WHITESPACE@5086..5087 " "
+                                - ENUM_VALUE@5087..5094
+                                    - NAME@5087..5094
+                                        - IDENT@5087..5094 "PRODUCT"
+                            - R_PAREN@5094..5095 ")"
+                            - WHITESPACE@5095..5098 "\n  "
+            - FIELD_DEFINITION@5098..5168
+                - NAME@5098..5109
+                    - IDENT@5098..5109 "topProducts"
+                - ARGUMENTS@5109..5125
+                    - L_PAREN@5109..5110 "("
+                    - INPUT_VALUE_DEFINITION@5110..5124
+                        - NAME@5110..5115
+                            - IDENT@5110..5115 "first"
+                        - COLON@5115..5116 ":"
+                        - WHITESPACE@5116..5117 " "
+                        - NAMED_TYPE@5117..5121
+                            - WHITESPACE@5117..5118 " "
+                            - NAME@5118..5121
+                                - IDENT@5118..5121 "Int"
+                        - DEFAULT_VALUE@5121..5124
+                            - EQ@5121..5122 "="
+                            - WHITESPACE@5122..5123 " "
+                            - INT_VALUE@5123..5124
+                                - INT@5123..5124 "5"
+                    - R_PAREN@5124..5125 ")"
+                - COLON@5125..5126 ":"
+                - WHITESPACE@5126..5127 " "
+                - LIST_TYPE@5127..5137
+                    - WHITESPACE@5127..5128 " "
+                    - L_BRACK@5128..5129 "["
+                    - NAMED_TYPE@5129..5136
+                        - NAME@5129..5136
+                            - IDENT@5129..5136 "Product"
+                    - R_BRACK@5136..5137 "]"
+                - DIRECTIVES@5137..5168
+                    - DIRECTIVE@5137..5168
+                        - AT@5137..5138 "@"
+                        - NAME@5138..5149
+                            - IDENT@5138..5149 "join__field"
+                        - ARGUMENTS@5149..5168
+                            - L_PAREN@5149..5150 "("
+                            - ARGUMENT@5150..5164
+                                - NAME@5150..5155
+                                    - IDENT@5150..5155 "graph"
+                                - COLON@5155..5156 ":"
+                                - WHITESPACE@5156..5157 " "
+                                - ENUM_VALUE@5157..5164
+                                    - NAME@5157..5164
+                                        - IDENT@5157..5164 "PRODUCT"
+                            - R_PAREN@5164..5165 ")"
+                            - WHITESPACE@5165..5168 "\n  "
+            - FIELD_DEFINITION@5168..5230
+                - NAME@5168..5175
+                    - IDENT@5168..5175 "topCars"
+                - ARGUMENTS@5175..5191
+                    - L_PAREN@5175..5176 "("
+                    - INPUT_VALUE_DEFINITION@5176..5190
+                        - NAME@5176..5181
+                            - IDENT@5176..5181 "first"
+                        - COLON@5181..5182 ":"
+                        - WHITESPACE@5182..5183 " "
+                        - NAMED_TYPE@5183..5187
+                            - WHITESPACE@5183..5184 " "
+                            - NAME@5184..5187
+                                - IDENT@5184..5187 "Int"
+                        - DEFAULT_VALUE@5187..5190
+                            - EQ@5187..5188 "="
+                            - WHITESPACE@5188..5189 " "
+                            - INT_VALUE@5189..5190
+                                - INT@5189..5190 "5"
+                    - R_PAREN@5190..5191 ")"
+                - COLON@5191..5192 ":"
+                - WHITESPACE@5192..5193 " "
+                - LIST_TYPE@5193..5199
+                    - WHITESPACE@5193..5194 " "
+                    - L_BRACK@5194..5195 "["
+                    - NAMED_TYPE@5195..5198
+                        - NAME@5195..5198
+                            - IDENT@5195..5198 "Car"
+                    - R_BRACK@5198..5199 "]"
+                - DIRECTIVES@5199..5230
+                    - DIRECTIVE@5199..5230
+                        - AT@5199..5200 "@"
+                        - NAME@5200..5211
+                            - IDENT@5200..5211 "join__field"
+                        - ARGUMENTS@5211..5230
+                            - L_PAREN@5211..5212 "("
+                            - ARGUMENT@5212..5226
+                                - NAME@5212..5217
+                                    - IDENT@5212..5217 "graph"
+                                - COLON@5217..5218 ":"
+                                - WHITESPACE@5218..5219 " "
+                                - ENUM_VALUE@5219..5226
+                                    - NAME@5219..5226
+                                        - IDENT@5219..5226 "PRODUCT"
+                            - R_PAREN@5226..5227 ")"
+                            - WHITESPACE@5227..5230 "\n  "
+            - FIELD_DEFINITION@5230..5296
+                - NAME@5230..5240
+                    - IDENT@5230..5240 "topReviews"
+                - ARGUMENTS@5240..5256
+                    - L_PAREN@5240..5241 "("
+                    - INPUT_VALUE_DEFINITION@5241..5255
+                        - NAME@5241..5246
+                            - IDENT@5241..5246 "first"
+                        - COLON@5246..5247 ":"
+                        - WHITESPACE@5247..5248 " "
+                        - NAMED_TYPE@5248..5252
+                            - WHITESPACE@5248..5249 " "
+                            - NAME@5249..5252
+                                - IDENT@5249..5252 "Int"
+                        - DEFAULT_VALUE@5252..5255
+                            - EQ@5252..5253 "="
+                            - WHITESPACE@5253..5254 " "
+                            - INT_VALUE@5254..5255
+                                - INT@5254..5255 "5"
+                    - R_PAREN@5255..5256 ")"
+                - COLON@5256..5257 ":"
+                - WHITESPACE@5257..5258 " "
+                - LIST_TYPE@5258..5267
+                    - WHITESPACE@5258..5259 " "
+                    - L_BRACK@5259..5260 "["
+                    - NAMED_TYPE@5260..5266
+                        - NAME@5260..5266
+                            - IDENT@5260..5266 "Review"
+                    - R_BRACK@5266..5267 "]"
+                - DIRECTIVES@5267..5296
+                    - DIRECTIVE@5267..5296
+                        - AT@5267..5268 "@"
+                        - NAME@5268..5279
+                            - IDENT@5268..5279 "join__field"
+                        - ARGUMENTS@5279..5296
+                            - L_PAREN@5279..5280 "("
+                            - ARGUMENT@5280..5294
+                                - NAME@5280..5285
+                                    - IDENT@5280..5285 "graph"
+                                - COLON@5285..5286 ":"
+                                - WHITESPACE@5286..5287 " "
+                                - ENUM_VALUE@5287..5294
+                                    - NAME@5287..5294
+                                        - IDENT@5287..5294 "REVIEWS"
+                            - R_PAREN@5294..5295 ")"
+                            - WHITESPACE@5295..5296 "\n"
+            - R_CURLY@5296..5297 "}"
+            - WHITESPACE@5297..5299 "\n\n"
+    - OBJECT_TYPE_DEFINITION@5299..5665
+        - type_KW@5299..5303 "type"
+        - WHITESPACE@5303..5304 " "
+        - NAME@5304..5311
+            - IDENT@5304..5310 "Review"
+            - WHITESPACE@5310..5311 "\n"
+        - DIRECTIVES@5311..5379
+            - DIRECTIVE@5311..5340
+                - AT@5311..5312 "@"
+                - NAME@5312..5323
+                    - IDENT@5312..5323 "join__owner"
+                - ARGUMENTS@5323..5340
+                    - L_PAREN@5323..5324 "("
+                    - ARGUMENT@5324..5338
+                        - NAME@5324..5329
+                            - IDENT@5324..5329 "graph"
+                        - COLON@5329..5330 ":"
+                        - WHITESPACE@5330..5331 " "
+                        - ENUM_VALUE@5331..5338
+                            - NAME@5331..5338
+                                - IDENT@5331..5338 "REVIEWS"
+                    - R_PAREN@5338..5339 ")"
+                    - WHITESPACE@5339..5340 "\n"
+            - DIRECTIVE@5340..5379
+                - AT@5340..5341 "@"
+                - NAME@5341..5351
+                    - IDENT@5341..5351 "join__type"
+                - ARGUMENTS@5351..5379
+                    - L_PAREN@5351..5352 "("
+                    - ARGUMENT@5352..5368
+                        - NAME@5352..5357
+                            - IDENT@5352..5357 "graph"
+                        - COLON@5357..5358 ":"
+                        - WHITESPACE@5358..5359 " "
+                        - ENUM_VALUE@5359..5368
+                            - NAME@5359..5368
+                                - IDENT@5359..5366 "REVIEWS"
+                                - COMMA@5366..5367 ","
+                                - WHITESPACE@5367..5368 " "
+                    - ARGUMENT@5368..5377
+                        - NAME@5368..5371
+                            - IDENT@5368..5371 "key"
+                        - COLON@5371..5372 ":"
+                        - WHITESPACE@5372..5373 " "
+                        - STRING_VALUE@5373..5377
+                            - STRING@5373..5377 "\"id\""
+                    - R_PAREN@5377..5378 ")"
+                    - WHITESPACE@5378..5379 "\n"
+        - FIELDS_DEFINITION@5379..5665
+            - L_CURLY@5379..5380 "{"
+            - WHITESPACE@5380..5383 "\n  "
+            - FIELD_DEFINITION@5383..5422
+                - NAME@5383..5385
+                    - IDENT@5383..5385 "id"
+                - COLON@5385..5386 ":"
+                - WHITESPACE@5386..5387 " "
+                - NON_NULL_TYPE@5387..5391
+                    - WHITESPACE@5387..5388 " "
+                    - NAMED_TYPE@5388..5390
+                        - NAME@5388..5390
+                            - IDENT@5388..5390 "ID"
+                    - BANG@5390..5391 "!"
+                - DIRECTIVES@5391..5422
+                    - DIRECTIVE@5391..5422
+                        - AT@5391..5392 "@"
+                        - NAME@5392..5403
+                            - IDENT@5392..5403 "join__field"
+                        - ARGUMENTS@5403..5422
+                            - L_PAREN@5403..5404 "("
+                            - ARGUMENT@5404..5418
+                                - NAME@5404..5409
+                                    - IDENT@5404..5409 "graph"
+                                - COLON@5409..5410 ":"
+                                - WHITESPACE@5410..5411 " "
+                                - ENUM_VALUE@5411..5418
+                                    - NAME@5411..5418
+                                        - IDENT@5411..5418 "REVIEWS"
+                            - R_PAREN@5418..5419 ")"
+                            - WHITESPACE@5419..5422 "\n  "
+            - FIELD_DEFINITION@5422..5491
+                - NAME@5422..5426
+                    - IDENT@5422..5426 "body"
+                - ARGUMENTS@5426..5451
+                    - L_PAREN@5426..5427 "("
+                    - INPUT_VALUE_DEFINITION@5427..5450
+                        - NAME@5427..5433
+                            - IDENT@5427..5433 "format"
+                        - COLON@5433..5434 ":"
+                        - WHITESPACE@5434..5435 " "
+                        - NAMED_TYPE@5435..5443
+                            - WHITESPACE@5435..5436 " "
+                            - NAME@5436..5443
+                                - IDENT@5436..5443 "Boolean"
+                        - DEFAULT_VALUE@5443..5450
+                            - EQ@5443..5444 "="
+                            - WHITESPACE@5444..5445 " "
+                            - BOOLEAN_VALUE@5445..5450
+                                - false_KW@5445..5450 "false"
+                    - R_PAREN@5450..5451 ")"
+                - COLON@5451..5452 ":"
+                - WHITESPACE@5452..5453 " "
+                - NAMED_TYPE@5453..5460
+                    - WHITESPACE@5453..5454 " "
+                    - NAME@5454..5460
+                        - IDENT@5454..5460 "String"
+                - DIRECTIVES@5460..5491
+                    - DIRECTIVE@5460..5491
+                        - AT@5460..5461 "@"
+                        - NAME@5461..5472
+                            - IDENT@5461..5472 "join__field"
+                        - ARGUMENTS@5472..5491
+                            - L_PAREN@5472..5473 "("
+                            - ARGUMENT@5473..5487
+                                - NAME@5473..5478
+                                    - IDENT@5473..5478 "graph"
+                                - COLON@5478..5479 ":"
+                                - WHITESPACE@5479..5480 " "
+                                - ENUM_VALUE@5480..5487
+                                    - NAME@5480..5487
+                                        - IDENT@5480..5487 "REVIEWS"
+                            - R_PAREN@5487..5488 ")"
+                            - WHITESPACE@5488..5491 "\n  "
+            - FIELD_DEFINITION@5491..5557
+                - NAME@5491..5497
+                    - IDENT@5491..5497 "author"
+                - COLON@5497..5498 ":"
+                - WHITESPACE@5498..5499 " "
+                - NAMED_TYPE@5499..5504
+                    - WHITESPACE@5499..5500 " "
+                    - NAME@5500..5504
+                        - IDENT@5500..5504 "User"
+                - DIRECTIVES@5504..5557
+                    - DIRECTIVE@5504..5557
+                        - AT@5504..5505 "@"
+                        - NAME@5505..5516
+                            - IDENT@5505..5516 "join__field"
+                        - ARGUMENTS@5516..5557
+                            - L_PAREN@5516..5517 "("
+                            - ARGUMENT@5517..5533
+                                - NAME@5517..5522
+                                    - IDENT@5517..5522 "graph"
+                                - COLON@5522..5523 ":"
+                                - WHITESPACE@5523..5524 " "
+                                - ENUM_VALUE@5524..5533
+                                    - NAME@5524..5533
+                                        - IDENT@5524..5531 "REVIEWS"
+                                        - COMMA@5531..5532 ","
+                                        - WHITESPACE@5532..5533 " "
+                            - ARGUMENT@5533..5553
+                                - NAME@5533..5541
+                                    - IDENT@5533..5541 "provides"
+                                - COLON@5541..5542 ":"
+                                - WHITESPACE@5542..5543 " "
+                                - STRING_VALUE@5543..5553
+                                    - STRING@5543..5553 "\"username\""
+                            - R_PAREN@5553..5554 ")"
+                            - WHITESPACE@5554..5557 "\n  "
+            - FIELD_DEFINITION@5557..5605
+                - NAME@5557..5564
+                    - IDENT@5557..5564 "product"
+                - COLON@5564..5565 ":"
+                - WHITESPACE@5565..5566 " "
+                - NAMED_TYPE@5566..5574
+                    - WHITESPACE@5566..5567 " "
+                    - NAME@5567..5574
+                        - IDENT@5567..5574 "Product"
+                - DIRECTIVES@5574..5605
+                    - DIRECTIVE@5574..5605
+                        - AT@5574..5575 "@"
+                        - NAME@5575..5586
+                            - IDENT@5575..5586 "join__field"
+                        - ARGUMENTS@5586..5605
+                            - L_PAREN@5586..5587 "("
+                            - ARGUMENT@5587..5601
+                                - NAME@5587..5592
+                                    - IDENT@5587..5592 "graph"
+                                - COLON@5592..5593 ":"
+                                - WHITESPACE@5593..5594 " "
+                                - ENUM_VALUE@5594..5601
+                                    - NAME@5594..5601
+                                        - IDENT@5594..5601 "REVIEWS"
+                            - R_PAREN@5601..5602 ")"
+                            - WHITESPACE@5602..5605 "\n  "
+            - FIELD_DEFINITION@5605..5662
+                - NAME@5605..5613
+                    - IDENT@5605..5613 "metadata"
+                - COLON@5613..5614 ":"
+                - WHITESPACE@5614..5615 " "
+                - LIST_TYPE@5615..5633
+                    - WHITESPACE@5615..5616 " "
+                    - L_BRACK@5616..5617 "["
+                    - NAMED_TYPE@5617..5632
+                        - NAME@5617..5632
+                            - IDENT@5617..5632 "MetadataOrError"
+                    - R_BRACK@5632..5633 "]"
+                - DIRECTIVES@5633..5662
+                    - DIRECTIVE@5633..5662
+                        - AT@5633..5634 "@"
+                        - NAME@5634..5645
+                            - IDENT@5634..5645 "join__field"
+                        - ARGUMENTS@5645..5662
+                            - L_PAREN@5645..5646 "("
+                            - ARGUMENT@5646..5660
+                                - NAME@5646..5651
+                                    - IDENT@5646..5651 "graph"
+                                - COLON@5651..5652 ":"
+                                - WHITESPACE@5652..5653 " "
+                                - ENUM_VALUE@5653..5660
+                                    - NAME@5653..5660
+                                        - IDENT@5653..5660 "REVIEWS"
+                            - R_PAREN@5660..5661 ")"
+                            - WHITESPACE@5661..5662 "\n"
+            - R_CURLY@5662..5663 "}"
+            - WHITESPACE@5663..5665 "\n\n"
+    - OBJECT_TYPE_DEFINITION@5665..5807
+        - type_KW@5665..5669 "type"
+        - WHITESPACE@5669..5670 " "
+        - NAME@5670..5681
+            - IDENT@5670..5680 "SMSAccount"
+            - WHITESPACE@5680..5681 "\n"
+        - DIRECTIVES@5681..5755
+            - DIRECTIVE@5681..5711
+                - AT@5681..5682 "@"
+                - NAME@5682..5693
+                    - IDENT@5682..5693 "join__owner"
+                - ARGUMENTS@5693..5711
+                    - L_PAREN@5693..5694 "("
+                    - ARGUMENT@5694..5709
+                        - NAME@5694..5699
+                            - IDENT@5694..5699 "graph"
+                        - COLON@5699..5700 ":"
+                        - WHITESPACE@5700..5701 " "
+                        - ENUM_VALUE@5701..5709
+                            - NAME@5701..5709
+                                - IDENT@5701..5709 "ACCOUNTS"
+                    - R_PAREN@5709..5710 ")"
+                    - WHITESPACE@5710..5711 "\n"
+            - DIRECTIVE@5711..5755
+                - AT@5711..5712 "@"
+                - NAME@5712..5722
+                    - IDENT@5712..5722 "join__type"
+                - ARGUMENTS@5722..5755
+                    - L_PAREN@5722..5723 "("
+                    - ARGUMENT@5723..5740
+                        - NAME@5723..5728
+                            - IDENT@5723..5728 "graph"
+                        - COLON@5728..5729 ":"
+                        - WHITESPACE@5729..5730 " "
+                        - ENUM_VALUE@5730..5740
+                            - NAME@5730..5740
+                                - IDENT@5730..5738 "ACCOUNTS"
+                                - COMMA@5738..5739 ","
+                                - WHITESPACE@5739..5740 " "
+                    - ARGUMENT@5740..5753
+                        - NAME@5740..5743
+                            - IDENT@5740..5743 "key"
+                        - COLON@5743..5744 ":"
+                        - WHITESPACE@5744..5745 " "
+                        - STRING_VALUE@5745..5753
+                            - STRING@5745..5753 "\"number\""
+                    - R_PAREN@5753..5754 ")"
+                    - WHITESPACE@5754..5755 "\n"
+        - FIELDS_DEFINITION@5755..5807
+            - L_CURLY@5755..5756 "{"
+            - WHITESPACE@5756..5759 "\n  "
+            - FIELD_DEFINITION@5759..5804
+                - NAME@5759..5765
+                    - IDENT@5759..5765 "number"
+                - COLON@5765..5766 ":"
+                - WHITESPACE@5766..5767 " "
+                - NAMED_TYPE@5767..5774
+                    - WHITESPACE@5767..5768 " "
+                    - NAME@5768..5774
+                        - IDENT@5768..5774 "String"
+                - DIRECTIVES@5774..5804
+                    - DIRECTIVE@5774..5804
+                        - AT@5774..5775 "@"
+                        - NAME@5775..5786
+                            - IDENT@5775..5786 "join__field"
+                        - ARGUMENTS@5786..5804
+                            - L_PAREN@5786..5787 "("
+                            - ARGUMENT@5787..5802
+                                - NAME@5787..5792
+                                    - IDENT@5787..5792 "graph"
+                                - COLON@5792..5793 ":"
+                                - WHITESPACE@5793..5794 " "
+                                - ENUM_VALUE@5794..5802
+                                    - NAME@5794..5802
+                                        - IDENT@5794..5802 "ACCOUNTS"
+                            - R_PAREN@5802..5803 ")"
+                            - WHITESPACE@5803..5804 "\n"
+            - R_CURLY@5804..5805 "}"
+            - WHITESPACE@5805..5807 "\n\n"
+    - OBJECT_TYPE_DEFINITION@5807..5891
+        - type_KW@5807..5811 "type"
+        - WHITESPACE@5811..5812 " "
+        - NAME@5812..5817
+            - IDENT@5812..5816 "Text"
+            - WHITESPACE@5816..5817 " "
+        - IMPLEMENTS_INTERFACES@5817..5840
+            - implements_KW@5817..5827 "implements"
+            - WHITESPACE@5827..5828 " "
+            - NAMED_TYPE@5828..5840
+                - NAME@5828..5840
+                    - IDENT@5828..5839 "NamedObject"
+                    - WHITESPACE@5839..5840 " "
+        - FIELDS_DEFINITION@5840..5891
+            - L_CURLY@5840..5841 "{"
+            - WHITESPACE@5841..5844 "\n  "
+            - FIELD_DEFINITION@5844..5860
+                - NAME@5844..5848
+                    - IDENT@5844..5848 "name"
+                - COLON@5848..5849 ":"
+                - WHITESPACE@5849..5850 " "
+                - NON_NULL_TYPE@5850..5860
+                    - WHITESPACE@5850..5853 "\n  "
+                    - NAMED_TYPE@5853..5859
+                        - NAME@5853..5859
+                            - IDENT@5853..5859 "String"
+                    - BANG@5859..5860 "!"
+            - FIELD_DEFINITION@5860..5888
+                - NAME@5860..5870
+                    - IDENT@5860..5870 "attributes"
+                - COLON@5870..5871 ":"
+                - WHITESPACE@5871..5872 " "
+                - NON_NULL_TYPE@5872..5888
+                    - WHITESPACE@5872..5873 "\n"
+                    - NAMED_TYPE@5873..5887
+                        - NAME@5873..5887
+                            - IDENT@5873..5887 "TextAttributes"
+                    - BANG@5887..5888 "!"
+            - R_CURLY@5888..5889 "}"
+            - WHITESPACE@5889..5891 "\n\n"
+    - OBJECT_TYPE_DEFINITION@5891..5947
+        - type_KW@5891..5895 "type"
+        - WHITESPACE@5895..5896 " "
+        - NAME@5896..5911
+            - IDENT@5896..5910 "TextAttributes"
+            - WHITESPACE@5910..5911 " "
+        - FIELDS_DEFINITION@5911..5947
+            - L_CURLY@5911..5912 "{"
+            - WHITESPACE@5912..5915 "\n  "
+            - FIELD_DEFINITION@5915..5931
+                - NAME@5915..5919
+                    - IDENT@5915..5919 "bold"
+                - COLON@5919..5920 ":"
+                - WHITESPACE@5920..5921 " "
+                - NAMED_TYPE@5921..5931
+                    - WHITESPACE@5921..5924 "\n  "
+                    - NAME@5924..5931
+                        - IDENT@5924..5931 "Boolean"
+            - FIELD_DEFINITION@5931..5944
+                - NAME@5931..5935
+                    - IDENT@5931..5935 "text"
+                - COLON@5935..5936 ":"
+                - WHITESPACE@5936..5937 " "
+                - NAMED_TYPE@5937..5944
+                    - WHITESPACE@5937..5938 "\n"
+                    - NAME@5938..5944
+                        - IDENT@5938..5944 "String"
+            - R_CURLY@5944..5945 "}"
+            - WHITESPACE@5945..5947 "\n\n"
+    - UNION_TYPE_DEFINITION@5947..5973
+        - union_KW@5947..5952 "union"
+        - WHITESPACE@5952..5953 " "
+        - NAME@5953..5959
+            - IDENT@5953..5958 "Thing"
+            - WHITESPACE@5958..5959 " "
+        - UNION_MEMBER_TYPES@5959..5973
+            - EQ@5959..5960 "="
+            - WHITESPACE@5960..5961 " "
+            - NAMED_TYPE@5961..5965
+                - NAME@5961..5965
+                    - IDENT@5961..5964 "Car"
+                    - WHITESPACE@5964..5965 " "
+            - PIPE@5965..5966 "|"
+            - WHITESPACE@5966..5967 " "
+            - NAMED_TYPE@5967..5973
+                - NAME@5967..5973
+                    - IDENT@5967..5971 "Ikea"
+                    - WHITESPACE@5971..5973 "\n\n"
+    - INPUT_OBJECT_TYPE_DEFINITION@5973..6027
+        - input_KW@5973..5978 "input"
+        - WHITESPACE@5978..5979 " "
+        - NAME@5979..5997
+            - IDENT@5979..5996 "UpdateReviewInput"
+            - WHITESPACE@5996..5997 " "
+        - INPUT_FIELDS_DEFINITION@5997..6027
+            - L_CURLY@5997..5998 "{"
+            - WHITESPACE@5998..6001 "\n  "
+            - INPUT_VALUE_DEFINITION@6001..6011
+                - NAME@6001..6003
+                    - IDENT@6001..6003 "id"
+                - COLON@6003..6004 ":"
+                - WHITESPACE@6004..6005 " "
+                - NON_NULL_TYPE@6005..6011
+                    - WHITESPACE@6005..6008 "\n  "
+                    - NAMED_TYPE@6008..6010
+                        - NAME@6008..6010
+                            - IDENT@6008..6010 "ID"
+                    - BANG@6010..6011 "!"
+            - INPUT_VALUE_DEFINITION@6011..6024
+                - NAME@6011..6015
+                    - IDENT@6011..6015 "body"
+                - COLON@6015..6016 ":"
+                - WHITESPACE@6016..6017 " "
+                - NAMED_TYPE@6017..6024
+                    - WHITESPACE@6017..6018 "\n"
+                    - NAME@6018..6024
+                        - IDENT@6018..6024 "String"
+            - R_CURLY@6024..6025 "}"
+            - WHITESPACE@6025..6027 "\n\n"
+    - OBJECT_TYPE_DEFINITION@6027..6972
+        - type_KW@6027..6031 "type"
+        - WHITESPACE@6031..6032 " "
+        - NAME@6032..6037
+            - IDENT@6032..6036 "User"
+            - WHITESPACE@6036..6037 "\n"
+        - DIRECTIVES@6037..6289
+            - DIRECTIVE@6037..6067
+                - AT@6037..6038 "@"
+                - NAME@6038..6049
+                    - IDENT@6038..6049 "join__owner"
+                - ARGUMENTS@6049..6067
+                    - L_PAREN@6049..6050 "("
+                    - ARGUMENT@6050..6065
+                        - NAME@6050..6055
+                            - IDENT@6050..6055 "graph"
+                        - COLON@6055..6056 ":"
+                        - WHITESPACE@6056..6057 " "
+                        - ENUM_VALUE@6057..6065
+                            - NAME@6057..6065
+                                - IDENT@6057..6065 "ACCOUNTS"
+                    - R_PAREN@6065..6066 ")"
+                    - WHITESPACE@6066..6067 "\n"
+            - DIRECTIVE@6067..6107
+                - AT@6067..6068 "@"
+                - NAME@6068..6078
+                    - IDENT@6068..6078 "join__type"
+                - ARGUMENTS@6078..6107
+                    - L_PAREN@6078..6079 "("
+                    - ARGUMENT@6079..6096
+                        - NAME@6079..6084
+                            - IDENT@6079..6084 "graph"
+                        - COLON@6084..6085 ":"
+                        - WHITESPACE@6085..6086 " "
+                        - ENUM_VALUE@6086..6096
+                            - NAME@6086..6096
+                                - IDENT@6086..6094 "ACCOUNTS"
+                                - COMMA@6094..6095 ","
+                                - WHITESPACE@6095..6096 " "
+                    - ARGUMENT@6096..6105
+                        - NAME@6096..6099
+                            - IDENT@6096..6099 "key"
+                        - COLON@6099..6100 ":"
+                        - WHITESPACE@6100..6101 " "
+                        - STRING_VALUE@6101..6105
+                            - STRING@6101..6105 "\"id\""
+                    - R_PAREN@6105..6106 ")"
+                    - WHITESPACE@6106..6107 "\n"
+            - DIRECTIVE@6107..6170
+                - AT@6107..6108 "@"
+                - NAME@6108..6118
+                    - IDENT@6108..6118 "join__type"
+                - ARGUMENTS@6118..6170
+                    - L_PAREN@6118..6119 "("
+                    - ARGUMENT@6119..6136
+                        - NAME@6119..6124
+                            - IDENT@6119..6124 "graph"
+                        - COLON@6124..6125 ":"
+                        - WHITESPACE@6125..6126 " "
+                        - ENUM_VALUE@6126..6136
+                            - NAME@6126..6136
+                                - IDENT@6126..6134 "ACCOUNTS"
+                                - COMMA@6134..6135 ","
+                                - WHITESPACE@6135..6136 " "
+                    - ARGUMENT@6136..6168
+                        - NAME@6136..6139
+                            - IDENT@6136..6139 "key"
+                        - COLON@6139..6140 ":"
+                        - WHITESPACE@6140..6141 " "
+                        - STRING_VALUE@6141..6168
+                            - STRING@6141..6168 "\"username name{first last}\""
+                    - R_PAREN@6168..6169 ")"
+                    - WHITESPACE@6169..6170 "\n"
+            - DIRECTIVE@6170..6211
+                - AT@6170..6171 "@"
+                - NAME@6171..6181
+                    - IDENT@6171..6181 "join__type"
+                - ARGUMENTS@6181..6211
+                    - L_PAREN@6181..6182 "("
+                    - ARGUMENT@6182..6200
+                        - NAME@6182..6187
+                            - IDENT@6182..6187 "graph"
+                        - COLON@6187..6188 ":"
+                        - WHITESPACE@6188..6189 " "
+                        - ENUM_VALUE@6189..6200
+                            - NAME@6189..6200
+                                - IDENT@6189..6198 "INVENTORY"
+                                - COMMA@6198..6199 ","
+                                - WHITESPACE@6199..6200 " "
+                    - ARGUMENT@6200..6209
+                        - NAME@6200..6203
+                            - IDENT@6200..6203 "key"
+                        - COLON@6203..6204 ":"
+                        - WHITESPACE@6204..6205 " "
+                        - STRING_VALUE@6205..6209
+                            - STRING@6205..6209 "\"id\""
+                    - R_PAREN@6209..6210 ")"
+                    - WHITESPACE@6210..6211 "\n"
+            - DIRECTIVE@6211..6250
+                - AT@6211..6212 "@"
+                - NAME@6212..6222
+                    - IDENT@6212..6222 "join__type"
+                - ARGUMENTS@6222..6250
+                    - L_PAREN@6222..6223 "("
+                    - ARGUMENT@6223..6239
+                        - NAME@6223..6228
+                            - IDENT@6223..6228 "graph"
+                        - COLON@6228..6229 ":"
+                        - WHITESPACE@6229..6230 " "
+                        - ENUM_VALUE@6230..6239
+                            - NAME@6230..6239
+                                - IDENT@6230..6237 "PRODUCT"
+                                - COMMA@6237..6238 ","
+                                - WHITESPACE@6238..6239 " "
+                    - ARGUMENT@6239..6248
+                        - NAME@6239..6242
+                            - IDENT@6239..6242 "key"
+                        - COLON@6242..6243 ":"
+                        - WHITESPACE@6243..6244 " "
+                        - STRING_VALUE@6244..6248
+                            - STRING@6244..6248 "\"id\""
+                    - R_PAREN@6248..6249 ")"
+                    - WHITESPACE@6249..6250 "\n"
+            - DIRECTIVE@6250..6289
+                - AT@6250..6251 "@"
+                - NAME@6251..6261
+                    - IDENT@6251..6261 "join__type"
+                - ARGUMENTS@6261..6289
+                    - L_PAREN@6261..6262 "("
+                    - ARGUMENT@6262..6278
+                        - NAME@6262..6267
+                            - IDENT@6262..6267 "graph"
+                        - COLON@6267..6268 ":"
+                        - WHITESPACE@6268..6269 " "
+                        - ENUM_VALUE@6269..6278
+                            - NAME@6269..6278
+                                - IDENT@6269..6276 "REVIEWS"
+                                - COMMA@6276..6277 ","
                                 - WHITESPACE@6277..6278 " "
-                                - ENUM_VALUE@6278..6286
-                                    - NAME@6278..6286
-                                        - IDENT@6278..6286 "ACCOUNTS"
-                            - R_PAREN@6286..6287 ")"
-                            - WHITESPACE@6287..6290 "\n  "
-            - FIELD_DEFINITION@6290..6333
-                - NAME@6290..6294
-                    - IDENT@6290..6294 "name"
-                - COLON@6294..6295 ":"
-                - WHITESPACE@6295..6296 " "
-                - NAMED_TYPE@6296..6301
-                    - WHITESPACE@6296..6297 " "
-                    - NAME@6297..6301
-                        - IDENT@6297..6301 "Name"
+                    - ARGUMENT@6278..6287
+                        - NAME@6278..6281
+                            - IDENT@6278..6281 "key"
+                        - COLON@6281..6282 ":"
+                        - WHITESPACE@6282..6283 " "
+                        - STRING_VALUE@6283..6287
+                            - STRING@6283..6287 "\"id\""
+                    - R_PAREN@6287..6288 ")"
+                    - WHITESPACE@6288..6289 "\n"
+        - FIELDS_DEFINITION@6289..6972
+            - L_CURLY@6289..6290 "{"
+            - WHITESPACE@6290..6293 "\n  "
+            - FIELD_DEFINITION@6293..6333
+                - NAME@6293..6295
+                    - IDENT@6293..6295 "id"
+                - COLON@6295..6296 ":"
+                - WHITESPACE@6296..6297 " "
+                - NON_NULL_TYPE@6297..6301
+                    - WHITESPACE@6297..6298 " "
+                    - NAMED_TYPE@6298..6300
+                        - NAME@6298..6300
+                            - IDENT@6298..6300 "ID"
+                    - BANG@6300..6301 "!"
                 - DIRECTIVES@6301..6333
                     - DIRECTIVE@6301..6333
                         - AT@6301..6302 "@"
@@ -3556,481 +3573,483 @@
                                         - IDENT@6321..6329 "ACCOUNTS"
                             - R_PAREN@6329..6330 ")"
                             - WHITESPACE@6330..6333 "\n  "
-            - FIELD_DEFINITION@6333..6382
-                - NAME@6333..6341
-                    - IDENT@6333..6341 "username"
-                - COLON@6341..6342 ":"
-                - WHITESPACE@6342..6343 " "
-                - NAMED_TYPE@6343..6350
-                    - WHITESPACE@6343..6344 " "
-                    - NAME@6344..6350
-                        - IDENT@6344..6350 "String"
-                - DIRECTIVES@6350..6382
-                    - DIRECTIVE@6350..6382
-                        - AT@6350..6351 "@"
-                        - NAME@6351..6362
-                            - IDENT@6351..6362 "join__field"
-                        - ARGUMENTS@6362..6382
-                            - L_PAREN@6362..6363 "("
-                            - ARGUMENT@6363..6378
-                                - NAME@6363..6368
-                                    - IDENT@6363..6368 "graph"
-                                - COLON@6368..6369 ":"
-                                - WHITESPACE@6369..6370 " "
-                                - ENUM_VALUE@6370..6378
-                                    - NAME@6370..6378
-                                        - IDENT@6370..6378 "ACCOUNTS"
-                            - R_PAREN@6378..6379 ")"
-                            - WHITESPACE@6379..6382 "\n  "
-            - FIELD_DEFINITION@6382..6448
-                - NAME@6382..6391
-                    - IDENT@6382..6391 "birthDate"
-                - ARGUMENTS@6391..6407
-                    - L_PAREN@6391..6392 "("
-                    - INPUT_VALUE_DEFINITION@6392..6406
-                        - NAME@6392..6398
-                            - IDENT@6392..6398 "locale"
-                        - COLON@6398..6399 ":"
-                        - WHITESPACE@6399..6400 " "
-                        - NAMED_TYPE@6400..6406
-                            - NAME@6400..6406
-                                - IDENT@6400..6406 "String"
-                    - R_PAREN@6406..6407 ")"
-                - COLON@6407..6408 ":"
-                - WHITESPACE@6408..6409 " "
-                - NAMED_TYPE@6409..6416
-                    - WHITESPACE@6409..6410 " "
-                    - NAME@6410..6416
-                        - IDENT@6410..6416 "String"
-                - DIRECTIVES@6416..6448
-                    - DIRECTIVE@6416..6448
-                        - AT@6416..6417 "@"
-                        - NAME@6417..6428
-                            - IDENT@6417..6428 "join__field"
-                        - ARGUMENTS@6428..6448
-                            - L_PAREN@6428..6429 "("
-                            - ARGUMENT@6429..6444
-                                - NAME@6429..6434
-                                    - IDENT@6429..6434 "graph"
-                                - COLON@6434..6435 ":"
-                                - WHITESPACE@6435..6436 " "
-                                - ENUM_VALUE@6436..6444
-                                    - NAME@6436..6444
-                                        - IDENT@6436..6444 "ACCOUNTS"
-                            - R_PAREN@6444..6445 ")"
-                            - WHITESPACE@6445..6448 "\n  "
-            - FIELD_DEFINITION@6448..6501
-                - NAME@6448..6455
-                    - IDENT@6448..6455 "account"
-                - COLON@6455..6456 ":"
-                - WHITESPACE@6456..6457 " "
-                - NAMED_TYPE@6457..6469
-                    - WHITESPACE@6457..6458 " "
-                    - NAME@6458..6469
-                        - IDENT@6458..6469 "AccountType"
-                - DIRECTIVES@6469..6501
-                    - DIRECTIVE@6469..6501
-                        - AT@6469..6470 "@"
-                        - NAME@6470..6481
-                            - IDENT@6470..6481 "join__field"
-                        - ARGUMENTS@6481..6501
-                            - L_PAREN@6481..6482 "("
-                            - ARGUMENT@6482..6497
-                                - NAME@6482..6487
-                                    - IDENT@6482..6487 "graph"
-                                - COLON@6487..6488 ":"
-                                - WHITESPACE@6488..6489 " "
-                                - ENUM_VALUE@6489..6497
-                                    - NAME@6489..6497
-                                        - IDENT@6489..6497 "ACCOUNTS"
-                            - R_PAREN@6497..6498 ")"
-                            - WHITESPACE@6498..6501 "\n  "
-            - FIELD_DEFINITION@6501..6558
-                - NAME@6501..6509
-                    - IDENT@6501..6509 "metadata"
-                - COLON@6509..6510 ":"
-                - WHITESPACE@6510..6511 " "
-                - LIST_TYPE@6511..6526
-                    - WHITESPACE@6511..6512 " "
-                    - L_BRACK@6512..6513 "["
-                    - NAMED_TYPE@6513..6525
-                        - NAME@6513..6525
-                            - IDENT@6513..6525 "UserMetadata"
-                    - R_BRACK@6525..6526 "]"
-                - DIRECTIVES@6526..6558
-                    - DIRECTIVE@6526..6558
-                        - AT@6526..6527 "@"
-                        - NAME@6527..6538
-                            - IDENT@6527..6538 "join__field"
-                        - ARGUMENTS@6538..6558
-                            - L_PAREN@6538..6539 "("
-                            - ARGUMENT@6539..6554
-                                - NAME@6539..6544
-                                    - IDENT@6539..6544 "graph"
-                                - COLON@6544..6545 ":"
-                                - WHITESPACE@6545..6546 " "
-                                - ENUM_VALUE@6546..6554
-                                    - NAME@6546..6554
-                                        - IDENT@6546..6554 "ACCOUNTS"
-                            - R_PAREN@6554..6555 ")"
-                            - WHITESPACE@6555..6558 "\n  "
-            - FIELD_DEFINITION@6558..6651
-                - NAME@6558..6573
-                    - IDENT@6558..6573 "goodDescription"
-                - COLON@6573..6574 ":"
-                - WHITESPACE@6574..6575 " "
-                - NAMED_TYPE@6575..6583
-                    - WHITESPACE@6575..6576 " "
-                    - NAME@6576..6583
-                        - IDENT@6576..6583 "Boolean"
-                - DIRECTIVES@6583..6651
-                    - DIRECTIVE@6583..6651
-                        - AT@6583..6584 "@"
-                        - NAME@6584..6595
-                            - IDENT@6584..6595 "join__field"
-                        - ARGUMENTS@6595..6651
-                            - L_PAREN@6595..6596 "("
-                            - ARGUMENT@6596..6614
-                                - NAME@6596..6601
-                                    - IDENT@6596..6601 "graph"
-                                - COLON@6601..6602 ":"
-                                - WHITESPACE@6602..6603 " "
-                                - ENUM_VALUE@6603..6614
-                                    - NAME@6603..6614
-                                        - IDENT@6603..6612 "INVENTORY"
-                                        - COMMA@6612..6613 ","
-                                        - WHITESPACE@6613..6614 " "
-                            - ARGUMENT@6614..6647
-                                - NAME@6614..6622
-                                    - IDENT@6614..6622 "requires"
-                                - COLON@6622..6623 ":"
-                                - WHITESPACE@6623..6624 " "
-                                - STRING_VALUE@6624..6647
-                                    - STRING@6624..6647 "\"metadata{description}\""
-                            - R_PAREN@6647..6648 ")"
-                            - WHITESPACE@6648..6651 "\n  "
-            - FIELD_DEFINITION@6651..6699
-                - NAME@6651..6658
-                    - IDENT@6651..6658 "vehicle"
-                - COLON@6658..6659 ":"
-                - WHITESPACE@6659..6660 " "
-                - NAMED_TYPE@6660..6668
-                    - WHITESPACE@6660..6661 " "
-                    - NAME@6661..6668
-                        - IDENT@6661..6668 "Vehicle"
-                - DIRECTIVES@6668..6699
-                    - DIRECTIVE@6668..6699
-                        - AT@6668..6669 "@"
-                        - NAME@6669..6680
-                            - IDENT@6669..6680 "join__field"
-                        - ARGUMENTS@6680..6699
-                            - L_PAREN@6680..6681 "("
-                            - ARGUMENT@6681..6695
-                                - NAME@6681..6686
-                                    - IDENT@6681..6686 "graph"
-                                - COLON@6686..6687 ":"
-                                - WHITESPACE@6687..6688 " "
-                                - ENUM_VALUE@6688..6695
-                                    - NAME@6688..6695
-                                        - IDENT@6688..6695 "PRODUCT"
-                            - R_PAREN@6695..6696 ")"
-                            - WHITESPACE@6696..6699 "\n  "
-            - FIELD_DEFINITION@6699..6743
-                - NAME@6699..6704
-                    - IDENT@6699..6704 "thing"
-                - COLON@6704..6705 ":"
-                - WHITESPACE@6705..6706 " "
-                - NAMED_TYPE@6706..6712
-                    - WHITESPACE@6706..6707 " "
-                    - NAME@6707..6712
-                        - IDENT@6707..6712 "Thing"
-                - DIRECTIVES@6712..6743
-                    - DIRECTIVE@6712..6743
-                        - AT@6712..6713 "@"
-                        - NAME@6713..6724
-                            - IDENT@6713..6724 "join__field"
-                        - ARGUMENTS@6724..6743
-                            - L_PAREN@6724..6725 "("
-                            - ARGUMENT@6725..6739
-                                - NAME@6725..6730
-                                    - IDENT@6725..6730 "graph"
-                                - COLON@6730..6731 ":"
-                                - WHITESPACE@6731..6732 " "
-                                - ENUM_VALUE@6732..6739
-                                    - NAME@6732..6739
-                                        - IDENT@6732..6739 "PRODUCT"
-                            - R_PAREN@6739..6740 ")"
-                            - WHITESPACE@6740..6743 "\n  "
-            - FIELD_DEFINITION@6743..6792
-                - NAME@6743..6750
-                    - IDENT@6743..6750 "reviews"
-                - COLON@6750..6751 ":"
-                - WHITESPACE@6751..6752 " "
-                - LIST_TYPE@6752..6761
-                    - WHITESPACE@6752..6753 " "
-                    - L_BRACK@6753..6754 "["
-                    - NAMED_TYPE@6754..6760
-                        - NAME@6754..6760
-                            - IDENT@6754..6760 "Review"
-                    - R_BRACK@6760..6761 "]"
-                - DIRECTIVES@6761..6792
-                    - DIRECTIVE@6761..6792
-                        - AT@6761..6762 "@"
-                        - NAME@6762..6773
-                            - IDENT@6762..6773 "join__field"
-                        - ARGUMENTS@6773..6792
-                            - L_PAREN@6773..6774 "("
-                            - ARGUMENT@6774..6788
-                                - NAME@6774..6779
-                                    - IDENT@6774..6779 "graph"
-                                - COLON@6779..6780 ":"
-                                - WHITESPACE@6780..6781 " "
-                                - ENUM_VALUE@6781..6788
-                                    - NAME@6781..6788
-                                        - IDENT@6781..6788 "REVIEWS"
-                            - R_PAREN@6788..6789 ")"
-                            - WHITESPACE@6789..6792 "\n  "
-            - FIELD_DEFINITION@6792..6844
-                - NAME@6792..6807
-                    - IDENT@6792..6807 "numberOfReviews"
-                - COLON@6807..6808 ":"
-                - WHITESPACE@6808..6809 " "
-                - NON_NULL_TYPE@6809..6813
-                    - WHITESPACE@6809..6810 " "
-                    - NAMED_TYPE@6810..6813
-                        - NAME@6810..6813
-                            - IDENT@6810..6813 "Int"
-                - DIRECTIVES@6813..6844
-                    - DIRECTIVE@6813..6844
-                        - AT@6813..6814 "@"
-                        - NAME@6814..6825
-                            - IDENT@6814..6825 "join__field"
-                        - ARGUMENTS@6825..6844
-                            - L_PAREN@6825..6826 "("
-                            - ARGUMENT@6826..6840
-                                - NAME@6826..6831
-                                    - IDENT@6826..6831 "graph"
-                                - COLON@6831..6832 ":"
-                                - WHITESPACE@6832..6833 " "
-                                - ENUM_VALUE@6833..6840
-                                    - NAME@6833..6840
-                                        - IDENT@6833..6840 "REVIEWS"
-                            - R_PAREN@6840..6841 ")"
-                            - WHITESPACE@6841..6844 "\n  "
-            - FIELD_DEFINITION@6844..6925
-                - NAME@6844..6855
-                    - IDENT@6844..6855 "goodAddress"
-                - COLON@6855..6856 ":"
-                - WHITESPACE@6856..6857 " "
-                - NAMED_TYPE@6857..6865
-                    - WHITESPACE@6857..6858 " "
-                    - NAME@6858..6865
-                        - IDENT@6858..6865 "Boolean"
-                - DIRECTIVES@6865..6925
-                    - DIRECTIVE@6865..6925
-                        - AT@6865..6866 "@"
-                        - NAME@6866..6877
-                            - IDENT@6866..6877 "join__field"
-                        - ARGUMENTS@6877..6925
-                            - L_PAREN@6877..6878 "("
-                            - ARGUMENT@6878..6894
-                                - NAME@6878..6883
-                                    - IDENT@6878..6883 "graph"
-                                - COLON@6883..6884 ":"
-                                - WHITESPACE@6884..6885 " "
-                                - ENUM_VALUE@6885..6894
-                                    - NAME@6885..6894
-                                        - IDENT@6885..6892 "REVIEWS"
-                                        - COMMA@6892..6893 ","
-                                        - WHITESPACE@6893..6894 " "
-                            - ARGUMENT@6894..6923
-                                - NAME@6894..6902
-                                    - IDENT@6894..6902 "requires"
-                                - COLON@6902..6903 ":"
-                                - WHITESPACE@6903..6904 " "
-                                - STRING_VALUE@6904..6923
-                                    - STRING@6904..6923 "\"metadata{address}\""
-                            - R_PAREN@6923..6924 ")"
-                            - WHITESPACE@6924..6925 "\n"
-            - R_CURLY@6925..6926 "}"
-            - WHITESPACE@6926..6928 "\n\n"
-    - OBJECT_TYPE_DEFINITION@6928..7006
-        - type_KW@6928..6932 "type"
-        - WHITESPACE@6932..6933 " "
-        - NAME@6933..6946
-            - IDENT@6933..6945 "UserMetadata"
-            - WHITESPACE@6945..6946 " "
-        - FIELDS_DEFINITION@6946..7006
-            - L_CURLY@6946..6947 "{"
-            - WHITESPACE@6947..6950 "\n  "
-            - FIELD_DEFINITION@6950..6965
-                - NAME@6950..6954
-                    - IDENT@6950..6954 "name"
-                - COLON@6954..6955 ":"
-                - WHITESPACE@6955..6956 " "
-                - NAMED_TYPE@6956..6965
-                    - WHITESPACE@6956..6959 "\n  "
-                    - NAME@6959..6965
-                        - IDENT@6959..6965 "String"
-            - FIELD_DEFINITION@6965..6983
-                - NAME@6965..6972
-                    - IDENT@6965..6972 "address"
-                - COLON@6972..6973 ":"
-                - WHITESPACE@6973..6974 " "
-                - NAMED_TYPE@6974..6983
-                    - WHITESPACE@6974..6977 "\n  "
-                    - NAME@6977..6983
-                        - IDENT@6977..6983 "String"
-            - FIELD_DEFINITION@6983..7003
-                - NAME@6983..6994
-                    - IDENT@6983..6994 "description"
-                - COLON@6994..6995 ":"
-                - WHITESPACE@6995..6996 " "
-                - NAMED_TYPE@6996..7003
-                    - WHITESPACE@6996..6997 "\n"
-                    - NAME@6997..7003
-                        - IDENT@6997..7003 "String"
-            - R_CURLY@7003..7004 "}"
-            - WHITESPACE@7004..7006 "\n\n"
-    - OBJECT_TYPE_DEFINITION@7006..7354
-        - type_KW@7006..7010 "type"
-        - WHITESPACE@7010..7011 " "
-        - NAME@7011..7015
-            - IDENT@7011..7014 "Van"
-            - WHITESPACE@7014..7015 " "
-        - IMPLEMENTS_INTERFACES@7015..7034
-            - implements_KW@7015..7025 "implements"
-            - WHITESPACE@7025..7026 " "
-            - NAMED_TYPE@7026..7034
-                - NAME@7026..7034
-                    - IDENT@7026..7033 "Vehicle"
-                    - WHITESPACE@7033..7034 "\n"
-        - DIRECTIVES@7034..7141
-            - DIRECTIVE@7034..7063
-                - AT@7034..7035 "@"
-                - NAME@7035..7046
-                    - IDENT@7035..7046 "join__owner"
-                - ARGUMENTS@7046..7063
-                    - L_PAREN@7046..7047 "("
-                    - ARGUMENT@7047..7061
-                        - NAME@7047..7052
-                            - IDENT@7047..7052 "graph"
-                        - COLON@7052..7053 ":"
-                        - WHITESPACE@7053..7054 " "
-                        - ENUM_VALUE@7054..7061
-                            - NAME@7054..7061
-                                - IDENT@7054..7061 "PRODUCT"
-                    - R_PAREN@7061..7062 ")"
-                    - WHITESPACE@7062..7063 "\n"
-            - DIRECTIVE@7063..7102
-                - AT@7063..7064 "@"
-                - NAME@7064..7074
-                    - IDENT@7064..7074 "join__type"
-                - ARGUMENTS@7074..7102
-                    - L_PAREN@7074..7075 "("
-                    - ARGUMENT@7075..7091
-                        - NAME@7075..7080
-                            - IDENT@7075..7080 "graph"
-                        - COLON@7080..7081 ":"
-                        - WHITESPACE@7081..7082 " "
-                        - ENUM_VALUE@7082..7091
-                            - NAME@7082..7091
-                                - IDENT@7082..7089 "PRODUCT"
-                                - COMMA@7089..7090 ","
-                                - WHITESPACE@7090..7091 " "
-                    - ARGUMENT@7091..7100
-                        - NAME@7091..7094
-                            - IDENT@7091..7094 "key"
-                        - COLON@7094..7095 ":"
-                        - WHITESPACE@7095..7096 " "
-                        - STRING_VALUE@7096..7100
-                            - STRING@7096..7100 "\"id\""
-                    - R_PAREN@7100..7101 ")"
-                    - WHITESPACE@7101..7102 "\n"
-            - DIRECTIVE@7102..7141
-                - AT@7102..7103 "@"
-                - NAME@7103..7113
-                    - IDENT@7103..7113 "join__type"
-                - ARGUMENTS@7113..7141
-                    - L_PAREN@7113..7114 "("
-                    - ARGUMENT@7114..7130
-                        - NAME@7114..7119
-                            - IDENT@7114..7119 "graph"
-                        - COLON@7119..7120 ":"
-                        - WHITESPACE@7120..7121 " "
-                        - ENUM_VALUE@7121..7130
-                            - NAME@7121..7130
-                                - IDENT@7121..7128 "REVIEWS"
-                                - COMMA@7128..7129 ","
-                                - WHITESPACE@7129..7130 " "
-                    - ARGUMENT@7130..7139
-                        - NAME@7130..7133
-                            - IDENT@7130..7133 "key"
-                        - COLON@7133..7134 ":"
-                        - WHITESPACE@7134..7135 " "
-                        - STRING_VALUE@7135..7139
-                            - STRING@7135..7139 "\"id\""
-                    - R_PAREN@7139..7140 ")"
-                    - WHITESPACE@7140..7141 "\n"
-        - FIELDS_DEFINITION@7141..7354
-            - L_CURLY@7141..7142 "{"
-            - WHITESPACE@7142..7145 "\n  "
-            - FIELD_DEFINITION@7145..7187
-                - NAME@7145..7147
-                    - IDENT@7145..7147 "id"
-                - COLON@7147..7148 ":"
-                - WHITESPACE@7148..7149 " "
-                - NON_NULL_TYPE@7149..7156
-                    - WHITESPACE@7149..7150 " "
-                    - NAMED_TYPE@7150..7156
-                        - NAME@7150..7156
-                            - IDENT@7150..7156 "String"
-                - DIRECTIVES@7156..7187
-                    - DIRECTIVE@7156..7187
-                        - AT@7156..7157 "@"
-                        - NAME@7157..7168
-                            - IDENT@7157..7168 "join__field"
-                        - ARGUMENTS@7168..7187
-                            - L_PAREN@7168..7169 "("
-                            - ARGUMENT@7169..7183
-                                - NAME@7169..7174
-                                    - IDENT@7169..7174 "graph"
-                                - COLON@7174..7175 ":"
-                                - WHITESPACE@7175..7176 " "
-                                - ENUM_VALUE@7176..7183
-                                    - NAME@7176..7183
-                                        - IDENT@7176..7183 "PRODUCT"
-                            - R_PAREN@7183..7184 ")"
-                            - WHITESPACE@7184..7187 "\n  "
-            - FIELD_DEFINITION@7187..7238
-                - NAME@7187..7198
-                    - IDENT@7187..7198 "description"
-                - COLON@7198..7199 ":"
-                - WHITESPACE@7199..7200 " "
-                - NAMED_TYPE@7200..7207
-                    - WHITESPACE@7200..7201 " "
-                    - NAME@7201..7207
-                        - IDENT@7201..7207 "String"
-                - DIRECTIVES@7207..7238
-                    - DIRECTIVE@7207..7238
-                        - AT@7207..7208 "@"
-                        - NAME@7208..7219
-                            - IDENT@7208..7219 "join__field"
-                        - ARGUMENTS@7219..7238
-                            - L_PAREN@7219..7220 "("
-                            - ARGUMENT@7220..7234
-                                - NAME@7220..7225
-                                    - IDENT@7220..7225 "graph"
-                                - COLON@7225..7226 ":"
-                                - WHITESPACE@7226..7227 " "
-                                - ENUM_VALUE@7227..7234
-                                    - NAME@7227..7234
-                                        - IDENT@7227..7234 "PRODUCT"
-                            - R_PAREN@7234..7235 ")"
-                            - WHITESPACE@7235..7238 "\n  "
-            - FIELD_DEFINITION@7238..7283
-                - NAME@7238..7243
-                    - IDENT@7238..7243 "price"
+            - FIELD_DEFINITION@6333..6376
+                - NAME@6333..6337
+                    - IDENT@6333..6337 "name"
+                - COLON@6337..6338 ":"
+                - WHITESPACE@6338..6339 " "
+                - NAMED_TYPE@6339..6344
+                    - WHITESPACE@6339..6340 " "
+                    - NAME@6340..6344
+                        - IDENT@6340..6344 "Name"
+                - DIRECTIVES@6344..6376
+                    - DIRECTIVE@6344..6376
+                        - AT@6344..6345 "@"
+                        - NAME@6345..6356
+                            - IDENT@6345..6356 "join__field"
+                        - ARGUMENTS@6356..6376
+                            - L_PAREN@6356..6357 "("
+                            - ARGUMENT@6357..6372
+                                - NAME@6357..6362
+                                    - IDENT@6357..6362 "graph"
+                                - COLON@6362..6363 ":"
+                                - WHITESPACE@6363..6364 " "
+                                - ENUM_VALUE@6364..6372
+                                    - NAME@6364..6372
+                                        - IDENT@6364..6372 "ACCOUNTS"
+                            - R_PAREN@6372..6373 ")"
+                            - WHITESPACE@6373..6376 "\n  "
+            - FIELD_DEFINITION@6376..6425
+                - NAME@6376..6384
+                    - IDENT@6376..6384 "username"
+                - COLON@6384..6385 ":"
+                - WHITESPACE@6385..6386 " "
+                - NAMED_TYPE@6386..6393
+                    - WHITESPACE@6386..6387 " "
+                    - NAME@6387..6393
+                        - IDENT@6387..6393 "String"
+                - DIRECTIVES@6393..6425
+                    - DIRECTIVE@6393..6425
+                        - AT@6393..6394 "@"
+                        - NAME@6394..6405
+                            - IDENT@6394..6405 "join__field"
+                        - ARGUMENTS@6405..6425
+                            - L_PAREN@6405..6406 "("
+                            - ARGUMENT@6406..6421
+                                - NAME@6406..6411
+                                    - IDENT@6406..6411 "graph"
+                                - COLON@6411..6412 ":"
+                                - WHITESPACE@6412..6413 " "
+                                - ENUM_VALUE@6413..6421
+                                    - NAME@6413..6421
+                                        - IDENT@6413..6421 "ACCOUNTS"
+                            - R_PAREN@6421..6422 ")"
+                            - WHITESPACE@6422..6425 "\n  "
+            - FIELD_DEFINITION@6425..6491
+                - NAME@6425..6434
+                    - IDENT@6425..6434 "birthDate"
+                - ARGUMENTS@6434..6450
+                    - L_PAREN@6434..6435 "("
+                    - INPUT_VALUE_DEFINITION@6435..6449
+                        - NAME@6435..6441
+                            - IDENT@6435..6441 "locale"
+                        - COLON@6441..6442 ":"
+                        - WHITESPACE@6442..6443 " "
+                        - NAMED_TYPE@6443..6449
+                            - NAME@6443..6449
+                                - IDENT@6443..6449 "String"
+                    - R_PAREN@6449..6450 ")"
+                - COLON@6450..6451 ":"
+                - WHITESPACE@6451..6452 " "
+                - NAMED_TYPE@6452..6459
+                    - WHITESPACE@6452..6453 " "
+                    - NAME@6453..6459
+                        - IDENT@6453..6459 "String"
+                - DIRECTIVES@6459..6491
+                    - DIRECTIVE@6459..6491
+                        - AT@6459..6460 "@"
+                        - NAME@6460..6471
+                            - IDENT@6460..6471 "join__field"
+                        - ARGUMENTS@6471..6491
+                            - L_PAREN@6471..6472 "("
+                            - ARGUMENT@6472..6487
+                                - NAME@6472..6477
+                                    - IDENT@6472..6477 "graph"
+                                - COLON@6477..6478 ":"
+                                - WHITESPACE@6478..6479 " "
+                                - ENUM_VALUE@6479..6487
+                                    - NAME@6479..6487
+                                        - IDENT@6479..6487 "ACCOUNTS"
+                            - R_PAREN@6487..6488 ")"
+                            - WHITESPACE@6488..6491 "\n  "
+            - FIELD_DEFINITION@6491..6544
+                - NAME@6491..6498
+                    - IDENT@6491..6498 "account"
+                - COLON@6498..6499 ":"
+                - WHITESPACE@6499..6500 " "
+                - NAMED_TYPE@6500..6512
+                    - WHITESPACE@6500..6501 " "
+                    - NAME@6501..6512
+                        - IDENT@6501..6512 "AccountType"
+                - DIRECTIVES@6512..6544
+                    - DIRECTIVE@6512..6544
+                        - AT@6512..6513 "@"
+                        - NAME@6513..6524
+                            - IDENT@6513..6524 "join__field"
+                        - ARGUMENTS@6524..6544
+                            - L_PAREN@6524..6525 "("
+                            - ARGUMENT@6525..6540
+                                - NAME@6525..6530
+                                    - IDENT@6525..6530 "graph"
+                                - COLON@6530..6531 ":"
+                                - WHITESPACE@6531..6532 " "
+                                - ENUM_VALUE@6532..6540
+                                    - NAME@6532..6540
+                                        - IDENT@6532..6540 "ACCOUNTS"
+                            - R_PAREN@6540..6541 ")"
+                            - WHITESPACE@6541..6544 "\n  "
+            - FIELD_DEFINITION@6544..6601
+                - NAME@6544..6552
+                    - IDENT@6544..6552 "metadata"
+                - COLON@6552..6553 ":"
+                - WHITESPACE@6553..6554 " "
+                - LIST_TYPE@6554..6569
+                    - WHITESPACE@6554..6555 " "
+                    - L_BRACK@6555..6556 "["
+                    - NAMED_TYPE@6556..6568
+                        - NAME@6556..6568
+                            - IDENT@6556..6568 "UserMetadata"
+                    - R_BRACK@6568..6569 "]"
+                - DIRECTIVES@6569..6601
+                    - DIRECTIVE@6569..6601
+                        - AT@6569..6570 "@"
+                        - NAME@6570..6581
+                            - IDENT@6570..6581 "join__field"
+                        - ARGUMENTS@6581..6601
+                            - L_PAREN@6581..6582 "("
+                            - ARGUMENT@6582..6597
+                                - NAME@6582..6587
+                                    - IDENT@6582..6587 "graph"
+                                - COLON@6587..6588 ":"
+                                - WHITESPACE@6588..6589 " "
+                                - ENUM_VALUE@6589..6597
+                                    - NAME@6589..6597
+                                        - IDENT@6589..6597 "ACCOUNTS"
+                            - R_PAREN@6597..6598 ")"
+                            - WHITESPACE@6598..6601 "\n  "
+            - FIELD_DEFINITION@6601..6694
+                - NAME@6601..6616
+                    - IDENT@6601..6616 "goodDescription"
+                - COLON@6616..6617 ":"
+                - WHITESPACE@6617..6618 " "
+                - NAMED_TYPE@6618..6626
+                    - WHITESPACE@6618..6619 " "
+                    - NAME@6619..6626
+                        - IDENT@6619..6626 "Boolean"
+                - DIRECTIVES@6626..6694
+                    - DIRECTIVE@6626..6694
+                        - AT@6626..6627 "@"
+                        - NAME@6627..6638
+                            - IDENT@6627..6638 "join__field"
+                        - ARGUMENTS@6638..6694
+                            - L_PAREN@6638..6639 "("
+                            - ARGUMENT@6639..6657
+                                - NAME@6639..6644
+                                    - IDENT@6639..6644 "graph"
+                                - COLON@6644..6645 ":"
+                                - WHITESPACE@6645..6646 " "
+                                - ENUM_VALUE@6646..6657
+                                    - NAME@6646..6657
+                                        - IDENT@6646..6655 "INVENTORY"
+                                        - COMMA@6655..6656 ","
+                                        - WHITESPACE@6656..6657 " "
+                            - ARGUMENT@6657..6690
+                                - NAME@6657..6665
+                                    - IDENT@6657..6665 "requires"
+                                - COLON@6665..6666 ":"
+                                - WHITESPACE@6666..6667 " "
+                                - STRING_VALUE@6667..6690
+                                    - STRING@6667..6690 "\"metadata{description}\""
+                            - R_PAREN@6690..6691 ")"
+                            - WHITESPACE@6691..6694 "\n  "
+            - FIELD_DEFINITION@6694..6742
+                - NAME@6694..6701
+                    - IDENT@6694..6701 "vehicle"
+                - COLON@6701..6702 ":"
+                - WHITESPACE@6702..6703 " "
+                - NAMED_TYPE@6703..6711
+                    - WHITESPACE@6703..6704 " "
+                    - NAME@6704..6711
+                        - IDENT@6704..6711 "Vehicle"
+                - DIRECTIVES@6711..6742
+                    - DIRECTIVE@6711..6742
+                        - AT@6711..6712 "@"
+                        - NAME@6712..6723
+                            - IDENT@6712..6723 "join__field"
+                        - ARGUMENTS@6723..6742
+                            - L_PAREN@6723..6724 "("
+                            - ARGUMENT@6724..6738
+                                - NAME@6724..6729
+                                    - IDENT@6724..6729 "graph"
+                                - COLON@6729..6730 ":"
+                                - WHITESPACE@6730..6731 " "
+                                - ENUM_VALUE@6731..6738
+                                    - NAME@6731..6738
+                                        - IDENT@6731..6738 "PRODUCT"
+                            - R_PAREN@6738..6739 ")"
+                            - WHITESPACE@6739..6742 "\n  "
+            - FIELD_DEFINITION@6742..6786
+                - NAME@6742..6747
+                    - IDENT@6742..6747 "thing"
+                - COLON@6747..6748 ":"
+                - WHITESPACE@6748..6749 " "
+                - NAMED_TYPE@6749..6755
+                    - WHITESPACE@6749..6750 " "
+                    - NAME@6750..6755
+                        - IDENT@6750..6755 "Thing"
+                - DIRECTIVES@6755..6786
+                    - DIRECTIVE@6755..6786
+                        - AT@6755..6756 "@"
+                        - NAME@6756..6767
+                            - IDENT@6756..6767 "join__field"
+                        - ARGUMENTS@6767..6786
+                            - L_PAREN@6767..6768 "("
+                            - ARGUMENT@6768..6782
+                                - NAME@6768..6773
+                                    - IDENT@6768..6773 "graph"
+                                - COLON@6773..6774 ":"
+                                - WHITESPACE@6774..6775 " "
+                                - ENUM_VALUE@6775..6782
+                                    - NAME@6775..6782
+                                        - IDENT@6775..6782 "PRODUCT"
+                            - R_PAREN@6782..6783 ")"
+                            - WHITESPACE@6783..6786 "\n  "
+            - FIELD_DEFINITION@6786..6835
+                - NAME@6786..6793
+                    - IDENT@6786..6793 "reviews"
+                - COLON@6793..6794 ":"
+                - WHITESPACE@6794..6795 " "
+                - LIST_TYPE@6795..6804
+                    - WHITESPACE@6795..6796 " "
+                    - L_BRACK@6796..6797 "["
+                    - NAMED_TYPE@6797..6803
+                        - NAME@6797..6803
+                            - IDENT@6797..6803 "Review"
+                    - R_BRACK@6803..6804 "]"
+                - DIRECTIVES@6804..6835
+                    - DIRECTIVE@6804..6835
+                        - AT@6804..6805 "@"
+                        - NAME@6805..6816
+                            - IDENT@6805..6816 "join__field"
+                        - ARGUMENTS@6816..6835
+                            - L_PAREN@6816..6817 "("
+                            - ARGUMENT@6817..6831
+                                - NAME@6817..6822
+                                    - IDENT@6817..6822 "graph"
+                                - COLON@6822..6823 ":"
+                                - WHITESPACE@6823..6824 " "
+                                - ENUM_VALUE@6824..6831
+                                    - NAME@6824..6831
+                                        - IDENT@6824..6831 "REVIEWS"
+                            - R_PAREN@6831..6832 ")"
+                            - WHITESPACE@6832..6835 "\n  "
+            - FIELD_DEFINITION@6835..6888
+                - NAME@6835..6850
+                    - IDENT@6835..6850 "numberOfReviews"
+                - COLON@6850..6851 ":"
+                - WHITESPACE@6851..6852 " "
+                - NON_NULL_TYPE@6852..6857
+                    - WHITESPACE@6852..6853 " "
+                    - NAMED_TYPE@6853..6856
+                        - NAME@6853..6856
+                            - IDENT@6853..6856 "Int"
+                    - BANG@6856..6857 "!"
+                - DIRECTIVES@6857..6888
+                    - DIRECTIVE@6857..6888
+                        - AT@6857..6858 "@"
+                        - NAME@6858..6869
+                            - IDENT@6858..6869 "join__field"
+                        - ARGUMENTS@6869..6888
+                            - L_PAREN@6869..6870 "("
+                            - ARGUMENT@6870..6884
+                                - NAME@6870..6875
+                                    - IDENT@6870..6875 "graph"
+                                - COLON@6875..6876 ":"
+                                - WHITESPACE@6876..6877 " "
+                                - ENUM_VALUE@6877..6884
+                                    - NAME@6877..6884
+                                        - IDENT@6877..6884 "REVIEWS"
+                            - R_PAREN@6884..6885 ")"
+                            - WHITESPACE@6885..6888 "\n  "
+            - FIELD_DEFINITION@6888..6969
+                - NAME@6888..6899
+                    - IDENT@6888..6899 "goodAddress"
+                - COLON@6899..6900 ":"
+                - WHITESPACE@6900..6901 " "
+                - NAMED_TYPE@6901..6909
+                    - WHITESPACE@6901..6902 " "
+                    - NAME@6902..6909
+                        - IDENT@6902..6909 "Boolean"
+                - DIRECTIVES@6909..6969
+                    - DIRECTIVE@6909..6969
+                        - AT@6909..6910 "@"
+                        - NAME@6910..6921
+                            - IDENT@6910..6921 "join__field"
+                        - ARGUMENTS@6921..6969
+                            - L_PAREN@6921..6922 "("
+                            - ARGUMENT@6922..6938
+                                - NAME@6922..6927
+                                    - IDENT@6922..6927 "graph"
+                                - COLON@6927..6928 ":"
+                                - WHITESPACE@6928..6929 " "
+                                - ENUM_VALUE@6929..6938
+                                    - NAME@6929..6938
+                                        - IDENT@6929..6936 "REVIEWS"
+                                        - COMMA@6936..6937 ","
+                                        - WHITESPACE@6937..6938 " "
+                            - ARGUMENT@6938..6967
+                                - NAME@6938..6946
+                                    - IDENT@6938..6946 "requires"
+                                - COLON@6946..6947 ":"
+                                - WHITESPACE@6947..6948 " "
+                                - STRING_VALUE@6948..6967
+                                    - STRING@6948..6967 "\"metadata{address}\""
+                            - R_PAREN@6967..6968 ")"
+                            - WHITESPACE@6968..6969 "\n"
+            - R_CURLY@6969..6970 "}"
+            - WHITESPACE@6970..6972 "\n\n"
+    - OBJECT_TYPE_DEFINITION@6972..7050
+        - type_KW@6972..6976 "type"
+        - WHITESPACE@6976..6977 " "
+        - NAME@6977..6990
+            - IDENT@6977..6989 "UserMetadata"
+            - WHITESPACE@6989..6990 " "
+        - FIELDS_DEFINITION@6990..7050
+            - L_CURLY@6990..6991 "{"
+            - WHITESPACE@6991..6994 "\n  "
+            - FIELD_DEFINITION@6994..7009
+                - NAME@6994..6998
+                    - IDENT@6994..6998 "name"
+                - COLON@6998..6999 ":"
+                - WHITESPACE@6999..7000 " "
+                - NAMED_TYPE@7000..7009
+                    - WHITESPACE@7000..7003 "\n  "
+                    - NAME@7003..7009
+                        - IDENT@7003..7009 "String"
+            - FIELD_DEFINITION@7009..7027
+                - NAME@7009..7016
+                    - IDENT@7009..7016 "address"
+                - COLON@7016..7017 ":"
+                - WHITESPACE@7017..7018 " "
+                - NAMED_TYPE@7018..7027
+                    - WHITESPACE@7018..7021 "\n  "
+                    - NAME@7021..7027
+                        - IDENT@7021..7027 "String"
+            - FIELD_DEFINITION@7027..7047
+                - NAME@7027..7038
+                    - IDENT@7027..7038 "description"
+                - COLON@7038..7039 ":"
+                - WHITESPACE@7039..7040 " "
+                - NAMED_TYPE@7040..7047
+                    - WHITESPACE@7040..7041 "\n"
+                    - NAME@7041..7047
+                        - IDENT@7041..7047 "String"
+            - R_CURLY@7047..7048 "}"
+            - WHITESPACE@7048..7050 "\n\n"
+    - OBJECT_TYPE_DEFINITION@7050..7399
+        - type_KW@7050..7054 "type"
+        - WHITESPACE@7054..7055 " "
+        - NAME@7055..7059
+            - IDENT@7055..7058 "Van"
+            - WHITESPACE@7058..7059 " "
+        - IMPLEMENTS_INTERFACES@7059..7078
+            - implements_KW@7059..7069 "implements"
+            - WHITESPACE@7069..7070 " "
+            - NAMED_TYPE@7070..7078
+                - NAME@7070..7078
+                    - IDENT@7070..7077 "Vehicle"
+                    - WHITESPACE@7077..7078 "\n"
+        - DIRECTIVES@7078..7185
+            - DIRECTIVE@7078..7107
+                - AT@7078..7079 "@"
+                - NAME@7079..7090
+                    - IDENT@7079..7090 "join__owner"
+                - ARGUMENTS@7090..7107
+                    - L_PAREN@7090..7091 "("
+                    - ARGUMENT@7091..7105
+                        - NAME@7091..7096
+                            - IDENT@7091..7096 "graph"
+                        - COLON@7096..7097 ":"
+                        - WHITESPACE@7097..7098 " "
+                        - ENUM_VALUE@7098..7105
+                            - NAME@7098..7105
+                                - IDENT@7098..7105 "PRODUCT"
+                    - R_PAREN@7105..7106 ")"
+                    - WHITESPACE@7106..7107 "\n"
+            - DIRECTIVE@7107..7146
+                - AT@7107..7108 "@"
+                - NAME@7108..7118
+                    - IDENT@7108..7118 "join__type"
+                - ARGUMENTS@7118..7146
+                    - L_PAREN@7118..7119 "("
+                    - ARGUMENT@7119..7135
+                        - NAME@7119..7124
+                            - IDENT@7119..7124 "graph"
+                        - COLON@7124..7125 ":"
+                        - WHITESPACE@7125..7126 " "
+                        - ENUM_VALUE@7126..7135
+                            - NAME@7126..7135
+                                - IDENT@7126..7133 "PRODUCT"
+                                - COMMA@7133..7134 ","
+                                - WHITESPACE@7134..7135 " "
+                    - ARGUMENT@7135..7144
+                        - NAME@7135..7138
+                            - IDENT@7135..7138 "key"
+                        - COLON@7138..7139 ":"
+                        - WHITESPACE@7139..7140 " "
+                        - STRING_VALUE@7140..7144
+                            - STRING@7140..7144 "\"id\""
+                    - R_PAREN@7144..7145 ")"
+                    - WHITESPACE@7145..7146 "\n"
+            - DIRECTIVE@7146..7185
+                - AT@7146..7147 "@"
+                - NAME@7147..7157
+                    - IDENT@7147..7157 "join__type"
+                - ARGUMENTS@7157..7185
+                    - L_PAREN@7157..7158 "("
+                    - ARGUMENT@7158..7174
+                        - NAME@7158..7163
+                            - IDENT@7158..7163 "graph"
+                        - COLON@7163..7164 ":"
+                        - WHITESPACE@7164..7165 " "
+                        - ENUM_VALUE@7165..7174
+                            - NAME@7165..7174
+                                - IDENT@7165..7172 "REVIEWS"
+                                - COMMA@7172..7173 ","
+                                - WHITESPACE@7173..7174 " "
+                    - ARGUMENT@7174..7183
+                        - NAME@7174..7177
+                            - IDENT@7174..7177 "key"
+                        - COLON@7177..7178 ":"
+                        - WHITESPACE@7178..7179 " "
+                        - STRING_VALUE@7179..7183
+                            - STRING@7179..7183 "\"id\""
+                    - R_PAREN@7183..7184 ")"
+                    - WHITESPACE@7184..7185 "\n"
+        - FIELDS_DEFINITION@7185..7399
+            - L_CURLY@7185..7186 "{"
+            - WHITESPACE@7186..7189 "\n  "
+            - FIELD_DEFINITION@7189..7232
+                - NAME@7189..7191
+                    - IDENT@7189..7191 "id"
+                - COLON@7191..7192 ":"
+                - WHITESPACE@7192..7193 " "
+                - NON_NULL_TYPE@7193..7201
+                    - WHITESPACE@7193..7194 " "
+                    - NAMED_TYPE@7194..7200
+                        - NAME@7194..7200
+                            - IDENT@7194..7200 "String"
+                    - BANG@7200..7201 "!"
+                - DIRECTIVES@7201..7232
+                    - DIRECTIVE@7201..7232
+                        - AT@7201..7202 "@"
+                        - NAME@7202..7213
+                            - IDENT@7202..7213 "join__field"
+                        - ARGUMENTS@7213..7232
+                            - L_PAREN@7213..7214 "("
+                            - ARGUMENT@7214..7228
+                                - NAME@7214..7219
+                                    - IDENT@7214..7219 "graph"
+                                - COLON@7219..7220 ":"
+                                - WHITESPACE@7220..7221 " "
+                                - ENUM_VALUE@7221..7228
+                                    - NAME@7221..7228
+                                        - IDENT@7221..7228 "PRODUCT"
+                            - R_PAREN@7228..7229 ")"
+                            - WHITESPACE@7229..7232 "\n  "
+            - FIELD_DEFINITION@7232..7283
+                - NAME@7232..7243
+                    - IDENT@7232..7243 "description"
                 - COLON@7243..7244 ":"
                 - WHITESPACE@7244..7245 " "
                 - NAMED_TYPE@7245..7252
@@ -4054,87 +4073,114 @@
                                         - IDENT@7272..7279 "PRODUCT"
                             - R_PAREN@7279..7280 ")"
                             - WHITESPACE@7280..7283 "\n  "
-            - FIELD_DEFINITION@7283..7351
-                - NAME@7283..7294
-                    - IDENT@7283..7294 "retailPrice"
-                - COLON@7294..7295 ":"
-                - WHITESPACE@7295..7296 " "
-                - NAMED_TYPE@7296..7303
-                    - WHITESPACE@7296..7297 " "
-                    - NAME@7297..7303
-                        - IDENT@7297..7303 "String"
-                - DIRECTIVES@7303..7351
-                    - DIRECTIVE@7303..7351
-                        - AT@7303..7304 "@"
-                        - NAME@7304..7315
-                            - IDENT@7304..7315 "join__field"
-                        - ARGUMENTS@7315..7351
-                            - L_PAREN@7315..7316 "("
-                            - ARGUMENT@7316..7332
-                                - NAME@7316..7321
-                                    - IDENT@7316..7321 "graph"
-                                - COLON@7321..7322 ":"
-                                - WHITESPACE@7322..7323 " "
-                                - ENUM_VALUE@7323..7332
-                                    - NAME@7323..7332
-                                        - IDENT@7323..7330 "REVIEWS"
-                                        - COMMA@7330..7331 ","
-                                        - WHITESPACE@7331..7332 " "
-                            - ARGUMENT@7332..7349
-                                - NAME@7332..7340
-                                    - IDENT@7332..7340 "requires"
-                                - COLON@7340..7341 ":"
-                                - WHITESPACE@7341..7342 " "
-                                - STRING_VALUE@7342..7349
-                                    - STRING@7342..7349 "\"price\""
-                            - R_PAREN@7349..7350 ")"
-                            - WHITESPACE@7350..7351 "\n"
-            - R_CURLY@7351..7352 "}"
-            - WHITESPACE@7352..7354 "\n\n"
-    - INTERFACE_TYPE_DEFINITION@7354..7448
-        - interface_KW@7354..7363 "interface"
-        - WHITESPACE@7363..7364 " "
-        - NAME@7364..7372
-            - IDENT@7364..7371 "Vehicle"
-            - WHITESPACE@7371..7372 " "
-        - FIELDS_DEFINITION@7372..7448
-            - L_CURLY@7372..7373 "{"
-            - WHITESPACE@7373..7376 "\n  "
-            - FIELD_DEFINITION@7376..7389
-                - NAME@7376..7378
-                    - IDENT@7376..7378 "id"
-                - COLON@7378..7379 ":"
-                - WHITESPACE@7379..7380 " "
-                - NON_NULL_TYPE@7380..7389
-                    - WHITESPACE@7380..7383 "\n  "
-                    - NAMED_TYPE@7383..7389
-                        - NAME@7383..7389
-                            - IDENT@7383..7389 "String"
-            - FIELD_DEFINITION@7389..7411
-                - NAME@7389..7400
-                    - IDENT@7389..7400 "description"
-                - COLON@7400..7401 ":"
-                - WHITESPACE@7401..7402 " "
-                - NAMED_TYPE@7402..7411
-                    - WHITESPACE@7402..7405 "\n  "
-                    - NAME@7405..7411
-                        - IDENT@7405..7411 "String"
-            - FIELD_DEFINITION@7411..7427
-                - NAME@7411..7416
-                    - IDENT@7411..7416 "price"
-                - COLON@7416..7417 ":"
-                - WHITESPACE@7417..7418 " "
-                - NAMED_TYPE@7418..7427
-                    - WHITESPACE@7418..7421 "\n  "
-                    - NAME@7421..7427
-                        - IDENT@7421..7427 "String"
-            - FIELD_DEFINITION@7427..7447
-                - NAME@7427..7438
-                    - IDENT@7427..7438 "retailPrice"
-                - COLON@7438..7439 ":"
-                - WHITESPACE@7439..7440 " "
-                - NAMED_TYPE@7440..7447
-                    - WHITESPACE@7440..7441 "\n"
-                    - NAME@7441..7447
-                        - IDENT@7441..7447 "String"
-            - R_CURLY@7447..7448 "}"
+            - FIELD_DEFINITION@7283..7328
+                - NAME@7283..7288
+                    - IDENT@7283..7288 "price"
+                - COLON@7288..7289 ":"
+                - WHITESPACE@7289..7290 " "
+                - NAMED_TYPE@7290..7297
+                    - WHITESPACE@7290..7291 " "
+                    - NAME@7291..7297
+                        - IDENT@7291..7297 "String"
+                - DIRECTIVES@7297..7328
+                    - DIRECTIVE@7297..7328
+                        - AT@7297..7298 "@"
+                        - NAME@7298..7309
+                            - IDENT@7298..7309 "join__field"
+                        - ARGUMENTS@7309..7328
+                            - L_PAREN@7309..7310 "("
+                            - ARGUMENT@7310..7324
+                                - NAME@7310..7315
+                                    - IDENT@7310..7315 "graph"
+                                - COLON@7315..7316 ":"
+                                - WHITESPACE@7316..7317 " "
+                                - ENUM_VALUE@7317..7324
+                                    - NAME@7317..7324
+                                        - IDENT@7317..7324 "PRODUCT"
+                            - R_PAREN@7324..7325 ")"
+                            - WHITESPACE@7325..7328 "\n  "
+            - FIELD_DEFINITION@7328..7396
+                - NAME@7328..7339
+                    - IDENT@7328..7339 "retailPrice"
+                - COLON@7339..7340 ":"
+                - WHITESPACE@7340..7341 " "
+                - NAMED_TYPE@7341..7348
+                    - WHITESPACE@7341..7342 " "
+                    - NAME@7342..7348
+                        - IDENT@7342..7348 "String"
+                - DIRECTIVES@7348..7396
+                    - DIRECTIVE@7348..7396
+                        - AT@7348..7349 "@"
+                        - NAME@7349..7360
+                            - IDENT@7349..7360 "join__field"
+                        - ARGUMENTS@7360..7396
+                            - L_PAREN@7360..7361 "("
+                            - ARGUMENT@7361..7377
+                                - NAME@7361..7366
+                                    - IDENT@7361..7366 "graph"
+                                - COLON@7366..7367 ":"
+                                - WHITESPACE@7367..7368 " "
+                                - ENUM_VALUE@7368..7377
+                                    - NAME@7368..7377
+                                        - IDENT@7368..7375 "REVIEWS"
+                                        - COMMA@7375..7376 ","
+                                        - WHITESPACE@7376..7377 " "
+                            - ARGUMENT@7377..7394
+                                - NAME@7377..7385
+                                    - IDENT@7377..7385 "requires"
+                                - COLON@7385..7386 ":"
+                                - WHITESPACE@7386..7387 " "
+                                - STRING_VALUE@7387..7394
+                                    - STRING@7387..7394 "\"price\""
+                            - R_PAREN@7394..7395 ")"
+                            - WHITESPACE@7395..7396 "\n"
+            - R_CURLY@7396..7397 "}"
+            - WHITESPACE@7397..7399 "\n\n"
+    - INTERFACE_TYPE_DEFINITION@7399..7494
+        - interface_KW@7399..7408 "interface"
+        - WHITESPACE@7408..7409 " "
+        - NAME@7409..7417
+            - IDENT@7409..7416 "Vehicle"
+            - WHITESPACE@7416..7417 " "
+        - FIELDS_DEFINITION@7417..7494
+            - L_CURLY@7417..7418 "{"
+            - WHITESPACE@7418..7421 "\n  "
+            - FIELD_DEFINITION@7421..7435
+                - NAME@7421..7423
+                    - IDENT@7421..7423 "id"
+                - COLON@7423..7424 ":"
+                - WHITESPACE@7424..7425 " "
+                - NON_NULL_TYPE@7425..7435
+                    - WHITESPACE@7425..7428 "\n  "
+                    - NAMED_TYPE@7428..7434
+                        - NAME@7428..7434
+                            - IDENT@7428..7434 "String"
+                    - BANG@7434..7435 "!"
+            - FIELD_DEFINITION@7435..7457
+                - NAME@7435..7446
+                    - IDENT@7435..7446 "description"
+                - COLON@7446..7447 ":"
+                - WHITESPACE@7447..7448 " "
+                - NAMED_TYPE@7448..7457
+                    - WHITESPACE@7448..7451 "\n  "
+                    - NAME@7451..7457
+                        - IDENT@7451..7457 "String"
+            - FIELD_DEFINITION@7457..7473
+                - NAME@7457..7462
+                    - IDENT@7457..7462 "price"
+                - COLON@7462..7463 ":"
+                - WHITESPACE@7463..7464 " "
+                - NAMED_TYPE@7464..7473
+                    - WHITESPACE@7464..7467 "\n  "
+                    - NAME@7467..7473
+                        - IDENT@7467..7473 "String"
+            - FIELD_DEFINITION@7473..7493
+                - NAME@7473..7484
+                    - IDENT@7473..7484 "retailPrice"
+                - COLON@7484..7485 ":"
+                - WHITESPACE@7485..7486 " "
+                - NAMED_TYPE@7486..7493
+                    - WHITESPACE@7486..7487 "\n"
+                    - NAME@7487..7493
+                        - IDENT@7487..7493 "String"
+            - R_CURLY@7493..7494 "}"

--- a/crates/apollo-parser/test_data/parser/ok/0037_operation_type_definition_with_inline_fragment.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0037_operation_type_definition_with_inline_fragment.txt
@@ -1,105 +1,107 @@
-- DOCUMENT@0..191
-    - OPERATION_DEFINITION@0..191
+- DOCUMENT@0..193
+    - OPERATION_DEFINITION@0..193
         - OPERATION_TYPE@0..6
             - query_KW@0..5 "query"
             - WHITESPACE@5..6 " "
         - NAME@6..15
             - IDENT@6..15 "SomeQuery"
-        - VARIABLE_DEFINITIONS@15..55
+        - VARIABLE_DEFINITIONS@15..57
             - L_PAREN@15..16 "("
             - WHITESPACE@16..19 "\n  "
-            - VARIABLE_DEFINITION@19..37
+            - VARIABLE_DEFINITION@19..38
                 - VARIABLE@19..26
                     - DOLLAR@19..20 "$"
                     - NAME@20..26
                         - IDENT@20..26 "param1"
                 - COLON@26..27 ":"
                 - WHITESPACE@27..28 " "
-                - NON_NULL_TYPE@28..37
+                - NON_NULL_TYPE@28..38
                     - WHITESPACE@28..31 "\n  "
                     - NAMED_TYPE@31..37
                         - NAME@31..37
                             - IDENT@31..37 "String"
-            - VARIABLE_DEFINITION@37..53
-                - VARIABLE@37..44
-                    - DOLLAR@37..38 "$"
-                    - NAME@38..44
-                        - IDENT@38..44 "param2"
-                - COLON@44..45 ":"
-                - WHITESPACE@45..46 " "
-                - NON_NULL_TYPE@46..53
-                    - WHITESPACE@46..47 "\n"
-                    - NAMED_TYPE@47..53
-                        - NAME@47..53
-                            - IDENT@47..53 "String"
-            - R_PAREN@53..54 ")"
-            - WHITESPACE@54..55 " "
-        - SELECTION_SET@55..191
-            - L_CURLY@55..56 "{"
-            - WHITESPACE@56..59 "\n  "
-            - FIELD@59..190
-                - NAME@59..64
-                    - IDENT@59..64 "item1"
-                - ARGUMENTS@64..110
-                    - L_PAREN@64..65 "("
-                    - WHITESPACE@65..70 "\n    "
-                    - ARGUMENT@70..90
-                        - NAME@70..76
-                            - IDENT@70..76 "param1"
-                        - COLON@76..77 ":"
-                        - WHITESPACE@77..78 " "
-                        - VARIABLE@78..90
-                            - DOLLAR@78..79 "$"
-                            - NAME@79..90
-                                - IDENT@79..85 "param1"
-                                - WHITESPACE@85..90 "\n    "
-                    - ARGUMENT@90..108
-                        - NAME@90..96
-                            - IDENT@90..96 "param2"
-                        - COLON@96..97 ":"
-                        - WHITESPACE@97..98 " "
-                        - VARIABLE@98..108
-                            - DOLLAR@98..99 "$"
-                            - NAME@99..108
-                                - IDENT@99..105 "param2"
-                                - WHITESPACE@105..108 "\n  "
-                    - R_PAREN@108..109 ")"
-                    - WHITESPACE@109..110 " "
-                - SELECTION_SET@110..190
-                    - L_CURLY@110..111 "{"
-                    - WHITESPACE@111..116 "\n    "
-                    - FIELD@116..123
-                        - NAME@116..123
-                            - IDENT@116..118 "id"
-                            - WHITESPACE@118..123 "\n    "
-                    - INLINE_FRAGMENT@123..188
-                        - SPREAD@123..126 "..."
-                        - WHITESPACE@126..127 " "
-                        - TYPE_CONDITION@127..140
-                            - on_KW@127..129 "on"
-                            - WHITESPACE@129..130 " "
-                            - NAMED_TYPE@130..140
-                                - NAME@130..140
-                                    - IDENT@130..139 "Fragment1"
-                                    - WHITESPACE@139..140 " "
-                        - SELECTION_SET@140..188
-                            - L_CURLY@140..141 "{"
-                            - WHITESPACE@141..148 "\n      "
-                            - FIELD@148..184
-                                - NAME@148..155
-                                    - IDENT@148..154 "field3"
-                                    - WHITESPACE@154..155 " "
-                                - SELECTION_SET@155..184
-                                    - L_CURLY@155..156 "{"
-                                    - WHITESPACE@156..165 "\n        "
-                                    - FIELD@165..178
-                                        - NAME@165..178
-                                            - IDENT@165..171 "field4"
-                                            - WHITESPACE@171..178 "\n      "
-                                    - R_CURLY@178..179 "}"
-                                    - WHITESPACE@179..184 "\n    "
-                            - R_CURLY@184..185 "}"
-                            - WHITESPACE@185..188 "\n  "
-                    - R_CURLY@188..189 "}"
-                    - WHITESPACE@189..190 "\n"
-            - R_CURLY@190..191 "}"
+                    - BANG@37..38 "!"
+            - VARIABLE_DEFINITION@38..55
+                - VARIABLE@38..45
+                    - DOLLAR@38..39 "$"
+                    - NAME@39..45
+                        - IDENT@39..45 "param2"
+                - COLON@45..46 ":"
+                - WHITESPACE@46..47 " "
+                - NON_NULL_TYPE@47..55
+                    - WHITESPACE@47..48 "\n"
+                    - NAMED_TYPE@48..54
+                        - NAME@48..54
+                            - IDENT@48..54 "String"
+                    - BANG@54..55 "!"
+            - R_PAREN@55..56 ")"
+            - WHITESPACE@56..57 " "
+        - SELECTION_SET@57..193
+            - L_CURLY@57..58 "{"
+            - WHITESPACE@58..61 "\n  "
+            - FIELD@61..192
+                - NAME@61..66
+                    - IDENT@61..66 "item1"
+                - ARGUMENTS@66..112
+                    - L_PAREN@66..67 "("
+                    - WHITESPACE@67..72 "\n    "
+                    - ARGUMENT@72..92
+                        - NAME@72..78
+                            - IDENT@72..78 "param1"
+                        - COLON@78..79 ":"
+                        - WHITESPACE@79..80 " "
+                        - VARIABLE@80..92
+                            - DOLLAR@80..81 "$"
+                            - NAME@81..92
+                                - IDENT@81..87 "param1"
+                                - WHITESPACE@87..92 "\n    "
+                    - ARGUMENT@92..110
+                        - NAME@92..98
+                            - IDENT@92..98 "param2"
+                        - COLON@98..99 ":"
+                        - WHITESPACE@99..100 " "
+                        - VARIABLE@100..110
+                            - DOLLAR@100..101 "$"
+                            - NAME@101..110
+                                - IDENT@101..107 "param2"
+                                - WHITESPACE@107..110 "\n  "
+                    - R_PAREN@110..111 ")"
+                    - WHITESPACE@111..112 " "
+                - SELECTION_SET@112..192
+                    - L_CURLY@112..113 "{"
+                    - WHITESPACE@113..118 "\n    "
+                    - FIELD@118..125
+                        - NAME@118..125
+                            - IDENT@118..120 "id"
+                            - WHITESPACE@120..125 "\n    "
+                    - INLINE_FRAGMENT@125..190
+                        - SPREAD@125..128 "..."
+                        - WHITESPACE@128..129 " "
+                        - TYPE_CONDITION@129..142
+                            - on_KW@129..131 "on"
+                            - WHITESPACE@131..132 " "
+                            - NAMED_TYPE@132..142
+                                - NAME@132..142
+                                    - IDENT@132..141 "Fragment1"
+                                    - WHITESPACE@141..142 " "
+                        - SELECTION_SET@142..190
+                            - L_CURLY@142..143 "{"
+                            - WHITESPACE@143..150 "\n      "
+                            - FIELD@150..186
+                                - NAME@150..157
+                                    - IDENT@150..156 "field3"
+                                    - WHITESPACE@156..157 " "
+                                - SELECTION_SET@157..186
+                                    - L_CURLY@157..158 "{"
+                                    - WHITESPACE@158..167 "\n        "
+                                    - FIELD@167..180
+                                        - NAME@167..180
+                                            - IDENT@167..173 "field4"
+                                            - WHITESPACE@173..180 "\n      "
+                                    - R_CURLY@180..181 "}"
+                                    - WHITESPACE@181..186 "\n    "
+                            - R_CURLY@186..187 "}"
+                            - WHITESPACE@187..190 "\n  "
+                    - R_CURLY@190..191 "}"
+                    - WHITESPACE@191..192 "\n"
+            - R_CURLY@192..193 "}"

--- a/crates/apollo-parser/test_data/parser/ok/0038_wrapped_named_types.graphql
+++ b/crates/apollo-parser/test_data/parser/ok/0038_wrapped_named_types.graphql
@@ -1,0 +1,7 @@
+type ObjectDef {
+    a: String
+    b: Int!
+    c: [Int!]!
+    d: [[[[[Int]]]]]
+    d: [[[[[Int!]!]!]!]!]!
+}

--- a/crates/apollo-parser/test_data/parser/ok/0038_wrapped_named_types.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0038_wrapped_named_types.txt
@@ -1,0 +1,107 @@
+- DOCUMENT@0..107
+    - OBJECT_TYPE_DEFINITION@0..107
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..5 " "
+        - NAME@5..15
+            - IDENT@5..14 "ObjectDef"
+            - WHITESPACE@14..15 " "
+        - FIELDS_DEFINITION@15..107
+            - L_CURLY@15..16 "{"
+            - WHITESPACE@16..21 "\n    "
+            - FIELD_DEFINITION@21..35
+                - NAME@21..22
+                    - IDENT@21..22 "a"
+                - COLON@22..23 ":"
+                - WHITESPACE@23..24 " "
+                - NAMED_TYPE@24..35
+                    - WHITESPACE@24..29 "\n    "
+                    - NAME@29..35
+                        - IDENT@29..35 "String"
+            - FIELD_DEFINITION@35..47
+                - NAME@35..36
+                    - IDENT@35..36 "b"
+                - COLON@36..37 ":"
+                - WHITESPACE@37..38 " "
+                - NON_NULL_TYPE@38..47
+                    - WHITESPACE@38..43 "\n    "
+                    - NAMED_TYPE@43..46
+                        - NAME@43..46
+                            - IDENT@43..46 "Int"
+                    - BANG@46..47 "!"
+            - FIELD_DEFINITION@47..62
+                - NAME@47..48
+                    - IDENT@47..48 "c"
+                - COLON@48..49 ":"
+                - WHITESPACE@49..50 " "
+                - NON_NULL_TYPE@50..62
+                    - WHITESPACE@50..55 "\n    "
+                    - LIST_TYPE@55..61
+                        - L_BRACK@55..56 "["
+                        - NON_NULL_TYPE@56..60
+                            - NAMED_TYPE@56..59
+                                - NAME@56..59
+                                    - IDENT@56..59 "Int"
+                            - BANG@59..60 "!"
+                        - R_BRACK@60..61 "]"
+                    - BANG@61..62 "!"
+            - FIELD_DEFINITION@62..83
+                - NAME@62..63
+                    - IDENT@62..63 "d"
+                - COLON@63..64 ":"
+                - WHITESPACE@64..65 " "
+                - LIST_TYPE@65..83
+                    - WHITESPACE@65..70 "\n    "
+                    - L_BRACK@70..71 "["
+                    - LIST_TYPE@71..82
+                        - L_BRACK@71..72 "["
+                        - LIST_TYPE@72..81
+                            - L_BRACK@72..73 "["
+                            - LIST_TYPE@73..80
+                                - L_BRACK@73..74 "["
+                                - LIST_TYPE@74..79
+                                    - L_BRACK@74..75 "["
+                                    - NAMED_TYPE@75..78
+                                        - NAME@75..78
+                                            - IDENT@75..78 "Int"
+                                    - R_BRACK@78..79 "]"
+                                - R_BRACK@79..80 "]"
+                            - R_BRACK@80..81 "]"
+                        - R_BRACK@81..82 "]"
+                    - R_BRACK@82..83 "]"
+            - FIELD_DEFINITION@83..106
+                - NAME@83..84
+                    - IDENT@83..84 "d"
+                - COLON@84..85 ":"
+                - WHITESPACE@85..86 " "
+                - NON_NULL_TYPE@86..106
+                    - WHITESPACE@86..87 "\n"
+                    - LIST_TYPE@87..105
+                        - L_BRACK@87..88 "["
+                        - NON_NULL_TYPE@88..104
+                            - LIST_TYPE@88..103
+                                - L_BRACK@88..89 "["
+                                - NON_NULL_TYPE@89..102
+                                    - LIST_TYPE@89..101
+                                        - L_BRACK@89..90 "["
+                                        - NON_NULL_TYPE@90..100
+                                            - LIST_TYPE@90..99
+                                                - L_BRACK@90..91 "["
+                                                - NON_NULL_TYPE@91..98
+                                                    - LIST_TYPE@91..97
+                                                        - L_BRACK@91..92 "["
+                                                        - NON_NULL_TYPE@92..96
+                                                            - NAMED_TYPE@92..95
+                                                                - NAME@92..95
+                                                                    - IDENT@92..95 "Int"
+                                                            - BANG@95..96 "!"
+                                                        - R_BRACK@96..97 "]"
+                                                    - BANG@97..98 "!"
+                                                - R_BRACK@98..99 "]"
+                                            - BANG@99..100 "!"
+                                        - R_BRACK@100..101 "]"
+                                    - BANG@101..102 "!"
+                                - R_BRACK@102..103 "]"
+                            - BANG@103..104 "!"
+                        - R_BRACK@104..105 "]"
+                    - BANG@105..106 "!"
+            - R_CURLY@106..107 "}"


### PR DESCRIPTION
We are missing BANG token in the AST when a NON_NULL_TYPE gets created. Although the node created is indeed NON_NULL_TYPE, it's also important to keep the original set of tokens. The NON_NULL_TYPE after this commit looks like this:

```txt
- NON_NULL_TYPE@38..47
    - WHITESPACE@38..43 "\n    "
    - NAMED_TYPE@43..46
        - NAME@43..46
            - IDENT@43..46 "Int"
    - BANG@46..47 "!"
```

fixes #142