### PR TITLE
Simplify fuzzing targets

### DIFF
--- a/fuzz/fuzz_targets/lexer.rs
+++ b/fuzz/fuzz_targets/lexer.rs
@@ -2,11 +2,6 @@
 use apollo_parser::Parser;
 use libfuzzer_sys::fuzz_target;
 
-fuzz_target!(|data: &[u8]| {
-    let s = match std::str::from_utf8(data) {
-        Err(_) => return,
-        Ok(s) => s,
-    };
-
-    let _parser = Parser::new(s);
+fuzz_target!(|data: &str| {
+    let _parser = Parser::new(data);
 });

--- a/fuzz/fuzz_targets/parser.rs
+++ b/fuzz/fuzz_targets/parser.rs
@@ -3,13 +3,8 @@ use apollo_parser::Parser;
 use libfuzzer_sys::fuzz_target;
 use std::panic;
 
-fuzz_target!(|data: &[u8]| {
-    let s = match std::str::from_utf8(data) {
-        Err(_) => return,
-        Ok(s) => s,
-    };
-
-    let parser = panic::catch_unwind(|| Parser::new(s));
+fuzz_target!(|data: &str| {
+    let parser = panic::catch_unwind(|| Parser::new(data));
 
     let parser = match parser {
         Err(_) => return,


### PR DESCRIPTION
By passing &str, rather than [u8], the output is also nicer (i.e.
```bash
Output of  `std::fmt::Debug`:

        "\u{0}\u{0}\"\"\u{5}{ca*a,r#")
```