### PR TITLE
Replace `p.err` with `p.err_and_pop` to prevent infinite loop.

### DIFF
--- a/crates/apollo-parser/src/parser/grammar/operation.rs
+++ b/crates/apollo-parser/src/parser/grammar/operation.rs
@@ -65,7 +65,7 @@ pub(crate) fn operation_definition(p: &mut Parser) {
             }
         }
         Some(T!['{']) => selection::selection_set(p),
-        _ => p.err("expected an Operation Type or a Selection Set"),
+        _ => p.err_and_pop("expected an Operation Type or a Selection Set"),
     }
 }
 
@@ -82,5 +82,17 @@ pub(crate) fn operation_type(p: &mut Parser) {
             "mutation" => p.bump(SyntaxKind::mutation_KW),
             _ => p.err("expected either a 'mutation', a 'query', or a 'subscription'"),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Parser;
+
+    #[test]
+    fn pop_when_peek_errored() {
+        let input = "\"s\"{";
+        let parser = Parser::new(input);
+        let _ = parser.parse();
     }
 }


### PR DESCRIPTION
`operation_definition` is called in a loop where the we never progress
in which tokens we're looking at.
Pop while reporting the error such that progress can be made.