### PR TITLE
apollo-parser: update operation definition tests for #158

### DIFF
--- a/crates/apollo-parser/src/parser/grammar/operation.rs
+++ b/crates/apollo-parser/src/parser/grammar/operation.rs
@@ -42,10 +42,10 @@ pub(crate) fn root_operation_type_definition(p: &mut Parser, is_operation_type: 
 ///    SelectionSet
 
 pub(crate) fn operation_definition(p: &mut Parser) {
-    let _g = p.start_node(SyntaxKind::OPERATION_DEFINITION);
-
     match p.peek() {
         Some(TokenKind::Name) => {
+            let _g = p.start_node(SyntaxKind::OPERATION_DEFINITION);
+
             operation_type(p);
 
             if let Some(TokenKind::Name) = p.peek() {
@@ -64,7 +64,11 @@ pub(crate) fn operation_definition(p: &mut Parser) {
                 selection::selection_set(p)
             }
         }
-        Some(T!['{']) => selection::selection_set(p),
+        Some(T!['{']) => {
+            let _g = p.start_node(SyntaxKind::OPERATION_DEFINITION);
+
+            selection::selection_set(p)
+        }
         _ => p.err_and_pop("expected an Operation Type or a Selection Set"),
     }
 }
@@ -89,10 +93,15 @@ pub(crate) fn operation_type(p: &mut Parser) {
 mod test {
     use crate::Parser;
 
+    // NOTE @lrlna: related PR to the spec to avoid this issue:
+    // https://github.com/graphql/graphql-spec/pull/892
     #[test]
-    fn pop_when_peek_errored() {
-        let input = "\"s\"{";
+    fn it_continues_parsing_when_operation_definition_starts_with_description() {
+        let input = "\"description\"{}";
         let parser = Parser::new(input);
-        let _ = parser.parse();
+        let ast = parser.parse();
+
+        assert_eq!(ast.errors().len(), 2);
+        assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }
 }

--- a/crates/apollo-parser/test_data/parser/err/0030_operation_definition_with_description.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0030_operation_definition_with_description.graphql
@@ -1,0 +1,2 @@
+"after this PR this should not be an issue: https://github.com/graphql/graphql-spec/pull/892"
+query empty {}

--- a/crates/apollo-parser/test_data/parser/err/0030_operation_definition_with_description.txt
+++ b/crates/apollo-parser/test_data/parser/err/0030_operation_definition_with_description.txt
@@ -1,0 +1,14 @@
+- DOCUMENT@0..15
+    - WHITESPACE@0..1 "\n"
+    - OPERATION_DEFINITION@1..15
+        - OPERATION_TYPE@1..7
+            - query_KW@1..6 "query"
+            - WHITESPACE@6..7 " "
+        - NAME@7..13
+            - IDENT@7..12 "empty"
+            - WHITESPACE@12..13 " "
+        - SELECTION_SET@13..15
+            - L_CURLY@13..14 "{"
+            - R_CURLY@14..15 "}"
+- ERROR@0:93 "expected an Operation Type or a Selection Set" "after this PR this should not be an issue: https://github.com/graphql/graphql-spec/pull/892"
+- ERROR@107:108 "exepcted at least one Selection in Selection Set" }


### PR DESCRIPTION
Avoids creating an operation definition node when an unrelated token is popped off in the parsing of operation definition nodes.

Instead of having an incorrect AST for input `"description"{}`
```
- DOCUMENT@0..2
    - OPERATION_DEFINITION@0..0
    - OPERATION_DEFINITION@0..2
        - SELECTION_SET@0..2
            - L_CURLY@0..1 "{"
            - R_CURLY@1..2 "}"
```

We are now correctly creating an AST that looks like this:
```
- DOCUMENT@0..2
    - OPERATION_DEFINITION@0..2
        - SELECTION_SET@0..2
            - L_CURLY@0..1 "{"
            - R_CURLY@1..2 "}"
```

Additionally, we are adding an correctly testing for number of errors and definitions in the AST when a description precedes an Operation Definition. We are also adding an error test case to the test suite with a description before an operation definition.