### PR TITLE
fix(apollo-encoder): do not trim double quotes when needed, rename method input_object_ and type InputValueDef for consistency

### DIFF
--- a/crates/apollo-encoder/CHANGELOG.md
+++ b/crates/apollo-encoder/CHANGELOG.md
@@ -17,6 +17,40 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 ## Documentation -->
+
+# [0.2.2] (unreleased)
+## Fixes
+- **Remove leading and ending `"` in `BlockStringCharacter` encoding only when it starts and end with a `"` - [bnjjj], [pull/182]**
+  This ensures that a StringValue of type BlockStringCharacter, like the one in
+  the test example below, does not getting encoded with an additional `"` ending
+  up with `""""` leading set of characters.
+
+  ```rust
+  let desc = StringValue::Reason {
+            source: Some("One of my cat is called:\r \"Mozart\"".to_string()),
+        };
+
+        assert_eq!(
+            desc.to_string(),
+            String::from("\n  \"\"\"\n  One of my cat is called:\r \"Mozart\"\n  \"\"\"\n  ")
+        );
+    );
+  ```
+
+  [bnjjj]: https://github.com/bnjjj
+  [pull/168]: https://github.com/apollographql/apollo-rs/pull/182
+
+## BREAKING
+- **Rename `InputValueDef` into `InputValueDefinition` for consistency - [bnjjj], [pull/182]**
+
+  [bnjjj]: https://github.com/bnjjj
+  [pull/168]: https://github.com/apollographql/apollo-rs/pull/182
+
+- **Rename `input_object_` method into `input_object` on `Document` - [bnjjj], [pull/182]**
+
+  [bnjjj]: https://github.com/bnjjj
+  [pull/168]: https://github.com/apollographql/apollo-rs/pull/182
+
 # [0.2.1](https://crates.io/crates/apollo-encoder/0.2.1) - 2021-02-17
 ## Fixes
 

--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-encoder"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Irina Shestak <shestak.irina@gmail.com>",
     "Benjamin Coenen <benjamin.coenen@apollographql.com>",

--- a/crates/apollo-encoder/src/argument.rs
+++ b/crates/apollo-encoder/src/argument.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{InputValueDef, Value};
+use crate::{InputValueDefinition, Value};
 
 /// The `ArgumentsDefinition` type represents an arguments definition
 ///
@@ -11,17 +11,17 @@ use crate::{InputValueDef, Value};
 ///
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{ArgumentsDefinition, InputValueDef, Type_};
+/// use apollo_encoder::{ArgumentsDefinition, InputValueDefinition, Type_};
 /// use indoc::indoc;
 ///
 /// let input_value_defs = vec![
-///     InputValueDef::new(
+///     InputValueDefinition::new(
 ///         String::from("first"),
 ///         Type_::NamedType {
 ///             name: String::from("Int"),
 ///         },
 ///     ),
-///     InputValueDef::new(
+///     InputValueDefinition::new(
 ///         String::from("second"),
 ///         Type_::List {
 ///             ty: Box::new(Type_::NamedType {
@@ -36,12 +36,12 @@ use crate::{InputValueDef, Value};
 /// ```
 #[derive(Debug)]
 pub struct ArgumentsDefinition {
-    input_value_definitions: Vec<InputValueDef>,
+    input_value_definitions: Vec<InputValueDefinition>,
 }
 
 impl ArgumentsDefinition {
     /// Create a new instance of Argument definition.
-    pub fn new(input_value_definitions: Vec<InputValueDef>) -> Self {
+    pub fn new(input_value_definitions: Vec<InputValueDefinition>) -> Self {
         Self {
             input_value_definitions,
         }
@@ -115,13 +115,13 @@ mod tests {
     #[test]
     fn it_encodes_arguments_definitions() {
         let input_value_defs = vec![
-            InputValueDef::new(
+            InputValueDefinition::new(
                 String::from("first"),
                 Type_::NamedType {
                     name: String::from("Int"),
                 },
             ),
-            InputValueDef::new(
+            InputValueDefinition::new(
                 String::from("second"),
                 Type_::List {
                     ty: Box::new(Type_::NamedType {

--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{InputValueDef, StringValue};
+use crate::{InputValueDefinition, StringValue};
 
 /// The `DirectiveDefinition` type represents a Directive definition.
 ///
@@ -38,7 +38,7 @@ pub struct DirectiveDefinition {
     description: StringValue,
     // Args returns a Vector of __InputValue representing the arguments this
     // directive accepts.
-    args: Vec<InputValueDef>,
+    args: Vec<InputValueDefinition>,
     // Locations returns a List of __DirectiveLocation representing the valid
     // locations this directive may be placed.
     locations: Vec<String>,
@@ -71,7 +71,7 @@ impl DirectiveDefinition {
     }
 
     /// Set the Directive's args.
-    pub fn arg(&mut self, arg: InputValueDef) {
+    pub fn arg(&mut self, arg: InputValueDefinition) {
         self.args.push(arg);
     }
 
@@ -162,7 +162,7 @@ directive @infer on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
         };
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let arg = InputValueDef::new("cat".to_string(), ty_2);
+        let arg = InputValueDefinition::new("cat".to_string(), ty_2);
         directive.arg(arg);
 
         assert_eq!(

--- a/crates/apollo-encoder/src/document.rs
+++ b/crates/apollo-encoder/src/document.rs
@@ -132,7 +132,7 @@ impl Document {
     }
 
     /// Add input_object
-    pub fn input_object_(&mut self, input_object_type_definition: InputObjectDefinition) {
+    pub fn input_object(&mut self, input_object_type_definition: InputObjectDefinition) {
         self.input_object_type_definitions
             .push(input_object_type_definition);
     }

--- a/crates/apollo-encoder/src/field.rs
+++ b/crates/apollo-encoder/src/field.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{Argument, Directive, InputValueDef, SelectionSet, StringValue, Type_};
+use crate::{Argument, Directive, InputValueDefinition, SelectionSet, StringValue, Type_};
 /// The FieldDefinition type represents each field definition in an Object
 /// definition or Interface type definition.
 ///
@@ -11,7 +11,7 @@ use crate::{Argument, Directive, InputValueDef, SelectionSet, StringValue, Type_
 ///
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{Type_, FieldDefinition, InputValueDef};
+/// use apollo_encoder::{Type_, FieldDefinition, InputValueDefinition};
 ///
 /// let ty_1 = Type_::NamedType {
 ///     name: "CatBreed".to_string(),
@@ -23,7 +23,7 @@ use crate::{Argument, Directive, InputValueDef, SelectionSet, StringValue, Type_
 ///     name: "CatBreed".to_string(),
 /// };
 ///
-/// let arg = InputValueDef::new("breed".to_string(), value_1);
+/// let arg = InputValueDefinition::new("breed".to_string(), value_1);
 ///
 /// field.arg(arg);
 ///
@@ -39,7 +39,7 @@ pub struct FieldDefinition {
     // Description may return a String.
     description: StringValue,
     // Args returns a List of __InputValue representing the arguments this field accepts.
-    args: Vec<InputValueDef>,
+    args: Vec<InputValueDefinition>,
     // Type must return a __Type that represents the type of value returned by this field.
     type_: Type_,
     /// Contains all directives.
@@ -66,7 +66,7 @@ impl FieldDefinition {
     }
 
     /// Set the Field's arguments.
-    pub fn arg(&mut self, arg: InputValueDef) {
+    pub fn arg(&mut self, arg: InputValueDefinition) {
         self.args.push(arg);
     }
 
@@ -306,7 +306,7 @@ mod tests {
         let value_2 = Type_::List {
             ty: Box::new(value_1),
         };
-        let mut arg = InputValueDef::new("cat".to_string(), value_2);
+        let mut arg = InputValueDefinition::new("cat".to_string(), value_2);
         let mut deprecated_directive = Directive::new(String::from("deprecated"));
         deprecated_directive.arg(Argument::new(
             String::from("reason"),

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -11,14 +11,14 @@ use crate::{Directive, StringValue, Type_};
 ///
 /// ### Example
 /// ```rust
-/// use apollo_encoder::{Type_, InputValueDef};
+/// use apollo_encoder::{Type_, InputValueDefinition};
 ///
 /// let ty_1 = Type_::NamedType {
 ///     name: "SpaceProgram".to_string(),
 /// };
 ///
 /// let ty_2 = Type_::List { ty: Box::new(ty_1) };
-/// let mut value = InputValueDef::new("cat".to_string(), ty_2);
+/// let mut value = InputValueDefinition::new("cat".to_string(), ty_2);
 /// value.description(Some("Very good cats".to_string()));
 ///
 /// assert_eq!(
@@ -27,7 +27,7 @@ use crate::{Directive, StringValue, Type_};
 /// );
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct InputValueDef {
+pub struct InputValueDefinition {
     // Name must return a String.
     name: String,
     // Description may return a String.
@@ -43,7 +43,7 @@ pub struct InputValueDef {
     directives: Vec<Directive>,
 }
 
-impl InputValueDef {
+impl InputValueDefinition {
     /// Create a new instance of InputValueDef.
     pub fn new(name: String, type_: Type_) -> Self {
         Self {
@@ -73,7 +73,7 @@ impl InputValueDef {
     }
 }
 
-impl fmt::Display for InputValueDef {
+impl fmt::Display for InputValueDefinition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description)?;
 
@@ -106,7 +106,7 @@ mod tests {
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
         let ty_3 = Type_::NonNull { ty: Box::new(ty_2) };
-        let value = InputValueDef::new("spaceCat".to_string(), ty_3);
+        let value = InputValueDefinition::new("spaceCat".to_string(), ty_3);
 
         assert_eq!(value.to_string(), r#"spaceCat: [SpaceProgram]!"#);
     }
@@ -118,7 +118,7 @@ mod tests {
         };
 
         let ty_2 = Type_::NonNull { ty: Box::new(ty_1) };
-        let mut value = InputValueDef::new("spaceCat".to_string(), ty_2);
+        let mut value = InputValueDefinition::new("spaceCat".to_string(), ty_2);
         value.default(Some("\"Norwegian Forest\"".to_string()));
 
         assert_eq!(
@@ -134,7 +134,7 @@ mod tests {
         };
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
-        let mut value = InputValueDef::new("cat".to_string(), ty_2);
+        let mut value = InputValueDefinition::new("cat".to_string(), ty_2);
         let mut directive = Directive::new(String::from("testDirective"));
         directive.arg(Argument::new(String::from("first"), Value::Int(1)));
         value.description(Some("Very good cats".to_string()));
@@ -155,7 +155,7 @@ mod tests {
         let ty_2 = Type_::NonNull { ty: Box::new(ty_1) };
         let ty_3 = Type_::List { ty: Box::new(ty_2) };
         let ty_4 = Type_::NonNull { ty: Box::new(ty_3) };
-        let mut value = InputValueDef::new("spaceCat".to_string(), ty_4);
+        let mut value = InputValueDefinition::new("spaceCat".to_string(), ty_4);
         value.description(Some("Very good space cats".to_string()));
 
         assert_eq!(

--- a/crates/apollo-encoder/src/lib.rs
+++ b/crates/apollo-encoder/src/lib.rs
@@ -38,7 +38,7 @@ pub use field_value::Type_;
 pub use fragment::{FragmentDefinition, FragmentSpread, InlineFragment, TypeCondition};
 pub use input_field::InputField;
 pub use input_object_def::InputObjectDefinition;
-pub use input_value::InputValueDef;
+pub use input_value::InputValueDefinition;
 pub use interface_def::InterfaceDefinition;
 pub use object_def::ObjectDefinition;
 pub use operation::{OperationDefinition, OperationType};

--- a/crates/apollo-parser/examples/unused_vars.rs
+++ b/crates/apollo-parser/examples/unused_vars.rs
@@ -23,8 +23,7 @@ fn are_variables_unused() {
             // We grab all the variables defined in the mutation
             let variables: Vec<String> = variable_defs
                 .iter()
-                .map(|v| v.variable_definitions())
-                .flatten()
+                .flat_map(|v| v.variable_definitions())
                 .filter_map(|v| Some(v.variable()?.text().to_string()))
                 .collect();
 
@@ -49,8 +48,7 @@ fn get_variables_from_selection(
                 let arguments = field.arguments();
                 let mut vars: Vec<String> = arguments
                     .iter()
-                    .map(|a| a.arguments())
-                    .flatten()
+                    .flat_map(|a| a.arguments())
                     .filter_map(|v| {
                         if let ast::Value::Variable(var) = v.value()? {
                             return Some(var.text().to_string());

--- a/crates/apollo-parser/src/parser/grammar/selection.rs
+++ b/crates/apollo-parser/src/parser/grammar/selection.rs
@@ -154,8 +154,7 @@ query GraphQuery($graph_id: ID!, $variant: String) {
                 let variable_defs = op_def.variable_definitions();
                 let variables: Vec<TokenText> = variable_defs
                     .iter()
-                    .map(|v| v.variable_definitions())
-                    .flatten()
+                    .flat_map(|v| v.variable_definitions())
                     .filter_map(|v| Some(v.variable()?.name()?.text()))
                     .collect();
 
@@ -177,8 +176,7 @@ query GraphQuery($graph_id: ID!, $variant: String) {
                         let arguments = field.arguments();
                         let mut vars: Vec<TokenText> = arguments
                             .iter()
-                            .map(|a| a.arguments())
-                            .flatten()
+                            .flat_map(|a| a.arguments())
                             .filter_map(|v| {
                                 if let ast::Value::Variable(var) = v.value()? {
                                     return Some(var.name()?.text());

--- a/crates/apollo-parser/src/parser/grammar/value.rs
+++ b/crates/apollo-parser/src/parser/grammar/value.rs
@@ -284,8 +284,7 @@ query GraphQuery($graph_id: ID!, $variant: String) {
                 let variable_defs = op_def.variable_definitions();
                 let variables: Vec<String> = variable_defs
                     .iter()
-                    .map(|v| v.variable_definitions())
-                    .flatten()
+                    .flat_map(|v| v.variable_definitions())
                     .filter_map(|v| Some(v.variable()?.text().to_string()))
                     .collect();
                 assert_eq!(

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -87,7 +87,7 @@ impl Parser {
         let mut tokens = Vec::new();
         let mut errors = Vec::new();
 
-        for s in lexer.tokens().to_owned() {
+        for s in lexer.tokens().iter().cloned() {
             tokens.push(s);
         }
 

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -24,6 +24,6 @@ categories = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-apollo-encoder = { path = "../apollo-encoder", version = "0.2.1" }
+apollo-encoder = { path = "../apollo-encoder", version = "0.2.2" }
 arbitrary = { version = "1.0.3", features = ["derive"] }
 once_cell = "1.9.0"

--- a/crates/apollo-smith/src/document.rs
+++ b/crates/apollo-smith/src/document.rs
@@ -55,7 +55,7 @@ impl From<Document> for apollo_encoder::Document {
             .for_each(|union_type_def| new_doc.union(union_type_def.into()));
         doc.input_object_type_definitions
             .into_iter()
-            .for_each(|input_object_type_def| new_doc.input_object_(input_object_type_def.into()));
+            .for_each(|input_object_type_def| new_doc.input_object(input_object_type_def.into()));
         doc.interface_type_definitions
             .into_iter()
             .for_each(|interface_type_def| new_doc.interface(interface_type_def.into()));

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -76,7 +76,7 @@ pub struct InputValueDef {
     pub(crate) directives: Vec<Directive>,
 }
 
-impl From<InputValueDef> for apollo_encoder::InputValueDef {
+impl From<InputValueDef> for apollo_encoder::InputValueDefinition {
     fn from(input_val: InputValueDef) -> Self {
         let mut new_input_val = Self::new(input_val.name.into(), input_val.ty.into());
         new_input_val.description(input_val.description.map(String::from));


### PR DESCRIPTION
Bugs detected when implementing the new version of apollo encoder into Rover (https://github.com/apollographql/rover/pull/1017)