### PR TITLE
apollo-smith: generate semantically valid GraphQL document

### DIFF
--- a/crates/apollo-encoder/src/field.rs
+++ b/crates/apollo-encoder/src/field.rs
@@ -165,7 +165,10 @@ impl Field {
     /// Should be used everywhere in this crate instead of the Display implementation
     /// Display implementation is only useful as a public api
     pub(crate) fn format_with_indent(&self, indent_level: usize) -> String {
-        let mut text = String::from(&self.name);
+        let mut text = match &self.alias {
+            Some(alias) => format!("{alias}: {}", self.name),
+            None => String::from(&self.name),
+        };
 
         if !self.args.is_empty() {
             for (i, arg) in self.args.iter().enumerate() {

--- a/crates/apollo-encoder/src/value.rs
+++ b/crates/apollo-encoder/src/value.rs
@@ -12,7 +12,7 @@ pub enum Value {
     /// Name of a variable example: `varName`
     Variable(String),
     /// Int value example: `7`
-    Int(i64),
+    Int(i32),
     /// Float value example: `25.4`
     Float(f64),
     /// String value example: `"My string"`
@@ -82,16 +82,16 @@ macro_rules! to_number_value {
 
 // Numbers
 to_number_value!(
-    {i64, i64, Int},
-    {i32, i64, Int},
-    {i16, i64, Int},
-    {i8, i64, Int},
-    {isize, i64, Int},
-    {u64, i64, Int},
-    {u32, i64, Int},
-    {u16, i64, Int},
-    {u8, i64, Int},
-    {usize, i64, Int},
+    {i64, i32, Int},
+    {i32, i32, Int},
+    {i16, i32, Int},
+    {i8, i32, Int},
+    {isize, i32, Int},
+    {u64, i32, Int},
+    {u32, i32, Int},
+    {u16, i32, Int},
+    {u8, i32, Int},
+    {usize, i32, Int},
     {f64, f64, Float},
     {f32, f64, Float}
 );

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -42,6 +42,13 @@ impl Into<i64> for ast::IntValue {
     }
 }
 
+impl Into<i32> for ast::IntValue {
+    fn into(self) -> i32 {
+        let text = text_of_first_token(self.syntax());
+        text.parse().expect("Cannot parse IntValue")
+    }
+}
+
 impl Into<f64> for ast::FloatValue {
     fn into(self) -> f64 {
         let text = text_of_first_token(self.syntax());

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -26,6 +26,52 @@ impl ast::EnumValue {
     }
 }
 
+impl ast::DirectiveLocation {
+    pub fn token_string(self) -> Option<&'static str> {
+        if self.query_token().is_some() {
+            Some("QUERY")
+        } else if self.mutation_token().is_some() {
+            Some("MUTATION")
+        } else if self.subscription_token().is_some() {
+            Some("SUBSCRIPTION")
+        } else if self.field_token().is_some() {
+            Some("FIELD")
+        } else if self.fragment_definition_token().is_some() {
+            Some("FRAGMENT_DEFINITION")
+        } else if self.fragment_spread_token().is_some() {
+            Some("FRAGMENT_SPREAD")
+        } else if self.inline_fragment_token().is_some() {
+            Some("INLINE_FRAGMENT")
+        } else if self.variable_definition_token().is_some() {
+            Some("VARIABLE_DEFINITION")
+        } else if self.schema_token().is_some() {
+            Some("SCHEMA")
+        } else if self.scalar_token().is_some() {
+            Some("SCALAR")
+        } else if self.object_token().is_some() {
+            Some("OBJECT")
+        } else if self.field_definition_token().is_some() {
+            Some("FIELD_DEFINITION")
+        } else if self.argument_definition_token().is_some() {
+            Some("ARGUMENT_DEFINITION")
+        } else if self.interface_token().is_some() {
+            Some("INTERFACE")
+        } else if self.union_token().is_some() {
+            Some("UNION")
+        } else if self.enum_token().is_some() {
+            Some("ENUM")
+        } else if self.enum_value_token().is_some() {
+            Some("ENUM_VALUE")
+        } else if self.input_object_token().is_some() {
+            Some("INPUT_OBJECT")
+        } else if self.input_field_definition_token().is_some() {
+            Some("INPUT_FIELD_DEFINITION")
+        } else {
+            None
+        }
+    }
+}
+
 impl Into<String> for ast::StringValue {
     fn into(self) -> String {
         let text = text_of_first_token(self.syntax());

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -25,6 +25,9 @@ categories = [
 
 [dependencies]
 apollo-encoder = { path = "../apollo-encoder", version = "0.2.2" }
-apollo-parser = { path = "../apollo-parser", version = "0.2.4" }
+apollo-parser = { path = "../apollo-parser", version = "0.2.4", optional = true }
 arbitrary = { version = "1.0.3", features = ["derive"] }
 once_cell = "1.9.0"
+
+[features]
+parser-impl = ["apollo-parser"]

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -25,5 +25,6 @@ categories = [
 
 [dependencies]
 apollo-encoder = { path = "../apollo-encoder", version = "0.2.2" }
+apollo-parser = { path = "../apollo-parser", version = "0.2.3" }
 arbitrary = { version = "1.0.3", features = ["derive"] }
 once_cell = "1.9.0"

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -25,6 +25,6 @@ categories = [
 
 [dependencies]
 apollo-encoder = { path = "../apollo-encoder", version = "0.2.2" }
-apollo-parser = { path = "../apollo-parser", version = "0.2.3" }
+apollo-parser = { path = "../apollo-parser", version = "0.2.4" }
 arbitrary = { version = "1.0.3", features = ["derive"] }
 once_cell = "1.9.0"

--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -30,6 +30,17 @@ impl From<ArgumentsDef> for apollo_encoder::ArgumentsDefinition {
     }
 }
 
+impl From<apollo_parser::ast::ArgumentsDefinition> for ArgumentsDef {
+    fn from(args_def: apollo_parser::ast::ArgumentsDefinition) -> Self {
+        Self {
+            input_value_definitions: args_def
+                .input_value_definitions()
+                .map(InputValueDef::from)
+                .collect(),
+        }
+    }
+}
+
 /// The `__Argument` type represents an argument
 ///
 /// *Argument*:
@@ -59,9 +70,28 @@ impl<'a> DocumentBuilder<'a> {
         Ok(arguments)
     }
 
+    /// Create an arbitrary vector of `Argument` given ArgumentsDef
+    pub fn arguments_with_def(&mut self, args_def: &ArgumentsDef) -> Result<Vec<Argument>> {
+        let arguments = args_def
+            .input_value_definitions
+            .iter()
+            .map(|input_val_def| self.argument_with_def(input_val_def))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(arguments)
+    }
+
     /// Create an arbitrary `Argument`
     pub fn argument(&mut self) -> Result<Argument> {
         let name = self.name()?;
+        let value = self.input_value()?;
+
+        Ok(Argument { name, value })
+    }
+
+    /// Create an arbitrary `Argument`
+    pub fn argument_with_def(&mut self, input_val_def: &InputValueDef) -> Result<Argument> {
+        let name = input_val_def.name.clone();
         let value = self.input_value()?;
 
         Ok(Argument { name, value })

--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -30,6 +30,7 @@ impl From<ArgumentsDef> for apollo_encoder::ArgumentsDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::ArgumentsDefinition> for ArgumentsDef {
     fn from(args_def: apollo_parser::ast::ArgumentsDefinition) -> Self {
         Self {
@@ -59,6 +60,7 @@ impl From<Argument> for apollo_encoder::Argument {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::Argument> for Argument {
     fn from(argument: apollo_parser::ast::Argument) -> Self {
         Self {

--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -92,7 +92,7 @@ impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `Argument`
     pub fn argument_with_def(&mut self, input_val_def: &InputValueDef) -> Result<Argument> {
         let name = input_val_def.name.clone();
-        let value = self.input_value()?;
+        let value = self.input_value_for_type(&input_val_def.ty)?;
 
         Ok(Argument { name, value })
     }

--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -59,6 +59,15 @@ impl From<Argument> for apollo_encoder::Argument {
     }
 }
 
+impl From<apollo_parser::ast::Argument> for Argument {
+    fn from(argument: apollo_parser::ast::Argument) -> Self {
+        Self {
+            name: argument.name().unwrap().into(),
+            value: argument.value().unwrap().into(),
+        }
+    }
+}
+
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary vector of `Argument`
     pub fn arguments(&mut self) -> Result<Vec<Argument>> {

--- a/crates/apollo-smith/src/description.rs
+++ b/crates/apollo-smith/src/description.rs
@@ -21,6 +21,18 @@ impl From<Description> for String {
     }
 }
 
+impl From<apollo_parser::ast::Description> for Description {
+    fn from(desc: apollo_parser::ast::Description) -> Self {
+        Description(StringValue::from(desc.to_string()))
+    }
+}
+
+impl From<String> for Description {
+    fn from(desc: String) -> Self {
+        Description(StringValue::from(desc))
+    }
+}
+
 /// The `__StringValue` type represents a sequence of characters
 ///
 /// *StringValue*:
@@ -42,6 +54,16 @@ impl From<StringValue> for String {
             StringValue::Block(str_val) => format!(r#""""{str_val}""""#),
             StringValue::Line(str_val) => format!(r#"{str_val}""#),
         }
+    }
+}
+
+impl From<String> for StringValue {
+    fn from(str_value: String) -> Self {
+        // TODO check
+        if str_value.contains(['"', '\t', '\r', '\n']) {
+            return StringValue::Block(str_value);
+        }
+        StringValue::Line(str_value)
     }
 }
 

--- a/crates/apollo-smith/src/description.rs
+++ b/crates/apollo-smith/src/description.rs
@@ -21,6 +21,7 @@ impl From<Description> for String {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::Description> for Description {
     fn from(desc: apollo_parser::ast::Description) -> Self {
         Description(StringValue::from(desc.to_string()))

--- a/crates/apollo-smith/src/description.rs
+++ b/crates/apollo-smith/src/description.rs
@@ -70,7 +70,10 @@ impl From<String> for StringValue {
 
 impl Arbitrary<'_> for StringValue {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> Result<Self> {
-        let arbitrary_str = limited_string_desc(u, 100)?;
+        let mut arbitrary_str = limited_string_desc(u, 100)?;
+        if arbitrary_str.trim_matches('"').is_empty() {
+            arbitrary_str.push_str(&format!("{}", u.arbitrary::<usize>()?));
+        }
         let variant_idx = u.int_in_range(0..=1usize)?;
         let str_value = match variant_idx {
             0 => Self::Block(arbitrary_str),

--- a/crates/apollo-smith/src/directive.rs
+++ b/crates/apollo-smith/src/directive.rs
@@ -54,8 +54,7 @@ impl From<apollo_parser::ast::DirectiveDefinition> for DirectiveDef {
                 .map(|d| Description::from(d.to_string())),
             name: directive_def.name().unwrap().into(),
             arguments_definition: directive_def.arguments_definition().map(ArgumentsDef::from),
-            // TODO, fixed by https://github.com/apollographql/apollo-rs/pull/189
-            repeatable: false,
+            repeatable: directive_def.repeatable_token().is_some(),
             directive_locations: directive_def
                 .directive_locations()
                 .map(|dls| {

--- a/crates/apollo-smith/src/directive.rs
+++ b/crates/apollo-smith/src/directive.rs
@@ -46,6 +46,7 @@ impl From<DirectiveDef> for apollo_encoder::DirectiveDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::DirectiveDefinition> for DirectiveDef {
     fn from(directive_def: apollo_parser::ast::DirectiveDefinition) -> Self {
         Self {
@@ -91,6 +92,7 @@ impl From<Directive> for apollo_encoder::Directive {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::Directive> for Directive {
     fn from(directive: apollo_parser::ast::Directive) -> Self {
         Self {

--- a/crates/apollo-smith/src/directive.rs
+++ b/crates/apollo-smith/src/directive.rs
@@ -59,7 +59,7 @@ impl From<apollo_parser::ast::DirectiveDefinition> for DirectiveDef {
                 .directive_locations()
                 .map(|dls| {
                     dls.directive_locations()
-                        .map(|dl| DirectiveLocation::from(dl.to_string().trim().to_string()))
+                        .map(|dl| DirectiveLocation::from(dl.token_string().unwrap().to_string()))
                         .collect()
                 })
                 .unwrap_or_default(),

--- a/crates/apollo-smith/src/document.rs
+++ b/crates/apollo-smith/src/document.rs
@@ -88,6 +88,7 @@ impl From<apollo_parser::ast::Document> for Document {
         let mut enum_defs = Vec::new();
         let mut object_defs = Vec::new();
         let mut schema_defs = Vec::new();
+        let mut directive_defs = Vec::new();
 
         for definition in doc.definitions() {
             match definition {
@@ -99,6 +100,9 @@ impl From<apollo_parser::ast::Document> for Document {
                 }
                 apollo_parser::ast::Definition::SchemaDefinition(schema_def) => {
                     schema_defs.push(SchemaDef::from(schema_def));
+                }
+                apollo_parser::ast::Definition::DirectiveDefinition(dir_def) => {
+                    directive_defs.push(DirectiveDef::from(dir_def));
                 }
                 // TODO
                 // apollo_parser::ast::Definition::ScalarTypeDefinition(_) => todo!(),
@@ -131,7 +135,7 @@ impl From<apollo_parser::ast::Document> for Document {
             union_type_definitions: Vec::new(),
             enum_type_definitions: enum_defs,
             input_object_type_definitions: Vec::new(),
-            directive_definitions: Vec::new(),
+            directive_definitions: directive_defs,
         }
     }
 }

--- a/crates/apollo-smith/src/document.rs
+++ b/crates/apollo-smith/src/document.rs
@@ -73,17 +73,19 @@ impl From<Document> for apollo_encoder::Document {
     }
 }
 
-// Maybe under a feature flag ?
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::Document> for Document {
     fn from(doc: apollo_parser::ast::Document) -> Self {
-        // All commented parts are TODO
-        // The main goal is to support minimal federation demo schema
         let mut enum_defs = Vec::new();
         let mut object_defs = Vec::new();
         let mut schema_defs = Vec::new();
         let mut directive_defs = Vec::new();
         let mut scalar_defs = Vec::new();
         let mut operation_defs = Vec::new();
+        let mut interface_defs = Vec::new();
+        let mut union_defs = Vec::new();
+        let mut input_object_defs = Vec::new();
+        let mut fragment_defs = Vec::new();
 
         for definition in doc.definitions() {
             match definition {
@@ -117,31 +119,40 @@ impl From<apollo_parser::ast::Document> for Document {
                 apollo_parser::ast::Definition::OperationDefinition(operation_def) => {
                     operation_defs.push(OperationDef::from(operation_def))
                 }
-                // TODO
-                // apollo_parser::ast::Definition::InterfaceTypeDefinition(_) => todo!(),
-                // apollo_parser::ast::Definition::UnionTypeDefinition(_) => todo!(),
-                // apollo_parser::ast::Definition::InputObjectTypeDefinition(_) => todo!(),
-                // apollo_parser::ast::Definition::DirectiveDefinition(_) => todo!(),
-                // apollo_parser::ast::Definition::FragmentDefinition(_) => todo!(),
-                // apollo_parser::ast::Definition::InterfaceTypeExtension(_) => todo!(),
-                // apollo_parser::ast::Definition::UnionTypeExtension(_) => todo!(),
-                // apollo_parser::ast::Definition::InputObjectTypeExtension(_) => todo!(),
-                _ => {
-                    // TODO
+                apollo_parser::ast::Definition::InterfaceTypeDefinition(interface_def) => {
+                    interface_defs.push(InterfaceTypeDef::from(interface_def))
+                }
+                apollo_parser::ast::Definition::InterfaceTypeExtension(interface_def) => {
+                    interface_defs.push(InterfaceTypeDef::from(interface_def))
+                }
+                apollo_parser::ast::Definition::UnionTypeDefinition(union_def) => {
+                    union_defs.push(UnionTypeDef::from(union_def))
+                }
+                apollo_parser::ast::Definition::UnionTypeExtension(union_def) => {
+                    union_defs.push(UnionTypeDef::from(union_def))
+                }
+                apollo_parser::ast::Definition::InputObjectTypeDefinition(input_object_def) => {
+                    input_object_defs.push(InputObjectTypeDef::from(input_object_def))
+                }
+                apollo_parser::ast::Definition::InputObjectTypeExtension(input_object_def) => {
+                    input_object_defs.push(InputObjectTypeDef::from(input_object_def))
+                }
+                apollo_parser::ast::Definition::FragmentDefinition(fragment_def) => {
+                    fragment_defs.push(FragmentDef::from(fragment_def))
                 }
             }
         }
 
         Self {
-            operation_definitions: Vec::new(),
+            operation_definitions: operation_defs,
             fragment_definitions: Vec::new(),
             schema_definitions: schema_defs,
-            scalar_type_definitions: Vec::new(),
+            scalar_type_definitions: scalar_defs,
             object_type_definitions: object_defs,
-            interface_type_definitions: Vec::new(),
-            union_type_definitions: Vec::new(),
+            interface_type_definitions: interface_defs,
+            union_type_definitions: union_defs,
             enum_type_definitions: enum_defs,
-            input_object_type_definitions: Vec::new(),
+            input_object_type_definitions: input_object_defs,
             directive_definitions: directive_defs,
         }
     }

--- a/crates/apollo-smith/src/document.rs
+++ b/crates/apollo-smith/src/document.rs
@@ -73,6 +73,69 @@ impl From<Document> for apollo_encoder::Document {
     }
 }
 
+// Maybe under a feature flag ?
+impl From<apollo_parser::ast::Document> for Document {
+    fn from(doc: apollo_parser::ast::Document) -> Self {
+        // All commented parts are TODO
+        // The main goal is to support minimal federation demo schema
+        // doc.fragment_definitions
+        //     .into_iter()
+        //     .for_each(|fragment_def| new_doc.fragment(fragment_def.into()));
+
+        // doc.scalar_type_definitions
+        //     .into_iter()
+        //     .for_each(|scalar_type_def| new_doc.scalar(scalar_type_def.into()));
+        let mut enum_defs = Vec::new();
+        let mut object_defs = Vec::new();
+        let mut schema_defs = Vec::new();
+
+        for definition in doc.definitions() {
+            match definition {
+                apollo_parser::ast::Definition::EnumTypeDefinition(enum_def) => {
+                    enum_defs.push(EnumTypeDef::from(enum_def));
+                }
+                apollo_parser::ast::Definition::ObjectTypeDefinition(obj_def) => {
+                    object_defs.push(ObjectTypeDef::from(obj_def));
+                }
+                apollo_parser::ast::Definition::SchemaDefinition(schema_def) => {
+                    schema_defs.push(SchemaDef::from(schema_def));
+                }
+                // TODO
+                // apollo_parser::ast::Definition::ScalarTypeDefinition(_) => todo!(),
+                // apollo_parser::ast::Definition::InterfaceTypeDefinition(_) => todo!(),
+                // apollo_parser::ast::Definition::UnionTypeDefinition(_) => todo!(),
+                // apollo_parser::ast::Definition::InputObjectTypeDefinition(_) => todo!(),
+                // apollo_parser::ast::Definition::ScalarTypeExtension(_) => todo!(),
+                // apollo_parser::ast::Definition::DirectiveDefinition(_) => todo!(),
+                // apollo_parser::ast::Definition::FragmentDefinition(_) => todo!(),
+                // apollo_parser::ast::Definition::InterfaceTypeExtension(_) => todo!(),
+                // apollo_parser::ast::Definition::SchemaExtension(_) => todo!(),
+                // apollo_parser::ast::Definition::EnumTypeExtension(_) => todo!(),
+                // apollo_parser::ast::Definition::ObjectTypeExtension(_) => todo!(),
+                // apollo_parser::ast::Definition::UnionTypeExtension(_) => todo!(),
+                // apollo_parser::ast::Definition::OperationDefinition(_) => todo!(),
+                // apollo_parser::ast::Definition::InputObjectTypeExtension(_) => todo!(),
+                _ => {
+                    // TODO
+                }
+            }
+        }
+
+        Self {
+            operation_definitions: Vec::new(),
+            fragment_definitions: Vec::new(),
+            schema_definitions: schema_defs,
+            scalar_type_definitions: Vec::new(),
+            object_type_definitions: object_defs,
+            interface_type_definitions: Vec::new(),
+            union_type_definitions: Vec::new(),
+            enum_type_definitions: enum_defs,
+            input_object_type_definitions: Vec::new(),
+            directive_definitions: Vec::new(),
+        }
+    }
+}
+
 impl From<Document> for String {
     fn from(doc: Document) -> Self {
         apollo_encoder::Document::from(doc).to_string()

--- a/crates/apollo-smith/src/document.rs
+++ b/crates/apollo-smith/src/document.rs
@@ -78,46 +78,53 @@ impl From<apollo_parser::ast::Document> for Document {
     fn from(doc: apollo_parser::ast::Document) -> Self {
         // All commented parts are TODO
         // The main goal is to support minimal federation demo schema
-        // doc.fragment_definitions
-        //     .into_iter()
-        //     .for_each(|fragment_def| new_doc.fragment(fragment_def.into()));
-
-        // doc.scalar_type_definitions
-        //     .into_iter()
-        //     .for_each(|scalar_type_def| new_doc.scalar(scalar_type_def.into()));
         let mut enum_defs = Vec::new();
         let mut object_defs = Vec::new();
         let mut schema_defs = Vec::new();
         let mut directive_defs = Vec::new();
+        let mut scalar_defs = Vec::new();
+        let mut operation_defs = Vec::new();
 
         for definition in doc.definitions() {
             match definition {
                 apollo_parser::ast::Definition::EnumTypeDefinition(enum_def) => {
                     enum_defs.push(EnumTypeDef::from(enum_def));
                 }
+                apollo_parser::ast::Definition::EnumTypeExtension(enum_def) => {
+                    enum_defs.push(EnumTypeDef::from(enum_def));
+                }
                 apollo_parser::ast::Definition::ObjectTypeDefinition(obj_def) => {
+                    object_defs.push(ObjectTypeDef::from(obj_def));
+                }
+                apollo_parser::ast::Definition::ObjectTypeExtension(obj_def) => {
                     object_defs.push(ObjectTypeDef::from(obj_def));
                 }
                 apollo_parser::ast::Definition::SchemaDefinition(schema_def) => {
                     schema_defs.push(SchemaDef::from(schema_def));
                 }
+                apollo_parser::ast::Definition::SchemaExtension(schema_def) => {
+                    schema_defs.push(SchemaDef::from(schema_def));
+                }
                 apollo_parser::ast::Definition::DirectiveDefinition(dir_def) => {
                     directive_defs.push(DirectiveDef::from(dir_def));
                 }
+                apollo_parser::ast::Definition::ScalarTypeDefinition(scalar_def) => {
+                    scalar_defs.push(ScalarTypeDef::from(scalar_def))
+                }
+                apollo_parser::ast::Definition::ScalarTypeExtension(scalar_def) => {
+                    scalar_defs.push(ScalarTypeDef::from(scalar_def))
+                }
+                apollo_parser::ast::Definition::OperationDefinition(operation_def) => {
+                    operation_defs.push(OperationDef::from(operation_def))
+                }
                 // TODO
-                // apollo_parser::ast::Definition::ScalarTypeDefinition(_) => todo!(),
                 // apollo_parser::ast::Definition::InterfaceTypeDefinition(_) => todo!(),
                 // apollo_parser::ast::Definition::UnionTypeDefinition(_) => todo!(),
                 // apollo_parser::ast::Definition::InputObjectTypeDefinition(_) => todo!(),
-                // apollo_parser::ast::Definition::ScalarTypeExtension(_) => todo!(),
                 // apollo_parser::ast::Definition::DirectiveDefinition(_) => todo!(),
                 // apollo_parser::ast::Definition::FragmentDefinition(_) => todo!(),
                 // apollo_parser::ast::Definition::InterfaceTypeExtension(_) => todo!(),
-                // apollo_parser::ast::Definition::SchemaExtension(_) => todo!(),
-                // apollo_parser::ast::Definition::EnumTypeExtension(_) => todo!(),
-                // apollo_parser::ast::Definition::ObjectTypeExtension(_) => todo!(),
                 // apollo_parser::ast::Definition::UnionTypeExtension(_) => todo!(),
-                // apollo_parser::ast::Definition::OperationDefinition(_) => todo!(),
                 // apollo_parser::ast::Definition::InputObjectTypeExtension(_) => todo!(),
                 _ => {
                     // TODO

--- a/crates/apollo-smith/src/enum_.rs
+++ b/crates/apollo-smith/src/enum_.rs
@@ -74,6 +74,30 @@ impl From<apollo_parser::ast::EnumTypeDefinition> for EnumTypeDef {
     }
 }
 
+impl From<apollo_parser::ast::EnumTypeExtension> for EnumTypeDef {
+    fn from(enum_def: apollo_parser::ast::EnumTypeExtension) -> Self {
+        Self {
+            description: None,
+            name: enum_def.name().unwrap().into(),
+            directives: enum_def
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            enum_values_def: enum_def
+                .enum_values_definition()
+                .expect("must have enum values definition")
+                .enum_value_definitions()
+                .map(EnumValueDefinition::from)
+                .collect(),
+            extend: true,
+        }
+    }
+}
+
 /// The __EnumValue type represents one of possible values of an enum.
 ///
 /// *EnumValueDefinition*:

--- a/crates/apollo-smith/src/enum_.rs
+++ b/crates/apollo-smith/src/enum_.rs
@@ -48,6 +48,7 @@ impl From<EnumTypeDef> for EnumDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::EnumTypeDefinition> for EnumTypeDef {
     fn from(enum_def: apollo_parser::ast::EnumTypeDefinition) -> Self {
         Self {
@@ -74,6 +75,7 @@ impl From<apollo_parser::ast::EnumTypeDefinition> for EnumTypeDef {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::EnumTypeExtension> for EnumTypeDef {
     fn from(enum_def: apollo_parser::ast::EnumTypeExtension) -> Self {
         Self {
@@ -124,6 +126,7 @@ impl From<EnumValueDefinition> for EnumValue {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::EnumValueDefinition> for EnumValueDefinition {
     fn from(enum_value_def: apollo_parser::ast::EnumValueDefinition) -> Self {
         Self {

--- a/crates/apollo-smith/src/enum_.rs
+++ b/crates/apollo-smith/src/enum_.rs
@@ -40,6 +40,26 @@ impl From<EnumTypeDef> for EnumDefinition {
     }
 }
 
+impl From<apollo_parser::ast::EnumTypeDefinition> for EnumTypeDef {
+    fn from(enum_def: apollo_parser::ast::EnumTypeDefinition) -> Self {
+        Self {
+            description: enum_def
+                .description()
+                .map(|d| Description::from(d.to_string())),
+            name: enum_def.name().unwrap().into(),
+            // TODO
+            directives: Vec::new(),
+            enum_values_def: enum_def
+                .enum_values_definition()
+                .expect("must have enum values definition")
+                .enum_value_definitions()
+                .map(|ev| EnumValueDefinition::from(ev))
+                .collect(),
+            extend: false,
+        }
+    }
+}
+
 /// The __EnumValue type represents one of possible values of an enum.
 ///
 /// *EnumValueDefinition*:
@@ -63,6 +83,22 @@ impl From<EnumValueDefinition> for EnumValue {
             .for_each(|directive| new_enum_val.directive(directive.into()));
 
         new_enum_val
+    }
+}
+
+impl From<apollo_parser::ast::EnumValueDefinition> for EnumValueDefinition {
+    fn from(enum_value_def: apollo_parser::ast::EnumValueDefinition) -> Self {
+        Self {
+            description: enum_value_def.description().map(Description::from),
+            value: enum_value_def
+                .enum_value()
+                .expect("enum value def must have enum value")
+                .name()
+                .expect("enum value mus have a name")
+                .into(),
+            // TODO
+            directives: Vec::new(),
+        }
     }
 }
 

--- a/crates/apollo-smith/src/field.rs
+++ b/crates/apollo-smith/src/field.rs
@@ -38,7 +38,7 @@ impl From<FieldDef> for apollo_encoder::FieldDefinition {
         field.description(val.description.map(String::from));
         val.directives
             .into_iter()
-            .for_each(|(dir_name, directive)| field.directive(directive.into()));
+            .for_each(|(_dir_name, directive)| field.directive(directive.into()));
 
         field
     }
@@ -96,6 +96,28 @@ impl From<Field> for apollo_encoder::Field {
         new_field.selection_set(field.selection_set.map(Into::into));
 
         new_field
+    }
+}
+
+impl From<apollo_parser::ast::Field> for Field {
+    fn from(field: apollo_parser::ast::Field) -> Self {
+        Self {
+            alias: field.alias().map(|alias| alias.name().unwrap().into()),
+            name: field.name().unwrap().into(),
+            args: field
+                .arguments()
+                .map(|arguments| arguments.arguments().map(Argument::from).collect())
+                .unwrap_or_default(),
+            directives: field
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            selection_set: field.selection_set().map(SelectionSet::from),
+        }
     }
 }
 

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -1,7 +1,13 @@
+use std::collections::HashMap;
+
 use arbitrary::Result;
 
 use crate::{
-    directive::Directive, name::Name, selection_set::SelectionSet, ty::Ty, DocumentBuilder,
+    directive::{Directive, DirectiveLocation},
+    name::Name,
+    selection_set::SelectionSet,
+    ty::Ty,
+    DocumentBuilder,
 };
 
 /// The __fragmentDef type represents a fragment definition
@@ -14,7 +20,7 @@ use crate::{
 pub struct FragmentDef {
     pub(crate) name: Name,
     pub(crate) type_condition: TypeCondition,
-    pub(crate) directives: Vec<Directive>,
+    pub(crate) directives: HashMap<Name, Directive>,
     pub(crate) selection_set: SelectionSet,
 }
 
@@ -28,7 +34,7 @@ impl From<FragmentDef> for apollo_encoder::FragmentDefinition {
         frag_def
             .directives
             .into_iter()
-            .for_each(|directive| new_frag_def.directive(directive.into()));
+            .for_each(|(_, directive)| new_frag_def.directive(directive.into()));
 
         new_frag_def
     }
@@ -43,7 +49,7 @@ impl From<FragmentDef> for apollo_encoder::FragmentDefinition {
 #[derive(Debug)]
 pub struct FragmentSpread {
     pub(crate) name: Name,
-    pub(crate) directives: Vec<Directive>,
+    pub(crate) directives: HashMap<Name, Directive>,
 }
 
 impl From<FragmentSpread> for apollo_encoder::FragmentSpread {
@@ -52,7 +58,7 @@ impl From<FragmentSpread> for apollo_encoder::FragmentSpread {
         fragment_spread
             .directives
             .into_iter()
-            .for_each(|directive| new_fragment_spread.directive(directive.into()));
+            .for_each(|(_, directive)| new_fragment_spread.directive(directive.into()));
 
         new_fragment_spread
     }
@@ -67,7 +73,7 @@ impl From<FragmentSpread> for apollo_encoder::FragmentSpread {
 #[derive(Debug)]
 pub struct InlineFragment {
     pub(crate) type_condition: Option<TypeCondition>,
-    pub(crate) directives: Vec<Directive>,
+    pub(crate) directives: HashMap<Name, Directive>,
     pub(crate) selection_set: SelectionSet,
 }
 
@@ -78,7 +84,7 @@ impl From<InlineFragment> for apollo_encoder::InlineFragment {
         inline_fragment
             .directives
             .into_iter()
-            .for_each(|directive| new_inline_fragment.directive(directive.into()));
+            .for_each(|(_, directive)| new_inline_fragment.directive(directive.into()));
 
         new_inline_fragment
     }
@@ -105,7 +111,7 @@ impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `FragmentDef`
     pub fn fragment_definition(&mut self) -> Result<FragmentDef> {
         let name = self.type_name()?;
-        let directives = self.directives()?;
+        let directives = self.directives(DirectiveLocation::FragmentDefinition)?;
         let selection_set = self.selection_set()?;
         let type_condition = self.type_condition()?;
 
@@ -130,7 +136,7 @@ impl<'a> DocumentBuilder<'a> {
         } else {
             self.u.choose(&available_fragment)?.name.clone()
         };
-        let directives = self.directives()?;
+        let directives = self.directives(DirectiveLocation::FragmentSpread)?;
         excludes.push(name.clone());
 
         Ok(Some(FragmentSpread { name, directives }))
@@ -145,7 +151,7 @@ impl<'a> DocumentBuilder<'a> {
             .then(|| self.type_condition())
             .transpose()?;
         let selection_set = self.selection_set()?;
-        let directives = self.directives()?;
+        let directives = self.directives(DirectiveLocation::InlineFragment)?;
 
         Ok(InlineFragment {
             type_condition,

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -125,7 +125,7 @@ impl<'a> DocumentBuilder<'a> {
             .filter(|f| excludes.contains(&f.name))
             .collect();
 
-        let name = if !available_fragment.is_empty() {
+        let name = if available_fragment.is_empty() {
             return Ok(None);
         } else {
             self.u.choose(&available_fragment)?.name.clone()
@@ -156,14 +156,25 @@ impl<'a> DocumentBuilder<'a> {
 
     /// Create an arbitrary `TypeCondition`
     pub fn type_condition(&mut self) -> Result<TypeCondition> {
-        let named_types: Vec<Ty> = self
-            .list_existing_object_types()
-            .into_iter()
-            .filter(Ty::is_named)
-            .collect();
+        let last_element = self
+            .stack
+            .last()
+            .and_then(|last_element| last_element.as_object());
+        match last_element {
+            Some(last_element) => Ok(TypeCondition {
+                name: last_element.name.clone(),
+            }),
+            None => {
+                let named_types: Vec<Ty> = self
+                    .list_existing_object_types()
+                    .into_iter()
+                    .filter(Ty::is_named)
+                    .collect();
 
-        Ok(TypeCondition {
-            name: self.choose_named_ty(&named_types)?.name().clone(),
-        })
+                Ok(TypeCondition {
+                    name: self.choose_named_ty(&named_types)?.name().clone(),
+                })
+            }
+        }
     }
 }

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -64,6 +64,27 @@ impl From<FragmentSpread> for apollo_encoder::FragmentSpread {
     }
 }
 
+impl From<apollo_parser::ast::FragmentSpread> for FragmentSpread {
+    fn from(fragment_spread: apollo_parser::ast::FragmentSpread) -> Self {
+        Self {
+            name: fragment_spread
+                .fragment_name()
+                .unwrap()
+                .name()
+                .unwrap()
+                .into(),
+            directives: fragment_spread
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        }
+    }
+}
+
 /// The __inlineFragment type represents an inline fragment in a selection set that could be used as a field
 ///
 /// *InlineFragment*:
@@ -90,6 +111,26 @@ impl From<InlineFragment> for apollo_encoder::InlineFragment {
     }
 }
 
+impl From<apollo_parser::ast::InlineFragment> for InlineFragment {
+    fn from(inline_fragment: apollo_parser::ast::InlineFragment) -> Self {
+        Self {
+            directives: inline_fragment
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            selection_set: inline_fragment
+                .selection_set()
+                .map(SelectionSet::from)
+                .unwrap(),
+            type_condition: inline_fragment.type_condition().map(TypeCondition::from),
+        }
+    }
+}
+
 /// The __typeCondition type represents where a fragment could be applied
 ///
 /// *TypeCondition*:
@@ -104,6 +145,14 @@ pub struct TypeCondition {
 impl From<TypeCondition> for apollo_encoder::TypeCondition {
     fn from(ty_cond: TypeCondition) -> Self {
         Self::new(ty_cond.name.into())
+    }
+}
+
+impl From<apollo_parser::ast::TypeCondition> for TypeCondition {
+    fn from(type_condition: apollo_parser::ast::TypeCondition) -> Self {
+        Self {
+            name: type_condition.named_type().unwrap().name().unwrap().into(),
+        }
     }
 }
 

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -181,10 +181,14 @@ impl From<apollo_parser::ast::TypeCondition> for TypeCondition {
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `FragmentDef`
     pub fn fragment_definition(&mut self) -> Result<FragmentDef> {
+        // TODO: also choose between enum/scalars/object
+        let selected_object_type_name = self.u.choose(&self.object_type_defs)?.name.clone();
+        let _ = self.stack_ty(&Ty::Named(selected_object_type_name));
         let name = self.type_name()?;
         let directives = self.directives(DirectiveLocation::FragmentDefinition)?;
         let selection_set = self.selection_set()?;
         let type_condition = self.type_condition()?;
+        self.stack.pop();
 
         Ok(FragmentDef {
             name,

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -40,6 +40,25 @@ impl From<FragmentDef> for apollo_encoder::FragmentDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
+impl From<apollo_parser::ast::FragmentDefinition> for FragmentDef {
+    fn from(fragment_def: apollo_parser::ast::FragmentDefinition) -> Self {
+        Self {
+            name: fragment_def.fragment_name().unwrap().name().unwrap().into(),
+            directives: fragment_def
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            type_condition: fragment_def.type_condition().unwrap().into(),
+            selection_set: fragment_def.selection_set().unwrap().into(),
+        }
+    }
+}
+
 /// The __fragmentSpread type represents a named fragment used in a selection set.
 ///
 /// *FragmentSpread*:
@@ -64,6 +83,7 @@ impl From<FragmentSpread> for apollo_encoder::FragmentSpread {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::FragmentSpread> for FragmentSpread {
     fn from(fragment_spread: apollo_parser::ast::FragmentSpread) -> Self {
         Self {
@@ -111,6 +131,7 @@ impl From<InlineFragment> for apollo_encoder::InlineFragment {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::InlineFragment> for InlineFragment {
     fn from(inline_fragment: apollo_parser::ast::InlineFragment) -> Self {
         Self {
@@ -148,6 +169,7 @@ impl From<TypeCondition> for apollo_encoder::TypeCondition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::TypeCondition> for TypeCondition {
     fn from(type_condition: apollo_parser::ast::TypeCondition) -> Self {
         Self {
@@ -211,10 +233,7 @@ impl<'a> DocumentBuilder<'a> {
 
     /// Create an arbitrary `TypeCondition`
     pub fn type_condition(&mut self) -> Result<TypeCondition> {
-        let last_element = self
-            .stack
-            .last()
-            .and_then(|last_element| last_element.as_object());
+        let last_element = self.stack.last();
         match last_element {
             Some(last_element) => Ok(TypeCondition {
                 name: last_element.name.clone(),

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -1,7 +1,12 @@
+use std::collections::HashMap;
+
 use arbitrary::Result;
 
 use crate::{
-    description::Description, directive::Directive, input_value::InputValueDef, name::Name,
+    description::Description,
+    directive::{Directive, DirectiveLocation},
+    input_value::InputValueDef,
+    name::Name,
     DocumentBuilder,
 };
 
@@ -22,7 +27,7 @@ pub struct InputObjectTypeDef {
     // A vector of fields
     pub(crate) fields: Vec<InputValueDef>,
     /// Contains all directives.
-    pub(crate) directives: Vec<Directive>,
+    pub(crate) directives: HashMap<Name, Directive>,
     pub(crate) extend: bool,
 }
 
@@ -37,7 +42,7 @@ impl From<InputObjectTypeDef> for apollo_encoder::InputObjectDefinition {
         input_object_def
             .directives
             .into_iter()
-            .for_each(|directive| new_input_object_def.directive(directive.into()));
+            .for_each(|(_, directive)| new_input_object_def.directive(directive.into()));
         input_object_def
             .fields
             .into_iter()
@@ -61,7 +66,7 @@ impl<'a> DocumentBuilder<'a> {
 
         Ok(InputObjectTypeDef {
             description,
-            directives: self.directives()?,
+            directives: self.directives(DirectiveLocation::InputObject)?,
             name,
             extend: self.u.arbitrary().unwrap_or(false),
             fields,

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -52,6 +52,68 @@ impl From<InputObjectTypeDef> for apollo_encoder::InputObjectDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
+impl From<apollo_parser::ast::InputObjectTypeDefinition> for InputObjectTypeDef {
+    fn from(input_object: apollo_parser::ast::InputObjectTypeDefinition) -> Self {
+        Self {
+            name: input_object
+                .name()
+                .expect("object type definition must have a name")
+                .into(),
+            description: input_object.description().map(Description::from),
+            directives: input_object
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            extend: false,
+            fields: input_object
+                .input_fields_definition()
+                .map(|input_fields| {
+                    input_fields
+                        .input_value_definitions()
+                        .map(InputValueDef::from)
+                        .collect()
+                })
+                .unwrap_or_default(),
+        }
+    }
+}
+
+#[cfg(feature = "parser-impl")]
+impl From<apollo_parser::ast::InputObjectTypeExtension> for InputObjectTypeDef {
+    fn from(input_object: apollo_parser::ast::InputObjectTypeExtension) -> Self {
+        Self {
+            name: input_object
+                .name()
+                .expect("object type definition must have a name")
+                .into(),
+            directives: input_object
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            extend: true,
+            fields: input_object
+                .input_fields_definition()
+                .map(|input_fields| {
+                    input_fields
+                        .input_value_definitions()
+                        .map(InputValueDef::from)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            description: None,
+        }
+    }
+}
+
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `InputObjectTypeDef`
     pub fn input_object_type_definition(&mut self) -> Result<InputObjectTypeDef> {

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -5,7 +5,7 @@ use arbitrary::Result;
 
 pub enum InputValue {
     Variable(Name),
-    Int(i64),
+    Int(i32),
     Float(f64),
     String(String),
     Boolean(bool),
@@ -198,7 +198,7 @@ impl<'a> DocumentBuilder<'a> {
         let gen_val = |doc_builder: &mut DocumentBuilder<'_>| -> Result<InputValue> {
             if ty.is_builtin() {
                 match ty.name().name.as_str() {
-                    "String" => Ok(InputValue::String(doc_builder.u.arbitrary::<String>()?)),
+                    "String" => Ok(InputValue::String(doc_builder.limited_string(1000)?)),
                     "Int" => Ok(InputValue::Int(doc_builder.u.arbitrary()?)),
                     "Float" => Ok(InputValue::Float(doc_builder.u.arbitrary()?)),
                     "Boolean" => Ok(InputValue::Boolean(doc_builder.u.arbitrary()?)),
@@ -320,7 +320,7 @@ impl<'a> DocumentBuilder<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use arbitrary::Unstructured;
 
@@ -344,6 +344,7 @@ mod tests {
             operation_defs: Vec::new(),
             fragment_defs: Vec::new(),
             stack: Vec::new(),
+            choosen_arguments: HashMap::new(),
         };
         let my_nested_type = ObjectTypeDef {
             description: None,

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -27,7 +27,7 @@ impl From<InputValue> for apollo_encoder::Value {
     fn from(input_value: InputValue) -> Self {
         match input_value {
             InputValue::Variable(v) => Self::Variable(v.into()),
-            InputValue::Int(i) => Self::Int(i),
+            InputValue::Int(i) => Self::Int(i.into()),
             InputValue::Float(f) => Self::Float(f),
             InputValue::String(s) => Self::String(s),
             InputValue::Boolean(b) => Self::Boolean(b),
@@ -41,12 +41,14 @@ impl From<InputValue> for apollo_encoder::Value {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::DefaultValue> for InputValue {
     fn from(default_val: apollo_parser::ast::DefaultValue) -> Self {
         default_val.value().unwrap().into()
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::Value> for InputValue {
     fn from(value: apollo_parser::ast::Value) -> Self {
         match value {
@@ -128,6 +130,7 @@ impl From<InputValueDef> for apollo_encoder::InputValueDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::InputValueDefinition> for InputValueDef {
     fn from(input_val_def: apollo_parser::ast::InputValueDefinition) -> Self {
         Self {
@@ -360,7 +363,8 @@ mod tests {
             operation_defs: Vec::new(),
             fragment_defs: Vec::new(),
             stack: Vec::new(),
-            choosen_arguments: HashMap::new(),
+            chosen_arguments: HashMap::new(),
+            chosen_aliases: HashMap::new(),
         };
         let my_nested_type = ObjectTypeDef {
             description: None,

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -57,7 +57,7 @@ impl From<apollo_parser::ast::Value> for InputValue {
             apollo_parser::ast::Value::FloatValue(val) => Self::Float(val.into()),
             apollo_parser::ast::Value::IntValue(val) => Self::Int(val.into()),
             apollo_parser::ast::Value::BooleanValue(val) => Self::Boolean(val.into()),
-            apollo_parser::ast::Value::NullValue(val) => Self::Null,
+            apollo_parser::ast::Value::NullValue(_val) => Self::Null,
             apollo_parser::ast::Value::EnumValue(val) => Self::Enum(val.name().unwrap().into()),
             apollo_parser::ast::Value::ListValue(val) => {
                 Self::List(val.values().map(Self::from).collect())

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -358,7 +358,7 @@ mod tests {
             union_type_defs: Vec::new(),
             enum_type_defs: Vec::new(),
             scalar_type_defs: Vec::new(),
-            schema_defs: Vec::new(),
+            schema_def: None,
             directive_defs: Vec::new(),
             operation_defs: Vec::new(),
             fragment_defs: Vec::new(),

--- a/crates/apollo-smith/src/interface.rs
+++ b/crates/apollo-smith/src/interface.rs
@@ -1,10 +1,14 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use apollo_encoder::InterfaceDefinition;
 use arbitrary::Result;
 
 use crate::{
-    description::Description, directive::Directive, field::FieldDef, name::Name, DocumentBuilder,
+    description::Description,
+    directive::{Directive, DirectiveLocation},
+    field::FieldDef,
+    name::Name,
+    DocumentBuilder,
 };
 
 /// InterfaceTypeDef is an abstract type where there are common fields declared.
@@ -22,7 +26,7 @@ pub struct InterfaceTypeDef {
     pub(crate) description: Option<Description>,
     pub(crate) name: Name,
     pub(crate) interfaces: HashSet<Name>,
-    pub(crate) directives: Vec<Directive>,
+    pub(crate) directives: HashMap<Name, Directive>,
     pub(crate) fields_def: Vec<FieldDef>,
     pub(crate) extend: bool,
 }
@@ -36,7 +40,7 @@ impl From<InterfaceTypeDef> for InterfaceDefinition {
             .for_each(|f| itf_def.field(f.into()));
         itf.directives
             .into_iter()
-            .for_each(|directive| itf_def.directive(directive.into()));
+            .for_each(|(_, directive)| itf_def.directive(directive.into()));
         itf.interfaces
             .into_iter()
             .for_each(|interface| itf_def.interface(interface.into()));
@@ -59,7 +63,7 @@ impl<'a> DocumentBuilder<'a> {
             .transpose()?;
         let name = self.type_name()?;
         let fields_def = self.fields_definition(&[])?;
-        let directives = self.directives()?;
+        let directives = self.directives(DirectiveLocation::Interface)?;
         let interfaces = self.implements_interfaces()?;
 
         Ok(InterfaceTypeDef {

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -71,10 +71,12 @@ pub struct DocumentBuilder<'a> {
     pub(crate) directive_defs: Vec<DirectiveDef>,
     pub(crate) operation_defs: Vec<OperationDef>,
     pub(crate) fragment_defs: Vec<FragmentDef>,
-    // A stack to set current TypeDef
-    pub(crate) stack: Vec<TypeDefinition>,
+    // A stack to set current ObjectTypeDef
+    pub(crate) stack: Vec<ObjectTypeDef>,
     // Useful to keep the same arguments for a specific field
-    pub(crate) choosen_arguments: HashMap<Name, Vec<Argument>>,
+    pub(crate) chosen_arguments: HashMap<Name, Vec<Argument>>,
+    // Useful to keep the same aliases for a specific field name
+    pub(crate) chosen_aliases: HashMap<Name, Name>,
 }
 
 impl<'a> Debug for DocumentBuilder<'a> {
@@ -110,7 +112,8 @@ impl<'a> DocumentBuilder<'a> {
             union_type_defs: Vec::new(),
             input_object_type_defs: Vec::new(),
             stack: Vec::new(),
-            choosen_arguments: HashMap::new(),
+            chosen_arguments: HashMap::new(),
+            chosen_aliases: HashMap::new(),
         };
 
         for _ in 0..builder.u.int_in_range(1..=50)? {
@@ -182,7 +185,8 @@ impl<'a> DocumentBuilder<'a> {
             union_type_defs: document.union_type_definitions,
             input_object_type_defs: document.input_object_type_definitions,
             stack: Vec::new(),
-            choosen_arguments: HashMap::new(),
+            chosen_arguments: HashMap::new(),
+            chosen_aliases: HashMap::new(),
         };
 
         Ok(builder)
@@ -216,7 +220,7 @@ impl<'a> DocumentBuilder<'a> {
             .find(|object_ty_def| &object_ty_def.name == type_name)
             .cloned()
         {
-            self.stack.push(TypeDefinition::Object(object_ty));
+            self.stack.push(object_ty);
             true
         } else if let Some(_enum_ty) = self
             .enum_type_defs
@@ -227,29 +231,6 @@ impl<'a> DocumentBuilder<'a> {
             false
         } else {
             todo!("need to implement for union, scalar, ...")
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) enum TypeDefinition {
-    Enum(EnumTypeDef),
-    Object(ObjectTypeDef),
-}
-
-impl TypeDefinition {
-    pub(crate) fn as_object(&self) -> Option<&ObjectTypeDef> {
-        if let Self::Object(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn need_selection_set(&self) -> bool {
-        match self {
-            TypeDefinition::Enum(_) => false,
-            TypeDefinition::Object(_) => true,
         }
     }
 }

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -117,11 +117,6 @@ impl<'a> DocumentBuilder<'a> {
         };
 
         for _ in 0..builder.u.int_in_range(1..=50)? {
-            let fragment_def = builder.fragment_definition()?;
-            builder.fragment_defs.push(fragment_def);
-        }
-
-        for _ in 0..builder.u.int_in_range(1..=50)? {
             let scalar_type_def = builder.scalar_type_definition()?;
             builder.scalar_type_defs.push(scalar_type_def);
         }
@@ -149,6 +144,11 @@ impl<'a> DocumentBuilder<'a> {
         for _ in 0..builder.u.int_in_range(1..=50)? {
             let input_object_type_def = builder.input_object_type_definition()?;
             builder.input_object_type_defs.push(input_object_type_def);
+        }
+
+        for _ in 0..builder.u.int_in_range(1..=50)? {
+            let fragment_def = builder.fragment_definition()?;
+            builder.fragment_defs.push(fragment_def);
         }
 
         for _ in 0..builder.u.int_in_range(1..=50)? {

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -20,11 +20,12 @@ pub(crate) mod ty;
 pub(crate) mod union;
 pub(crate) mod variable;
 
-use std::fmt::Debug;
+use std::{collections::HashMap, fmt::Debug};
 
 use arbitrary::Unstructured;
 
 pub use arbitrary::Result;
+use argument::Argument;
 pub use directive::DirectiveDef;
 pub use document::Document;
 pub use enum_::EnumTypeDef;
@@ -72,6 +73,8 @@ pub struct DocumentBuilder<'a> {
     pub(crate) fragment_defs: Vec<FragmentDef>,
     // A stack to set current TypeDef
     pub(crate) stack: Vec<TypeDefinition>,
+    // Useful to keep the same arguments for a specific field
+    pub(crate) choosen_arguments: HashMap<Name, Vec<Argument>>,
 }
 
 impl<'a> Debug for DocumentBuilder<'a> {
@@ -107,6 +110,7 @@ impl<'a> DocumentBuilder<'a> {
             union_type_defs: Vec::new(),
             input_object_type_defs: Vec::new(),
             stack: Vec::new(),
+            choosen_arguments: HashMap::new(),
         };
 
         for _ in 0..builder.u.int_in_range(1..=50)? {
@@ -178,6 +182,7 @@ impl<'a> DocumentBuilder<'a> {
             union_type_defs: document.union_type_definitions,
             input_object_type_defs: document.input_object_type_definitions,
             stack: Vec::new(),
+            choosen_arguments: HashMap::new(),
         };
 
         Ok(builder)

--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -43,6 +43,14 @@ impl From<Name> for String {
     }
 }
 
+impl From<apollo_parser::ast::Name> for Name {
+    fn from(name: apollo_parser::ast::Name) -> Self {
+        Self {
+            name: name.ident_token().unwrap().to_string(),
+        }
+    }
+}
+
 impl Name {
     pub const fn new(name: String) -> Self {
         Self { name }

--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -43,6 +43,7 @@ impl From<Name> for String {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::Name> for Name {
     fn from(name: apollo_parser::ast::Name) -> Self {
         Self {

--- a/crates/apollo-smith/src/object.rs
+++ b/crates/apollo-smith/src/object.rs
@@ -80,6 +80,35 @@ impl From<apollo_parser::ast::ObjectTypeDefinition> for ObjectTypeDef {
     }
 }
 
+impl From<apollo_parser::ast::ObjectTypeExtension> for ObjectTypeDef {
+    fn from(object_def: apollo_parser::ast::ObjectTypeExtension) -> Self {
+        Self {
+            name: object_def
+                .name()
+                .expect("object type definition must have a name")
+                .into(),
+            description: None,
+            directives: object_def
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            // TODO
+            interface_impls: HashSet::new(),
+            extend: true,
+            fields_def: object_def
+                .fields_definition()
+                .expect("object type definition must have fields definition")
+                .field_definitions()
+                .map(FieldDef::from)
+                .collect(),
+        }
+    }
+}
+
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `ObjectTypeDef`
     pub fn object_type_definition(&mut self) -> Result<ObjectTypeDef> {

--- a/crates/apollo-smith/src/object.rs
+++ b/crates/apollo-smith/src/object.rs
@@ -16,7 +16,7 @@ use crate::{
 ///     Description? **type** Name ImplementsInterfaces? Directives? FieldsDefinition?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Object).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ObjectTypeDef {
     pub(crate) description: Option<Description>,
     pub(crate) name: Name,
@@ -44,6 +44,29 @@ impl From<ObjectTypeDef> for ObjectDefinition {
         }
 
         object_def
+    }
+}
+
+impl From<apollo_parser::ast::ObjectTypeDefinition> for ObjectTypeDef {
+    fn from(object_def: apollo_parser::ast::ObjectTypeDefinition) -> Self {
+        Self {
+            name: object_def
+                .name()
+                .expect("object type definition must have a name")
+                .into(),
+            description: object_def.description().map(Description::from),
+            // TODO
+            directives: Vec::new(),
+            // TODO
+            interface_impls: HashSet::new(),
+            extend: false,
+            fields_def: object_def
+                .fields_definition()
+                .expect("object type definition must have fields definition")
+                .field_definitions()
+                .map(FieldDef::from)
+                .collect(),
+        }
     }
 }
 

--- a/crates/apollo-smith/src/object.rs
+++ b/crates/apollo-smith/src/object.rs
@@ -51,6 +51,7 @@ impl From<ObjectTypeDef> for ObjectDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::ObjectTypeDefinition> for ObjectTypeDef {
     fn from(object_def: apollo_parser::ast::ObjectTypeDefinition) -> Self {
         Self {
@@ -67,8 +68,15 @@ impl From<apollo_parser::ast::ObjectTypeDefinition> for ObjectTypeDef {
                         .collect()
                 })
                 .unwrap_or_default(),
-            // TODO
-            interface_impls: HashSet::new(),
+            interface_impls: object_def
+                .implements_interfaces()
+                .map(|impl_int| {
+                    impl_int
+                        .named_types()
+                        .map(|n| n.name().unwrap().into())
+                        .collect()
+                })
+                .unwrap_or_default(),
             extend: false,
             fields_def: object_def
                 .fields_definition()
@@ -80,6 +88,7 @@ impl From<apollo_parser::ast::ObjectTypeDefinition> for ObjectTypeDef {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::ObjectTypeExtension> for ObjectTypeDef {
     fn from(object_def: apollo_parser::ast::ObjectTypeExtension) -> Self {
         Self {
@@ -96,8 +105,15 @@ impl From<apollo_parser::ast::ObjectTypeExtension> for ObjectTypeDef {
                         .collect()
                 })
                 .unwrap_or_default(),
-            // TODO
-            interface_impls: HashSet::new(),
+            interface_impls: object_def
+                .implements_interfaces()
+                .map(|impl_int| {
+                    impl_int
+                        .named_types()
+                        .map(|n| n.name().unwrap().into())
+                        .collect()
+                })
+                .unwrap_or_default(),
             extend: true,
             fields_def: object_def
                 .fields_definition()

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -113,38 +113,6 @@ impl From<apollo_parser::ast::OperationType> for OperationType {
 }
 
 impl<'a> DocumentBuilder<'a> {
-    /// Create an arbitrary `OperationDef`
-    pub fn operation_definition_bis(&mut self) -> Result<OperationDef> {
-        let name = self
-            .u
-            .arbitrary()
-            .unwrap_or(false)
-            .then(|| self.type_name())
-            .transpose()?;
-
-        let operation_type = self.u.arbitrary()?;
-        let directive_location = match operation_type {
-            OperationType::Query => DirectiveLocation::Query,
-            OperationType::Mutation => DirectiveLocation::Mutation,
-            OperationType::Subscription => DirectiveLocation::Subscription,
-        };
-        let directives = self.directives(directive_location)?;
-        let selection_set = self.selection_set()?;
-        let variable_definitions = self.variable_definitions()?;
-        let shorthand = self.operation_defs.is_empty()
-            && operation_type == OperationType::Query
-            && self.u.arbitrary().unwrap_or(false);
-
-        Ok(OperationDef {
-            operation_type,
-            name,
-            variable_definitions,
-            directives,
-            selection_set,
-            shorthand,
-        })
-    }
-
     /// Create an arbitrary `OperationDef` taking the last `SchemaDef`
     pub fn operation_definition(&mut self) -> Result<Option<OperationDef>> {
         let schema = match self.schema_def.clone() {
@@ -171,6 +139,7 @@ impl<'a> DocumentBuilder<'a> {
 
             ops
         };
+
         let (operation_type, chosen_ty) = self.u.choose(&available_operations)?;
         let directive_location = match operation_type {
             OperationType::Query => DirectiveLocation::Query,

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -53,7 +53,7 @@ impl From<OperationDef> for String {
 ///     query | mutation | subscription
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#OperationType).
-#[derive(Debug, Arbitrary, Clone, Copy)]
+#[derive(Debug, Arbitrary, Clone, Copy, PartialEq)]
 pub enum OperationType {
     Query,
     Mutation,
@@ -84,7 +84,9 @@ impl<'a> DocumentBuilder<'a> {
         let directives = self.directives()?;
         let selection_set = self.selection_set()?;
         let variable_definitions = self.variable_definitions()?;
-        let shorthand = self.operation_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
+        let shorthand = self.operation_defs.is_empty()
+            && operation_type == OperationType::Query
+            && self.u.arbitrary().unwrap_or(false);
 
         Ok(OperationDef {
             operation_type,
@@ -110,12 +112,13 @@ impl<'a> DocumentBuilder<'a> {
             if let Some(query) = &schema.query {
                 ops.push((OperationType::Query, query));
             }
-            if let Some(mutation) = &schema.mutation {
-                ops.push((OperationType::Mutation, mutation));
-            }
-            if let Some(subscription) = &schema.subscription {
-                ops.push((OperationType::Subscription, subscription));
-            }
+            // TODO re-enable them. The issue is about argumentsDef
+            // if let Some(mutation) = &schema.mutation {
+            //     ops.push((OperationType::Mutation, mutation));
+            // }
+            // if let Some(subscription) = &schema.subscription {
+            //     ops.push((OperationType::Subscription, subscription));
+            // }
 
             ops
         };
@@ -132,7 +135,9 @@ impl<'a> DocumentBuilder<'a> {
         // TODO
         let variable_definitions = vec![];
 
-        let shorthand = self.operation_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
+        let shorthand = self.operation_defs.is_empty()
+            && operation_type == &OperationType::Query
+            && self.u.arbitrary().unwrap_or(false);
 
         Ok(OperationDef {
             operation_type: *operation_type,

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -112,13 +112,12 @@ impl<'a> DocumentBuilder<'a> {
             if let Some(query) = &schema.query {
                 ops.push((OperationType::Query, query));
             }
-            // TODO re-enable them. The issue is about argumentsDef
-            // if let Some(mutation) = &schema.mutation {
-            //     ops.push((OperationType::Mutation, mutation));
-            // }
-            // if let Some(subscription) = &schema.subscription {
-            //     ops.push((OperationType::Subscription, subscription));
-            // }
+            if let Some(mutation) = &schema.mutation {
+                ops.push((OperationType::Mutation, mutation));
+            }
+            if let Some(subscription) = &schema.subscription {
+                ops.push((OperationType::Subscription, subscription));
+            }
 
             ops
         };

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -114,7 +114,7 @@ impl From<apollo_parser::ast::OperationType> for OperationType {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `OperationDef`
-    pub fn operation_definition(&mut self) -> Result<OperationDef> {
+    pub fn operation_definition_bis(&mut self) -> Result<OperationDef> {
         let name = self
             .u
             .arbitrary()
@@ -145,9 +145,12 @@ impl<'a> DocumentBuilder<'a> {
         })
     }
 
-    /// Create an arbitrary `OperationDef` given a `SchemaDef`
-    pub fn operation_definition_from_schema(&mut self) -> Result<OperationDef> {
-        let schema = self.schema_defs.last().cloned().unwrap();
+    /// Create an arbitrary `OperationDef` taking the last `SchemaDef`
+    pub fn operation_definition(&mut self) -> Result<Option<OperationDef>> {
+        let schema = match self.schema_def.clone() {
+            Some(schema_def) => schema_def,
+            None => return Ok(None),
+        };
         let name = self
             .u
             .arbitrary()
@@ -199,13 +202,13 @@ impl<'a> DocumentBuilder<'a> {
             && operation_type == &OperationType::Query
             && self.u.arbitrary().unwrap_or(false);
 
-        Ok(OperationDef {
+        Ok(Some(OperationDef {
             operation_type: *operation_type,
             name,
             variable_definitions,
             directives,
             selection_set,
             shorthand,
-        })
+        }))
     }
 }

--- a/crates/apollo-smith/src/scalar.rs
+++ b/crates/apollo-smith/src/scalar.rs
@@ -1,6 +1,13 @@
+use std::collections::HashMap;
+
 use arbitrary::Result;
 
-use crate::{description::Description, directive::Directive, name::Name, DocumentBuilder};
+use crate::{
+    description::Description,
+    directive::{Directive, DirectiveLocation},
+    name::Name,
+    DocumentBuilder,
+};
 
 /// Represents scalar types such as Int, String, and Boolean.
 /// Scalars cannot have fields.
@@ -13,7 +20,7 @@ use crate::{description::Description, directive::Directive, name::Name, Document
 pub struct ScalarTypeDef {
     pub(crate) name: Name,
     pub(crate) description: Option<Description>,
-    pub(crate) directives: Vec<Directive>,
+    pub(crate) directives: HashMap<Name, Directive>,
     pub(crate) extend: bool,
 }
 
@@ -24,7 +31,7 @@ impl From<ScalarTypeDef> for apollo_encoder::ScalarDefinition {
         scalar_def
             .directives
             .into_iter()
-            .for_each(|directive| new_scalar_def.directive(directive.into()));
+            .for_each(|(_, directive)| new_scalar_def.directive(directive.into()));
         if scalar_def.extend {
             new_scalar_def.extend();
         }
@@ -43,7 +50,7 @@ impl<'a> DocumentBuilder<'a> {
             .unwrap_or(false)
             .then(|| self.description())
             .transpose()?;
-        let directives = self.directives()?;
+        let directives = self.directives(DirectiveLocation::Scalar)?;
         // Extended scalar must have directive
         let extend = !directives.is_empty() && self.u.arbitrary().unwrap_or(false);
 

--- a/crates/apollo-smith/src/scalar.rs
+++ b/crates/apollo-smith/src/scalar.rs
@@ -40,6 +40,44 @@ impl From<ScalarTypeDef> for apollo_encoder::ScalarDefinition {
     }
 }
 
+impl From<apollo_parser::ast::ScalarTypeDefinition> for ScalarTypeDef {
+    fn from(scalar_def: apollo_parser::ast::ScalarTypeDefinition) -> Self {
+        Self {
+            description: scalar_def
+                .description()
+                .map(|d| Description::from(d.to_string())),
+            name: scalar_def.name().unwrap().into(),
+            directives: scalar_def
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            extend: false,
+        }
+    }
+}
+
+impl From<apollo_parser::ast::ScalarTypeExtension> for ScalarTypeDef {
+    fn from(scalar_def: apollo_parser::ast::ScalarTypeExtension) -> Self {
+        Self {
+            description: None,
+            name: scalar_def.name().unwrap().into(),
+            directives: scalar_def
+                .directives()
+                .map(|d| {
+                    d.directives()
+                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            extend: true,
+        }
+    }
+}
+
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `ScalarTypeDef`
     pub fn scalar_type_definition(&mut self) -> Result<ScalarTypeDef> {

--- a/crates/apollo-smith/src/scalar.rs
+++ b/crates/apollo-smith/src/scalar.rs
@@ -40,6 +40,7 @@ impl From<ScalarTypeDef> for apollo_encoder::ScalarDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::ScalarTypeDefinition> for ScalarTypeDef {
     fn from(scalar_def: apollo_parser::ast::ScalarTypeDefinition) -> Self {
         Self {
@@ -60,6 +61,7 @@ impl From<apollo_parser::ast::ScalarTypeDefinition> for ScalarTypeDef {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::ScalarTypeExtension> for ScalarTypeDef {
     fn from(scalar_def: apollo_parser::ast::ScalarTypeExtension) -> Self {
         Self {

--- a/crates/apollo-smith/src/schema.rs
+++ b/crates/apollo-smith/src/schema.rs
@@ -137,26 +137,30 @@ impl<'a> DocumentBuilder<'a> {
         let named_types: Vec<Ty> = self
             .list_existing_object_types()
             .into_iter()
-            .filter(Ty::is_named)
+            .filter(|ty| ty.is_named() && !ty.is_builtin())
             .collect();
 
         let arbitrary_idx: usize = self.u.arbitrary::<usize>()?;
 
         let mut query = (arbitrary_idx % 2 == 0)
-            .then(|| self.choose_named_ty(&named_types))
-            .transpose()?;
+            .then(|| self.u.choose(&named_types))
+            .transpose()?
+            .cloned();
         let mut mutation = (arbitrary_idx % 3 == 0)
-            .then(|| self.choose_named_ty(&named_types))
-            .transpose()?;
+            .then(|| self.u.choose(&named_types))
+            .transpose()?
+            .cloned();
         let mut subscription = (arbitrary_idx % 5 == 0)
-            .then(|| self.choose_named_ty(&named_types))
-            .transpose()?;
+            .then(|| self.u.choose(&named_types))
+            .transpose()?
+            .cloned();
         // If no one has been filled
         if let (None, None, None) = (&query, &mutation, &subscription) {
-            match self.u.int_in_range(0..=2usize)? {
-                0 => query = Some(self.choose_named_ty(&named_types)?),
-                1 => mutation = Some(self.choose_named_ty(&named_types)?),
-                2 => subscription = Some(self.choose_named_ty(&named_types)?),
+            let arbitrary_op_type_idx = self.u.int_in_range(0..=2usize)?;
+            match arbitrary_op_type_idx {
+                0 => query = Some(self.u.choose(&named_types)?.clone()),
+                1 => mutation = Some(self.u.choose(&named_types)?.clone()),
+                2 => subscription = Some(self.u.choose(&named_types)?.clone()),
                 _ => unreachable!(),
             }
         }

--- a/crates/apollo-smith/src/schema.rs
+++ b/crates/apollo-smith/src/schema.rs
@@ -50,6 +50,7 @@ impl From<SchemaDef> for apollo_encoder::SchemaDefinition {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::SchemaDefinition> for SchemaDef {
     fn from(schema_def: apollo_parser::ast::SchemaDefinition) -> Self {
         let mut query = None;
@@ -86,6 +87,7 @@ impl From<apollo_parser::ast::SchemaDefinition> for SchemaDef {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::SchemaExtension> for SchemaDef {
     fn from(schema_def: apollo_parser::ast::SchemaExtension) -> Self {
         let mut query = None;

--- a/crates/apollo-smith/src/selection_set.rs
+++ b/crates/apollo-smith/src/selection_set.rs
@@ -63,18 +63,25 @@ impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `SelectionSet`
     pub fn selection_set(&mut self) -> Result<SelectionSet> {
         let mut exclude_names = Vec::new();
-        let selections = (0..self.u.int_in_range(2..=7usize)?)
+        let selection_nb = self
+            .stack
+            .last()
+            .map(|o| o.as_object().unwrap().fields_def.len())
+            .unwrap_or(7);
+        let selections = (0..self.u.int_in_range(2..=selection_nb)?)
             .map(|i| self.selection(i, &mut exclude_names)) // TODO do not generate duplication variable name
             .collect::<Result<Vec<_>>>()?;
         Ok(SelectionSet { selections })
     }
+
     /// Create an arbitrary `Selection`
     pub fn selection(&mut self, index: usize, excludes: &mut Vec<Name>) -> Result<Selection> {
+        // TODO take only selection set field available
         let selection = match self.u.int_in_range(0..=2usize)? {
-            0 => Selection::Field(self.field_with_index(index)?),
+            0 => Selection::Field(self.field()?),
             1 => match self.fragment_spread(excludes)? {
                 Some(frag_spread) => Selection::FragmentSpread(frag_spread),
-                None => Selection::Field(self.field_with_index(index)?),
+                None => Selection::Field(self.field()?),
             },
             2 => Selection::InlineFragment(self.inline_fragment()?),
             _ => unreachable!(),

--- a/crates/apollo-smith/src/ty.rs
+++ b/crates/apollo-smith/src/ty.rs
@@ -2,7 +2,11 @@ use apollo_encoder::Type_;
 use arbitrary::Result;
 use once_cell::sync::Lazy;
 
-use crate::{input_value::InputValue, name::Name, DocumentBuilder};
+use crate::{
+    input_value::InputValue,
+    name::{self, Name},
+    DocumentBuilder,
+};
 
 static BUILTIN_SCALAR_NAMES: Lazy<[Ty; 5]> = Lazy::new(|| {
     [
@@ -42,6 +46,34 @@ impl From<Ty> for Type_ {
     }
 }
 
+impl From<apollo_parser::ast::Type> for Ty {
+    fn from(ty: apollo_parser::ast::Type) -> Self {
+        match ty {
+            apollo_parser::ast::Type::NamedType(named_ty) => named_ty.into(),
+            apollo_parser::ast::Type::ListType(list_type) => {
+                Self::List(Box::new(list_type.ty().unwrap().into()))
+            }
+            apollo_parser::ast::Type::NonNullType(non_null) => {
+                if let Some(named_ty) = non_null.named_type() {
+                    Self::NonNull(Box::new(named_ty.into()))
+                } else if let Some(list_type) = non_null.list_type() {
+                    Self::NonNull(Box::new(Self::List(Box::new(
+                        list_type.ty().unwrap().into(),
+                    ))))
+                } else {
+                    panic!("a non null type must have a type")
+                }
+            }
+        }
+    }
+}
+
+impl From<apollo_parser::ast::NamedType> for Ty {
+    fn from(ty: apollo_parser::ast::NamedType) -> Self {
+        Self::Named(ty.name().unwrap().into())
+    }
+}
+
 impl Ty {
     pub(crate) fn name(&self) -> &Name {
         match self {
@@ -56,6 +88,10 @@ impl Ty {
     /// [`Named`]: Ty::Named
     pub fn is_named(&self) -> bool {
         matches!(self, Self::Named(..))
+    }
+
+    pub(crate) fn is_builtin(&self) -> bool {
+        BUILTIN_SCALAR_NAMES.contains(&Ty::Named(self.name().clone()))
     }
 }
 

--- a/crates/apollo-smith/src/ty.rs
+++ b/crates/apollo-smith/src/ty.rs
@@ -2,11 +2,7 @@ use apollo_encoder::Type_;
 use arbitrary::Result;
 use once_cell::sync::Lazy;
 
-use crate::{
-    input_value::InputValue,
-    name::{self, Name},
-    DocumentBuilder,
-};
+use crate::{input_value::InputValue, name::Name, DocumentBuilder};
 
 static BUILTIN_SCALAR_NAMES: Lazy<[Ty; 5]> = Lazy::new(|| {
     [

--- a/crates/apollo-smith/src/ty.rs
+++ b/crates/apollo-smith/src/ty.rs
@@ -42,6 +42,7 @@ impl From<Ty> for Type_ {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::Type> for Ty {
     fn from(ty: apollo_parser::ast::Type) -> Self {
         match ty {
@@ -64,6 +65,7 @@ impl From<apollo_parser::ast::Type> for Ty {
     }
 }
 
+#[cfg(feature = "parser-impl")]
 impl From<apollo_parser::ast::NamedType> for Ty {
     fn from(ty: apollo_parser::ast::NamedType) -> Self {
         Self::Named(ty.name().unwrap().into())

--- a/crates/apollo-smith/src/variable.rs
+++ b/crates/apollo-smith/src/variable.rs
@@ -1,6 +1,14 @@
+use std::collections::HashMap;
+
 use arbitrary::Result;
 
-use crate::{directive::Directive, input_value::InputValue, name::Name, ty::Ty, DocumentBuilder};
+use crate::{
+    directive::{Directive, DirectiveLocation},
+    input_value::InputValue,
+    name::Name,
+    ty::Ty,
+    DocumentBuilder,
+};
 
 /// The __variableDef type represents a variable definition
 ///
@@ -13,7 +21,7 @@ pub struct VariableDef {
     name: Name,
     ty: Ty,
     default_value: Option<InputValue>,
-    directives: Vec<Directive>,
+    directives: HashMap<Name, Directive>,
 }
 
 impl From<VariableDef> for apollo_encoder::VariableDefinition {
@@ -23,7 +31,7 @@ impl From<VariableDef> for apollo_encoder::VariableDefinition {
         var_def
             .directives
             .into_iter()
-            .for_each(|directive| new_var_def.directive(directive.into()));
+            .for_each(|(_, directive)| new_var_def.directive(directive.into()));
 
         new_var_def
     }
@@ -47,7 +55,7 @@ impl<'a> DocumentBuilder<'a> {
             .unwrap_or(false)
             .then(|| self.input_value())
             .transpose()?;
-        let directives = self.directives()?;
+        let directives = self.directives(DirectiveLocation::VariableDefinition)?;
 
         Ok(VariableDef {
             name,

--- a/fuzz/fuzz_targets/parser.rs
+++ b/fuzz/fuzz_targets/parser.rs
@@ -8,7 +8,7 @@ use std::panic;
 fuzz_target!(|data: &[u8]| {
     let doc_generated = match generate_valid_document(data) {
         Ok(d) => d,
-        Err(_) => {
+        Err(_err) => {
             return;
         }
     };


### PR DESCRIPTION
close #179
Generate semantically valid graphql document.

- [x]  Directives used must already be defined
- [x]  Default values for fields must be of correctly defined type
- [x]  Input values for fields must be of correctly defined type
- [x]  Generate only operations respecting the generated schema

Fix on `apollo-encoder`:
+ Switch from an `i64` to an `i32` type for `Int` type in graphql.

Changes on `apollo-parser`:
+ Add `token_string` on `DirectiveLocation` to have the token as a string for a `DirectiveLocation`
