### PR TITLE
chore(ci): enforce https:// for cargo fetches

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,6 @@
 [alias]
 xtask = "run --package xtask --"
+
+# circle seems to install cargo packages via ssh:// rather than https://
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
It seems like there is an issue with CircleCI running cargo install over ssh instead of https. This commit attempts to enforce an https:// install in cargo's config.