### PR TITLE
feat(apollo-parser): impl PartialEq, Eq and Clone on SyntaxTree

### DIFF
--- a/crates/apollo-parser/src/parser/syntax_tree.rs
+++ b/crates/apollo-parser/src/parser/syntax_tree.rs
@@ -37,6 +37,8 @@ use super::GraphQLLanguage;
 /// let nodes: Vec<_> = doc.definitions().into_iter().collect();
 /// assert_eq!(nodes.len(), 1);
 /// ```
+
+#[derive(PartialEq, Eq, Clone)]
 pub struct SyntaxTree {
     pub(crate) ast: rowan::SyntaxNode<GraphQLLanguage>,
     pub(crate) errors: Vec<crate::Error>,


### PR DESCRIPTION
Adds `PartialEq`, `Eq` and `Clone` derives. These are necessary to feed the SyntaxTree to salsa in #202, but I am sure will be quite handy for other reasons.