### PR TITLE
feat(apollo-encoder): default setters accept String as parameter

### DIFF
--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-encoder"
-version = "0.2.3"
+version = "0.3.0"
 authors = [
     "Irina Shestak <shestak.irina@gmail.com>",
     "Benjamin Coenen <benjamin.coenen@apollographql.com>",

--- a/crates/apollo-encoder/src/input_field.rs
+++ b/crates/apollo-encoder/src/input_field.rs
@@ -17,7 +17,7 @@ use crate::{Directive, StringValue, Type_};
 /// };
 ///
 /// let mut field = InputField::new("cat".to_string(), ty_1);
-/// field.default(Some("\"Norwegian Forest\"".to_string()));
+/// field.default_value("\"Norwegian Forest\"".to_string());
 ///
 /// assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
 /// ```
@@ -54,8 +54,8 @@ impl InputField {
     }
 
     /// Set the InputField's default value.
-    pub fn default(&mut self, default: String) {
-        self.default_value = Some(default);
+    pub fn default_value(&mut self, default_value: String) {
+        self.default_value = Some(default_value);
     }
 
     /// Add a directive.
@@ -97,7 +97,7 @@ mod tests {
         };
 
         let mut field = InputField::new("cat".to_string(), ty_1);
-        field.default("\"Norwegian Forest\"".to_string());
+        field.default_value("\"Norwegian Forest\"".to_string());
 
         assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
     }
@@ -110,7 +110,7 @@ mod tests {
         directive.arg(Argument::new(String::from("first"), Value::Int(1)));
 
         let mut field = InputField::new("cat".to_string(), ty_1);
-        field.default("\"Norwegian Forest\"".to_string());
+        field.default_value("\"Norwegian Forest\"".to_string());
         field.directive(directive);
 
         assert_eq!(

--- a/crates/apollo-encoder/src/input_field.rs
+++ b/crates/apollo-encoder/src/input_field.rs
@@ -54,8 +54,8 @@ impl InputField {
     }
 
     /// Set the InputField's default value.
-    pub fn default(&mut self, default: Option<String>) {
-        self.default_value = default;
+    pub fn default(&mut self, default: String) {
+        self.default_value = Some(default);
     }
 
     /// Add a directive.
@@ -97,7 +97,7 @@ mod tests {
         };
 
         let mut field = InputField::new("cat".to_string(), ty_1);
-        field.default(Some("\"Norwegian Forest\"".to_string()));
+        field.default("\"Norwegian Forest\"".to_string());
 
         assert_eq!(field.to_string(), r#"  cat: CatBreed = "Norwegian Forest""#);
     }
@@ -110,7 +110,7 @@ mod tests {
         directive.arg(Argument::new(String::from("first"), Value::Int(1)));
 
         let mut field = InputField::new("cat".to_string(), ty_1);
-        field.default(Some("\"Norwegian Forest\"".to_string()));
+        field.default("\"Norwegian Forest\"".to_string());
         field.directive(directive);
 
         assert_eq!(

--- a/crates/apollo-encoder/src/input_object_def.rs
+++ b/crates/apollo-encoder/src/input_object_def.rs
@@ -130,7 +130,7 @@ mod tests {
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
         let mut field = InputField::new("toys".to_string(), ty_2);
-        field.default(Some("\"Cat Dangler Pole Bird\"".to_string()));
+        field.default("\"Cat Dangler Pole Bird\"".to_string());
         let ty_3 = Type_::NamedType {
             name: "FavouriteSpots".to_string(),
         };
@@ -167,7 +167,7 @@ mod tests {
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
         let mut field = InputField::new("toys".to_string(), ty_2);
-        field.default(Some("\"Cat Dangler Pole Bird\"".to_string()));
+        field.default("\"Cat Dangler Pole Bird\"".to_string());
         let ty_3 = Type_::NamedType {
             name: "FavouriteSpots".to_string(),
         };
@@ -200,7 +200,7 @@ mod tests {
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
         let mut field = InputField::new("toys".to_string(), ty_2);
-        field.default(Some("\"Cat Dangler Pole Bird\"".to_string()));
+        field.default("\"Cat Dangler Pole Bird\"".to_string());
         let ty_3 = Type_::NamedType {
             name: "FavouriteSpots".to_string(),
         };

--- a/crates/apollo-encoder/src/input_object_def.rs
+++ b/crates/apollo-encoder/src/input_object_def.rs
@@ -20,7 +20,7 @@ use crate::{Directive, InputField, StringValue};
 ///
 /// let ty_2 = Type_::List { ty: Box::new(ty_1) };
 /// let mut field = InputField::new("toys".to_string(), ty_2);
-/// field.default(Some("\"Cat Dangler Pole Bird\"".to_string()));
+/// field.default_value("\"Cat Dangler Pole Bird\"".to_string());
 /// let ty_3 = Type_::NamedType {
 ///     name: "FavouriteSpots".to_string(),
 /// };
@@ -130,7 +130,7 @@ mod tests {
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
         let mut field = InputField::new("toys".to_string(), ty_2);
-        field.default("\"Cat Dangler Pole Bird\"".to_string());
+        field.default_value("\"Cat Dangler Pole Bird\"".to_string());
         let ty_3 = Type_::NamedType {
             name: "FavouriteSpots".to_string(),
         };
@@ -167,7 +167,7 @@ mod tests {
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
         let mut field = InputField::new("toys".to_string(), ty_2);
-        field.default("\"Cat Dangler Pole Bird\"".to_string());
+        field.default_value("\"Cat Dangler Pole Bird\"".to_string());
         let ty_3 = Type_::NamedType {
             name: "FavouriteSpots".to_string(),
         };
@@ -200,7 +200,7 @@ mod tests {
 
         let ty_2 = Type_::List { ty: Box::new(ty_1) };
         let mut field = InputField::new("toys".to_string(), ty_2);
-        field.default("\"Cat Dangler Pole Bird\"".to_string());
+        field.default_value("\"Cat Dangler Pole Bird\"".to_string());
         let ty_3 = Type_::NamedType {
             name: "FavouriteSpots".to_string(),
         };

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -40,7 +40,7 @@ pub struct InputValueDefinition {
     // the default value used by this input value in the condition a value is
     // not provided at runtime. If this input value has no default value,
     // returns null.
-    default: Option<String>,
+    default_value: Option<String>,
     /// Contains all directives for this input value definition
     directives: Vec<Directive>,
 }
@@ -52,7 +52,7 @@ impl InputValueDefinition {
             description: None,
             name,
             type_,
-            default: None,
+            default_value: None,
             directives: Vec::new(),
         }
     }
@@ -65,8 +65,8 @@ impl InputValueDefinition {
     }
 
     /// Set the InputValueDef's default value.
-    pub fn default(&mut self, default: String) {
-        self.default = Some(default);
+    pub fn default_value(&mut self, default_value: String) {
+        self.default_value = Some(default_value);
     }
 
     /// Add a directive to InputValueDefinition.
@@ -88,7 +88,7 @@ impl fmt::Display for InputValueDefinition {
             }
         }
 
-        if let Some(default) = &self.default {
+        if let Some(default) = &self.default_value {
             write!(f, " = {}", default)?;
         }
 
@@ -128,7 +128,7 @@ mod tests {
 
         let ty_2 = Type_::NonNull { ty: Box::new(ty_1) };
         let mut value = InputValueDefinition::new("spaceCat".to_string(), ty_2);
-        value.default("\"Norwegian Forest\"".to_string());
+        value.default_value("\"Norwegian Forest\"".to_string());
 
         assert_eq!(
             value.to_string(),

--- a/crates/apollo-encoder/src/input_value.rs
+++ b/crates/apollo-encoder/src/input_value.rs
@@ -64,9 +64,9 @@ impl InputValueDefinition {
         });
     }
 
-    /// Set the InputValueDefinition's default value.
-    pub fn default(&mut self, default: Option<String>) {
-        self.default = default;
+    /// Set the InputValueDef's default value.
+    pub fn default(&mut self, default: String) {
+        self.default = Some(default);
     }
 
     /// Add a directive to InputValueDefinition.
@@ -128,7 +128,7 @@ mod tests {
 
         let ty_2 = Type_::NonNull { ty: Box::new(ty_1) };
         let mut value = InputValueDefinition::new("spaceCat".to_string(), ty_2);
-        value.default(Some("\"Norwegian Forest\"".to_string()));
+        value.default("\"Norwegian Forest\"".to_string());
 
         assert_eq!(
             value.to_string(),

--- a/crates/apollo-encoder/src/variable.rs
+++ b/crates/apollo-encoder/src/variable.rs
@@ -19,10 +19,10 @@ use crate::{Directive, Type_, Value};
 ///         name: String::from("MyType"),
 ///     },
 /// );
-/// variable.default_value(Some(Value::Object(vec![
+/// variable.default_value(Value::Object(vec![
 ///     (String::from("first"), Value::Int(25)),
 ///     (String::from("second"), Value::String(String::from("test"))),
-/// ])));
+/// ]));
 ///
 /// assert_eq!(
 ///     variable.to_string(),

--- a/crates/apollo-encoder/src/variable.rs
+++ b/crates/apollo-encoder/src/variable.rs
@@ -49,8 +49,8 @@ impl VariableDefinition {
     }
 
     /// Set a default value to the variable
-    pub fn default_value(&mut self, default_value: Option<Value>) {
-        self.default_value = default_value;
+    pub fn default_value(&mut self, default_value: Value) {
+        self.default_value = Some(default_value);
     }
 
     /// Add a directive
@@ -87,10 +87,10 @@ mod tests {
                 name: String::from("MyType"),
             },
         );
-        variable.default_value(Some(Value::Object(vec![
+        variable.default_value(Value::Object(vec![
             (String::from("first"), Value::Int(25)),
             (String::from("second"), Value::String(String::from("test"))),
-        ])));
+        ]));
 
         assert_eq!(
             variable.to_string(),

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -24,7 +24,7 @@ categories = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-apollo-encoder = { path = "../apollo-encoder", version = "0.2.3" }
+apollo-encoder = { path = "../apollo-encoder", version = "0.3.0" }
 apollo-parser = { path = "../apollo-parser", version = "0.2.5", optional = true }
 arbitrary = { version = "1.0.3", features = ["derive"] }
 once_cell = "1.9.0"

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -161,7 +161,7 @@ impl From<InputValueDef> for apollo_encoder::InputField {
             new_input_val.description(description.into())
         }
         if let Some(default) = input_val.default_value {
-            new_input_val.default(default.into())
+            new_input_val.default_value(default.into())
         }
         input_val
             .directives

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -122,7 +122,9 @@ impl From<InputValueDef> for apollo_encoder::InputValueDefinition {
         if let Some(description) = input_val.description {
             new_input_val.description(description.into())
         }
-        new_input_val.default(input_val.default_value.map(String::from));
+        if let Some(default) = input_val.default_value {
+            new_input_val.default_value(default.into())
+        }
         input_val
             .directives
             .into_iter()
@@ -158,7 +160,9 @@ impl From<InputValueDef> for apollo_encoder::InputField {
         if let Some(description) = input_val.description {
             new_input_val.description(description.into())
         }
-        new_input_val.default(input_val.default_value.map(String::from));
+        if let Some(default) = input_val.default_value {
+            new_input_val.default(default.into())
+        }
         input_val
             .directives
             .into_iter()

--- a/crates/apollo-smith/src/variable.rs
+++ b/crates/apollo-smith/src/variable.rs
@@ -27,7 +27,9 @@ pub struct VariableDef {
 impl From<VariableDef> for apollo_encoder::VariableDefinition {
     fn from(var_def: VariableDef) -> Self {
         let mut new_var_def = Self::new(var_def.name.into(), var_def.ty.into());
-        new_var_def.default_value(var_def.default_value.map(Into::into));
+        if let Some(default) = var_def.default_value {
+            new_var_def.default_value(default.into())
+        }
         var_def
             .directives
             .into_iter()


### PR DESCRIPTION
While making changes to #207 I noticed we are also using `Option<String>` as the parameter type for `default_value` setters (just as we did for description setters). This PR changes the parameter type to `String`.