### PR TITLE
feat(apollo-compiler): add schema and object type definitions

### DIFF
--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -14,19 +14,29 @@ pub enum ApolloDiagnostic {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum ErrorDiagnostic {
     MissingIdent(String),
+    QueryRootOperationType(String),
     SingleRootField(String),
-    UniqueOperationDefinition {
-        message: String,
-        operation: String,
-    },
-    UndefinedVariable {
-        message: String,
-        variable: String,
-    },
     SyntaxError {
         message: String,
         data: String,
         index: usize,
+    },
+    UniqueOperationDefinition {
+        message: String,
+        operation: String,
+    },
+    UniqueRootOperationType {
+        message: String,
+        named_type: String,
+        operation_type: String,
+    },
+    UnsupportedOperation {
+        message: String,
+        operation: Option<String>,
+    },
+    UndefinedVariable {
+        message: String,
+        variable: String,
     },
 }
 

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -133,4 +133,40 @@ query ExampleQuery {
             ["name", "price", "dimensions", "size", "weight"]
         );
     }
+
+    #[test]
+    fn it_accesses_schema_operation_types() {
+        let input = r#"
+schema {
+  query: customPetQuery,
+  subscription: customPetQuery,
+}
+
+type customPetQuery {
+  name: String,
+  age: Int
+}
+
+type Subscription {
+  changeInPetHousehold: Result
+}
+
+type Mutation {
+  addPet (name: String!, petType: PetType): Result!
+}
+
+type Result {
+  id: String
+}
+"#;
+
+        let ctx = ApolloCompiler::new(input);
+        let errors = ctx.validate();
+
+        dbg!(&errors);
+        assert!(errors.is_empty());
+
+        let schema = ctx.schema();
+        dbg!(schema);
+    }
 }

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -139,7 +139,6 @@ query ExampleQuery {
         let input = r#"
 schema {
   query: customPetQuery,
-  subscription: customPetQuery,
 }
 
 type customPetQuery {

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -52,6 +52,14 @@ impl ApolloCompiler {
     pub fn fragments(&self) -> values::Fragments {
         self.db.fragments()
     }
+
+    pub fn schema(&self) -> Arc<values::SchemaDefinition> {
+        self.db.schema()
+    }
+
+    pub fn object_types(&self) -> Arc<Vec<values::ObjectTypeDefinition>> {
+        self.db.object_types()
+    }
 }
 
 #[cfg(test)]

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -70,7 +70,6 @@ mod test {
     fn it_accesses_operation_definition_parts() {
         let input = r#"
 query ExampleQuery($definedVariable: Int, $definedVariable2: Boolean) {
-
   topProducts(first: $definedVariable) {
     name
   }
@@ -82,6 +81,10 @@ fragment vipCustomer on User {
   name
   profilePic(size: 50)
   status(activity: $definedVariable2)
+}
+
+type Query {
+    topProducts: Products
 }
 "#;
 
@@ -117,6 +120,14 @@ query ExampleQuery {
   dimensions
   size
   weight
+}
+
+type Query {
+  name: String
+  price: Int
+  dimensions: Int
+  size: Int
+  weight: Int
 }
 "#;
 
@@ -162,7 +173,6 @@ type Result {
         let ctx = ApolloCompiler::new(input);
         let errors = ctx.validate();
 
-        dbg!(&errors);
         assert!(errors.is_empty());
 
         let schema = ctx.schema();

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -376,6 +376,16 @@ fn schema_definition(schema_def: ast::SchemaDefinition) -> SchemaDefinition {
     }
 }
 
+fn schema_extension(db: &dyn SourceDatabase) {
+    let schema = db.schema();
+    db.definitions()
+        .iter()
+        .filter_map(|definition| match definition {
+            ast::Definition::SchemaExtension(schema_ext) => todo!(),
+            _ => None,
+        });
+}
+
 fn root_operation_type_definition(
     root_type_def: AstChildren<ast::RootOperationTypeDefinition>,
 ) -> Arc<Vec<RootOperationTypeDefinition>> {

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -506,3 +506,16 @@ impl Float {
         }
     }
 }
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct SchemaDefinition {
+    pub(crate) description: Option<String>,
+    pub(crate) directives: Arc<Vec<Directive>>,
+    pub(crate) root_operation_type_definition: Arc<Vec<RootOperationTypeDefinition>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct RootOperationTypeDefinition {
+    pub(crate) operation_type: OperationType,
+    pub(crate) named_type: Type,
+}

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -213,6 +213,40 @@ impl OperationType {
     }
 }
 
+impl std::fmt::Display for OperationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OperationType::Query => write!(f, "Subscription"),
+            OperationType::Mutation => write!(f, "Mutation"),
+            OperationType::Subscription => write!(f, "Query"),
+        }
+    }
+}
+
+impl From<OperationType> for String {
+    fn from(op_type: OperationType) -> Self {
+        if op_type.is_subscription() {
+            "Subscription".to_string()
+        } else if op_type.is_mutation() {
+            "Mutation".to_string()
+        } else {
+            "Query".to_string()
+        }
+    }
+}
+
+impl<'a> From<&'a str> for OperationType {
+    fn from(op_type: &str) -> Self {
+        if op_type == "Query" {
+            OperationType::Query
+        } else if op_type == "Mutation" {
+            OperationType::Mutation
+        } else {
+            OperationType::Subscription
+        }
+    }
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct VariableDefinition {
     pub(crate) name: String,
@@ -599,6 +633,11 @@ impl RootOperationTypeDefinition {
     /// Get a reference to the root operation type definition's named type.
     pub fn named_type(&self) -> &Type {
         &self.named_type
+    }
+
+    /// Get the root operation type definition's operation type.
+    pub fn operation_type(&self) -> OperationType {
+        self.operation_type
     }
 }
 

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -581,9 +581,10 @@ impl SchemaDefinition {
     }
 
     /// Set the schema definition's root operation type definition.
-    pub fn set_root_operation_type_definition(&mut self, op: RootOperationTypeDefinition) {
-        let mut ops = self.root_operation_type_definition.as_ref().clone();
-        ops.push(op);
+    pub(crate) fn set_root_operation_type_definition(&mut self, op: RootOperationTypeDefinition) {
+        Arc::get_mut(&mut self.root_operation_type_definition)
+            .unwrap()
+            .push(op)
     }
     // NOTE(@lrlna): potentially have the following fns on the database itself
     // so they are memoised as well

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -313,6 +313,8 @@ impl Argument {
 
 pub type Variable = String;
 
+pub type DefaultValue = Value;
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Value {
     Variable(Variable),
@@ -507,7 +509,7 @@ impl Float {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Default, Eq)]
 pub struct SchemaDefinition {
     pub(crate) description: Option<String>,
     pub(crate) directives: Arc<Vec<Directive>>,
@@ -518,4 +520,52 @@ pub struct SchemaDefinition {
 pub struct RootOperationTypeDefinition {
     pub(crate) operation_type: OperationType,
     pub(crate) named_type: Type,
+}
+
+impl Default for RootOperationTypeDefinition {
+    fn default() -> Self {
+        Self {
+            operation_type: OperationType::Query,
+            named_type: Type::Named {
+                name: "Query".to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ObjectTypeDefinition {
+    pub(crate) description: Option<String>,
+    pub(crate) name: String,
+    pub(crate) implements_interfaces: ImplementsInterfaces,
+    pub(crate) directives: Arc<Vec<Directive>>,
+    pub(crate) fields_definition: Arc<Vec<FieldDefinition>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ImplementsInterfaces {
+    pub(crate) interfaces: Arc<Vec<Type>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct FieldDefinition {
+    pub(crate) description: Option<String>,
+    pub(crate) name: String,
+    pub(crate) arguments: ArgumentsDefinition,
+    pub(crate) ty: Type,
+    pub(crate) directives: Arc<Vec<Directive>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ArgumentsDefinition {
+    pub(crate) input_values: Arc<Vec<InputValueDefinition>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct InputValueDefinition {
+    pub(crate) description: Option<String>,
+    pub(crate) name: String,
+    pub(crate) ty: Type,
+    pub(crate) default_value: Option<DefaultValue>,
+    pub(crate) directives: Arc<Vec<Directive>>,
 }

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -20,9 +20,9 @@ impl<'a> Validator<'a> {
 
     pub fn validate(&mut self) -> &mut [ApolloDiagnostic] {
         self.errors.extend(self.db.syntax_errors());
+        self.errors.extend(schema::check(self.db));
         self.errors.extend(operations::check(self.db));
         self.errors.extend(unused_variables::check(self.db));
-        self.errors.extend(schema::check(self.db));
         self.errors.as_mut()
     }
 }

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -1,6 +1,7 @@
 use crate::{ApolloDiagnostic, SourceDatabase};
 
 pub mod operations;
+pub mod schema;
 pub mod unused_implements_interfaces;
 pub mod unused_variables;
 
@@ -21,6 +22,7 @@ impl<'a> Validator<'a> {
         self.errors.extend(self.db.syntax_errors());
         self.errors.extend(operations::check(self.db));
         self.errors.extend(unused_variables::check(self.db));
+        self.errors.extend(schema::check(self.db));
         self.errors.as_mut()
     }
 }

--- a/crates/apollo-compiler/src/validation/operations.rs
+++ b/crates/apollo-compiler/src/validation/operations.rs
@@ -137,6 +137,10 @@ query getName {
     }
   }
 }
+
+type Query {
+  cat: Pet
+}
 "#;
         let ctx = ApolloCompiler::new(input);
         let errors = ctx.validate();
@@ -158,6 +162,10 @@ query getOwnerName {
       name
     }
   }
+}
+
+type Query {
+  cat: Pet
 }
 "#;
         let ctx = ApolloCompiler::new(input);

--- a/crates/apollo-compiler/src/validation/operations.rs
+++ b/crates/apollo-compiler/src/validation/operations.rs
@@ -46,9 +46,9 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
 
     // A Subscription operation definition can only have **one** root level
     // field.
-    if db.subscriptions().len() >= 1 {
+    if db.subscription_operations().len() >= 1 {
         let single_root_field: Vec<ApolloDiagnostic> = db
-            .subscriptions()
+            .subscription_operations()
             .iter()
             .filter_map(|op| {
                 let mut fields = op.fields(db).as_ref().clone();

--- a/crates/apollo-compiler/src/validation/operations.rs
+++ b/crates/apollo-compiler/src/validation/operations.rs
@@ -66,6 +66,54 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
         errors.extend(single_root_field);
     }
 
+    // All query, subscription and mutation operations must be against legally
+    // defined schema root operation types.
+    //
+    //   * subscription operation - subscription root operation
+    if db.subscription_operations().len() >= 1 && db.schema().subscription(db).is_none() {
+        let unsupported_ops: Vec<ApolloDiagnostic> = db
+            .subscription_operations()
+            .iter()
+            .map(|op| {
+                ApolloDiagnostic::Error(ErrorDiagnostic::UnsupportedOperation {
+                    message: "Subscription operation not supported by the schema".into(),
+                    operation: op.name().map(|s| s.to_string()),
+                })
+            })
+            .collect();
+        errors.extend(unsupported_ops)
+    }
+    //
+    //   * query operation - query root operation
+    if db.query_operations().len() >= 1 && db.schema().query(db).is_none() {
+        let unsupported_ops: Vec<ApolloDiagnostic> = db
+            .query_operations()
+            .iter()
+            .map(|op| {
+                ApolloDiagnostic::Error(ErrorDiagnostic::UnsupportedOperation {
+                    message: "Query operation not supported by the schema".into(),
+                    operation: op.name().map(|s| s.to_string()),
+                })
+            })
+            .collect();
+        errors.extend(unsupported_ops)
+    }
+    //
+    //   * mutation operation - mutation root operation
+    if db.mutation_operations().len() >= 1 && db.schema().mutation(db).is_none() {
+        let unsupported_ops: Vec<ApolloDiagnostic> = db
+            .mutation_operations()
+            .iter()
+            .map(|op| {
+                ApolloDiagnostic::Error(ErrorDiagnostic::UnsupportedOperation {
+                    message: "Mutation operation not supported by the schema".into(),
+                    operation: op.name().map(|s| s.to_string()),
+                })
+            })
+            .collect();
+        errors.extend(unsupported_ops)
+    }
+
     errors
 }
 

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -1,0 +1,36 @@
+use std::collections::HashSet;
+
+use crate::{diagnostics::ErrorDiagnostic, ApolloDiagnostic, SourceDatabase};
+
+pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
+    let mut errors = Vec::new();
+
+    // A GraphQL schema must have a Query root operation.
+    if db.schema().query(db).is_none() {
+        let error = ApolloDiagnostic::Error(ErrorDiagnostic::QueryRootOperationType(
+            "Missing query root operation type in schema definition".to_string(),
+        ));
+        errors.push(error);
+    }
+
+    // All root operations in a schema definition must be unique.
+    //
+    // Return a Unique Operation Definition error in case of a duplicate name.
+    let mut seen = HashSet::new();
+    for op_type in db.schema().root_operation_type_definition().iter() {
+        let name = op_type.named_type().name();
+        if seen.contains(&name) {
+            errors.push(ApolloDiagnostic::Error(
+                ErrorDiagnostic::UniqueRootOperationType {
+                    message: "Root Operation Types must be unique".into(),
+                    operation_type: op_type.operation_type().to_string(),
+                    named_type: name,
+                },
+            ));
+        } else {
+            seen.insert(name);
+        }
+    }
+
+    errors
+}

--- a/crates/apollo-compiler/src/validation/unused_variables.rs
+++ b/crates/apollo-compiler/src/validation/unused_variables.rs
@@ -64,6 +64,10 @@ query ExampleQuery {
   }
 
 }
+
+type Query {
+  topProducts: Products 
+}
 "#;
 
         let ctx = ApolloCompiler::new(input);
@@ -91,6 +95,10 @@ query ExampleQuery {
 
 fragment fragmentOne on User {
     profilePic(size: $dimensions)
+}
+
+type Query {
+  topProducts: Products 
 }
 "#;
 

--- a/crates/apollo-compiler/test_data/err/0001_duplicate_operatoin_names.graphql
+++ b/crates/apollo-compiler/test_data/err/0001_duplicate_operatoin_names.graphql
@@ -11,3 +11,7 @@ query getName {
     }
   }
 }
+
+type Query {
+  cat: String
+}

--- a/crates/apollo-compiler/test_data/err/0002_multiple_anonymous_operations.graphql
+++ b/crates/apollo-compiler/test_data/err/0002_multiple_anonymous_operations.graphql
@@ -5,9 +5,17 @@ query {
 }
 
 mutation {
-  cat {
+  addPet {
     owner {
       name
     }
   }
+}
+
+type Query {
+  cat: String
+}
+
+type Mutation {
+  addPet (name: String!, petType: PetType): Result!
 }

--- a/crates/apollo-compiler/test_data/err/0003_anonymous_and_named_operation.graphql
+++ b/crates/apollo-compiler/test_data/err/0003_anonymous_and_named_operation.graphql
@@ -5,9 +5,17 @@ query {
 }
 
 mutation getName {
-  cat {
+  addPet {
     owner {
       name
     }
   }
+}
+
+type Query {
+  cat: String
+}
+
+type Mutation {
+  addPet (name: String!, petType: PetType): Result!
 }

--- a/crates/apollo-compiler/test_data/err/0004_subscription_with_multiple_root_fields.graphql
+++ b/crates/apollo-compiler/test_data/err/0004_subscription_with_multiple_root_fields.graphql
@@ -14,3 +14,7 @@ type Result {
   body: String,
   sender: String
 }
+
+type Query {
+  message: String
+}

--- a/crates/apollo-compiler/test_data/err/0004_subscription_with_multiple_root_fields.graphql
+++ b/crates/apollo-compiler/test_data/err/0004_subscription_with_multiple_root_fields.graphql
@@ -5,3 +5,12 @@ subscription sub {
   }
   disallowedSecondRootField
 }
+
+type Subscription {
+  newMessage: Result
+}
+
+type Result {
+  body: String,
+  sender: String
+}

--- a/crates/apollo-compiler/test_data/err/0005_subscription_with_multiple_root_fields_in_fragment_spreads.graphql
+++ b/crates/apollo-compiler/test_data/err/0005_subscription_with_multiple_root_fields_in_fragment_spreads.graphql
@@ -9,3 +9,12 @@ fragment multipleSubscriptions on Subscription {
   }
   disallowedSecondRootField
 }
+
+type Subscription {
+  newMessage: Result
+}
+
+type Result {
+  body: String,
+  sender: String
+}

--- a/crates/apollo-compiler/test_data/err/0005_subscription_with_multiple_root_fields_in_fragment_spreads.graphql
+++ b/crates/apollo-compiler/test_data/err/0005_subscription_with_multiple_root_fields_in_fragment_spreads.graphql
@@ -18,3 +18,7 @@ type Result {
   body: String,
   sender: String
 }
+
+type Query {
+  message: String
+}

--- a/crates/apollo-compiler/test_data/err/0006_subscription_with_multiple_root_fields_in_inline_fragments.graphql
+++ b/crates/apollo-compiler/test_data/err/0006_subscription_with_multiple_root_fields_in_inline_fragments.graphql
@@ -16,3 +16,7 @@ type Result {
   body: String,
   sender: String
 }
+
+type Query {
+  message: String
+}

--- a/crates/apollo-compiler/test_data/err/0006_subscription_with_multiple_root_fields_in_inline_fragments.graphql
+++ b/crates/apollo-compiler/test_data/err/0006_subscription_with_multiple_root_fields_in_inline_fragments.graphql
@@ -7,3 +7,12 @@ subscription sub {
         disallowedSecondRootField
     }
 }
+
+type Subscription {
+  newMessage: Result
+}
+
+type Result {
+  body: String,
+  sender: String
+}

--- a/crates/apollo-compiler/test_data/err/0007_operation_with_undefined_variables.graphql
+++ b/crates/apollo-compiler/test_data/err/0007_operation_with_undefined_variables.graphql
@@ -3,3 +3,11 @@ query ExampleQuery {
     name
   }
 }
+
+type Query {
+  topProducts(first: Int): TopProduct,
+}
+
+type TopProduct {
+  name: String
+}

--- a/crates/apollo-compiler/test_data/err/0008_operation_with_undefined_variables_in_inline_fragment.graphql
+++ b/crates/apollo-compiler/test_data/err/0008_operation_with_undefined_variables_in_inline_fragment.graphql
@@ -6,3 +6,12 @@ query ExampleQuery {
       price(setPrice: $value)
   }
 }
+
+type Query {
+  topProducts(first: Int): Product,
+}
+
+type Product {
+  name: String
+  price(setPrice: Int): Int
+}

--- a/crates/apollo-compiler/test_data/err/0009_operation_with_undefined_variables_in_fragment.graphql
+++ b/crates/apollo-compiler/test_data/err/0009_operation_with_undefined_variables_in_fragment.graphql
@@ -11,3 +11,12 @@ fragment multipleSubscriptions on Subscription {
     sender(attribute: $value)
   }
 }
+
+type Query {
+  topProducts(first: Int): Product,
+}
+
+type Product {
+  name: String
+  price(setPrice: Int): Int
+}

--- a/crates/apollo-compiler/test_data/err/0010_operation_with_unused_variable.graphql
+++ b/crates/apollo-compiler/test_data/err/0010_operation_with_unused_variable.graphql
@@ -4,3 +4,12 @@ query ExampleQuery($unusedVariable: Int) {
   }
   ... multipleSubscriptions
 }
+
+type Query {
+  topProducts(first: Int): Product,
+}
+
+type Product {
+  name: String
+  price(setPrice: Int): Int
+}

--- a/crates/apollo-compiler/test_data/err/0011_syntactic_errors_from_parser.graphql
+++ b/crates/apollo-compiler/test_data/err/0011_syntactic_errors_from_parser.graphql
@@ -4,3 +4,7 @@ fragment fragmentOne {
     name
     birthday
 }
+
+type Query {
+  topProducts(first: Int): Product,
+}

--- a/crates/apollo-compiler/test_data/err/0012_schema_definition_with_missing_query_operation_type.graphql
+++ b/crates/apollo-compiler/test_data/err/0012_schema_definition_with_missing_query_operation_type.graphql
@@ -1,0 +1,11 @@
+schema {
+  subscription: customSubscription
+}
+
+type customSubscription {
+  changeInPetHousehold: Result
+}
+
+type Result {
+  id: String
+}

--- a/crates/apollo-compiler/test_data/err/0012_schema_definition_with_missing_query_operation_type.txt
+++ b/crates/apollo-compiler/test_data/err/0012_schema_definition_with_missing_query_operation_type.txt
@@ -1,0 +1,1 @@
+[Error(QueryRootOperationType("Missing query root operation type in schema definition"))]

--- a/crates/apollo-compiler/test_data/err/0013_schema_definition_with_duplicate_root_type_operations.graphql
+++ b/crates/apollo-compiler/test_data/err/0013_schema_definition_with_duplicate_root_type_operations.graphql
@@ -1,0 +1,9 @@
+schema {
+  query: customPetQuery,
+  subscription: customPetQuery
+}
+
+type customPetQuery {
+  name: String,
+  age: Int
+}

--- a/crates/apollo-compiler/test_data/err/0013_schema_definition_with_duplicate_root_type_operations.txt
+++ b/crates/apollo-compiler/test_data/err/0013_schema_definition_with_duplicate_root_type_operations.txt
@@ -1,0 +1,1 @@
+[Error(UniqueRootOperationType { message: "Root Operation Types must be unique", named_type: "customPetQuery", operation_type: "Query" })]

--- a/crates/apollo-compiler/test_data/err/0014_subscription_operation_without_subscription_schema_operation_type.graphql
+++ b/crates/apollo-compiler/test_data/err/0014_subscription_operation_without_subscription_schema_operation_type.graphql
@@ -1,0 +1,15 @@
+subscription messageSubscription {
+  newMessage {
+    body
+    sender
+  }
+}
+
+schema {
+  query: customPetQuery,
+}
+
+type customPetQuery {
+  name: String,
+  age: Int
+}

--- a/crates/apollo-compiler/test_data/err/0014_subscription_operation_without_subscription_schema_operation_type.txt
+++ b/crates/apollo-compiler/test_data/err/0014_subscription_operation_without_subscription_schema_operation_type.txt
@@ -1,0 +1,1 @@
+[Error(UnsupportedOperation { message: "Subscription operation not supported by the schema", operation: Some("messageSubscription") })]

--- a/crates/apollo-compiler/test_data/err/0015_mutation_operation_without_mutation_schema_definition.graphql
+++ b/crates/apollo-compiler/test_data/err/0015_mutation_operation_without_mutation_schema_definition.graphql
@@ -1,0 +1,12 @@
+mutation adoptAPetMutation {
+  addPet {
+    owner {
+      name
+    }
+  }
+}
+
+type Query {
+  name: String,
+  age: Int
+}

--- a/crates/apollo-compiler/test_data/err/0015_mutation_operation_without_mutation_schema_definition.txt
+++ b/crates/apollo-compiler/test_data/err/0015_mutation_operation_without_mutation_schema_definition.txt
@@ -1,0 +1,1 @@
+[Error(UnsupportedOperation { message: "Mutation operation not supported by the schema", operation: Some("adoptAPetMutation") })]

--- a/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.graphql
+++ b/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.graphql
@@ -4,3 +4,11 @@ query {
     name
   }
 }
+
+type Query {
+  cat: Pet
+}
+
+type Pet {
+  name: String
+}

--- a/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
@@ -1,10 +1,10 @@
-- DOCUMENT@0..32
+- DOCUMENT@0..87
     - WHITESPACE@0..1 "\n"
-    - OPERATION_DEFINITION@1..32
+    - OPERATION_DEFINITION@1..33
         - OPERATION_TYPE@1..7
             - query_KW@1..6 "query"
             - WHITESPACE@6..7 " "
-        - SELECTION_SET@7..32
+        - SELECTION_SET@7..33
             - L_CURLY@7..8 "{"
             - WHITESPACE@8..11 "\n  "
             - FIELD@11..30
@@ -21,5 +21,44 @@
                     - R_CURLY@28..29 "}"
                     - WHITESPACE@29..30 "\n"
             - R_CURLY@30..31 "}"
-            - WHITESPACE@31..32 "\n"
+            - WHITESPACE@31..33 "\n\n"
+    - OBJECT_TYPE_DEFINITION@33..60
+        - type_KW@33..37 "type"
+        - WHITESPACE@37..38 " "
+        - NAME@38..44
+            - IDENT@38..43 "Query"
+            - WHITESPACE@43..44 " "
+        - FIELDS_DEFINITION@44..60
+            - L_CURLY@44..45 "{"
+            - WHITESPACE@45..48 "\n  "
+            - FIELD_DEFINITION@48..57
+                - NAME@48..51
+                    - IDENT@48..51 "cat"
+                - COLON@51..52 ":"
+                - WHITESPACE@52..53 " "
+                - NAMED_TYPE@53..56
+                    - NAME@53..56
+                        - IDENT@53..56 "Pet"
+                - WHITESPACE@56..57 "\n"
+            - R_CURLY@57..58 "}"
+            - WHITESPACE@58..60 "\n\n"
+    - OBJECT_TYPE_DEFINITION@60..87
+        - type_KW@60..64 "type"
+        - WHITESPACE@64..65 " "
+        - NAME@65..69
+            - IDENT@65..68 "Pet"
+            - WHITESPACE@68..69 " "
+        - FIELDS_DEFINITION@69..87
+            - L_CURLY@69..70 "{"
+            - WHITESPACE@70..73 "\n  "
+            - FIELD_DEFINITION@73..86
+                - NAME@73..77
+                    - IDENT@73..77 "name"
+                - COLON@77..78 ":"
+                - WHITESPACE@78..79 " "
+                - NAMED_TYPE@79..85
+                    - NAME@79..85
+                        - IDENT@79..85 "String"
+                - WHITESPACE@85..86 "\n"
+            - R_CURLY@86..87 "}"
 

--- a/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.graphql
+++ b/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.graphql
@@ -11,3 +11,17 @@ query getOwnerName {
     }
   }
 }
+
+
+type Query {
+  cat: Pet
+}
+
+type Pet {
+  name: String,
+  owner: PetOwner
+}
+
+type PetOwner {
+  name: String
+}

--- a/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
@@ -1,4 +1,4 @@
-- DOCUMENT@0..107
+- DOCUMENT@0..217
     - OPERATION_DEFINITION@0..43
         - OPERATION_TYPE@0..6
             - query_KW@0..5 "query"
@@ -24,14 +24,14 @@
                     - WHITESPACE@39..40 "\n"
             - R_CURLY@40..41 "}"
             - WHITESPACE@41..43 "\n\n"
-    - OPERATION_DEFINITION@43..107
+    - OPERATION_DEFINITION@43..109
         - OPERATION_TYPE@43..49
             - query_KW@43..48 "query"
             - WHITESPACE@48..49 " "
         - NAME@49..62
             - IDENT@49..61 "getOwnerName"
             - WHITESPACE@61..62 " "
-        - SELECTION_SET@62..107
+        - SELECTION_SET@62..109
             - L_CURLY@62..63 "{"
             - WHITESPACE@63..66 "\n  "
             - FIELD@66..105
@@ -57,5 +57,75 @@
                     - R_CURLY@103..104 "}"
                     - WHITESPACE@104..105 "\n"
             - R_CURLY@105..106 "}"
-            - WHITESPACE@106..107 "\n"
+            - WHITESPACE@106..109 "\n\n\n"
+    - OBJECT_TYPE_DEFINITION@109..136
+        - type_KW@109..113 "type"
+        - WHITESPACE@113..114 " "
+        - NAME@114..120
+            - IDENT@114..119 "Query"
+            - WHITESPACE@119..120 " "
+        - FIELDS_DEFINITION@120..136
+            - L_CURLY@120..121 "{"
+            - WHITESPACE@121..124 "\n  "
+            - FIELD_DEFINITION@124..133
+                - NAME@124..127
+                    - IDENT@124..127 "cat"
+                - COLON@127..128 ":"
+                - WHITESPACE@128..129 " "
+                - NAMED_TYPE@129..132
+                    - NAME@129..132
+                        - IDENT@129..132 "Pet"
+                - WHITESPACE@132..133 "\n"
+            - R_CURLY@133..134 "}"
+            - WHITESPACE@134..136 "\n\n"
+    - OBJECT_TYPE_DEFINITION@136..184
+        - type_KW@136..140 "type"
+        - WHITESPACE@140..141 " "
+        - NAME@141..145
+            - IDENT@141..144 "Pet"
+            - WHITESPACE@144..145 " "
+        - FIELDS_DEFINITION@145..184
+            - L_CURLY@145..146 "{"
+            - WHITESPACE@146..149 "\n  "
+            - FIELD_DEFINITION@149..165
+                - NAME@149..153
+                    - IDENT@149..153 "name"
+                - COLON@153..154 ":"
+                - WHITESPACE@154..155 " "
+                - NAMED_TYPE@155..161
+                    - NAME@155..161
+                        - IDENT@155..161 "String"
+                - COMMA@161..162 ","
+                - WHITESPACE@162..165 "\n  "
+            - FIELD_DEFINITION@165..181
+                - NAME@165..170
+                    - IDENT@165..170 "owner"
+                - COLON@170..171 ":"
+                - WHITESPACE@171..172 " "
+                - NAMED_TYPE@172..180
+                    - NAME@172..180
+                        - IDENT@172..180 "PetOwner"
+                - WHITESPACE@180..181 "\n"
+            - R_CURLY@181..182 "}"
+            - WHITESPACE@182..184 "\n\n"
+    - OBJECT_TYPE_DEFINITION@184..217
+        - type_KW@184..188 "type"
+        - WHITESPACE@188..189 " "
+        - NAME@189..198
+            - IDENT@189..197 "PetOwner"
+            - WHITESPACE@197..198 " "
+        - FIELDS_DEFINITION@198..217
+            - L_CURLY@198..199 "{"
+            - WHITESPACE@199..202 "\n  "
+            - FIELD_DEFINITION@202..215
+                - NAME@202..206
+                    - IDENT@202..206 "name"
+                - COLON@206..207 ":"
+                - WHITESPACE@207..208 " "
+                - NAMED_TYPE@208..214
+                    - NAME@208..214
+                        - IDENT@208..214 "String"
+                - WHITESPACE@214..215 "\n"
+            - R_CURLY@215..216 "}"
+            - WHITESPACE@216..217 "\n"
 

--- a/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.graphql
+++ b/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.graphql
@@ -1,0 +1,22 @@
+schema {
+  query: customPetQuery,
+  subscription: customPetSubscription
+  mutation: customPetMutation
+}
+
+type customPetQuery {
+  name: String,
+  age: Int
+}
+
+type customPetSubscription {
+  changeInPetHousehold: Result
+}
+
+type customPetMutation {
+  addPet (name: String!, petType: PetType): Result!
+}
+
+type Result {
+  id: String
+}

--- a/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
@@ -1,0 +1,152 @@
+- DOCUMENT@0..328
+    - SCHEMA_DEFINITION@0..105
+        - schema_KW@0..6 "schema"
+        - WHITESPACE@6..7 " "
+        - L_CURLY@7..8 "{"
+        - WHITESPACE@8..11 "\n  "
+        - ROOT_OPERATION_TYPE_DEFINITION@11..36
+            - OPERATION_TYPE@11..16
+                - query_KW@11..16 "query"
+            - COLON@16..17 ":"
+            - WHITESPACE@17..18 " "
+            - NAMED_TYPE@18..36
+                - NAME@18..36
+                    - IDENT@18..32 "customPetQuery"
+                    - COMMA@32..33 ","
+                    - WHITESPACE@33..36 "\n  "
+        - ROOT_OPERATION_TYPE_DEFINITION@36..74
+            - OPERATION_TYPE@36..48
+                - subscription_KW@36..48 "subscription"
+            - COLON@48..49 ":"
+            - WHITESPACE@49..50 " "
+            - NAMED_TYPE@50..74
+                - NAME@50..74
+                    - IDENT@50..71 "customPetSubscription"
+                    - WHITESPACE@71..74 "\n  "
+        - ROOT_OPERATION_TYPE_DEFINITION@74..102
+            - OPERATION_TYPE@74..82
+                - mutation_KW@74..82 "mutation"
+            - COLON@82..83 ":"
+            - WHITESPACE@83..84 " "
+            - NAMED_TYPE@84..102
+                - NAME@84..102
+                    - IDENT@84..101 "customPetMutation"
+                    - WHITESPACE@101..102 "\n"
+        - R_CURLY@102..103 "}"
+        - WHITESPACE@103..105 "\n\n"
+    - OBJECT_TYPE_DEFINITION@105..157
+        - type_KW@105..109 "type"
+        - WHITESPACE@109..110 " "
+        - NAME@110..125
+            - IDENT@110..124 "customPetQuery"
+            - WHITESPACE@124..125 " "
+        - FIELDS_DEFINITION@125..157
+            - L_CURLY@125..126 "{"
+            - WHITESPACE@126..129 "\n  "
+            - FIELD_DEFINITION@129..145
+                - NAME@129..133
+                    - IDENT@129..133 "name"
+                - COLON@133..134 ":"
+                - WHITESPACE@134..135 " "
+                - NAMED_TYPE@135..141
+                    - NAME@135..141
+                        - IDENT@135..141 "String"
+                - COMMA@141..142 ","
+                - WHITESPACE@142..145 "\n  "
+            - FIELD_DEFINITION@145..154
+                - NAME@145..148
+                    - IDENT@145..148 "age"
+                - COLON@148..149 ":"
+                - WHITESPACE@149..150 " "
+                - NAMED_TYPE@150..153
+                    - NAME@150..153
+                        - IDENT@150..153 "Int"
+                - WHITESPACE@153..154 "\n"
+            - R_CURLY@154..155 "}"
+            - WHITESPACE@155..157 "\n\n"
+    - OBJECT_TYPE_DEFINITION@157..220
+        - type_KW@157..161 "type"
+        - WHITESPACE@161..162 " "
+        - NAME@162..184
+            - IDENT@162..183 "customPetSubscription"
+            - WHITESPACE@183..184 " "
+        - FIELDS_DEFINITION@184..220
+            - L_CURLY@184..185 "{"
+            - WHITESPACE@185..188 "\n  "
+            - FIELD_DEFINITION@188..217
+                - NAME@188..208
+                    - IDENT@188..208 "changeInPetHousehold"
+                - COLON@208..209 ":"
+                - WHITESPACE@209..210 " "
+                - NAMED_TYPE@210..216
+                    - NAME@210..216
+                        - IDENT@210..216 "Result"
+                - WHITESPACE@216..217 "\n"
+            - R_CURLY@217..218 "}"
+            - WHITESPACE@218..220 "\n\n"
+    - OBJECT_TYPE_DEFINITION@220..300
+        - type_KW@220..224 "type"
+        - WHITESPACE@224..225 " "
+        - NAME@225..243
+            - IDENT@225..242 "customPetMutation"
+            - WHITESPACE@242..243 " "
+        - FIELDS_DEFINITION@243..300
+            - L_CURLY@243..244 "{"
+            - WHITESPACE@244..247 "\n  "
+            - FIELD_DEFINITION@247..297
+                - NAME@247..254
+                    - IDENT@247..253 "addPet"
+                    - WHITESPACE@253..254 " "
+                - ARGUMENTS_DEFINITION@254..287
+                    - L_PAREN@254..255 "("
+                    - INPUT_VALUE_DEFINITION@255..270
+                        - NAME@255..259
+                            - IDENT@255..259 "name"
+                        - COLON@259..260 ":"
+                        - WHITESPACE@260..261 " "
+                        - NON_NULL_TYPE@261..270
+                            - NAMED_TYPE@261..267
+                                - NAME@261..267
+                                    - IDENT@261..267 "String"
+                            - BANG@267..268 "!"
+                            - COMMA@268..269 ","
+                            - WHITESPACE@269..270 " "
+                    - INPUT_VALUE_DEFINITION@270..286
+                        - NAME@270..277
+                            - IDENT@270..277 "petType"
+                        - COLON@277..278 ":"
+                        - WHITESPACE@278..279 " "
+                        - NAMED_TYPE@279..286
+                            - NAME@279..286
+                                - IDENT@279..286 "PetType"
+                    - R_PAREN@286..287 ")"
+                - COLON@287..288 ":"
+                - WHITESPACE@288..289 " "
+                - NON_NULL_TYPE@289..297
+                    - NAMED_TYPE@289..295
+                        - NAME@289..295
+                            - IDENT@289..295 "Result"
+                    - BANG@295..296 "!"
+                    - WHITESPACE@296..297 "\n"
+            - R_CURLY@297..298 "}"
+            - WHITESPACE@298..300 "\n\n"
+    - OBJECT_TYPE_DEFINITION@300..328
+        - type_KW@300..304 "type"
+        - WHITESPACE@304..305 " "
+        - NAME@305..312
+            - IDENT@305..311 "Result"
+            - WHITESPACE@311..312 " "
+        - FIELDS_DEFINITION@312..328
+            - L_CURLY@312..313 "{"
+            - WHITESPACE@313..316 "\n  "
+            - FIELD_DEFINITION@316..327
+                - NAME@316..318
+                    - IDENT@316..318 "id"
+                - COLON@318..319 ":"
+                - WHITESPACE@319..320 " "
+                - NAMED_TYPE@320..326
+                    - NAME@320..326
+                        - IDENT@320..326 "String"
+                - WHITESPACE@326..327 "\n"
+            - R_CURLY@327..328 "}"
+


### PR DESCRIPTION
This adds Schema Definition and Object type definitions to compiler's context.

A few validations are introduced as part of this addition:
- schema must have a query operation type
- schema's operation types must be unique
- subscription, mutation and query operations can only be present if the schema defines these operation types

Adds a few more diagnostic types:
- QueryRootOperationType
- UniqueRootOperation
- UnsupportedOperation

We also link the schema definition to their applicable object types, that is a mutation operation type defined in the schema is linked to an object type with that name (UUIDs for now until #218)

closes #215 closes #216 