### PR TITLE
feat(apollo-compiler): add directive definitions to source database

### DIFF
--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -336,14 +336,19 @@ type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
         let directives = ctx.directive_definitions();
         let locations: Vec<String> = directives
             .iter()
-            .flat_map(|dir| {
-                let locations: Vec<String> = dir
-                    .directive_locations()
-                    .iter()
-                    .map(|loc| loc.clone().into())
-                    .collect();
-                locations
+            .filter_map(|dir| {
+                if dir.name() == "delegateField" {
+                    let locations: Vec<String> = dir
+                        .directive_locations()
+                        .iter()
+                        .map(|loc| loc.clone().into())
+                        .collect();
+                    Some(locations)
+                } else {
+                    None
+                }
             })
+            .flatten()
             .collect();
 
         assert_eq!(["OBJECT", "INTERFACE"], locations.as_ref());

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -72,6 +72,10 @@ impl ApolloCompiler {
     pub fn unions(&self) -> Arc<Vec<values::UnionDefinition>> {
         self.db.unions()
     }
+
+    pub fn directive_definitions(&self) -> Arc<Vec<values::DirectiveDefinition>> {
+        self.db.directive_definitions()
+    }
 }
 
 #[cfg(test)]

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -465,7 +465,37 @@ fn directive_definitions(db: &dyn SourceDatabase) -> Arc<Vec<DirectiveDefinition
             _ => None,
         })
         .collect();
+
+    let directives = built_in_directives(directives);
+
     Arc::new(directives)
+}
+
+fn built_in_directives(directives: Vec<DirectiveDefinition>) -> Vec<DirectiveDefinition> {
+    if !directives.iter().any(|dir| dir.name == "skip") {
+        let skip = DirectiveDefinition {
+            id: Uuid::new_v4(),
+            description: todo!(),
+            name: todo!(),
+            arguments: todo!(),
+            repeatable: todo!(),
+            directive_locations: todo!(),
+        };
+        directives.push(skip);
+    }
+    if !directives.iter().any(|dir| dir.name == "include") {
+        let include = DirectiveDefinition {
+            id: Uuid::new_v4(),
+            description: todo!(),
+            name: todo!(),
+            arguments: todo!(),
+            repeatable: todo!(),
+            directive_locations: todo!(),
+        };
+        directives.push(include);
+    }
+
+    directives
 }
 
 fn find_directive_definition(

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -348,7 +348,7 @@ fn object_types(db: &dyn SourceDatabase) -> Arc<Vec<ObjectTypeDefinition>> {
         .iter()
         .filter_map(|definition| match definition {
             ast::Definition::ObjectTypeDefinition(obj_def) => {
-                Some(object_type_definition(db, obj_def.clone()))
+                Some(object_type_definition(obj_def.clone()))
             }
             _ => None,
         })
@@ -383,7 +383,7 @@ fn scalars(db: &dyn SourceDatabase) -> Arc<Vec<ScalarDefinition>> {
         .iter()
         .filter_map(|definition| match definition {
             ast::Definition::ScalarTypeDefinition(scalar_def) => {
-                Some(scalar_definition(db, scalar_def.clone()))
+                Some(scalar_definition(scalar_def.clone()))
             }
             _ => None,
         })
@@ -397,7 +397,7 @@ fn enums(db: &dyn SourceDatabase) -> Arc<Vec<EnumDefinition>> {
         .iter()
         .filter_map(|definition| match definition {
             ast::Definition::EnumTypeDefinition(enum_def) => {
-                Some(enum_definition(db, enum_def.clone()))
+                Some(enum_definition(enum_def.clone()))
             }
             _ => None,
         })
@@ -425,7 +425,7 @@ fn interfaces(db: &dyn SourceDatabase) -> Arc<Vec<InterfaceDefinition>> {
         .iter()
         .filter_map(|definition| match definition {
             ast::Definition::InterfaceTypeDefinition(interface_def) => {
-                Some(interface_definition(db, interface_def.clone()))
+                Some(interface_definition(interface_def.clone()))
             }
             _ => None,
         })
@@ -460,7 +460,7 @@ fn directive_definitions(db: &dyn SourceDatabase) -> Arc<Vec<DirectiveDefinition
         .iter()
         .filter_map(|definition| match definition {
             ast::Definition::DirectiveDefinition(directive_def) => {
-                Some(directive_definition(db, directive_def.clone()))
+                Some(directive_definition(directive_def.clone()))
             }
             _ => None,
         })
@@ -501,9 +501,9 @@ fn operation_definition(
     // if there are no names, an error must be raised that all operations must have a name
     let name = op_def.name().map(|name| name.text().to_string());
     let ty = operation_type(op_def.operation_type());
-    let variables = variable_definitions(db, op_def.variable_definitions());
+    let variables = variable_definitions(op_def.variable_definitions());
     let selection_set = selection_set(db, op_def.selection_set());
-    let directives = directives(db, op_def.directives());
+    let directives = directives(op_def.directives());
 
     OperationDefinition {
         id: Uuid::new_v4(),
@@ -535,7 +535,7 @@ fn fragment_definition(
         .text()
         .to_string();
     let selection_set = selection_set(db, fragment_def.selection_set());
-    let directives = directives(db, fragment_def.directives());
+    let directives = directives(fragment_def.directives());
 
     FragmentDefinition {
         id: Uuid::new_v4(),
@@ -551,7 +551,7 @@ fn schema_definition(
     schema_def: ast::SchemaDefinition,
 ) -> SchemaDefinition {
     let description = description(schema_def.description());
-    let directives = directives(db, schema_def.directives());
+    let directives = directives(schema_def.directives());
     let root_operation_type_definition =
         root_operation_type_definition(db, schema_def.root_operation_type_definitions());
 
@@ -562,16 +562,13 @@ fn schema_definition(
     }
 }
 
-fn object_type_definition(
-    db: &dyn SourceDatabase,
-    obj_def: ast::ObjectTypeDefinition,
-) -> ObjectTypeDefinition {
+fn object_type_definition(obj_def: ast::ObjectTypeDefinition) -> ObjectTypeDefinition {
     let id = Uuid::new_v4();
     let description = description(obj_def.description());
     let name = name(obj_def.name());
     let implements_interfaces = implements_interfaces(obj_def.implements_interfaces());
-    let directives = directives(db, obj_def.directives());
-    let fields_definition = fields_definition(db, obj_def.fields_definition());
+    let directives = directives(obj_def.directives());
+    let fields_definition = fields_definition(obj_def.fields_definition());
 
     ObjectTypeDefinition {
         id,
@@ -583,13 +580,10 @@ fn object_type_definition(
     }
 }
 
-fn scalar_definition(
-    db: &dyn SourceDatabase,
-    scalar_def: ast::ScalarTypeDefinition,
-) -> ScalarDefinition {
+fn scalar_definition(scalar_def: ast::ScalarTypeDefinition) -> ScalarDefinition {
     let description = description(scalar_def.description());
     let name = name(scalar_def.name());
-    let directives = directives(db, scalar_def.directives());
+    let directives = directives(scalar_def.directives());
 
     ScalarDefinition {
         description,
@@ -598,11 +592,11 @@ fn scalar_definition(
     }
 }
 
-fn enum_definition(db: &dyn SourceDatabase, enum_def: ast::EnumTypeDefinition) -> EnumDefinition {
+fn enum_definition(enum_def: ast::EnumTypeDefinition) -> EnumDefinition {
     let description = description(enum_def.description());
     let name = name(enum_def.name());
-    let directives = directives(db, enum_def.directives());
-    let enum_values_definition = enum_values_definition(db, enum_def.enum_values_definition());
+    let directives = directives(enum_def.directives());
+    let enum_values_definition = enum_values_definition(enum_def.enum_values_definition());
 
     EnumDefinition {
         description,
@@ -613,7 +607,6 @@ fn enum_definition(db: &dyn SourceDatabase, enum_def: ast::EnumTypeDefinition) -
 }
 
 fn enum_values_definition(
-    db: &dyn SourceDatabase,
     enum_values_def: Option<ast::EnumValuesDefinition>,
 ) -> Arc<Vec<EnumValueDefinition>> {
     match enum_values_def {
@@ -621,7 +614,7 @@ fn enum_values_definition(
             let enum_values = enum_values
                 .enum_value_definitions()
                 .into_iter()
-                .map(|enum_val_def| enum_value_definition(db, enum_val_def))
+                .map(enum_value_definition)
                 .collect();
             Arc::new(enum_values)
         }
@@ -629,13 +622,10 @@ fn enum_values_definition(
     }
 }
 
-fn enum_value_definition(
-    db: &dyn SourceDatabase,
-    enum_value_def: ast::EnumValueDefinition,
-) -> EnumValueDefinition {
+fn enum_value_definition(enum_value_def: ast::EnumValueDefinition) -> EnumValueDefinition {
     let description = description(enum_value_def.description());
     let enum_value = enum_value(enum_value_def.enum_value());
-    let directives = directives(db, enum_value_def.directives());
+    let directives = directives(enum_value_def.directives());
 
     EnumValueDefinition {
         description,
@@ -650,7 +640,7 @@ fn union_definition(
 ) -> UnionDefinition {
     let description = description(union_def.description());
     let name = name(union_def.name());
-    let directives = directives(db, union_def.directives());
+    let directives = directives(union_def.directives());
     let union_members = union_members(db, union_def.union_member_types());
 
     UnionDefinition {
@@ -687,16 +677,13 @@ fn union_member(db: &dyn SourceDatabase, member: ast::NamedType) -> UnionMember 
     UnionMember { name, object_id }
 }
 
-fn interface_definition(
-    db: &dyn SourceDatabase,
-    interface_def: ast::InterfaceTypeDefinition,
-) -> InterfaceDefinition {
+fn interface_definition(interface_def: ast::InterfaceTypeDefinition) -> InterfaceDefinition {
     let id = Uuid::new_v4();
     let description = description(interface_def.description());
     let name = name(interface_def.name());
     let implements_interfaces = implements_interfaces(interface_def.implements_interfaces());
-    let directives = directives(db, interface_def.directives());
-    let fields_definition = fields_definition(db, interface_def.fields_definition());
+    let directives = directives(interface_def.directives());
+    let fields_definition = fields_definition(interface_def.fields_definition());
 
     InterfaceDefinition {
         id,
@@ -708,13 +695,10 @@ fn interface_definition(
     }
 }
 
-fn directive_definition(
-    db: &dyn SourceDatabase,
-    directive_def: ast::DirectiveDefinition,
-) -> DirectiveDefinition {
+fn directive_definition(directive_def: ast::DirectiveDefinition) -> DirectiveDefinition {
     let name = name(directive_def.name());
     let description = description(directive_def.description());
-    let arguments = arguments_definition(db, directive_def.arguments_definition());
+    let arguments = arguments_definition(directive_def.arguments_definition());
     let repeatable = directive_def.repeatable_token().is_some();
     let directive_locations = directive_locations(directive_def.directive_locations());
 
@@ -779,7 +763,6 @@ fn implements_interfaces(
 }
 
 fn fields_definition(
-    db: &dyn SourceDatabase,
     fields_definition: Option<ast::FieldsDefinition>,
 ) -> Arc<Vec<FieldDefinition>> {
     match fields_definition {
@@ -789,9 +772,9 @@ fn fields_definition(
                 .map(|field| {
                     let description = description(field.description());
                     let name = name(field.name());
-                    let arguments = arguments_definition(db, field.arguments_definition());
+                    let arguments = arguments_definition(field.arguments_definition());
                     let ty = ty(field.ty().expect("Field must have a type"));
-                    let directives = directives(db, field.directives());
+                    let directives = directives(field.directives());
 
                     FieldDefinition {
                         description,
@@ -809,12 +792,11 @@ fn fields_definition(
 }
 
 fn arguments_definition(
-    db: &dyn SourceDatabase,
     arguments_definition: Option<ast::ArgumentsDefinition>,
 ) -> ArgumentsDefinition {
     match arguments_definition {
         Some(arguments) => {
-            let input_values = input_value_definitions(db, arguments.input_value_definitions());
+            let input_values = input_value_definitions(arguments.input_value_definitions());
             ArgumentsDefinition { input_values }
         }
         None => ArgumentsDefinition {
@@ -824,7 +806,6 @@ fn arguments_definition(
 }
 
 fn input_value_definitions(
-    db: &dyn SourceDatabase,
     input_values: AstChildren<ast::InputValueDefinition>,
 ) -> Arc<Vec<InputValueDefinition>> {
     let input_values: Vec<InputValueDefinition> = input_values
@@ -833,7 +814,7 @@ fn input_value_definitions(
             let name = name(input.name());
             let ty = ty(input.ty().expect("Input Definition must have a type"));
             let default_value = default_value(input.default_value());
-            let directives = directives(db, input.directives());
+            let directives = directives(input.directives());
 
             InputValueDefinition {
                 description,
@@ -896,7 +877,6 @@ fn operation_type(op_type: Option<ast::OperationType>) -> OperationType {
 }
 
 fn variable_definitions(
-    db: &dyn SourceDatabase,
     variable_definitions: Option<ast::VariableDefinitions>,
 ) -> Arc<Vec<VariableDefinition>> {
     match variable_definitions {
@@ -904,7 +884,7 @@ fn variable_definitions(
             let variable_definitions = vars
                 .variable_definitions()
                 .into_iter()
-                .map(|var_def| variable_definition(db, var_def))
+                .map(variable_definition)
                 .collect();
             Arc::new(variable_definitions)
         }
@@ -912,16 +892,13 @@ fn variable_definitions(
     }
 }
 
-fn variable_definition(
-    db: &dyn SourceDatabase,
-    var: ast::VariableDefinition,
-) -> VariableDefinition {
+fn variable_definition(var: ast::VariableDefinition) -> VariableDefinition {
     let name = name(
         var.variable()
             .expect("Variable Definition must have a variable")
             .name(),
     );
-    let directives = directives(db, var.directives());
+    let directives = directives(var.directives());
     let default_value = default_value(var.default_value());
     let ty = ty(var.ty().expect("Variable Definition must have a type"));
 
@@ -982,35 +959,21 @@ fn directive_locations(
     }
 }
 
-fn directives(db: &dyn SourceDatabase, directives: Option<ast::Directives>) -> Arc<Vec<Directive>> {
+fn directives(directives: Option<ast::Directives>) -> Arc<Vec<Directive>> {
     match directives {
         Some(directives) => {
-            let directives = directives
-                .directives()
-                .into_iter()
-                .map(|dir| directive(db, dir))
-                .collect();
+            let directives = directives.directives().into_iter().map(directive).collect();
             Arc::new(directives)
         }
         None => Arc::new(Vec::new()),
     }
 }
 
-fn directive(db: &dyn SourceDatabase, directive: ast::Directive) -> Directive {
+fn directive(directive: ast::Directive) -> Directive {
     let name = name(directive.name());
     let arguments = arguments(directive.arguments());
-    // NOTE @lrlna: this should just be Uuid.  If we can't find the framgment we
-    // are looking for when populating this field, we should throw a semantic
-    // error.
-    let directive_id = db
-        .find_directive_definition_by_name(name.clone())
-        .map(|directive_def| *directive_def.id());
 
-    Directive {
-        name,
-        arguments,
-        directive_id,
-    }
+    Directive { name, arguments }
 }
 
 fn arguments(arguments: Option<ast::Arguments>) -> Arc<Vec<Argument>> {
@@ -1097,7 +1060,7 @@ fn inline_fragment(db: &dyn SourceDatabase, fragment: ast::InlineFragment) -> Ar
             .text()
             .to_string()
     });
-    let directives = directives(db, fragment.directives());
+    let directives = directives(fragment.directives());
     let selection_set: Arc<Vec<Selection>> = selection_set(db, fragment.selection_set());
 
     let fragment_data = InlineFragment {
@@ -1115,7 +1078,7 @@ fn fragment_spread(db: &dyn SourceDatabase, fragment: ast::FragmentSpread) -> Ar
             .expect("Fragment Spread must have a name")
             .name(),
     );
-    let directives = directives(db, fragment.directives());
+    let directives = directives(fragment.directives());
     // NOTE @lrlna: this should just be Uuid.  If we can't find the framgment we
     // are looking for when populating this field, we should throw a semantic
     // error.
@@ -1134,7 +1097,7 @@ fn field(db: &dyn SourceDatabase, field: ast::Field) -> Arc<Field> {
     let name = name(field.name());
     let alias = alias(field.alias());
     let selection_set = selection_set(db, field.selection_set());
-    let directives = directives(db, field.directives());
+    let directives = directives(field.directives());
     let arguments = arguments(field.arguments());
 
     let field_data = Field {

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -471,33 +471,6 @@ fn directive_definitions(db: &dyn SourceDatabase) -> Arc<Vec<DirectiveDefinition
     Arc::new(directives)
 }
 
-fn built_in_directives(directives: Vec<DirectiveDefinition>) -> Vec<DirectiveDefinition> {
-    if !directives.iter().any(|dir| dir.name == "skip") {
-        let skip = DirectiveDefinition {
-            id: Uuid::new_v4(),
-            description: todo!(),
-            name: todo!(),
-            arguments: todo!(),
-            repeatable: todo!(),
-            directive_locations: todo!(),
-        };
-        directives.push(skip);
-    }
-    if !directives.iter().any(|dir| dir.name == "include") {
-        let include = DirectiveDefinition {
-            id: Uuid::new_v4(),
-            description: todo!(),
-            name: todo!(),
-            arguments: todo!(),
-            repeatable: todo!(),
-            directive_locations: todo!(),
-        };
-        directives.push(include);
-    }
-
-    directives
-}
-
 fn find_directive_definition(
     db: &dyn SourceDatabase,
     id: Uuid,
@@ -1167,4 +1140,157 @@ fn alias(alias: Option<ast::Alias>) -> Option<Arc<Alias>> {
         let alias_data = Alias(name);
         Arc::new(alias_data)
     })
+}
+
+fn built_in_directives(mut directives: Vec<DirectiveDefinition>) -> Vec<DirectiveDefinition> {
+    if !directives.iter().any(|dir| dir.name == "skip") {
+        directives.push(skip_directive());
+    }
+
+    if !directives.iter().any(|dir| dir.name == "specifiedBy") {
+        directives.push(specified_by_directive());
+    }
+
+    if !directives.iter().any(|dir| dir.name == "deprecated") {
+        directives.push(deprecated_directive());
+    }
+
+    if !directives.iter().any(|dir| dir.name == "include") {
+        directives.push(include_directive());
+    }
+
+    directives
+}
+
+fn skip_directive() -> DirectiveDefinition {
+    // "Directs the executor to skip this field or fragment when the `if` argument is true."
+    // directive @skip(
+    //   "Skipped when true."
+    //   if: Boolean!
+    // ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+    DirectiveDefinition {
+        id: Uuid::new_v4(),
+        description: Some(
+            "Directs the executor to skip this field or fragment when the `if` argument is true."
+                .into(),
+        ),
+        name: "skip".into(),
+        arguments: ArgumentsDefinition {
+            input_values: Arc::new(vec![InputValueDefinition {
+                description: Some("Skipped when true.".into()),
+                name: "if".into(),
+                ty: Type::NonNull {
+                    ty: Box::new(Type::Named {
+                        name: "Boolean".into(),
+                    }),
+                },
+                default_value: None,
+                directives: Arc::new(Vec::new()),
+            }]),
+        },
+        repeatable: false,
+        directive_locations: Arc::new(vec![
+            DirectiveLocation::Field,
+            DirectiveLocation::FragmentSpread,
+            DirectiveLocation::InlineFragment,
+        ]),
+    }
+}
+
+fn specified_by_directive() -> DirectiveDefinition {
+    // "Exposes a URL that specifies the behaviour of this scalar."
+    // directive @specifiedBy(
+    //     "The URL that specifies the behaviour of this scalar."
+    //     url: String!
+    // ) on SCALAR
+    DirectiveDefinition {
+        id: Uuid::new_v4(),
+        description: Some("Exposes a URL that specifies the behaviour of this scalar.".into()),
+        name: "specifiedBy".into(),
+        arguments: ArgumentsDefinition {
+            input_values: Arc::new(vec![InputValueDefinition {
+                description: Some("The URL that specifies the behaviour of this scalar.".into()),
+                name: "url".into(),
+                ty: Type::NonNull {
+                    ty: Box::new(Type::Named {
+                        name: "String".into(),
+                    }),
+                },
+                default_value: None,
+                directives: Arc::new(Vec::new()),
+            }]),
+        },
+        repeatable: false,
+        directive_locations: Arc::new(vec![DirectiveLocation::Scalar]),
+    }
+}
+
+fn deprecated_directive() -> DirectiveDefinition {
+    // "Marks an element of a GraphQL schema as no longer supported."
+    // directive @deprecated(
+    //   """
+    //   Explains why this element was deprecated, usually also including a
+    //   suggestion for how to access supported similar data. Formatted using
+    //   the Markdown syntax, as specified by
+    //   [CommonMark](https://commonmark.org/).
+    //   """
+    //   reason: String = "No longer supported"
+    // ) on FIELD_DEFINITION | ENUM_VALUE
+    DirectiveDefinition {
+        id: Uuid::new_v4(),
+        description: Some("Marks an element of a GraphQL schema as no longer supported.".into()),
+        name: "deprecated".into(),
+        arguments: ArgumentsDefinition {
+            input_values: Arc::new(vec![InputValueDefinition {
+                description: Some(
+                    "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).".into(),
+                ),
+                name: "reason".into(),
+                ty: Type::Named {
+                    name: "String".into(),
+                },
+                default_value: Some(DefaultValue::String("No longer supported".into())),
+                directives: Arc::new(Vec::new()),
+            }]),
+        },
+        repeatable: false,
+        directive_locations: Arc::new(vec![
+            DirectiveLocation::FieldDefinition,
+            DirectiveLocation::EnumValue
+        ]),
+    }
+}
+
+fn include_directive() -> DirectiveDefinition {
+    // "Directs the executor to include this field or fragment only when the `if` argument is true."
+    // directive @include(
+    //   "Included when true."
+    //   if: Boolean!
+    // ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+    DirectiveDefinition {
+        id: Uuid::new_v4(),
+        description: Some("Directs the executor to include this field or fragment only when the `if` argument is true.".into()),
+        name: "include".into(),
+        arguments: ArgumentsDefinition {
+            input_values: Arc::new(vec![InputValueDefinition {
+                description: Some(
+                    "Included when true.".into(),
+                ),
+                name: "if".into(),
+                ty: Type::NonNull {
+                    ty: Box::new(Type::Named {
+                        name: "Boolean".into(),
+                    }),
+                },
+                default_value: None,
+                directives: Arc::new(Vec::new()),
+            }]),
+        },
+        repeatable: false,
+        directive_locations: Arc::new(vec![
+            DirectiveLocation::Field,
+            DirectiveLocation::FragmentDefinition,
+            DirectiveLocation::InlineFragment,
+        ]),
+    }
 }

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -379,6 +379,10 @@ impl DirectiveDefinition {
     pub fn id(&self) -> &Uuid {
         &self.id
     }
+
+    pub fn arguments(&self) -> &ArgumentsDefinition {
+        &self.arguments
+    }
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -822,6 +826,13 @@ pub struct ArgumentsDefinition {
     pub(crate) input_values: Arc<Vec<InputValueDefinition>>,
 }
 
+impl ArgumentsDefinition {
+    /// Get a reference to arguments definition's input values.
+    pub fn input_values(&self) -> &[InputValueDefinition] {
+        self.input_values.as_ref()
+    }
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct InputValueDefinition {
     pub(crate) description: Option<String>,
@@ -829,6 +840,13 @@ pub struct InputValueDefinition {
     pub(crate) ty: Type,
     pub(crate) default_value: Option<DefaultValue>,
     pub(crate) directives: Arc<Vec<Directive>>,
+}
+
+impl InputValueDefinition {
+    // Get a reference to input value definition's directives.
+    pub fn directives(&self) -> &[Directive] {
+        self.directives.as_ref()
+    }
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -339,7 +339,6 @@ fn get_name(ty: Type) -> String {
 pub struct Directive {
     pub(crate) name: String,
     pub(crate) arguments: Arc<Vec<Argument>>,
-    pub(crate) directive_id: Option<Uuid>,
 }
 
 impl Directive {
@@ -355,7 +354,7 @@ impl Directive {
 
     // Get directive definition of the currently used directive
     pub fn directive(&self, db: &dyn SourceDatabase) -> Option<Arc<DirectiveDefinition>> {
-        db.find_directive_definition(self.directive_id?)
+        db.find_directive_definition_by_name(self.name().to_string())
     }
 }
 
@@ -380,8 +379,14 @@ impl DirectiveDefinition {
         &self.id
     }
 
+    // Get a reference to argument definition's locations.
     pub fn arguments(&self) -> &ArgumentsDefinition {
         &self.arguments
+    }
+
+    // Get a reference to directive definition's locations.
+    pub fn directive_locations(&self) -> &[DirectiveLocation] {
+        self.directive_locations.as_ref()
     }
 }
 
@@ -448,6 +453,32 @@ impl From<ast::DirectiveLocation> for DirectiveLocation {
             DirectiveLocation::InputObject
         } else {
             DirectiveLocation::InputFieldDefinition
+        }
+    }
+}
+
+impl From<DirectiveLocation> for String {
+    fn from(dir_loc: DirectiveLocation) -> Self {
+        match dir_loc {
+            DirectiveLocation::Query => "QUERY".to_string(),
+            DirectiveLocation::Mutation => "MUTATION".to_string(),
+            DirectiveLocation::Subscription => "SUBSCRIPTION".to_string(),
+            DirectiveLocation::Field => "FIELD".to_string(),
+            DirectiveLocation::FragmentDefinition => "FRAGMENT_DEFINITION".to_string(),
+            DirectiveLocation::FragmentSpread => "FRAGMENT_SPREAD".to_string(),
+            DirectiveLocation::InlineFragment => "INLINE_FRAGMENT".to_string(),
+            DirectiveLocation::VariableDefinition => "VARIABLE_DEFINITION".to_string(),
+            DirectiveLocation::Schema => "SCHEMA".to_string(),
+            DirectiveLocation::Scalar => "SCALAR".to_string(),
+            DirectiveLocation::Object => "OBJECT".to_string(),
+            DirectiveLocation::FieldDefinition => "FIELD_DEFINITION".to_string(),
+            DirectiveLocation::ArgumentDefinition => "ARGUMENT_DEFINITION".to_string(),
+            DirectiveLocation::Interface => "INTERFACE".to_string(),
+            DirectiveLocation::Union => "UNION".to_string(),
+            DirectiveLocation::Enum => "ENUM".to_string(),
+            DirectiveLocation::EnumValue => "ENUM_VALUE".to_string(),
+            DirectiveLocation::InputObject => "INPUT_OBJECT".to_string(),
+            DirectiveLocation::InputFieldDefinition => "INPUT_FIELD_DEFINITION".to_string(),
         }
     }
 }

--- a/crates/apollo-compiler/src/validation/directives.rs
+++ b/crates/apollo-compiler/src/validation/directives.rs
@@ -1,7 +1,25 @@
+use std::collections::HashSet;
+
 use crate::{diagnostics::ErrorDiagnostic, ApolloDiagnostic, SourceDatabase};
 
 pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
     let mut errors = Vec::new();
+
+    // Directive definitions must have unique names.
+    //
+    // Return a Unique Definition error in case of a duplicate name.
+    let mut seen = HashSet::new();
+    for directive_definitions in db.directive_definitions().iter() {
+        let name = directive_definitions.name();
+        if seen.contains(name) {
+            errors.push(ApolloDiagnostic::Error(ErrorDiagnostic::UniqueDefinition {
+                message: "Directive Definitions must have unique names".into(),
+                definition: name.to_string(),
+            }));
+        } else {
+            seen.insert(name);
+        }
+    }
 
     // A directive definition must not contain the use of a directive which
     // references itself directly.

--- a/crates/apollo-compiler/src/validation/directives.rs
+++ b/crates/apollo-compiler/src/validation/directives.rs
@@ -1,0 +1,30 @@
+use std::collections::HashSet;
+
+use crate::{diagnostics::ErrorDiagnostic, ApolloDiagnostic, SourceDatabase};
+
+pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
+    let mut errors = Vec::new();
+
+    // A directive definition must not contain the use of a directive which
+    // references itself directly.
+    //
+    // Returns Recursive Definition error.
+    for directive_def in db.directive_definitions().iter() {
+        let name = directive_def.name();
+        for input_values in directive_def.arguments().input_values() {
+            for directive in input_values.directives().iter() {
+                let directive_name = directive.name();
+                if name == directive_name {
+                    errors.push(ApolloDiagnostic::Error(
+                        ErrorDiagnostic::RecursiveDefinition {
+                            message: "Directive definition cannot reference itself".into(),
+                            definition: directive_name.to_string(),
+                        },
+                    ));
+                }
+            }
+        }
+    }
+
+    errors
+}

--- a/crates/apollo-compiler/src/validation/directives.rs
+++ b/crates/apollo-compiler/src/validation/directives.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::{diagnostics::ErrorDiagnostic, ApolloDiagnostic, SourceDatabase};
 
 pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -9,6 +9,7 @@ pub mod scalars;
 pub mod unions;
 
 // composite nodes
+pub mod directives;
 pub mod interfaces;
 
 // executable definitions
@@ -40,6 +41,7 @@ impl<'a> Validator<'a> {
         self.errors.extend(unions::check(self.db));
 
         self.errors.extend(interfaces::check(self.db));
+        self.errors.extend(directives::check(self.db));
 
         self.errors.extend(operations::check(self.db));
         self.errors.extend(unused_variables::check(self.db));

--- a/crates/apollo-compiler/test_data/err/0028_self_referential_directive_definition.graphql
+++ b/crates/apollo-compiler/test_data/err/0028_self_referential_directive_definition.graphql
@@ -1,0 +1,6 @@
+type Query {
+    id: ID!
+    field(arg: Int @invalidExample): String
+}
+
+directive @invalidExample(arg: String @invalidExample) on ARGUMENT_DEFINITION

--- a/crates/apollo-compiler/test_data/err/0028_self_referential_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/err/0028_self_referential_directive_definition.txt
@@ -1,0 +1,1 @@
+[Error(RecursiveDefinition { message: "Directive definition cannot reference itself", definition: "invalidExample" })]

--- a/crates/apollo-compiler/test_data/err/0029_directive_definitions_with_duplicate_names.graphql
+++ b/crates/apollo-compiler/test_data/err/0029_directive_definitions_with_duplicate_names.graphql
@@ -1,0 +1,11 @@
+schema @foo {
+    query: Query
+}
+
+type Query {
+    id: ID!
+    field: String
+}
+
+directive @foo on SCHEMA
+directive @foo on SCHEMA

--- a/crates/apollo-compiler/test_data/err/0029_directive_definitions_with_duplicate_names.txt
+++ b/crates/apollo-compiler/test_data/err/0029_directive_definitions_with_duplicate_names.txt
@@ -1,0 +1,1 @@
+[Error(UniqueRootOperationType { message: "Root Operation Types must be unique", named_type: "Query", operation_type: "Subscription" }), Error(UniqueDefinition { message: "Directive Definitions must have unique names", definition: "foo" })]

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.graphql
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.graphql
@@ -1,0 +1,9 @@
+type Query {
+    literature: Book
+}
+
+directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE
+
+type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
+  id: ID!
+}

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
@@ -1,0 +1,107 @@
+- DOCUMENT@0..199
+    - OBJECT_TYPE_DEFINITION@0..37
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..5 " "
+        - NAME@5..11
+            - IDENT@5..10 "Query"
+            - WHITESPACE@10..11 " "
+        - FIELDS_DEFINITION@11..37
+            - L_CURLY@11..12 "{"
+            - WHITESPACE@12..17 "\n    "
+            - FIELD_DEFINITION@17..34
+                - NAME@17..27
+                    - IDENT@17..27 "literature"
+                - COLON@27..28 ":"
+                - WHITESPACE@28..29 " "
+                - NAMED_TYPE@29..33
+                    - NAME@29..33
+                        - IDENT@29..33 "Book"
+                - WHITESPACE@33..34 "\n"
+            - R_CURLY@34..35 "}"
+            - WHITESPACE@35..37 "\n\n"
+    - DIRECTIVE_DEFINITION@37..111
+        - directive_KW@37..46 "directive"
+        - WHITESPACE@46..47 " "
+        - AT@47..48 "@"
+        - NAME@48..61
+            - IDENT@48..61 "delegateField"
+        - ARGUMENTS_DEFINITION@61..77
+            - L_PAREN@61..62 "("
+            - INPUT_VALUE_DEFINITION@62..75
+                - NAME@62..66
+                    - IDENT@62..66 "name"
+                - COLON@66..67 ":"
+                - WHITESPACE@67..68 " "
+                - NON_NULL_TYPE@68..75
+                    - NAMED_TYPE@68..74
+                        - NAME@68..74
+                            - IDENT@68..74 "String"
+                    - BANG@74..75 "!"
+            - R_PAREN@75..76 ")"
+            - WHITESPACE@76..77 " "
+        - repeatable_KW@77..87 "repeatable"
+        - WHITESPACE@87..88 " "
+        - on_KW@88..90 "on"
+        - WHITESPACE@90..91 " "
+        - DIRECTIVE_LOCATIONS@91..111
+            - DIRECTIVE_LOCATION@91..98
+                - OBJECT_KW@91..97 "OBJECT"
+                - WHITESPACE@97..98 " "
+            - PIPE@98..99 "|"
+            - WHITESPACE@99..100 " "
+            - DIRECTIVE_LOCATION@100..111
+                - INTERFACE_KW@100..109 "INTERFACE"
+                - WHITESPACE@109..111 "\n\n"
+    - OBJECT_TYPE_DEFINITION@111..199
+        - type_KW@111..115 "type"
+        - WHITESPACE@115..116 " "
+        - NAME@116..121
+            - IDENT@116..120 "Book"
+            - WHITESPACE@120..121 " "
+        - DIRECTIVES@121..186
+            - DIRECTIVE@121..155
+                - AT@121..122 "@"
+                - NAME@122..135
+                    - IDENT@122..135 "delegateField"
+                - ARGUMENTS@135..155
+                    - L_PAREN@135..136 "("
+                    - ARGUMENT@136..153
+                        - NAME@136..140
+                            - IDENT@136..140 "name"
+                        - COLON@140..141 ":"
+                        - WHITESPACE@141..142 " "
+                        - STRING_VALUE@142..153
+                            - STRING@142..153 "\"pageCount\""
+                    - R_PAREN@153..154 ")"
+                    - WHITESPACE@154..155 " "
+            - DIRECTIVE@155..186
+                - AT@155..156 "@"
+                - NAME@156..169
+                    - IDENT@156..169 "delegateField"
+                - ARGUMENTS@169..186
+                    - L_PAREN@169..170 "("
+                    - ARGUMENT@170..184
+                        - NAME@170..174
+                            - IDENT@170..174 "name"
+                        - COLON@174..175 ":"
+                        - WHITESPACE@175..176 " "
+                        - STRING_VALUE@176..184
+                            - STRING@176..184 "\"author\""
+                    - R_PAREN@184..185 ")"
+                    - WHITESPACE@185..186 " "
+        - FIELDS_DEFINITION@186..199
+            - L_CURLY@186..187 "{"
+            - WHITESPACE@187..190 "\n  "
+            - FIELD_DEFINITION@190..198
+                - NAME@190..192
+                    - IDENT@190..192 "id"
+                - COLON@192..193 ":"
+                - WHITESPACE@193..194 " "
+                - NON_NULL_TYPE@194..198
+                    - NAMED_TYPE@194..196
+                        - NAME@194..196
+                            - IDENT@194..196 "ID"
+                    - BANG@196..197 "!"
+                    - WHITESPACE@197..198 "\n"
+            - R_CURLY@198..199 "}"
+


### PR DESCRIPTION
- adds directive definition to compiler's context
- adds find_directive_definition and find_directive_definition_by_name functions
- adds built-in directives to cumulative directive definitions in compiler (`@include`, `@skip`, `@deprecated`, `@specifiedBy`)
- adds directive definition validations:
    - Directive definitions must have unique names (Unique Definition error)
    - A directive definition must not contain the use of a directive which references itself directly. (Recursive Definition error)

closes #241 