### PR TITLE
feat(apollo-compiler): add input object definitions to source database

### DIFF
--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -1010,3 +1010,29 @@ impl InterfaceDefinition {
         self.fields_definition.as_ref()
     }
 }
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct InputObjectDefinition {
+    pub(crate) id: Uuid,
+    pub(crate) description: Option<String>,
+    pub(crate) name: String,
+    pub(crate) directives: Arc<Vec<Directive>>,
+    pub(crate) input_fields_definition: Arc<Vec<InputValueDefinition>>,
+}
+
+impl InputObjectDefinition {
+    /// Get the input object definition's id.
+    pub fn id(&self) -> &Uuid {
+        &self.id
+    }
+
+    /// Get a reference to the input object definition's name.
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+
+    /// Get a reference to input object definition's directives.
+    pub fn directives(&self) -> &[Directive] {
+        self.directives.as_ref()
+    }
+}

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -874,6 +874,11 @@ pub struct InputValueDefinition {
 }
 
 impl InputValueDefinition {
+    // Get a reference to input value definition's name.
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+
     // Get a reference to input value definition's directives.
     pub fn directives(&self) -> &[Directive] {
         self.directives.as_ref()
@@ -1034,5 +1039,9 @@ impl InputObjectDefinition {
     /// Get a reference to input object definition's directives.
     pub fn directives(&self) -> &[Directive] {
         self.directives.as_ref()
+    }
+
+    pub fn input_fields_definition(&self) -> &[InputValueDefinition] {
+        self.input_fields_definition.as_ref()
     }
 }

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -1,0 +1,45 @@
+use std::collections::HashSet;
+
+use crate::{diagnostics::ErrorDiagnostic, ApolloDiagnostic, SourceDatabase};
+
+pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
+    let mut errors = Vec::new();
+
+    // Input Object Definitions must have unique names.
+    //
+    // Return a Unique Definition error in case of a duplicate name.
+    let mut seen = HashSet::new();
+    for input_objects in db.input_objects().iter() {
+        let name = input_objects.name();
+        if seen.contains(name) {
+            errors.push(ApolloDiagnostic::Error(ErrorDiagnostic::UniqueDefinition {
+                message: "Input Object Definitions must have unique names".into(),
+                definition: name.to_string(),
+            }));
+        } else {
+            seen.insert(name);
+        }
+    }
+
+    // Fields in an Input Object Definition must be unique
+    //
+    // Returns Unique Value error.
+    for input_objects in db.input_objects().iter() {
+        let mut seen = HashSet::new();
+
+        let input_fields = input_objects.input_fields_definition();
+
+        for field in input_fields {
+            let field_name = field.name();
+            if seen.contains(&field_name) {
+                errors.push(ApolloDiagnostic::Error(ErrorDiagnostic::UniqueValue {
+                    message: "Input Fields must be unique".into(),
+                    value: field_name.into(),
+                }));
+            } else {
+                seen.insert(field_name);
+            }
+        }
+    }
+    errors
+}

--- a/crates/apollo-compiler/src/validation/interfaces.rs
+++ b/crates/apollo-compiler/src/validation/interfaces.rs
@@ -53,6 +53,8 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
     }
 
     // Fields in an Interface definition must be unique
+    //
+    // Returns Unique Value error.
     for interface_def in db.interfaces().iter() {
         let mut seen = HashSet::new();
 

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -10,6 +10,7 @@ pub mod unions;
 
 // composite nodes
 pub mod directives;
+pub mod input_object;
 pub mod interfaces;
 
 // executable definitions
@@ -42,6 +43,7 @@ impl<'a> Validator<'a> {
 
         self.errors.extend(interfaces::check(self.db));
         self.errors.extend(directives::check(self.db));
+        self.errors.extend(input_object::check(self.db));
 
         self.errors.extend(operations::check(self.db));
         self.errors.extend(unused_variables::check(self.db));

--- a/crates/apollo-compiler/test_data/err/0030_schema_with_duplicate_input_objects.graphql
+++ b/crates/apollo-compiler/test_data/err/0030_schema_with_duplicate_input_objects.graphql
@@ -1,0 +1,14 @@
+type Query {
+  point1: Point2D
+  point2: Point2D
+}
+
+input Point2D {
+  x: Float
+  y: Float
+}
+
+input Point2D {
+  x: Float
+  y: Float
+}

--- a/crates/apollo-compiler/test_data/err/0030_schema_with_duplicate_input_objects.txt
+++ b/crates/apollo-compiler/test_data/err/0030_schema_with_duplicate_input_objects.txt
@@ -1,0 +1,1 @@
+[Error(UniqueDefinition { message: "Input Object Definitions must have unique names", definition: "Point2D" })]

--- a/crates/apollo-compiler/test_data/err/0031_input_object_with_duplicate_fields.graphql
+++ b/crates/apollo-compiler/test_data/err/0031_input_object_with_duplicate_fields.graphql
@@ -1,0 +1,9 @@
+type Query {
+  point1: Point2D
+  point2: Point2D
+}
+
+input Point2D {
+  x: Float
+  x: Float
+}

--- a/crates/apollo-compiler/test_data/err/0031_input_object_with_duplicate_fields.txt
+++ b/crates/apollo-compiler/test_data/err/0031_input_object_with_duplicate_fields.txt
@@ -1,0 +1,1 @@
+[Error(UniqueValue { message: "Input Fields must be unique", value: "x" })]

--- a/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.graphql
+++ b/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.graphql
@@ -1,0 +1,9 @@
+type Query {
+  point1: Point2D
+  point2: Point2D
+}
+
+input Point2D {
+  x: Float
+  y: Float
+}

--- a/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
@@ -1,0 +1,59 @@
+- DOCUMENT@0..91
+    - OBJECT_TYPE_DEFINITION@0..52
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..5 " "
+        - NAME@5..11
+            - IDENT@5..10 "Query"
+            - WHITESPACE@10..11 " "
+        - FIELDS_DEFINITION@11..52
+            - L_CURLY@11..12 "{"
+            - WHITESPACE@12..15 "\n  "
+            - FIELD_DEFINITION@15..33
+                - NAME@15..21
+                    - IDENT@15..21 "point1"
+                - COLON@21..22 ":"
+                - WHITESPACE@22..23 " "
+                - NAMED_TYPE@23..30
+                    - NAME@23..30
+                        - IDENT@23..30 "Point2D"
+                - WHITESPACE@30..33 "\n  "
+            - FIELD_DEFINITION@33..49
+                - NAME@33..39
+                    - IDENT@33..39 "point2"
+                - COLON@39..40 ":"
+                - WHITESPACE@40..41 " "
+                - NAMED_TYPE@41..48
+                    - NAME@41..48
+                        - IDENT@41..48 "Point2D"
+                - WHITESPACE@48..49 "\n"
+            - R_CURLY@49..50 "}"
+            - WHITESPACE@50..52 "\n\n"
+    - INPUT_OBJECT_TYPE_DEFINITION@52..91
+        - input_KW@52..57 "input"
+        - WHITESPACE@57..58 " "
+        - NAME@58..66
+            - IDENT@58..65 "Point2D"
+            - WHITESPACE@65..66 " "
+        - INPUT_FIELDS_DEFINITION@66..91
+            - L_CURLY@66..67 "{"
+            - WHITESPACE@67..70 "\n  "
+            - INPUT_VALUE_DEFINITION@70..81
+                - NAME@70..71
+                    - IDENT@70..71 "x"
+                - COLON@71..72 ":"
+                - WHITESPACE@72..73 " "
+                - NAMED_TYPE@73..78
+                    - NAME@73..78
+                        - IDENT@73..78 "Float"
+                - WHITESPACE@78..81 "\n  "
+            - INPUT_VALUE_DEFINITION@81..90
+                - NAME@81..82
+                    - IDENT@81..82 "y"
+                - COLON@82..83 ":"
+                - WHITESPACE@83..84 " "
+                - NAMED_TYPE@84..89
+                    - NAME@84..89
+                        - IDENT@84..89 "Float"
+                - WHITESPACE@89..90 "\n"
+            - R_CURLY@90..91 "}"
+recursion limit: 4096, high: 0


### PR DESCRIPTION
- adds input object values
- adds validation for unique input object definition and unique input fields in input object

related to #247 