### PR TITLE
chore: make clippy happy and avoid extra allocations

### DIFF
--- a/crates/apollo-encoder/src/field.rs
+++ b/crates/apollo-encoder/src/field.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Write as _};
 
 use crate::{
     Argument, ArgumentsDefinition, Directive, InputValueDefinition, SelectionSet, StringValue,
@@ -173,19 +173,21 @@ impl Field {
             for (i, arg) in self.args.iter().enumerate() {
                 match i {
                     0 => {
-                        text.push_str(&format!("({arg}"));
+                        let _ = write!(text, "({arg}");
                     }
-                    _ => text.push_str(&format!(", {arg}")),
+                    _ => {
+                        let _ = write!(text, ", {arg}");
+                    }
                 }
             }
             text.push(')');
         }
 
         for directive in &self.directives {
-            text.push_str(&format!(" {directive}"));
+            let _ = write!(text, " {directive}");
         }
         if let Some(sel_set) = &self.selection_set {
-            text.push_str(&format!(" {}", sel_set.format_with_indent(indent_level)));
+            let _ = write!(text, " {}", sel_set.format_with_indent(indent_level));
         }
 
         text

--- a/crates/apollo-encoder/src/fragment.rs
+++ b/crates/apollo-encoder/src/fragment.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Write as _};
 
 use crate::{Directive, SelectionSet};
 
@@ -187,16 +187,16 @@ impl InlineFragment {
         let mut text = String::from("...");
 
         if let Some(type_condition) = &self.type_condition {
-            text.push_str(&format!(" {}", type_condition));
+            let _ = write!(text," {}", type_condition);
         }
         for directive in &self.directives {
-            text.push_str(&format!(" {}", directive));
+            let _ = write!(text, " {}", directive);
         }
 
-        text.push_str(&format!(
+        let _ = write!(text,
             " {}",
             self.selection_set.format_with_indent(indent_level),
-        ));
+        );
 
         text
     }

--- a/crates/apollo-encoder/src/selection_set.rs
+++ b/crates/apollo-encoder/src/selection_set.rs
@@ -1,5 +1,6 @@
+use std::fmt::{self, Write as _};
+
 use crate::{Field, FragmentSpread, InlineFragment};
-use std::fmt;
 
 /// The SelectionSet type represents a selection_set type in a fragment spread,
 /// an operation or a field
@@ -61,16 +62,16 @@ impl SelectionSet {
         indent_level += 1;
         let indent = "  ".repeat(indent_level);
         for sel in &self.selections {
-            text.push_str(&format!(
-                "{}{}\n",
+            let _ = writeln!(text,
+                "{}{}",
                 indent,
                 sel.format_with_indent(indent_level)
-            ));
+            );
         }
         if indent_level <= 1 {
             text.push_str("}\n");
         } else {
-            text.push_str(&format!("{}}}", "  ".repeat(indent_level - 1)));
+            let _ = write!(text, "{}}}", "  ".repeat(indent_level - 1));
         }
 
         text

--- a/crates/apollo-smith/src/description.rs
+++ b/crates/apollo-smith/src/description.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use arbitrary::{Arbitrary, Result, Unstructured};
 
 use crate::DocumentBuilder;
@@ -72,7 +74,7 @@ impl Arbitrary<'_> for StringValue {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> Result<Self> {
         let mut arbitrary_str = limited_string_desc(u, 100)?;
         if arbitrary_str.trim_matches('"').is_empty() {
-            arbitrary_str.push_str(&format!("{}", u.arbitrary::<usize>()?));
+            let _ = write!(arbitrary_str, "{}", u.arbitrary::<usize>()?);
         }
         let variant_idx = u.int_in_range(0..=1usize)?;
         let str_value = match variant_idx {

--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use arbitrary::Result;
 
 use crate::DocumentBuilder;
@@ -68,10 +70,10 @@ impl<'a> DocumentBuilder<'a> {
     pub fn type_name(&mut self) -> Result<Name> {
         let mut new_name = self.limited_string(30)?;
         if self.list_existing_type_names().any(|n| n.name == new_name) {
-            new_name.push_str(&format!(
+            let _ = write!(new_name,
                 "{}",
                 self.object_type_defs.len() + self.enum_type_defs.len() + self.directive_defs.len()
-            ));
+            );
         }
         Ok(Name::new(new_name))
     }
@@ -79,7 +81,7 @@ impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `Name` with an index included in the name (to avoid name conflict)
     pub fn name_with_index(&mut self, index: usize) -> Result<Name> {
         let mut name = self.limited_string(30)?;
-        name.push_str(&format!("{}", index));
+        let _ = write!(name, "{}", index);
 
         Ok(Name::new(name))
     }

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,4 +1,0 @@
-
-target
-corpus
-artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,7 +4,12 @@ name = "apollo-rs-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+autotests = false
+edition = "2021"
+
+[lib]
+test = false
+doc = false
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
switches all `str.push_str(format!())` usecases to `write!()` instead (#[warn(format_push_string)])