### PR TITLE
feat(apollo-compiler): add relationship between field types and definitions they refer to

### DIFF
--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     diagnostics::{UniqueDefinition, UniqueField},
-    values::{InputObjectDefinition, InputValueDefinition},
+    values::{InputObjectTypeDefinition, InputValueDefinition},
     ApolloDiagnostic, SourceDatabase,
 };
 
@@ -12,7 +12,7 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
     // Input Object Definitions must have unique names.
     //
     // Return a Unique Definition error in case of a duplicate name.
-    let mut seen: HashMap<&str, &InputObjectDefinition> = HashMap::new();
+    let mut seen: HashMap<&str, &InputObjectTypeDefinition> = HashMap::new();
     for input_object in db.input_objects().iter() {
         let name = input_object.name();
         if let Some(prev_def) = seen.get(name) {

--- a/crates/apollo-compiler/src/validation/interfaces.rs
+++ b/crates/apollo-compiler/src/validation/interfaces.rs
@@ -6,7 +6,7 @@ use crate::{
         UniqueDefinition, UniqueField,
     },
     validation::ValidationSet,
-    values::{FieldDefinition, InterfaceDefinition},
+    values::{FieldDefinition, InterfaceTypeDefinition},
     ApolloDiagnostic, SourceDatabase,
 };
 
@@ -16,7 +16,7 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
     // Interface definitions must have unique names.
     //
     // Return a Unique Definition error in case of a duplicate name.
-    let mut seen: HashMap<&str, &InterfaceDefinition> = HashMap::new();
+    let mut seen: HashMap<&str, &InterfaceTypeDefinition> = HashMap::new();
     for interface in db.interfaces().iter() {
         let name = interface.name();
         if let Some(prev_def) = seen.get(&name) {


### PR DESCRIPTION
Let's say we have a graphql schema that looks like this:

```
type Person {
  name: String
  picture(size: Number): Url
}

enum Number {
    INT
    FLOAT
}

scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
```

We want to be able to easily access the `picture` field's Url definition and its attributes, as well as the `picture` argument's definition (`Number`). This establishes a relationship between `Type` and various definitions, as well as provides a few easier to use access methods.

All GraphQL definitions are not also grouped under `Definition` value in the database. In the `db`, they can be accessed via `db_definitions()`. The separation between `definitions` and `db_definitions` ensures we don't prefill the entire database in one go, and still proceed to set up queries as they are called.