### PR TITLE
feat(apollo-compiler): add field types to operation definitions

### DIFF
--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -84,10 +84,7 @@ impl ApolloCompiler {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        values::{Definition, Type},
-        ApolloCompiler, SourceDatabase,
-    };
+    use crate::{values::Definition, ApolloCompiler, SourceDatabase};
 
     #[test]
     fn it_accesses_operation_definition_parts() {
@@ -188,11 +185,11 @@ type Query {
     fn it_accesses_field_definitions_from_operation_definition() {
         let input = r#"
 query getProduct {
+  size
   topProducts {
     name
     inStock
   }
-  name
 }
 
 type Query {
@@ -202,8 +199,8 @@ type Query {
 }
 
 type Product {
-  inStock: Boolean
-  name: String
+  inStock: Boolean @join__field(graph: INVENTORY)
+  name: String @join__field(graph: PRODUCTS)
   price: Int
   shippingEstimate: Int
   upc: String!
@@ -218,6 +215,7 @@ type Product {
         }
         assert!(diagnostics.is_empty());
 
+        // Get the types of the two top level fields - topProducts and size
         let operations = ctx.operations();
         let get_product_op = operations
             .iter()
@@ -226,10 +224,11 @@ type Product {
         let op_fields = get_product_op.fields(&ctx.db);
         let name_field_def: Vec<String> = op_fields
             .iter()
-            .filter_map(|field| Some(field.ty(&ctx.db)?.name()))
+            .filter_map(|field| Some(field.ty()?.name()))
             .collect();
-        assert_eq!(name_field_def, ["Product", "String"]);
+        assert_eq!(name_field_def, ["Int", "Product"]);
 
+        // get the types of the two topProducts selection set fields - name and inStock
         let top_products = op_fields
             .iter()
             .find(|f| f.name() == "topProducts")
@@ -239,9 +238,28 @@ type Product {
 
         let top_product_fields: Vec<String> = top_products
             .iter()
-            .filter_map(|f| Some(f.ty(&ctx.db)?.name()))
+            .filter_map(|f| Some(f.ty()?.name()))
             .collect();
-        dbg!(&top_product_fields);
+        assert_eq!(top_product_fields, ["String", "Boolean"]);
+
+        // you can also search for a field in a selection_set and then get its
+        // field definition. This looks for topProducts' inStock field's
+        // directives.
+        let in_stock_field = op_fields
+            .iter()
+            .find(|f| f.name() == "topProducts")
+            .unwrap()
+            .selection_set()
+            .field("inStock")
+            .unwrap()
+            .field_definition(&ctx.db)
+            .unwrap();
+        let in_stock_directive: Vec<&str> = in_stock_field
+            .directives()
+            .iter()
+            .map(|dir| dir.name())
+            .collect();
+        assert_eq!(in_stock_directive, ["join__field"]);
     }
 
     #[test]

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -1462,9 +1462,8 @@ fn field_ty_id(
     match field_ty {
         Some(ty) => {
             if field.selection_set().is_some() {
-                return db
-                    .find_type_system_definition_by_name(ty.name())
-                    .and_then(|def| def.id().cloned());
+                db.find_type_system_definition_by_name(ty.name())
+                    .and_then(|def| def.id().cloned())
             } else {
                 None
             }

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -39,7 +39,7 @@ pub trait SourceDatabase {
 
     fn db_definitions(&self) -> Arc<Vec<Definition>>;
 
-    fn find_definition_by_name(&self, name: String) -> Option<Arc<Definition>>;
+    fn type_system_definitions(&self) -> Arc<Vec<Definition>>;
 
     fn operations(&self) -> Arc<Vec<OperationDefinition>>;
 
@@ -88,6 +88,10 @@ pub trait SourceDatabase {
     fn find_input_object(&self, id: Uuid) -> Option<Arc<InputObjectTypeDefinition>>;
 
     fn find_input_object_by_name(&self, name: String) -> Option<Arc<InputObjectTypeDefinition>>;
+
+    fn find_definition_by_name(&self, name: String) -> Option<Arc<Definition>>;
+
+    fn find_type_system_definition_by_name(&self, name: String) -> Option<Arc<Definition>>;
 
     fn operation_definition_variables(&self, id: Uuid) -> Arc<HashSet<Variable>>;
 
@@ -195,8 +199,74 @@ fn db_definitions(db: &dyn SourceDatabase) -> Arc<Vec<Definition>> {
     Arc::new(definitions)
 }
 
+fn type_system_definitions(db: &dyn SourceDatabase) -> Arc<Vec<Definition>> {
+    let mut definitions = Vec::new();
+
+    let directives: Vec<Definition> = db
+        .directive_definitions()
+        .iter()
+        .map(|def| Definition::DirectiveDefinition(def.clone()))
+        .collect();
+    let scalars: Vec<Definition> = db
+        .scalars()
+        .iter()
+        .map(|def| Definition::ScalarTypeDefinition(def.clone()))
+        .collect();
+    let objects: Vec<Definition> = db
+        .object_types()
+        .iter()
+        .map(|def| Definition::ObjectTypeDefinition(def.clone()))
+        .collect();
+    let interfaces: Vec<Definition> = db
+        .interfaces()
+        .iter()
+        .map(|def| Definition::InterfaceTypeDefinition(def.clone()))
+        .collect();
+    let unions: Vec<Definition> = db
+        .unions()
+        .iter()
+        .map(|def| Definition::UnionTypeDefinition(def.clone()))
+        .collect();
+    let enums: Vec<Definition> = db
+        .enums()
+        .iter()
+        .map(|def| Definition::EnumTypeDefinition(def.clone()))
+        .collect();
+    let input_objects: Vec<Definition> = db
+        .input_objects()
+        .iter()
+        .map(|def| Definition::InputObjectTypeDefinition(def.clone()))
+        .collect();
+    let schema = Definition::SchemaDefinition(db.schema().as_ref().clone());
+
+    definitions.extend(directives);
+    definitions.extend(scalars);
+    definitions.extend(objects);
+    definitions.extend(interfaces);
+    definitions.extend(unions);
+    definitions.extend(enums);
+    definitions.extend(input_objects);
+    definitions.push(schema);
+
+    Arc::new(definitions)
+}
+
 fn find_definition_by_name(db: &dyn SourceDatabase, name: String) -> Option<Arc<Definition>> {
     db.db_definitions().iter().find_map(|def| {
+        if let Some(n) = def.name() {
+            if name == n {
+                return Some(Arc::new(def.clone()));
+            }
+        }
+        None
+    })
+}
+
+fn find_type_system_definition_by_name(
+    db: &dyn SourceDatabase,
+    name: String,
+) -> Option<Arc<Definition>> {
+    db.type_system_definitions().iter().find_map(|def| {
         if let Some(n) = def.name() {
             if name == n {
                 return Some(Arc::new(def.clone()));
@@ -279,6 +349,7 @@ fn operation_fields(db: &dyn SourceDatabase, id: Uuid) -> Arc<Vec<Field>> {
     let fields = match db.find_operation(id) {
         Some(op) => op
             .selection_set()
+            .selection()
             .iter()
             .filter_map(|sel| match sel {
                 Selection::Field(field) => Some(field.as_ref().clone()),
@@ -294,17 +365,11 @@ fn operation_inline_fragment_fields(db: &dyn SourceDatabase, id: Uuid) -> Arc<Ve
     let fields: Vec<Field> = match db.find_operation(id) {
         Some(op) => op
             .selection_set()
+            .selection()
             .iter()
             .filter_map(|sel| match sel {
                 Selection::InlineFragment(fragment) => {
-                    let fields: Vec<Field> = fragment
-                        .selection_set()
-                        .iter()
-                        .filter_map(|sel| match sel {
-                            Selection::Field(field) => Some(field.as_ref().clone()),
-                            _ => None,
-                        })
-                        .collect();
+                    let fields: Vec<Field> = fragment.selection_set().fields();
                     Some(fields)
                 }
                 _ => None,
@@ -320,18 +385,11 @@ fn operation_fragment_spread_fields(db: &dyn SourceDatabase, id: Uuid) -> Arc<Ve
     let fields: Vec<Field> = match db.find_operation(id) {
         Some(op) => op
             .selection_set()
+            .selection()
             .iter()
             .filter_map(|sel| match sel {
                 Selection::FragmentSpread(fragment_spread) => {
-                    let fields: Vec<Field> = fragment_spread
-                        .fragment(db)?
-                        .selection_set()
-                        .iter()
-                        .filter_map(|sel| match sel {
-                            Selection::Field(field) => Some(field.as_ref().clone()),
-                            _ => None,
-                        })
-                        .collect();
+                    let fields: Vec<Field> = fragment_spread.fragment(db)?.selection_set().fields();
                     Some(fields)
                 }
                 _ => None,
@@ -633,8 +691,9 @@ fn operation_definition(
     // if there are no names, an error must be raised that all operations must have a name
     let name = op_def.name().map(|name| name.text().to_string());
     let ty = operation_type(op_def.operation_type());
+    let object_id = object_type_uuid(db, ty);
     let variables = variable_definitions(op_def.variable_definitions());
-    let selection_set = selection_set(db, op_def.selection_set());
+    let selection_set = selection_set(db, op_def.selection_set(), object_id);
     let directives = directives(op_def.directives());
     let ast_ptr = SyntaxNodePtr::new(op_def.syntax());
 
@@ -645,6 +704,7 @@ fn operation_definition(
         variables,
         selection_set,
         directives,
+        object_id,
         ast_ptr,
     }
 }
@@ -668,7 +728,8 @@ fn fragment_definition(
         .expect("Name must have text")
         .text()
         .to_string();
-    let selection_set = selection_set(db, fragment_def.selection_set());
+    // TODO @lrlna: how do we find which current object id this selection is referring to?
+    let selection_set = selection_set(db, fragment_def.selection_set(), None);
     let directives = directives(fragment_def.directives());
     let ast_ptr = SyntaxNodePtr::new(fragment_def.syntax());
 
@@ -721,21 +782,24 @@ fn object_type_definition(obj_def: ast::ObjectTypeDefinition) -> ObjectTypeDefin
 }
 
 fn scalar_definition(scalar_def: ast::ScalarTypeDefinition) -> ScalarTypeDefinition {
+    let id = Uuid::new_v4();
     let description = description(scalar_def.description());
     let name = name(scalar_def.name());
     let directives = directives(scalar_def.directives());
     let ast_ptr = SyntaxNodePtr::new(scalar_def.syntax());
 
     ScalarTypeDefinition {
+        id,
         description,
         name,
         directives,
         ast_ptr: Some(ast_ptr),
-        built_in: false
+        built_in: false,
     }
 }
 
 fn enum_definition(enum_def: ast::EnumTypeDefinition) -> EnumTypeDefinition {
+    let id = Uuid::new_v4();
     let description = description(enum_def.description());
     let name = name(enum_def.name());
     let directives = directives(enum_def.directives());
@@ -743,6 +807,7 @@ fn enum_definition(enum_def: ast::EnumTypeDefinition) -> EnumTypeDefinition {
     let ast_ptr = SyntaxNodePtr::new(enum_def.syntax());
 
     EnumTypeDefinition {
+        id,
         description,
         name,
         directives,
@@ -785,6 +850,7 @@ fn union_definition(
     db: &dyn SourceDatabase,
     union_def: ast::UnionTypeDefinition,
 ) -> UnionTypeDefinition {
+    let id = Uuid::new_v4();
     let description = description(union_def.description());
     let name = name(union_def.name());
     let directives = directives(union_def.directives());
@@ -792,6 +858,7 @@ fn union_definition(
     let ast_ptr = SyntaxNodePtr::new(union_def.syntax());
 
     UnionTypeDefinition {
+        id,
         description,
         name,
         directives,
@@ -1250,22 +1317,30 @@ fn value(val: ast::Value) -> Value {
 fn selection_set(
     db: &dyn SourceDatabase,
     selections: Option<ast::SelectionSet>,
-) -> Arc<Vec<Selection>> {
+    object_id: Option<Uuid>,
+) -> SelectionSet {
     let selection_set = match selections {
         Some(sel) => sel
             .selections()
             .into_iter()
-            .map(|sel| selection(db, sel))
+            .map(|sel| selection(db, sel, object_id))
             .collect(),
         None => Vec::new(),
     };
-    Arc::new(selection_set)
+
+    SelectionSet {
+        selection: Arc::new(selection_set),
+    }
 }
 
-fn selection(db: &dyn SourceDatabase, selection: ast::Selection) -> Selection {
+fn selection(
+    db: &dyn SourceDatabase,
+    selection: ast::Selection,
+    object_id: Option<Uuid>,
+) -> Selection {
     match selection {
         ast::Selection::Field(sel_field) => {
-            let field = field(db, sel_field);
+            let field = field(db, sel_field, object_id);
             Selection::Field(field)
         }
         ast::Selection::FragmentSpread(fragment) => {
@@ -1273,13 +1348,17 @@ fn selection(db: &dyn SourceDatabase, selection: ast::Selection) -> Selection {
             Selection::FragmentSpread(fragment_spread)
         }
         ast::Selection::InlineFragment(fragment) => {
-            let inline_fragment = inline_fragment(db, fragment);
+            let inline_fragment = inline_fragment(db, fragment, object_id);
             Selection::InlineFragment(inline_fragment)
         }
     }
 }
 
-fn inline_fragment(db: &dyn SourceDatabase, fragment: ast::InlineFragment) -> Arc<InlineFragment> {
+fn inline_fragment(
+    db: &dyn SourceDatabase,
+    fragment: ast::InlineFragment,
+    object_id: Option<Uuid>,
+) -> Arc<InlineFragment> {
     let type_condition = fragment.type_condition().map(|tc| {
         tc.named_type()
             .expect("Type Condition must have a name")
@@ -1289,7 +1368,7 @@ fn inline_fragment(db: &dyn SourceDatabase, fragment: ast::InlineFragment) -> Ar
             .to_string()
     });
     let directives = directives(fragment.directives());
-    let selection_set: Arc<Vec<Selection>> = selection_set(db, fragment.selection_set());
+    let selection_set: SelectionSet = selection_set(db, fragment.selection_set(), object_id);
     let ast_ptr = SyntaxNodePtr::new(fragment.syntax());
 
     let fragment_data = InlineFragment {
@@ -1326,10 +1405,16 @@ fn fragment_spread(db: &dyn SourceDatabase, fragment: ast::FragmentSpread) -> Ar
     Arc::new(fragment_data)
 }
 
-fn field(db: &dyn SourceDatabase, field: ast::Field) -> Arc<Field> {
+fn field(db: &dyn SourceDatabase, field: ast::Field, ty_id: Option<Uuid>) -> Arc<Field> {
     let name = name(field.name());
     let alias = alias(field.alias());
-    let selection_set = selection_set(db, field.selection_set());
+    let new_ty_id = if field.selection_set().is_some() {
+        db.find_type_system_definition_by_name(name.clone())
+            .and_then(|def| def.id().cloned())
+    } else {
+        None
+    };
+    let selection_set = selection_set(db, field.selection_set(), new_ty_id);
     let directives = directives(field.directives());
     let arguments = arguments(field.arguments());
     let ast_ptr = SyntaxNodePtr::new(field.syntax());
@@ -1338,6 +1423,7 @@ fn field(db: &dyn SourceDatabase, field: ast::Field) -> Arc<Field> {
         name,
         alias,
         selection_set,
+        reference_ty_id: ty_id,
         directives,
         arguments,
         ast_ptr,
@@ -1374,6 +1460,14 @@ fn alias(alias: Option<ast::Alias>) -> Option<Arc<Alias>> {
     })
 }
 
+fn object_type_uuid(db: &dyn SourceDatabase, ty: OperationType) -> Option<Uuid> {
+    match ty {
+        OperationType::Query => db.schema().query(db).map(|query| *query.id()),
+        OperationType::Mutation => db.schema().mutation(db).map(|mutation| *mutation.id()),
+        OperationType::Subscription => db.schema().subscription(db).map(|sub| *sub.id()),
+    }
+}
+
 //  Int, Float, String, Boolean, and ID
 fn built_in_scalars(mut scalars: Vec<ScalarTypeDefinition>) -> Vec<ScalarTypeDefinition> {
     scalars.push(int_scalar());
@@ -1387,6 +1481,7 @@ fn built_in_scalars(mut scalars: Vec<ScalarTypeDefinition>) -> Vec<ScalarTypeDef
 
 fn int_scalar() -> ScalarTypeDefinition {
     ScalarTypeDefinition {
+        id: Uuid::new_v4(),
         description: Some("The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.".into()),
         name: "Int".into(),
         directives: Arc::new(Vec::new()),
@@ -1397,6 +1492,7 @@ fn int_scalar() -> ScalarTypeDefinition {
 
 fn float_scalar() -> ScalarTypeDefinition {
     ScalarTypeDefinition {
+        id: Uuid::new_v4(),
         description: Some("The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).".into()),
         name: "Float".into(),
         directives: Arc::new(Vec::new()),
@@ -1407,6 +1503,7 @@ fn float_scalar() -> ScalarTypeDefinition {
 
 fn string_scalar() -> ScalarTypeDefinition {
     ScalarTypeDefinition {
+        id: Uuid::new_v4(),
         description: Some("The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.".into()),
         name: "String".into(),
         directives: Arc::new(Vec::new()),
@@ -1417,16 +1514,18 @@ fn string_scalar() -> ScalarTypeDefinition {
 
 fn boolean_scalar() -> ScalarTypeDefinition {
     ScalarTypeDefinition {
+        id: Uuid::new_v4(),
         description: Some("The `Boolean` scalar type represents `true` or `false`.".into()),
         name: "Boolean".into(),
         directives: Arc::new(Vec::new()),
         ast_ptr: None,
-        built_in: true
+        built_in: true,
     }
 }
 
 fn id_scalar() -> ScalarTypeDefinition {
     ScalarTypeDefinition {
+        id: Uuid::new_v4(),
         description: Some("The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.".into()),
         name: "ID".into(),
         directives: Arc::new(Vec::new()),

--- a/crates/apollo-compiler/src/validation/unused_variables.rs
+++ b/crates/apollo-compiler/src/validation/unused_variables.rs
@@ -24,6 +24,7 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
             let used_vars: HashSet<ValidationSet> = op
                 .selection_set
                 .clone()
+                .selection()
                 .iter()
                 .flat_map(|sel| {
                     let vars: HashSet<ValidationSet> = sel


### PR DESCRIPTION
We want to be able to have access to type information in an executable definitions, i.e. tie schema information to query information. This PR introduces some basic relationships for more straightforward selection sets. A given `Field` now has both the `reference_ty_id` and `ty` information when available. This makes it possible to have access to schema-defined types. 