### PR TITLE
Add an accessor for `directives` on `ObjectTypeDefinition`

### DIFF
--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -508,6 +508,28 @@ input Point2D {
     }
 
     #[test]
+    fn it_accesses_object_directive_name() {
+        let input = r#"
+
+type Book @directiveA(name: "pageCount") @directiveB(name: "author") {
+  id: ID!
+}
+"#;
+
+        let ctx = ApolloCompiler::new(input);
+        let diagnostics = ctx.validate();
+        for diagnostic in &diagnostics {
+            println!("{}", diagnostic);
+        }
+        assert!(diagnostics.is_empty());
+
+        let book_obj = ctx.db.find_object_type_by_name("Book".to_string()).unwrap();
+
+        let directive_names : Vec<&str> = book_obj.directives().iter().map(|d|d.name()).collect();
+        assert_eq!(directive_names, ["directiveA", "directiveB"]);
+    }
+
+    #[test]
     fn it_accesses_object_field_types_directive_name() {
         let input = r#"
 type Person {

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -1229,6 +1229,11 @@ impl ObjectTypeDefinition {
         self.name.as_ref()
     }
 
+    /// Get a reference to the object type definition's directives.
+    pub fn directives(&self) -> &[Directive] {
+        self.directives.as_ref()
+    }
+
     /// Get a reference to the object type definition's field definitions.
     pub fn fields_definition(&self) -> &[FieldDefinition] {
         self.fields_definition.as_ref()


### PR DESCRIPTION
Currently it's impossible to get at `ObjectTypeDefinition::directives`