### PR TITLE
feat(apollo-compiler): add operation field validation

### DIFF
--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -13,6 +13,7 @@ pub enum ApolloDiagnostic {
     SyntaxError(SyntaxError),
     UniqueField(UniqueField),
     UndefinedDefinition(UndefinedDefinition),
+    UndefinedField(UndefinedField),
     RecursiveDefinition(RecursiveDefinition),
     TransitiveImplementedInterfaces(TransitiveImplementedInterfaces),
     QueryRootOperationType(QueryRootOperationType),
@@ -38,6 +39,7 @@ impl ApolloDiagnostic {
                 | ApolloDiagnostic::RecursiveDefinition(_)
                 | ApolloDiagnostic::TransitiveImplementedInterfaces(_)
                 | ApolloDiagnostic::QueryRootOperationType(_)
+                | ApolloDiagnostic::UndefinedField(_)
                 | ApolloDiagnostic::BuiltInScalarDefinition(_)
                 | ApolloDiagnostic::OutputType(_)
         )
@@ -78,6 +80,7 @@ impl fmt::Display for ApolloDiagnostic {
             ApolloDiagnostic::UnusedVariable(diagnostic) => Report::new(diagnostic.clone()),
             ApolloDiagnostic::MissingField(diagnostic) => Report::new(diagnostic.clone()),
             ApolloDiagnostic::OutputType(diagnostic) => Report::new(diagnostic.clone()),
+            ApolloDiagnostic::UndefinedField(diagnostic) => Report::new(diagnostic.clone()),
         };
 
         writeln!(f, "{:?}", report)
@@ -331,3 +334,22 @@ pub struct OutputType {
     #[label("this is of `{}` type", self.ty)]
     pub definition: SourceSpan,
 }
+
+#[derive(Diagnostic, Debug, Error, Clone, Hash, PartialEq, Eq)]
+#[error("Cannot query `{}` field", self.field)]
+/// Returns `true` if the definition is either a [`ScalarTypeDefinition`],
+#[diagnostic(code("apollo-compiler validation error"))]
+pub struct UndefinedField {
+    // field name
+    pub field: String,
+
+    #[source_code]
+    pub src: String,
+
+    #[label("`{}` field is not in scope", self.field)]
+    pub definition: SourceSpan,
+
+    #[help]
+    pub help: String,
+}
+

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -116,6 +116,7 @@ fn parse(db: &dyn SourceDatabase) -> Arc<SyntaxTree> {
 // NOTE: a very expensive clone - should more tightly couple the parser and the
 // source database for a cleaner solution
 fn document(db: &dyn SourceDatabase) -> Arc<ast::Document> {
+    dbg!(db.parse());
     Arc::new(db.parse().as_ref().clone().document())
 }
 

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -116,7 +116,6 @@ fn parse(db: &dyn SourceDatabase) -> Arc<SyntaxTree> {
 // NOTE: a very expensive clone - should more tightly couple the parser and the
 // source database for a cleaner solution
 fn document(db: &dyn SourceDatabase) -> Arc<ast::Document> {
-    dbg!(db.parse());
     Arc::new(db.parse().as_ref().clone().document())
 }
 

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -316,7 +316,8 @@ impl OperationDefinition {
         &self.selection_set
     }
 
-    /// Get fields in the operation definition.
+    /// Get fields in the operation definition (excluding inline fragments and
+    /// fragment spreads).
     pub fn fields(&self, db: &dyn SourceDatabase) -> Arc<Vec<Field>> {
         db.operation_fields(self.id)
     }

--- a/crates/apollo-compiler/src/validation/operations.rs
+++ b/crates/apollo-compiler/src/validation/operations.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    diagnostics::{MissingIdent, SingleRootField, UniqueDefinition, UnsupportedOperation},
-    values::OperationDefinition,
+    diagnostics::{MissingIdent, SingleRootField, UniqueDefinition, UnsupportedOperation, UndefinedField},
+    values::{OperationDefinition, Selection},
     ApolloDiagnostic, SourceDatabase,
 };
 // use crate::{diagnostics::ErrorDiagnostic, ApolloDiagnostic, SourceDatabase};
@@ -205,6 +205,31 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
         diagnostics.extend(unsupported_ops)
     }
 
+    // Fields must exist on the type being queried.
+    for op in db.operations().iter() {
+        for selection in op.selection_set().selection() {
+            let obj_name = op.object_id().and_then(|id| db.find_object_type(*id).map(|obj| obj.name().to_owned()));
+            if let Selection::Field(field) = selection {
+                if field.ty().is_none() {
+                    let offset: usize = field.ast_node(db).text_range().start().into();
+                    let len: usize = field.ast_node(db).text_range().len().into();
+                    let field_name = field.name().into();
+                    let help = if let Some(obj_type) = obj_name {
+                        format!("`{}` is not defined on `{}` type", field_name, obj_type)
+                    } else {
+                        format!("`{}` is not defined on the current {} root operation type.", field_name, op.ty())
+                    };
+                    diagnostics.push(ApolloDiagnostic::UndefinedField(UndefinedField {
+                        field: field_name,
+                        src: db.input_string(()).to_string(),
+                        definition: (offset, len).into(),
+                        help,
+                    }))
+                }
+            }
+        }
+    }
+
     diagnostics
 }
 
@@ -318,5 +343,58 @@ union Pet = Cat | Dog
         let ctx = ApolloCompiler::new(input);
         let diagnostics = ctx.validate();
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn it_raises_an_error_for_illegal_operations() {
+        let input = r#"
+subscription sub {
+  newMessage {
+    body
+    sender
+  }
+}
+
+type Query {
+  cat: Pet
+}
+
+union Pet = Cat | Dog
+"#;
+        let ctx = ApolloCompiler::new(input);
+        let diagnostics = ctx.validate();
+        for diagnostic in &diagnostics {
+            println!("{}", diagnostic)
+        }
+
+        assert_eq!(diagnostics.len(), 2)
+    }
+
+    #[test]
+    fn it_validates_fields_in_operations() {
+        let input = r#"
+query getProduct {
+  size
+  weight
+}
+
+type Query {
+  name: String
+  topProducts: Product
+}
+
+type Product {
+  inStock: Boolean @join__field(graph: INVENTORY)
+  name: String @join__field(graph: PRODUCTS)
+}
+"#;
+
+        let ctx = ApolloCompiler::new(input);
+        let diagnostics = ctx.validate();
+        for diagnostic in &diagnostics {
+            println!("{}", diagnostic);
+        }
+
+        assert_eq!(diagnostics.len(), 2)
     }
 }

--- a/crates/apollo-compiler/src/validation/operations.rs
+++ b/crates/apollo-compiler/src/validation/operations.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    diagnostics::{MissingIdent, SingleRootField, UniqueDefinition, UnsupportedOperation, UndefinedField},
+    diagnostics::{
+        MissingIdent, SingleRootField, UndefinedField, UniqueDefinition, UnsupportedOperation,
+    },
     values::{OperationDefinition, Selection},
     ApolloDiagnostic, SourceDatabase,
 };
@@ -208,7 +210,9 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
     // Fields must exist on the type being queried.
     for op in db.operations().iter() {
         for selection in op.selection_set().selection() {
-            let obj_name = op.object_id().and_then(|id| db.find_object_type(*id).map(|obj| obj.name().to_owned()));
+            let obj_name = op
+                .object_id()
+                .and_then(|id| db.find_object_type(*id).map(|obj| obj.name().to_owned()));
             if let Selection::Field(field) = selection {
                 if field.ty().is_none() {
                     let offset: usize = field.ast_node(db).text_range().start().into();
@@ -217,7 +221,11 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
                     let help = if let Some(obj_type) = obj_name {
                         format!("`{}` is not defined on `{}` type", field_name, obj_type)
                     } else {
-                        format!("`{}` is not defined on the current {} root operation type.", field_name, op.ty())
+                        format!(
+                            "`{}` is not defined on the current {} root operation type.",
+                            field_name,
+                            op.ty()
+                        )
                     };
                     diagnostics.push(ApolloDiagnostic::UndefinedField(UndefinedField {
                         field: field_name,
@@ -283,7 +291,7 @@ union Pet = Cat | Dog
         for diagnostic in &diagnostics {
             println!("{}", diagnostic)
         }
-        assert_eq!(diagnostics.len(), 4)
+        assert_eq!(diagnostics.len(), 5)
     }
 
     #[test]

--- a/crates/apollo-compiler/src/validation/unused_variables.rs
+++ b/crates/apollo-compiler/src/validation/unused_variables.rs
@@ -80,7 +80,7 @@ query ExampleQuery {
     name
   }
 
-  ... VipCustomer on User {
+  ...VipCustomer on User {
     id
     name
     profilePic(size: $dimensions)

--- a/crates/apollo-compiler/src/validation/unused_variables.rs
+++ b/crates/apollo-compiler/src/validation/unused_variables.rs
@@ -80,7 +80,7 @@ query ExampleQuery {
     name
   }
 
-  ...VipCustomer on User {
+  ... on User {
     id
     name
     profilePic(size: $dimensions)

--- a/crates/apollo-compiler/test_data/diagnostics/0004_subscription_with_multiple_root_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0004_subscription_with_multiple_root_fields.txt
@@ -16,4 +16,19 @@
             ),
         },
     ),
+    UndefinedField(
+        UndefinedField {
+            field: "disallowedSecondRootField",
+            src: "subscription sub {\n  newMessage {\n    body\n    sender\n  }\n  disallowedSecondRootField\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\ntype Query {\n  message: String\n}",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    60,
+                ),
+                length: SourceOffset(
+                    26,
+                ),
+            },
+            help: "`disallowedSecondRootField` is not defined on `Subscription` type",
+        },
+    ),
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0014_subscription_operation_without_subscription_schema_operation_type.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0014_subscription_operation_without_subscription_schema_operation_type.graphql
@@ -11,5 +11,11 @@ schema {
 
 type customPetQuery {
   name: String,
+  newMessage: Message
   age: Int
+}
+
+type Message {
+  body: String
+  sender: String
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0014_subscription_operation_without_subscription_schema_operation_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0014_subscription_operation_without_subscription_schema_operation_type.txt
@@ -24,4 +24,19 @@
             help: None,
         },
     ),
+    UndefinedField(
+        UndefinedField {
+            field: "newMessage",
+            src: "subscription messageSubscription {\n  newMessage {\n    body\n    sender\n  }\n}\n\nschema {\n  query: customPetQuery,\n}\n\ntype customPetQuery {\n  name: String,\n  age: Int\n}",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    37,
+                ),
+                length: SourceOffset(
+                    37,
+                ),
+            },
+            help: "`newMessage` is not defined on the current Subscription root operation type.",
+        },
+    ),
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0014_subscription_operation_without_subscription_schema_operation_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0014_subscription_operation_without_subscription_schema_operation_type.txt
@@ -2,7 +2,7 @@
     UnsupportedOperation(
         UnsupportedOperation {
             ty: "Subscription",
-            src: "subscription messageSubscription {\n  newMessage {\n    body\n    sender\n  }\n}\n\nschema {\n  query: customPetQuery,\n}\n\ntype customPetQuery {\n  name: String,\n  age: Int\n}",
+            src: "subscription messageSubscription {\n  newMessage {\n    body\n    sender\n  }\n}\n\nschema {\n  query: customPetQuery,\n}\n\ntype customPetQuery {\n  name: String,\n  newMessage: Message\n  age: Int\n}\n\ntype Message {\n  body: String\n  sender: String\n}",
             operation: SourceSpan {
                 offset: SourceOffset(
                     0,
@@ -27,7 +27,7 @@
     UndefinedField(
         UndefinedField {
             field: "newMessage",
-            src: "subscription messageSubscription {\n  newMessage {\n    body\n    sender\n  }\n}\n\nschema {\n  query: customPetQuery,\n}\n\ntype customPetQuery {\n  name: String,\n  age: Int\n}",
+            src: "subscription messageSubscription {\n  newMessage {\n    body\n    sender\n  }\n}\n\nschema {\n  query: customPetQuery,\n}\n\ntype customPetQuery {\n  name: String,\n  newMessage: Message\n  age: Int\n}\n\ntype Message {\n  body: String\n  sender: String\n}",
             definition: SourceSpan {
                 offset: SourceOffset(
                     37,

--- a/crates/apollo-compiler/test_data/diagnostics/0015_mutation_operation_without_mutation_schema_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0015_mutation_operation_without_mutation_schema_definition.txt
@@ -17,4 +17,19 @@
             ),
         },
     ),
+    UndefinedField(
+        UndefinedField {
+            field: "addPet",
+            src: "mutation adoptAPetMutation {\n  addPet {\n    owner {\n      name\n    }\n  }\n}\n\ntype Query {\n  name: String,\n  age: Int\n}",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    31,
+                ),
+                length: SourceOffset(
+                    42,
+                ),
+            },
+            help: "`addPet` is not defined on the current Mutation root operation type.",
+        },
+    ),
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.graphql
@@ -1,0 +1,14 @@
+query getProduct {
+  size
+  weight
+}
+
+type Query {
+  name: String
+  topProducts: Product
+}
+
+type Product {
+  inStock: Boolean @join__field(graph: INVENTORY)
+  name: String @join__field(graph: PRODUCTS)
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.txt
@@ -1,0 +1,32 @@
+[
+    UndefinedField(
+        UndefinedField {
+            field: "size",
+            src: "query getProduct {\n  size\n  weight\n}\n\ntype Query {\n  name: String\n  topProducts: Product\n}\n\ntype Product {\n  inStock: Boolean @join__field(graph: INVENTORY)\n  name: String @join__field(graph: PRODUCTS)\n}",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    21,
+                ),
+                length: SourceOffset(
+                    7,
+                ),
+            },
+            help: "`size` is not defined on `Query` type",
+        },
+    ),
+    UndefinedField(
+        UndefinedField {
+            field: "weight",
+            src: "query getProduct {\n  size\n  weight\n}\n\ntype Query {\n  name: String\n  topProducts: Product\n}\n\ntype Product {\n  inStock: Boolean @join__field(graph: INVENTORY)\n  name: String @join__field(graph: PRODUCTS)\n}",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    28,
+                ),
+                length: SourceOffset(
+                    7,
+                ),
+            },
+            help: "`weight` is not defined on `Query` type",
+        },
+    ),
+]

--- a/crates/apollo-compiler/test_data/diagnostics/0041_subscription_operation_with_undefined_fields.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0041_subscription_operation_with_undefined_fields.graphql
@@ -1,0 +1,16 @@
+subscription sub {
+  undefinedSubscriptionField
+}
+
+type Subscription {
+  newMessage: Result
+}
+
+type Result {
+  body: String,
+  sender: String
+}
+
+type Query {
+  message: String
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0041_subscription_operation_with_undefined_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0041_subscription_operation_with_undefined_fields.txt
@@ -1,0 +1,17 @@
+[
+    UndefinedField(
+        UndefinedField {
+            field: "undefinedSubscriptionField",
+            src: "subscription sub {\n  undefinedSubscriptionField\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\ntype Query {\n  message: String\n}",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    21,
+                ),
+                length: SourceOffset(
+                    27,
+                ),
+            },
+            help: "`undefinedSubscriptionField` is not defined on `Subscription` type",
+        },
+    ),
+]

--- a/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.graphql
@@ -1,0 +1,18 @@
+mutation adoptAPetMutation {
+  undefinedMutationField
+}
+
+type Query {
+  name: String,
+  age: Int
+}
+
+type Mutation {
+  addPet (name: String!, petType: PetType): Result!
+}
+
+type Result {
+  id: String
+}
+
+union PetType = Cat | Dog

--- a/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.txt
@@ -1,0 +1,17 @@
+[
+    UndefinedField(
+        UndefinedField {
+            field: "undefinedMutationField",
+            src: "mutation adoptAPetMutation {\n  undefinedMutationField\n}\n\ntype Query {\n  name: String,\n  age: Int\n}\n\ntype Mutation {\n  addPet (name: String!, petType: PetType): Result!\n}\n\ntype Result {\n  id: String\n}\n\nunion PetType = Cat | Dog\n",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    31,
+                ),
+                length: SourceOffset(
+                    23,
+                ),
+            },
+            help: "`undefinedMutationField` is not defined on `Mutation` type",
+        },
+    ),
+]

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.graphql
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.graphql
@@ -1,0 +1,22 @@
+query getProduct {
+  size
+  topProducts {
+    name
+    inStock
+  }
+}
+
+type Query {
+  topProducts: Product
+  name: String
+  size: Int
+}
+
+type Product {
+  inStock: Boolean @join__field(graph: INVENTORY)
+  name: String @join__field(graph: PRODUCTS)
+  price: Int
+  shippingEstimate: Int
+  upc: String!
+  weight: Int
+}

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -1,0 +1,173 @@
+- DOCUMENT@0..313
+    - OPERATION_DEFINITION@0..70
+        - OPERATION_TYPE@0..6
+            - query_KW@0..5 "query"
+            - WHITESPACE@5..6 " "
+        - NAME@6..17
+            - IDENT@6..16 "getProduct"
+            - WHITESPACE@16..17 " "
+        - SELECTION_SET@17..70
+            - L_CURLY@17..18 "{"
+            - WHITESPACE@18..21 "\n  "
+            - FIELD@21..28
+                - NAME@21..28
+                    - IDENT@21..25 "size"
+                    - WHITESPACE@25..28 "\n  "
+            - FIELD@28..67
+                - NAME@28..40
+                    - IDENT@28..39 "topProducts"
+                    - WHITESPACE@39..40 " "
+                - SELECTION_SET@40..67
+                    - L_CURLY@40..41 "{"
+                    - WHITESPACE@41..46 "\n    "
+                    - FIELD@46..55
+                        - NAME@46..55
+                            - IDENT@46..50 "name"
+                            - WHITESPACE@50..55 "\n    "
+                    - FIELD@55..65
+                        - NAME@55..65
+                            - IDENT@55..62 "inStock"
+                            - WHITESPACE@62..65 "\n  "
+                    - R_CURLY@65..66 "}"
+                    - WHITESPACE@66..67 "\n"
+            - R_CURLY@67..68 "}"
+            - WHITESPACE@68..70 "\n\n"
+    - OBJECT_TYPE_DEFINITION@70..136
+        - type_KW@70..74 "type"
+        - WHITESPACE@74..75 " "
+        - NAME@75..81
+            - IDENT@75..80 "Query"
+            - WHITESPACE@80..81 " "
+        - FIELDS_DEFINITION@81..136
+            - L_CURLY@81..82 "{"
+            - WHITESPACE@82..85 "\n  "
+            - FIELD_DEFINITION@85..108
+                - NAME@85..96
+                    - IDENT@85..96 "topProducts"
+                - COLON@96..97 ":"
+                - WHITESPACE@97..98 " "
+                - NAMED_TYPE@98..105
+                    - NAME@98..105
+                        - IDENT@98..105 "Product"
+                - WHITESPACE@105..108 "\n  "
+            - FIELD_DEFINITION@108..123
+                - NAME@108..112
+                    - IDENT@108..112 "name"
+                - COLON@112..113 ":"
+                - WHITESPACE@113..114 " "
+                - NAMED_TYPE@114..120
+                    - NAME@114..120
+                        - IDENT@114..120 "String"
+                - WHITESPACE@120..123 "\n  "
+            - FIELD_DEFINITION@123..133
+                - NAME@123..127
+                    - IDENT@123..127 "size"
+                - COLON@127..128 ":"
+                - WHITESPACE@128..129 " "
+                - NAMED_TYPE@129..132
+                    - NAME@129..132
+                        - IDENT@129..132 "Int"
+                - WHITESPACE@132..133 "\n"
+            - R_CURLY@133..134 "}"
+            - WHITESPACE@134..136 "\n\n"
+    - OBJECT_TYPE_DEFINITION@136..313
+        - type_KW@136..140 "type"
+        - WHITESPACE@140..141 " "
+        - NAME@141..149
+            - IDENT@141..148 "Product"
+            - WHITESPACE@148..149 " "
+        - FIELDS_DEFINITION@149..313
+            - L_CURLY@149..150 "{"
+            - WHITESPACE@150..153 "\n  "
+            - FIELD_DEFINITION@153..203
+                - NAME@153..160
+                    - IDENT@153..160 "inStock"
+                - COLON@160..161 ":"
+                - WHITESPACE@161..162 " "
+                - NAMED_TYPE@162..169
+                    - NAME@162..169
+                        - IDENT@162..169 "Boolean"
+                - WHITESPACE@169..170 " "
+                - DIRECTIVES@170..203
+                    - DIRECTIVE@170..203
+                        - AT@170..171 "@"
+                        - NAME@171..182
+                            - IDENT@171..182 "join__field"
+                        - ARGUMENTS@182..203
+                            - L_PAREN@182..183 "("
+                            - ARGUMENT@183..199
+                                - NAME@183..188
+                                    - IDENT@183..188 "graph"
+                                - COLON@188..189 ":"
+                                - WHITESPACE@189..190 " "
+                                - ENUM_VALUE@190..199
+                                    - NAME@190..199
+                                        - IDENT@190..199 "INVENTORY"
+                            - R_PAREN@199..200 ")"
+                            - WHITESPACE@200..203 "\n  "
+            - FIELD_DEFINITION@203..248
+                - NAME@203..207
+                    - IDENT@203..207 "name"
+                - COLON@207..208 ":"
+                - WHITESPACE@208..209 " "
+                - NAMED_TYPE@209..215
+                    - NAME@209..215
+                        - IDENT@209..215 "String"
+                - WHITESPACE@215..216 " "
+                - DIRECTIVES@216..248
+                    - DIRECTIVE@216..248
+                        - AT@216..217 "@"
+                        - NAME@217..228
+                            - IDENT@217..228 "join__field"
+                        - ARGUMENTS@228..248
+                            - L_PAREN@228..229 "("
+                            - ARGUMENT@229..244
+                                - NAME@229..234
+                                    - IDENT@229..234 "graph"
+                                - COLON@234..235 ":"
+                                - WHITESPACE@235..236 " "
+                                - ENUM_VALUE@236..244
+                                    - NAME@236..244
+                                        - IDENT@236..244 "PRODUCTS"
+                            - R_PAREN@244..245 ")"
+                            - WHITESPACE@245..248 "\n  "
+            - FIELD_DEFINITION@248..261
+                - NAME@248..253
+                    - IDENT@248..253 "price"
+                - COLON@253..254 ":"
+                - WHITESPACE@254..255 " "
+                - NAMED_TYPE@255..258
+                    - NAME@255..258
+                        - IDENT@255..258 "Int"
+                - WHITESPACE@258..261 "\n  "
+            - FIELD_DEFINITION@261..285
+                - NAME@261..277
+                    - IDENT@261..277 "shippingEstimate"
+                - COLON@277..278 ":"
+                - WHITESPACE@278..279 " "
+                - NAMED_TYPE@279..282
+                    - NAME@279..282
+                        - IDENT@279..282 "Int"
+                - WHITESPACE@282..285 "\n  "
+            - FIELD_DEFINITION@285..300
+                - NAME@285..288
+                    - IDENT@285..288 "upc"
+                - COLON@288..289 ":"
+                - WHITESPACE@289..290 " "
+                - NON_NULL_TYPE@290..300
+                    - NAMED_TYPE@290..296
+                        - NAME@290..296
+                            - IDENT@290..296 "String"
+                    - BANG@296..297 "!"
+                    - WHITESPACE@297..300 "\n  "
+            - FIELD_DEFINITION@300..312
+                - NAME@300..306
+                    - IDENT@300..306 "weight"
+                - COLON@306..307 ":"
+                - WHITESPACE@307..308 " "
+                - NAMED_TYPE@308..311
+                    - NAME@308..311
+                        - IDENT@308..311 "Int"
+                - WHITESPACE@311..312 "\n"
+            - R_CURLY@312..313 "}"
+recursion limit: 4096, high: 6


### PR DESCRIPTION
Some basic field validation.

This looks at current object type and its fields and makes sure they match those defined on an operation.