### PR TITLE
feat(apollo-compiler): add type information to fragment definition's fields

### DIFF
--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -89,7 +89,7 @@ mod test {
     #[test]
     fn it_accesses_operation_definition_parts() {
         let input = r#"
-query ExampleQuery($definedVariable: Int, $definedVariable2: Boolean) {
+query ExampleQuery($definedVariable: Int, $definedVariable2: Int) {
   topProducts(first: $definedVariable) {
     type
   }
@@ -99,7 +99,7 @@ query ExampleQuery($definedVariable: Int, $definedVariable2: Boolean) {
 fragment vipCustomer on User {
   id
   name
-  profilePic(size: 50)
+  profilePic(size: $definedVariable2)
 }
 
 type Query {

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -743,10 +743,10 @@ fn fragment_definition(
         .to_string();
     let reference_ty_id = db
         .find_type_system_definition_by_name(name.clone())
-        .and_then(|def| def.id())
-        .cloned();
+        .map(|def| def.id().cloned())
+        .flatten();
     // TODO @lrlna: how do we find which current object id this selection is referring to?
-    let selection_set = selection_set(db, fragment_def.selection_set(), None);
+    let selection_set = selection_set(db, fragment_def.selection_set(), reference_ty_id);
     let directives = directives(fragment_def.directives());
     let ast_ptr = SyntaxNodePtr::new(fragment_def.syntax());
 

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -310,7 +310,7 @@ fn query_operations(db: &dyn SourceDatabase) -> Arc<Vec<OperationDefinition>> {
     let operations = db
         .operations()
         .iter()
-        .filter_map(|op| op.ty.is_query().then(|| op.clone()))
+        .filter_map(|op| op.operation_ty.is_query().then(|| op.clone()))
         .collect();
     Arc::new(operations)
 }
@@ -319,7 +319,7 @@ fn subscription_operations(db: &dyn SourceDatabase) -> Arc<Vec<OperationDefiniti
     let operations = db
         .operations()
         .iter()
-        .filter_map(|op| op.ty.is_subscription().then(|| op.clone()))
+        .filter_map(|op| op.operation_ty.is_subscription().then(|| op.clone()))
         .collect();
     Arc::new(operations)
 }
@@ -328,7 +328,7 @@ fn mutation_operations(db: &dyn SourceDatabase) -> Arc<Vec<OperationDefinition>>
     let operations = db
         .operations()
         .iter()
-        .filter_map(|op| op.ty.is_mutation().then(|| op.clone()))
+        .filter_map(|op| op.operation_ty.is_mutation().then(|| op.clone()))
         .collect();
     Arc::new(operations)
 }
@@ -712,7 +712,7 @@ fn operation_definition(
 
     OperationDefinition {
         id: Uuid::new_v4(),
-        ty,
+        operation_ty: ty,
         name,
         variables,
         selection_set,
@@ -741,6 +741,10 @@ fn fragment_definition(
         .expect("Name must have text")
         .text()
         .to_string();
+    let reference_ty_id = db
+        .find_type_system_definition_by_name(name.clone())
+        .and_then(|def| def.id())
+        .cloned();
     // TODO @lrlna: how do we find which current object id this selection is referring to?
     let selection_set = selection_set(db, fragment_def.selection_set(), None);
     let directives = directives(fragment_def.directives());
@@ -750,6 +754,7 @@ fn fragment_definition(
         id: Uuid::new_v4(),
         name,
         type_condition,
+        reference_ty_id,
         selection_set,
         directives,
         ast_ptr,

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -866,6 +866,19 @@ impl SelectionSet {
         fields
     }
 
+    pub fn fragment_spreads(&self) -> Vec<FragmentSpread> {
+        let fragment_spread: Vec<FragmentSpread> = self
+            .selection()
+            .iter()
+            .filter_map(|sel| match sel {
+                Selection::FragmentSpread(fragment_spread) => return Some(fragment_spread.as_ref().clone()),
+                _ => None,
+            })
+            .collect();
+
+        fragment_spread
+    }
+
     pub fn field(&self, name: &str) -> Option<&Field> {
         self.selection().iter().find_map(|sel| {
             if let Selection::Field(field) = sel {

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -202,6 +202,7 @@ pub struct FragmentDefinition {
     pub(crate) id: Uuid,
     pub(crate) name: String,
     pub(crate) type_condition: String,
+    pub(crate) reference_ty_id: Option<Uuid>,
     pub(crate) directives: Arc<Vec<Directive>>,
     pub(crate) selection_set: SelectionSet,
     pub(crate) ast_ptr: SyntaxNodePtr,
@@ -252,6 +253,14 @@ impl FragmentDefinition {
             .collect()
     }
 
+    pub fn ty(&self, db: &dyn SourceDatabase) -> Option<Arc<Definition>> {
+        if let Some(id) = self.reference_ty_id {
+            db.find_type_system_definition(id)
+        } else {
+            None
+        }
+    }
+
     // Get a reference to SyntaxNodePtr of the current HIR node.
     pub fn ast_ptr(&self) -> &SyntaxNodePtr {
         &self.ast_ptr
@@ -267,7 +276,7 @@ impl FragmentDefinition {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct OperationDefinition {
     pub(crate) id: Uuid,
-    pub(crate) ty: OperationType,
+    pub(crate) operation_ty: OperationType,
     pub(crate) name: Option<String>,
     pub(crate) variables: Arc<Vec<VariableDefinition>>,
     pub(crate) object_id: Option<Uuid>,
@@ -283,8 +292,8 @@ impl OperationDefinition {
     }
 
     /// Get a reference to the operation definition's ty.
-    pub fn ty(&self) -> &OperationType {
-        &self.ty
+    pub fn operation_ty(&self) -> &OperationType {
+        &self.operation_ty
     }
 
     /// Get operation's definition object type.

--- a/crates/apollo-compiler/src/validation/operations.rs
+++ b/crates/apollo-compiler/src/validation/operations.rs
@@ -224,7 +224,7 @@ pub fn check(db: &dyn SourceDatabase) -> Vec<ApolloDiagnostic> {
                         format!(
                             "`{}` is not defined on the current {} root operation type.",
                             field_name,
-                            op.ty()
+                            op.operation_ty()
                         )
                     };
                     diagnostics.push(ApolloDiagnostic::UndefinedField(UndefinedField {

--- a/crates/apollo-compiler/src/validation/unused_variables.rs
+++ b/crates/apollo-compiler/src/validation/unused_variables.rs
@@ -155,7 +155,7 @@ query ExampleQuery {
   ... fragmentOne
 }
 
-fragment fragmentOne on User {
+fragment fragmentOne on Query {
     profilePic(size: $dimensions)
 }
 


### PR DESCRIPTION
Fragment definitions now keep a reference to their type in a given schema. This means that we can find type information on any field in a fragment definition.