### PR TITLE
DNM failing test for missing types on fields in inline fragments

### DIFF
--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -222,6 +222,7 @@ interface Interface {
 type Concrete implements Interface {
   a: String
   b: Int
+  c: Boolean
 }
 
 union Union = Concrete
@@ -238,10 +239,7 @@ union Union = Concrete
             .unwrap()
             .fields(&ctx.db);
 
-        let interface_field = fields
-            .iter()
-            .find(|f| f.name() == "interface")
-            .expect("interface field exists");
+        let interface_field = fields.iter().find(|f| f.name() == "interface").unwrap();
 
         let interface_fields = interface_field.selection_set().fields();
         let interface_selection_fields_types: HashMap<_, _> = interface_fields
@@ -253,22 +251,11 @@ union Union = Concrete
             HashMap::from([("a", Some("String".to_string()))])
         );
 
-        let inline_fragments: Vec<_> = interface_field
-            .selection_set()
-            .selection()
-            .iter()
-            .filter_map(|f| match f {
-                crate::values::Selection::InlineFragment(f) => Some(f),
-                _ => None,
-            })
-            .collect();
+        let inline_fragments: Vec<_> = interface_field.selection_set().inline_fragments();
 
         assert_eq!(inline_fragments.len(), 1);
-        let inline_fragment = inline_fragments.first().expect("qed");
-        assert_eq!(
-            inline_fragment.type_condition(),
-            Some(&"Concrete".to_string())
-        );
+        let inline_fragment = inline_fragments.first().unwrap();
+        assert_eq!(inline_fragment.type_condition(), Some("Concrete"));
 
         let inline_fragment_fields = inline_fragment.selection_set().fields();
         let inline_fragment_fields_types: HashMap<_, _> = inline_fragment_fields
@@ -280,27 +267,13 @@ union Union = Concrete
             HashMap::from([("b", Some("Int".to_string()))])
         );
 
-        let union_field = fields
-            .iter()
-            .find(|f| f.name() == "union")
-            .expect("union field exists");
+        let union_field = fields.iter().find(|f| f.name() == "union").unwrap();
 
-        let union_inline_fragments: Vec<_> = union_field
-            .selection_set()
-            .selection()
-            .iter()
-            .filter_map(|f| match f {
-                crate::values::Selection::InlineFragment(f) => Some(f),
-                _ => None,
-            })
-            .collect();
+        let union_inline_fragments: Vec<_> = union_field.selection_set().inline_fragments();
 
         assert_eq!(union_inline_fragments.len(), 1);
-        let union_inline_fragment = union_inline_fragments.first().expect("qed");
-        assert_eq!(
-            union_inline_fragment.type_condition(),
-            Some(&"Concrete".to_string())
-        );
+        let union_inline_fragment = union_inline_fragments.first().unwrap();
+        assert_eq!(union_inline_fragment.type_condition(), Some("Concrete"));
 
         let union_inline_fragment_fields = union_inline_fragment.selection_set().fields();
         let union_inline_fragment_field_types: HashMap<_, _> = union_inline_fragment_fields
@@ -311,7 +284,7 @@ union Union = Concrete
             union_inline_fragment_field_types,
             HashMap::from([
                 ("a", Some("String".to_string())),
-                ("b", Some("Int".to_string()))
+                ("b", Some("Int".to_string())),
             ])
         );
     }

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -866,12 +866,15 @@ impl SelectionSet {
         fields
     }
 
+    /// Get a reference to selection set's fragment spread.
     pub fn fragment_spreads(&self) -> Vec<FragmentSpread> {
         let fragment_spread: Vec<FragmentSpread> = self
             .selection()
             .iter()
             .filter_map(|sel| match sel {
-                Selection::FragmentSpread(fragment_spread) => return Some(fragment_spread.as_ref().clone()),
+                Selection::FragmentSpread(fragment_spread) => {
+                    return Some(fragment_spread.as_ref().clone())
+                }
                 _ => None,
             })
             .collect();
@@ -879,6 +882,21 @@ impl SelectionSet {
         fragment_spread
     }
 
+    /// Get a reference to selection set's inline fragments.
+    pub fn inline_fragments(&self) -> Vec<InlineFragment> {
+        let inline_fragments: Vec<InlineFragment> = self
+            .selection()
+            .iter()
+            .filter_map(|sel| match sel {
+                Selection::InlineFragment(inline) => return Some(inline.as_ref().clone()),
+                _ => None,
+            })
+            .collect();
+
+        inline_fragments
+    }
+
+    /// Find a field a selection set.
     pub fn field(&self, name: &str) -> Option<&Field> {
         self.selection().iter().find_map(|sel| {
             if let Selection::Field(field) = sel {
@@ -1038,8 +1056,8 @@ pub struct InlineFragment {
 
 impl InlineFragment {
     /// Get a reference to inline fragment's type condition.
-    pub fn type_condition(&self) -> Option<&String> {
-        self.type_condition.as_ref()
+    pub fn type_condition(&self) -> Option<&str> {
+        self.type_condition.as_deref()
     }
 
     /// Get a reference to inline fragment's directives.


### PR DESCRIPTION
here's a failing test showing that field return type info isn't present inside inline fragments cc @lrlna 