### PR TITLE
chore: update to xcode 13.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
     resource_class: medium+
   macos: &macos
     macos:
-      xcode: "11.4"
+      xcode: "13.4"
   windows: &windows
     machine:
       image: 'windows-server-2019-vs2019:stable'


### PR DESCRIPTION
this is the latest stable xcode build, 11.4 is no longer supported and builds are failing