### PR TITLE
fix(apollo-compiler): add type information to inline fragments

### DIFF
--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -166,6 +166,8 @@ impl ApolloCompiler {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use crate::{values::Definition, ApolloCompiler, SourceDatabase};
 
     #[test]
@@ -268,6 +270,131 @@ type Query {
         assert_eq!(
             field_names,
             ["name", "price", "dimensions", "size", "weight"]
+        );
+    }
+
+    #[test]
+    fn it_accesses_inline_fragment_field_types() {
+        let input = r#"
+query ExampleQuery {
+  interface {
+    a
+    ... on Concrete {
+      b
+    }
+  }
+
+  union {
+    ... on Concrete {
+      a
+      b
+    }
+  }
+}
+
+type Query {
+  interface: Interface
+  union: Union
+}
+
+interface Interface {
+  a: String
+}
+
+type Concrete implements Interface {
+  a: String
+  b: Int
+}
+
+union Union = Concrete
+"#;
+
+        let ctx = ApolloCompiler::new(input);
+        let diagnostics = ctx.validate();
+        assert!(diagnostics.is_empty());
+
+        let operations = ctx.operations();
+        let fields = operations
+            .iter()
+            .find(|op| op.name() == Some("ExampleQuery"))
+            .unwrap()
+            .fields(&ctx.db);
+
+        let interface_field = fields
+            .iter()
+            .find(|f| f.name() == "interface")
+            .expect("interface field exists");
+
+        let interface_fields = interface_field.selection_set().fields();
+        let interface_selection_fields_types: HashMap<_, _> = interface_fields
+            .iter()
+            .map(|f| (f.name(), f.ty().map(|f| f.name())))
+            .collect();
+        assert_eq!(
+            interface_selection_fields_types,
+            HashMap::from([("a", Some("String".to_string()))])
+        );
+
+        let inline_fragments: Vec<_> = interface_field
+            .selection_set()
+            .selection()
+            .iter()
+            .filter_map(|f| match f {
+                crate::values::Selection::InlineFragment(f) => Some(f),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(inline_fragments.len(), 1);
+        let inline_fragment = inline_fragments.first().expect("qed");
+        assert_eq!(
+            inline_fragment.type_condition(),
+            Some(&"Concrete".to_string())
+        );
+
+        let inline_fragment_fields = inline_fragment.selection_set().fields();
+        let inline_fragment_fields_types: HashMap<_, _> = inline_fragment_fields
+            .iter()
+            .map(|f| (f.name(), f.ty().map(|ty| ty.name())))
+            .collect();
+        assert_eq!(
+            inline_fragment_fields_types,
+            HashMap::from([("b", Some("Int".to_string()))])
+        );
+
+        let union_field = fields
+            .iter()
+            .find(|f| f.name() == "union")
+            .expect("union field exists");
+
+        let union_inline_fragments: Vec<_> = union_field
+            .selection_set()
+            .selection()
+            .iter()
+            .filter_map(|f| match f {
+                crate::values::Selection::InlineFragment(f) => Some(f),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(union_inline_fragments.len(), 1);
+        let union_inline_fragment = union_inline_fragments.first().expect("qed");
+        assert_eq!(
+            union_inline_fragment.type_condition(),
+            Some(&"Concrete".to_string())
+        );
+
+        let union_inline_fragment_fields = union_inline_fragment.selection_set().fields();
+        let union_inline_fragment_field_types: HashMap<_, _> = union_inline_fragment_fields
+            .iter()
+            .map(|f| (f.name(), f.ty().map(|ty| ty.name())))
+            .collect();
+        assert_eq!(
+            union_inline_fragment_field_types,
+            HashMap::from([
+                ("a", Some("String".to_string())),
+                ("b", Some("Int".to_string()))
+            ])
         );
     }
 

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -304,6 +304,7 @@ interface Interface {
 type Concrete implements Interface {
   a: String
   b: Int
+  c: Boolean
 }
 
 union Union = Concrete
@@ -320,10 +321,7 @@ union Union = Concrete
             .unwrap()
             .fields(&ctx.db);
 
-        let interface_field = fields
-            .iter()
-            .find(|f| f.name() == "interface")
-            .expect("interface field exists");
+        let interface_field = fields.iter().find(|f| f.name() == "interface").unwrap();
 
         let interface_fields = interface_field.selection_set().fields();
         let interface_selection_fields_types: HashMap<_, _> = interface_fields
@@ -335,22 +333,11 @@ union Union = Concrete
             HashMap::from([("a", Some("String".to_string()))])
         );
 
-        let inline_fragments: Vec<_> = interface_field
-            .selection_set()
-            .selection()
-            .iter()
-            .filter_map(|f| match f {
-                crate::values::Selection::InlineFragment(f) => Some(f),
-                _ => None,
-            })
-            .collect();
+        let inline_fragments: Vec<_> = interface_field.selection_set().inline_fragments();
 
         assert_eq!(inline_fragments.len(), 1);
-        let inline_fragment = inline_fragments.first().expect("qed");
-        assert_eq!(
-            inline_fragment.type_condition(),
-            Some(&"Concrete".to_string())
-        );
+        let inline_fragment = inline_fragments.first().unwrap();
+        assert_eq!(inline_fragment.type_condition(), Some("Concrete"));
 
         let inline_fragment_fields = inline_fragment.selection_set().fields();
         let inline_fragment_fields_types: HashMap<_, _> = inline_fragment_fields
@@ -362,27 +349,13 @@ union Union = Concrete
             HashMap::from([("b", Some("Int".to_string()))])
         );
 
-        let union_field = fields
-            .iter()
-            .find(|f| f.name() == "union")
-            .expect("union field exists");
+        let union_field = fields.iter().find(|f| f.name() == "union").unwrap();
 
-        let union_inline_fragments: Vec<_> = union_field
-            .selection_set()
-            .selection()
-            .iter()
-            .filter_map(|f| match f {
-                crate::values::Selection::InlineFragment(f) => Some(f),
-                _ => None,
-            })
-            .collect();
+        let union_inline_fragments: Vec<_> = union_field.selection_set().inline_fragments();
 
         assert_eq!(union_inline_fragments.len(), 1);
-        let union_inline_fragment = union_inline_fragments.first().expect("qed");
-        assert_eq!(
-            union_inline_fragment.type_condition(),
-            Some(&"Concrete".to_string())
-        );
+        let union_inline_fragment = union_inline_fragments.first().unwrap();
+        assert_eq!(union_inline_fragment.type_condition(), Some("Concrete"));
 
         let union_inline_fragment_fields = union_inline_fragment.selection_set().fields();
         let union_inline_fragment_field_types: HashMap<_, _> = union_inline_fragment_fields
@@ -393,7 +366,7 @@ union Union = Concrete
             union_inline_fragment_field_types,
             HashMap::from([
                 ("a", Some("String".to_string())),
-                ("b", Some("Int".to_string()))
+                ("b", Some("Int".to_string())),
             ])
         );
     }

--- a/crates/apollo-compiler/src/queries/database.rs
+++ b/crates/apollo-compiler/src/queries/database.rs
@@ -771,7 +771,6 @@ fn fragment_definition(
     let reference_ty_id = db
         .find_type_system_definition_by_name(type_condition.clone())
         .and_then(|def| def.id().cloned());
-    // TODO @lrlna: how do we find which current object id this selection is referring to?
     let selection_set = selection_set(db, fragment_def.selection_set(), reference_ty_id);
     let directives = directives(fragment_def.directives());
     let ast_ptr = SyntaxNodePtr::new(fragment_def.syntax());
@@ -1411,8 +1410,14 @@ fn inline_fragment(
             .text()
             .to_string()
     });
+    let reference_ty_id = if let Some(type_condition) = type_condition.clone() {
+        db.find_type_system_definition_by_name(type_condition)
+            .and_then(|def| def.id().cloned())
+    } else {
+        object_id
+    };
     let directives = directives(fragment.directives());
-    let selection_set: SelectionSet = selection_set(db, fragment.selection_set(), object_id);
+    let selection_set: SelectionSet = selection_set(db, fragment.selection_set(), reference_ty_id);
     let ast_ptr = SyntaxNodePtr::new(fragment.syntax());
 
     let fragment_data = InlineFragment {

--- a/crates/apollo-compiler/src/queries/values.rs
+++ b/crates/apollo-compiler/src/queries/values.rs
@@ -866,6 +866,7 @@ impl SelectionSet {
         fields
     }
 
+    /// Get a reference to selection set's fragment spread.
     pub fn fragment_spreads(&self) -> Vec<FragmentSpread> {
         let fragment_spread: Vec<FragmentSpread> = self
             .selection()
@@ -881,6 +882,21 @@ impl SelectionSet {
         fragment_spread
     }
 
+    /// Get a reference to selection set's inline fragments.
+    pub fn inline_fragments(&self) -> Vec<InlineFragment> {
+        let inline_fragments: Vec<InlineFragment> = self
+            .selection()
+            .iter()
+            .filter_map(|sel| match sel {
+                Selection::InlineFragment(inline) => return Some(inline.as_ref().clone()),
+                _ => None,
+            })
+            .collect();
+
+        inline_fragments
+    }
+
+    /// Find a field a selection set.
     pub fn field(&self, name: &str) -> Option<&Field> {
         self.selection().iter().find_map(|sel| {
             if let Selection::Field(field) = sel {
@@ -1040,8 +1056,8 @@ pub struct InlineFragment {
 
 impl InlineFragment {
     /// Get a reference to inline fragment's type condition.
-    pub fn type_condition(&self) -> Option<&String> {
-        self.type_condition.as_ref()
+    pub fn type_condition(&self) -> Option<&str> {
+        self.type_condition.as_deref()
     }
 
     /// Get a reference to inline fragment's directives.

--- a/crates/apollo-encoder/src/fragment.rs
+++ b/crates/apollo-encoder/src/fragment.rs
@@ -187,13 +187,14 @@ impl InlineFragment {
         let mut text = String::from("...");
 
         if let Some(type_condition) = &self.type_condition {
-            let _ = write!(text," {}", type_condition);
+            let _ = write!(text, " {}", type_condition);
         }
         for directive in &self.directives {
             let _ = write!(text, " {}", directive);
         }
 
-        let _ = write!(text,
+        let _ = write!(
+            text,
             " {}",
             self.selection_set.format_with_indent(indent_level),
         );
@@ -217,7 +218,7 @@ impl fmt::Display for InlineFragment {
 ///     on NamedType
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#TypeCondition).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeCondition {
     name: String,
 }

--- a/crates/apollo-encoder/src/string_value.rs
+++ b/crates/apollo-encoder/src/string_value.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 /// Convenience enum to create a Description. Can be a `Top` level, a `Field`
 /// level or an `Input` level. The variants are distinguished by the way they
 /// get displayed, e.g. number of leading spaces.

--- a/crates/apollo-parser/src/lexer/token_kind.rs
+++ b/crates/apollo-parser/src/lexer/token_kind.rs
@@ -12,7 +12,7 @@
 /// TokenKinds can be accessed by a convenience macro, `T!`. For example to
 /// access the Bang TokenKind, you may match with `TokenKind::Bang`, or use the
 /// macro `T![!]`.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
 pub enum TokenKind {
     Whitespace, // \r | \n |   | \t

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -80,7 +80,7 @@ impl From<apollo_parser::ast::OperationDefinition> for OperationDef {
 ///     query | mutation | subscription
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#OperationType).
-#[derive(Debug, Arbitrary, Clone, Copy, PartialEq)]
+#[derive(Debug, Arbitrary, Clone, Copy, PartialEq, Eq)]
 pub enum OperationType {
     Query,
     Mutation,


### PR DESCRIPTION
Inline fragments were missing type correct type information. We now search for applicable type's fields if a type condition exists, otherwise infer information from the current type in scope ([as per spec](https://spec.graphql.org/October2021/#sel-GAFbfJABAB_F3kG )).

This also adds a few ease-of-use getters for getting all inline_fragments from a selection set, and changes inline_fragment's type_condition getter to return `Option<&str>`. Previously returned `Option<&String>` was a bit less friendly to use.

Thank you for @lennyburdette for the test cases!

Fixes #280 