### PR TITLE
Add method to directly take ownership of lexer tokens

### DIFF
--- a/crates/apollo-parser/src/lexer/mod.rs
+++ b/crates/apollo-parser/src/lexer/mod.rs
@@ -83,6 +83,11 @@ impl Lexer {
     pub fn errors(&self) -> Iter<'_, Error> {
         self.errors.iter()
     }
+
+    /// Take ownership of lexer parts.
+    pub fn into_parts(self) -> (Vec<Token>, Vec<Error>) {
+        (self.tokens, self.errors)
+    }
 }
 
 impl Cursor<'_> {

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -88,16 +88,7 @@ impl Parser {
     pub fn new(input: &str) -> Self {
         let lexer = Lexer::new(input);
 
-        let mut tokens = Vec::new();
-        let mut errors = Vec::new();
-
-        for s in lexer.tokens().iter().cloned() {
-            tokens.push(s);
-        }
-
-        for e in lexer.errors().cloned() {
-            errors.push(e);
-        }
+        let (mut tokens, mut errors) = lexer.into_parts();
 
         tokens.reverse();
         errors.reverse();


### PR DESCRIPTION
Relates to #293.

For large queries, consuming the lexer into its parts instead of reallocating them reduces parse time ~25%. There are likely more improvements that can be made, but this change is backwards compatible and low-hanging.

```
parser_peek_n           time:   [2.6817 ms 2.6882 ms 2.6953 ms]                           
                        change: [-23.845% -23.622% -23.356%] (p = 0.00 < 0.05)
                        Performance has improved.
```