### PR TITLE
fix(parser): selection set is required for named operation definitions

### DIFF
--- a/crates/apollo-parser/src/parser/grammar/operation.rs
+++ b/crates/apollo-parser/src/parser/grammar/operation.rs
@@ -60,8 +60,9 @@ pub(crate) fn operation_definition(p: &mut Parser) {
                 directive::directives(p);
             }
 
-            if let Some(T!['{']) = p.peek() {
-                selection::top_selection_set(p)
+            match p.peek() {
+                Some(T!['{']) => selection::top_selection_set(p),
+                _ => p.err_and_pop("expected a Selection Set"),
             }
         }
         Some(T!['{']) => {
@@ -103,5 +104,20 @@ mod test {
 
         assert_eq!(ast.errors().len(), 2);
         assert_eq!(ast.document().definitions().into_iter().count(), 1);
+    }
+
+    #[test]
+    fn it_returns_errors_for_malformed_introspection_query() {
+        let input = "query __typename }";
+        let parser = Parser::new(input);
+        let ast = parser.parse();
+
+        assert_eq!(ast.errors().len(), 1);
+
+        let input = "query __typename";
+        let parser = Parser::new(input);
+        let ast = parser.parse();
+
+        assert_eq!(ast.errors().len(), 1);
     }
 }

--- a/crates/apollo-parser/src/parser/grammar/operation.rs
+++ b/crates/apollo-parser/src/parser/grammar/operation.rs
@@ -105,19 +105,4 @@ mod test {
         assert_eq!(ast.errors().len(), 2);
         assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }
-
-    #[test]
-    fn it_returns_errors_for_malformed_introspection_query() {
-        let input = "query __typename }";
-        let parser = Parser::new(input);
-        let ast = parser.parse();
-
-        assert_eq!(ast.errors().len(), 1);
-
-        let input = "query __typename";
-        let parser = Parser::new(input);
-        let ast = parser.parse();
-
-        assert_eq!(ast.errors().len(), 1);
-    }
 }

--- a/crates/apollo-parser/test_data/parser/err/0040_operation_definition_missing_selection_set.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0040_operation_definition_missing_selection_set.graphql
@@ -1,0 +1,1 @@
+query __typename }

--- a/crates/apollo-parser/test_data/parser/err/0040_operation_definition_missing_selection_set.txt
+++ b/crates/apollo-parser/test_data/parser/err/0040_operation_definition_missing_selection_set.txt
@@ -1,0 +1,10 @@
+- DOCUMENT@0..17
+    - OPERATION_DEFINITION@0..17
+        - OPERATION_TYPE@0..6
+            - query_KW@0..5 "query"
+            - WHITESPACE@5..6 " "
+        - NAME@6..17
+            - IDENT@6..16 "__typename"
+            - WHITESPACE@16..17 " "
+- ERROR@17:18 "expected a Selection Set" }
+recursion limit: 4096, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0041_operation_definition_with_missing_selection_set.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0041_operation_definition_with_missing_selection_set.graphql
@@ -1,0 +1,1 @@
+query __typename

--- a/crates/apollo-parser/test_data/parser/err/0041_operation_definition_with_missing_selection_set.txt
+++ b/crates/apollo-parser/test_data/parser/err/0041_operation_definition_with_missing_selection_set.txt
@@ -1,0 +1,9 @@
+- DOCUMENT@0..16
+    - OPERATION_DEFINITION@0..16
+        - OPERATION_TYPE@0..6
+            - query_KW@0..5 "query"
+            - WHITESPACE@5..6 " "
+        - NAME@6..16
+            - IDENT@6..16 "__typename"
+- ERROR@16:16 "expected a Selection Set" EOF
+recursion limit: 4096, high: 0


### PR DESCRIPTION
The parser was not creating errors for missing selection sets. fixes #300 