### PR TITLE
refactor(compiler): create a validation database

### DIFF
--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -86,7 +86,7 @@ assert!(diagnostics.is_empty());
 #### Accessing fragment definition field types
 
 ```rust
-use apollo_compiler::{ApolloCompiler, hir, Document};
+use apollo_compiler::{ApolloCompiler, hir, DocumentDatabase};
 use miette::Result;
 
 fn main() -> Result<()> {
@@ -151,7 +151,7 @@ fn main() -> Result<()> {
 
 #### Get a directive defined on a field used in a query operation definition.
 ```rust
-use apollo_compiler::{ApolloCompiler, hir, Definitions};
+use apollo_compiler::{ApolloCompiler, hir, HirDatabase};
 use anyhow::{anyhow, Result};
 
 fn main() -> Result<()> {

--- a/crates/apollo-compiler/examples/hello_world.rs
+++ b/crates/apollo-compiler/examples/hello_world.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use apollo_compiler::{hir, ApolloCompiler, Definitions};
+use apollo_compiler::{hir, ApolloCompiler, HirDatabase};
 
 fn compile_query() -> Option<hir::FragmentDefinition> {
     let file = Path::new("crates/apollo-compiler/examples/query_with_errors.graphql");

--- a/crates/apollo-compiler/src/database/ast.rs
+++ b/crates/apollo-compiler/src/database/ast.rs
@@ -1,10 +1,10 @@
 use apollo_parser::{Parser as ApolloParser, SyntaxTree};
 use rowan::GreenNode;
 
-use crate::{database::inputs::Inputs, diagnostics::SyntaxError, ApolloDiagnostic};
+use crate::{database::inputs::InputDatabase, diagnostics::SyntaxError, ApolloDiagnostic};
 
 #[salsa::query_group(AstStorage)]
-pub trait DocumentParser: Inputs {
+pub trait AstDatabase: InputDatabase {
     fn ast(&self) -> SyntaxTree;
 
     // root node
@@ -13,18 +13,18 @@ pub trait DocumentParser: Inputs {
     fn syntax_errors(&self) -> Vec<ApolloDiagnostic>;
 }
 
-fn ast(db: &dyn DocumentParser) -> SyntaxTree {
+fn ast(db: &dyn AstDatabase) -> SyntaxTree {
     let input = db.input();
 
     let parser = ApolloParser::new(&input);
     parser.parse()
 }
 
-fn document(db: &dyn DocumentParser) -> GreenNode {
+fn document(db: &dyn AstDatabase) -> GreenNode {
     db.ast().green()
 }
 
-fn syntax_errors(db: &dyn DocumentParser) -> Vec<ApolloDiagnostic> {
+fn syntax_errors(db: &dyn AstDatabase) -> Vec<ApolloDiagnostic> {
     db.ast()
         .errors()
         .into_iter()

--- a/crates/apollo-compiler/src/database/db.rs
+++ b/crates/apollo-compiler/src/database/db.rs
@@ -3,16 +3,20 @@
 
 use crate::{
     database::{
-        ast::AstStorage, def::DefinitionsStorage, document::DocumentStorage, inputs::InputsStorage,
+        ast::AstStorage, def::HirStorage, document::DocumentStorage, inputs::InputStorage,
+        DocumentDatabase,
     },
     validation::ValidationStorage,
 };
 
+pub trait Upcast<T: ?Sized> {
+    fn upcast(&self) -> &T;
+}
 #[salsa::database(
     DocumentStorage,
-    InputsStorage,
+    InputStorage,
     AstStorage,
-    DefinitionsStorage,
+    HirStorage,
     ValidationStorage
 )]
 #[derive(Default)]
@@ -29,5 +33,11 @@ impl salsa::ParallelDatabase for RootDatabase {
         salsa::Snapshot::new(RootDatabase {
             storage: self.storage.snapshot(),
         })
+    }
+}
+
+impl Upcast<dyn DocumentDatabase> for RootDatabase {
+    fn upcast(&self) -> &(dyn DocumentDatabase + 'static) {
+        self
     }
 }

--- a/crates/apollo-compiler/src/database/db.rs
+++ b/crates/apollo-compiler/src/database/db.rs
@@ -1,11 +1,20 @@
 // All .expect() calls are used for parts of the GraphQL grammar that are
 // non-optional and will have an error produced in the parser if they are missing.
 
-use crate::database::{
-    ast::AstStorage, def::DefinitionsStorage, document::DocumentStorage, inputs::InputsStorage,
+use crate::{
+    database::{
+        ast::AstStorage, def::DefinitionsStorage, document::DocumentStorage, inputs::InputsStorage,
+    },
+    validation::ValidationStorage,
 };
 
-#[salsa::database(DocumentStorage, InputsStorage, AstStorage, DefinitionsStorage)]
+#[salsa::database(
+    DocumentStorage,
+    InputsStorage,
+    AstStorage,
+    DefinitionsStorage,
+    ValidationStorage
+)]
 #[derive(Default)]
 pub struct RootDatabase {
     pub storage: salsa::Storage<RootDatabase>,

--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -2,10 +2,10 @@ use std::{collections::HashSet, sync::Arc};
 
 use uuid::Uuid;
 
-use crate::{hir::*, Definitions, DocumentParser, Inputs};
+use crate::{hir::*, AstDatabase, HirDatabase, InputDatabase};
 
 #[salsa::query_group(DocumentStorage)]
-pub trait Document: Inputs + DocumentParser + Definitions {
+pub trait DocumentDatabase: InputDatabase + AstDatabase + HirDatabase {
     fn find_operation(&self, id: Uuid) -> Option<Arc<OperationDefinition>>;
 
     fn find_operation_by_name(&self, name: String) -> Option<Arc<OperationDefinition>>;
@@ -55,7 +55,7 @@ pub trait Document: Inputs + DocumentParser + Definitions {
     fn operation_definition_variables(&self, id: Uuid) -> Arc<HashSet<Variable>>;
 }
 
-fn find_definition_by_name(db: &dyn Document, name: String) -> Option<Arc<Definition>> {
+fn find_definition_by_name(db: &dyn DocumentDatabase, name: String) -> Option<Arc<Definition>> {
     db.db_definitions().iter().find_map(|def| {
         if let Some(n) = def.name() {
             if name == n {
@@ -66,7 +66,7 @@ fn find_definition_by_name(db: &dyn Document, name: String) -> Option<Arc<Defini
     })
 }
 
-fn find_type_system_definition(db: &dyn Document, id: Uuid) -> Option<Arc<Definition>> {
+fn find_type_system_definition(db: &dyn DocumentDatabase, id: Uuid) -> Option<Arc<Definition>> {
     db.type_system_definitions().iter().find_map(|op| {
         if let Some(op_id) = op.id() {
             if op_id == &id {
@@ -77,7 +77,10 @@ fn find_type_system_definition(db: &dyn Document, id: Uuid) -> Option<Arc<Defini
     })
 }
 
-fn find_type_system_definition_by_name(db: &dyn Document, name: String) -> Option<Arc<Definition>> {
+fn find_type_system_definition_by_name(
+    db: &dyn DocumentDatabase,
+    name: String,
+) -> Option<Arc<Definition>> {
     db.type_system_definitions().iter().find_map(|def| {
         if let Some(n) = def.name() {
             if name == n {
@@ -88,7 +91,7 @@ fn find_type_system_definition_by_name(db: &dyn Document, name: String) -> Optio
     })
 }
 
-fn find_operation(db: &dyn Document, id: Uuid) -> Option<Arc<OperationDefinition>> {
+fn find_operation(db: &dyn DocumentDatabase, id: Uuid) -> Option<Arc<OperationDefinition>> {
     db.operations().iter().find_map(|op| {
         if &id == op.id() {
             return Some(Arc::new(op.clone()));
@@ -97,7 +100,10 @@ fn find_operation(db: &dyn Document, id: Uuid) -> Option<Arc<OperationDefinition
     })
 }
 
-fn find_operation_by_name(db: &dyn Document, name: String) -> Option<Arc<OperationDefinition>> {
+fn find_operation_by_name(
+    db: &dyn DocumentDatabase,
+    name: String,
+) -> Option<Arc<OperationDefinition>> {
     db.operations().iter().find_map(|op| {
         if let Some(n) = op.name() {
             if n == name {
@@ -108,7 +114,7 @@ fn find_operation_by_name(db: &dyn Document, name: String) -> Option<Arc<Operati
     })
 }
 
-fn find_fragment(db: &dyn Document, id: Uuid) -> Option<Arc<FragmentDefinition>> {
+fn find_fragment(db: &dyn DocumentDatabase, id: Uuid) -> Option<Arc<FragmentDefinition>> {
     db.fragments().iter().find_map(|fragment| {
         if &id == fragment.id() {
             return Some(Arc::new(fragment.clone()));
@@ -117,7 +123,10 @@ fn find_fragment(db: &dyn Document, id: Uuid) -> Option<Arc<FragmentDefinition>>
     })
 }
 
-fn find_fragment_by_name(db: &dyn Document, name: String) -> Option<Arc<FragmentDefinition>> {
+fn find_fragment_by_name(
+    db: &dyn DocumentDatabase,
+    name: String,
+) -> Option<Arc<FragmentDefinition>> {
     db.fragments().iter().find_map(|fragment| {
         if name == fragment.name() {
             return Some(Arc::new(fragment.clone()));
@@ -126,7 +135,7 @@ fn find_fragment_by_name(db: &dyn Document, name: String) -> Option<Arc<Fragment
     })
 }
 
-fn find_object_type(db: &dyn Document, id: Uuid) -> Option<Arc<ObjectTypeDefinition>> {
+fn find_object_type(db: &dyn DocumentDatabase, id: Uuid) -> Option<Arc<ObjectTypeDefinition>> {
     db.object_types().iter().find_map(|object_type| {
         if &id == object_type.id() {
             return Some(Arc::new(object_type.clone()));
@@ -135,7 +144,10 @@ fn find_object_type(db: &dyn Document, id: Uuid) -> Option<Arc<ObjectTypeDefinit
     })
 }
 
-fn find_object_type_by_name(db: &dyn Document, name: String) -> Option<Arc<ObjectTypeDefinition>> {
+fn find_object_type_by_name(
+    db: &dyn DocumentDatabase,
+    name: String,
+) -> Option<Arc<ObjectTypeDefinition>> {
     db.object_types().iter().find_map(|object_type| {
         if name == object_type.name() {
             return Some(Arc::new(object_type.clone()));
@@ -144,7 +156,7 @@ fn find_object_type_by_name(db: &dyn Document, name: String) -> Option<Arc<Objec
     })
 }
 
-fn find_union_by_name(db: &dyn Document, name: String) -> Option<Arc<UnionTypeDefinition>> {
+fn find_union_by_name(db: &dyn DocumentDatabase, name: String) -> Option<Arc<UnionTypeDefinition>> {
     db.unions().iter().find_map(|union| {
         if name == union.name() {
             return Some(Arc::new(union.clone()));
@@ -153,7 +165,7 @@ fn find_union_by_name(db: &dyn Document, name: String) -> Option<Arc<UnionTypeDe
     })
 }
 
-fn find_interface(db: &dyn Document, id: Uuid) -> Option<Arc<InterfaceTypeDefinition>> {
+fn find_interface(db: &dyn DocumentDatabase, id: Uuid) -> Option<Arc<InterfaceTypeDefinition>> {
     db.interfaces().iter().find_map(|interface| {
         if &id == interface.id() {
             return Some(Arc::new(interface.clone()));
@@ -162,7 +174,10 @@ fn find_interface(db: &dyn Document, id: Uuid) -> Option<Arc<InterfaceTypeDefini
     })
 }
 
-fn find_interface_by_name(db: &dyn Document, name: String) -> Option<Arc<InterfaceTypeDefinition>> {
+fn find_interface_by_name(
+    db: &dyn DocumentDatabase,
+    name: String,
+) -> Option<Arc<InterfaceTypeDefinition>> {
     db.interfaces().iter().find_map(|interface| {
         if name == interface.name() {
             return Some(Arc::new(interface.clone()));
@@ -171,7 +186,10 @@ fn find_interface_by_name(db: &dyn Document, name: String) -> Option<Arc<Interfa
     })
 }
 
-fn find_directive_definition(db: &dyn Document, id: Uuid) -> Option<Arc<DirectiveDefinition>> {
+fn find_directive_definition(
+    db: &dyn DocumentDatabase,
+    id: Uuid,
+) -> Option<Arc<DirectiveDefinition>> {
     db.directive_definitions().iter().find_map(|directive_def| {
         if &id == directive_def.id() {
             return Some(Arc::new(directive_def.clone()));
@@ -181,7 +199,7 @@ fn find_directive_definition(db: &dyn Document, id: Uuid) -> Option<Arc<Directiv
 }
 
 fn find_directive_definition_by_name(
-    db: &dyn Document,
+    db: &dyn DocumentDatabase,
     name: String,
 ) -> Option<Arc<DirectiveDefinition>> {
     db.directive_definitions().iter().find_map(|directive_def| {
@@ -192,7 +210,10 @@ fn find_directive_definition_by_name(
     })
 }
 
-fn find_input_object(db: &dyn Document, id: Uuid) -> Option<Arc<InputObjectTypeDefinition>> {
+fn find_input_object(
+    db: &dyn DocumentDatabase,
+    id: Uuid,
+) -> Option<Arc<InputObjectTypeDefinition>> {
     db.input_objects().iter().find_map(|input_obj| {
         if &id == input_obj.id() {
             return Some(Arc::new(input_obj.clone()));
@@ -202,7 +223,7 @@ fn find_input_object(db: &dyn Document, id: Uuid) -> Option<Arc<InputObjectTypeD
 }
 
 fn find_input_object_by_name(
-    db: &dyn Document,
+    db: &dyn DocumentDatabase,
     name: String,
 ) -> Option<Arc<InputObjectTypeDefinition>> {
     db.input_objects().iter().find_map(|input_obj| {
@@ -213,7 +234,7 @@ fn find_input_object_by_name(
     })
 }
 
-fn query_operations(db: &dyn Document) -> Arc<Vec<OperationDefinition>> {
+fn query_operations(db: &dyn DocumentDatabase) -> Arc<Vec<OperationDefinition>> {
     let operations = db
         .operations()
         .iter()
@@ -222,7 +243,7 @@ fn query_operations(db: &dyn Document) -> Arc<Vec<OperationDefinition>> {
     Arc::new(operations)
 }
 
-fn subscription_operations(db: &dyn Document) -> Arc<Vec<OperationDefinition>> {
+fn subscription_operations(db: &dyn DocumentDatabase) -> Arc<Vec<OperationDefinition>> {
     let operations = db
         .operations()
         .iter()
@@ -231,7 +252,7 @@ fn subscription_operations(db: &dyn Document) -> Arc<Vec<OperationDefinition>> {
     Arc::new(operations)
 }
 
-fn mutation_operations(db: &dyn Document) -> Arc<Vec<OperationDefinition>> {
+fn mutation_operations(db: &dyn DocumentDatabase) -> Arc<Vec<OperationDefinition>> {
     let operations = db
         .operations()
         .iter()
@@ -240,7 +261,7 @@ fn mutation_operations(db: &dyn Document) -> Arc<Vec<OperationDefinition>> {
     Arc::new(operations)
 }
 
-fn operation_fields(db: &dyn Document, id: Uuid) -> Arc<Vec<Field>> {
+fn operation_fields(db: &dyn DocumentDatabase, id: Uuid) -> Arc<Vec<Field>> {
     let fields = match db.find_operation(id) {
         Some(op) => op
             .selection_set()
@@ -256,7 +277,7 @@ fn operation_fields(db: &dyn Document, id: Uuid) -> Arc<Vec<Field>> {
     Arc::new(fields)
 }
 
-fn operation_inline_fragment_fields(db: &dyn Document, id: Uuid) -> Arc<Vec<Field>> {
+fn operation_inline_fragment_fields(db: &dyn DocumentDatabase, id: Uuid) -> Arc<Vec<Field>> {
     let fields: Vec<Field> = match db.find_operation(id) {
         Some(op) => op
             .selection_set()
@@ -276,7 +297,7 @@ fn operation_inline_fragment_fields(db: &dyn Document, id: Uuid) -> Arc<Vec<Fiel
     Arc::new(fields)
 }
 
-fn operation_fragment_spread_fields(db: &dyn Document, id: Uuid) -> Arc<Vec<Field>> {
+fn operation_fragment_spread_fields(db: &dyn DocumentDatabase, id: Uuid) -> Arc<Vec<Field>> {
     let fields: Vec<Field> = match db.find_operation(id) {
         Some(op) => op
             .selection_set()
@@ -298,7 +319,7 @@ fn operation_fragment_spread_fields(db: &dyn Document, id: Uuid) -> Arc<Vec<Fiel
 
 // Should be part of operation's db
 // NOTE: potentially want to return a hashmap of variables and their types?
-fn selection_variables(db: &dyn Document, id: Uuid) -> Arc<HashSet<Variable>> {
+fn selection_variables(db: &dyn DocumentDatabase, id: Uuid) -> Arc<HashSet<Variable>> {
     let vars = db
         .operation_fields(id)
         .iter()
@@ -331,7 +352,7 @@ fn get_field_variable_value(val: Value) -> Vec<Variable> {
 
 // should be part of operation's db
 // NOTE: potentially want to return a hashset of variables and their types?
-fn operation_definition_variables(db: &dyn Document, id: Uuid) -> Arc<HashSet<Variable>> {
+fn operation_definition_variables(db: &dyn DocumentDatabase, id: Uuid) -> Arc<HashSet<Variable>> {
     let vars: HashSet<Variable> = match db.find_operation(id) {
         Some(op) => op
             .variables()

--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -1,5 +1,5 @@
-#[salsa::query_group(InputsStorage)]
-pub trait Inputs {
+#[salsa::query_group(InputStorage)]
+pub trait InputDatabase {
     #[salsa::input]
     fn input(&self) -> String;
 }

--- a/crates/apollo-compiler/src/database/mod.rs
+++ b/crates/apollo-compiler/src/database/mod.rs
@@ -6,8 +6,8 @@ mod def;
 mod document;
 mod inputs;
 
-pub use ast::DocumentParser;
+pub use ast::AstDatabase;
 pub use db::RootDatabase;
-pub use def::Definitions;
-pub use document::Document;
-pub use inputs::Inputs;
+pub use def::HirDatabase;
+pub use document::DocumentDatabase;
+pub use inputs::InputDatabase;

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -6,7 +6,7 @@ mod diagnostics;
 mod tests;
 mod validation;
 
-use validation::Validator;
+use validation::Validation;
 
 pub use database::{hir, Definitions, Document, DocumentParser, Inputs, RootDatabase};
 pub use diagnostics::ApolloDiagnostic;
@@ -94,8 +94,7 @@ impl ApolloCompiler {
     /// assert_eq!(diagnostics.len(), 1);
     /// ```
     pub fn validate(&self) -> Vec<ApolloDiagnostic> {
-        let mut validator = Validator::new(&self.db);
-        validator.validate().into()
+        *self.db.validate()
     }
 }
 

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -8,7 +8,7 @@ mod validation;
 
 use validation::Validation;
 
-pub use database::{hir, Definitions, Document, DocumentParser, Inputs, RootDatabase};
+pub use database::{hir, AstDatabase, DocumentDatabase, HirDatabase, InputDatabase, RootDatabase};
 pub use diagnostics::ApolloDiagnostic;
 
 pub struct ApolloCompiler {
@@ -94,7 +94,7 @@ impl ApolloCompiler {
     /// assert_eq!(diagnostics.len(), 1);
     /// ```
     pub fn validate(&self) -> Vec<ApolloDiagnostic> {
-        *self.db.validate()
+        self.db.validate()
     }
 }
 
@@ -102,7 +102,7 @@ impl ApolloCompiler {
 mod test {
     use std::collections::HashMap;
 
-    use crate::{hir::Definition, ApolloCompiler, Definitions, Document};
+    use crate::{hir::Definition, ApolloCompiler, DocumentDatabase, HirDatabase};
 
     #[test]
     fn it_accesses_operation_definition_parts() {

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -6,7 +6,7 @@ mod diagnostics;
 mod tests;
 mod validation;
 
-use validation::Validation;
+use validation::ValidationDatabase;
 
 pub use database::{hir, AstDatabase, DocumentDatabase, HirDatabase, InputDatabase, RootDatabase};
 pub use diagnostics::ApolloDiagnostic;

--- a/crates/apollo-compiler/src/tests.rs
+++ b/crates/apollo-compiler/src/tests.rs
@@ -12,7 +12,7 @@ use std::{
 
 use expect_test::expect_file;
 
-use crate::{ApolloCompiler, ApolloDiagnostic, DocumentParser};
+use crate::{ApolloCompiler, ApolloDiagnostic, AstDatabase};
 
 // To run these tests and update files:
 // ```bash

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{RecursiveDefinition, UniqueDefinition},
     hir::DirectiveDefinition,
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut errors = Vec::new();
 
     // Directive definitions must have unique names.

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{RecursiveDefinition, UniqueDefinition},
     hir::DirectiveDefinition,
-    ApolloDiagnostic, Document, Validation,
+    ApolloDiagnostic, Validation,
 };
 
 pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
@@ -16,14 +16,32 @@ pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     for dir_def in db.directive_definitions().iter() {
         let name = dir_def.name();
         if let Some(prev_def) = seen.get(&name) {
-            if prev_def.ast_node(db).is_some() && dir_def.ast_node(db).is_some() {
-                let prev_offset: usize = prev_def.ast_node(db).unwrap().text_range().start().into();
-                let prev_node_len: usize = prev_def.ast_node(db).unwrap().text_range().len().into();
+            if prev_def.ast_node(db.upcast()).is_some() && dir_def.ast_node(db.upcast()).is_some() {
+                let prev_offset: usize = prev_def
+                    .ast_node(db.upcast())
+                    .unwrap()
+                    .text_range()
+                    .start()
+                    .into();
+                let prev_node_len: usize = prev_def
+                    .ast_node(db.upcast())
+                    .unwrap()
+                    .text_range()
+                    .len()
+                    .into();
 
-                let current_offset: usize =
-                    dir_def.ast_node(db).unwrap().text_range().start().into();
-                let current_node_len: usize =
-                    dir_def.ast_node(db).unwrap().text_range().len().into();
+                let current_offset: usize = dir_def
+                    .ast_node(db.upcast())
+                    .unwrap()
+                    .text_range()
+                    .start()
+                    .into();
+                let current_node_len: usize = dir_def
+                    .ast_node(db.upcast())
+                    .unwrap()
+                    .text_range()
+                    .len()
+                    .into();
                 errors.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
                     ty: "directive".into(),
                     name: name.into(),
@@ -50,8 +68,8 @@ pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
             for directive in input_values.directives().iter() {
                 let directive_name = directive.name();
                 if name == directive_name {
-                    let offset = directive.ast_node(db).text_range().start().into();
-                    let len: usize = directive.ast_node(db).text_range().len().into();
+                    let offset = directive.ast_node(db.upcast()).text_range().start().into();
+                    let len: usize = directive.ast_node(db.upcast()).text_range().len().into();
                     errors.push(ApolloDiagnostic::RecursiveDefinition(RecursiveDefinition {
                         message: format!("{} directive definition cannot reference itself", name),
                         definition: (offset, len).into(),

--- a/crates/apollo-compiler/src/validation/directives.rs
+++ b/crates/apollo-compiler/src/validation/directives.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{RecursiveDefinition, UniqueDefinition},
     hir::DirectiveDefinition,
-    ApolloDiagnostic, Document,
+    ApolloDiagnostic, Document, Validation,
 };
 
-pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     let mut errors = Vec::new();
 
     // Directive definitions must have unique names.

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{CapitalizedValue, UniqueDefinition},
     hir::EnumValueDefinition,
-    ApolloDiagnostic, Document,
+    ApolloDiagnostic, Validation,
 };
 
-pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     // An Enum type must define one or more unique enum values.
@@ -17,11 +17,13 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
         for enum_value in enum_def.enum_values_definition().iter() {
             let value = enum_value.enum_value();
             if let Some(prev_def) = seen.get(&value) {
-                let prev_offset: usize = prev_def.ast_node(db).text_range().start().into();
-                let prev_node_len: usize = prev_def.ast_node(db).text_range().len().into();
+                let prev_offset: usize = prev_def.ast_node(db.upcast()).text_range().start().into();
+                let prev_node_len: usize = prev_def.ast_node(db.upcast()).text_range().len().into();
 
-                let current_offset: usize = enum_value.ast_node(db).text_range().start().into();
-                let current_node_len: usize = enum_value.ast_node(db).text_range().len().into();
+                let current_offset: usize =
+                    enum_value.ast_node(db.upcast()).text_range().start().into();
+                let current_node_len: usize =
+                    enum_value.ast_node(db.upcast()).text_range().len().into();
                 diagnostics.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
                     ty: "enum".into(),
                     name: value.into(),
@@ -42,8 +44,8 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     for enum_def in db.enums().iter() {
         for enum_value in enum_def.enum_values_definition().iter() {
             let value = enum_value.enum_value();
-            let offset: usize = enum_value.ast_node(db).text_range().start().into();
-            let len: usize = enum_value.ast_node(db).text_range().len().into();
+            let offset: usize = enum_value.ast_node(db.upcast()).text_range().start().into();
+            let len: usize = enum_value.ast_node(db.upcast()).text_range().len().into();
 
             if value.to_uppercase() != value {
                 diagnostics.push(ApolloDiagnostic::CapitalizedValue(CapitalizedValue {

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{CapitalizedValue, UniqueDefinition},
     hir::EnumValueDefinition,
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     // An Enum type must define one or more unique enum values.

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{UniqueDefinition, UniqueField},
     hir::{InputObjectTypeDefinition, InputValueDefinition},
-    ApolloDiagnostic, Document,
+    ApolloDiagnostic, Validation,
 };
 
-pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     // Input Object Definitions must have unique names.
@@ -16,11 +16,16 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     for input_object in db.input_objects().iter() {
         let name = input_object.name();
         if let Some(prev_def) = seen.get(name) {
-            let prev_offset: usize = prev_def.ast_node(db).text_range().start().into();
-            let prev_node_len: usize = prev_def.ast_node(db).text_range().len().into();
+            let prev_offset: usize = prev_def.ast_node(db.upcast()).text_range().start().into();
+            let prev_node_len: usize = prev_def.ast_node(db.upcast()).text_range().len().into();
 
-            let current_offset: usize = input_object.ast_node(db).text_range().start().into();
-            let current_node_len: usize = input_object.ast_node(db).text_range().len().into();
+            let current_offset: usize = input_object
+                .ast_node(db.upcast())
+                .text_range()
+                .start()
+                .into();
+            let current_node_len: usize =
+                input_object.ast_node(db.upcast()).text_range().len().into();
             diagnostics.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
                 ty: "input object".into(),
                 name: name.into(),
@@ -47,16 +52,34 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
         for field in input_fields {
             let field_name = field.name();
             if let Some(prev_field) = seen.get(&field_name) {
-                if prev_field.ast_node(db).is_some() && field.ast_node(db).is_some() {
-                    let prev_offset: usize =
-                        prev_field.ast_node(db).unwrap().text_range().start().into();
-                    let prev_node_len: usize =
-                        prev_field.ast_node(db).unwrap().text_range().len().into();
+                if prev_field.ast_node(db.upcast()).is_some()
+                    && field.ast_node(db.upcast()).is_some()
+                {
+                    let prev_offset: usize = prev_field
+                        .ast_node(db.upcast())
+                        .unwrap()
+                        .text_range()
+                        .start()
+                        .into();
+                    let prev_node_len: usize = prev_field
+                        .ast_node(db.upcast())
+                        .unwrap()
+                        .text_range()
+                        .len()
+                        .into();
 
-                    let current_offset: usize =
-                        field.ast_node(db).unwrap().text_range().start().into();
-                    let current_node_len: usize =
-                        field.ast_node(db).unwrap().text_range().len().into();
+                    let current_offset: usize = field
+                        .ast_node(db.upcast())
+                        .unwrap()
+                        .text_range()
+                        .start()
+                        .into();
+                    let current_node_len: usize = field
+                        .ast_node(db.upcast())
+                        .unwrap()
+                        .text_range()
+                        .len()
+                        .into();
 
                     diagnostics.push(ApolloDiagnostic::UniqueField(UniqueField {
                         field: field_name.into(),

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{UniqueDefinition, UniqueField},
     hir::{InputObjectTypeDefinition, InputValueDefinition},
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     // Input Object Definitions must have unique names.

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -7,10 +7,10 @@ use crate::{
     },
     hir::{FieldDefinition, InterfaceTypeDefinition},
     validation::ValidationSet,
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     // Interface definitions must have unique names.

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -7,10 +7,10 @@ use crate::{
     },
     hir::{FieldDefinition, InterfaceTypeDefinition},
     validation::ValidationSet,
-    ApolloDiagnostic, Document,
+    ApolloDiagnostic, Validation,
 };
 
-pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     // Interface definitions must have unique names.
@@ -20,11 +20,11 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     for interface in db.interfaces().iter() {
         let name = interface.name();
         if let Some(prev_def) = seen.get(&name) {
-            let prev_offset: usize = prev_def.ast_node(db).text_range().start().into();
-            let prev_node_len: usize = prev_def.ast_node(db).text_range().len().into();
+            let prev_offset: usize = prev_def.ast_node(db.upcast()).text_range().start().into();
+            let prev_node_len: usize = prev_def.ast_node(db.upcast()).text_range().len().into();
 
-            let current_offset: usize = interface.ast_node(db).text_range().start().into();
-            let current_node_len: usize = interface.ast_node(db).text_range().len().into();
+            let current_offset: usize = interface.ast_node(db.upcast()).text_range().start().into();
+            let current_node_len: usize = interface.ast_node(db.upcast()).text_range().len().into();
             diagnostics.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
                 ty: "interface".into(),
                 name: name.into(),
@@ -58,15 +58,19 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     for interface_def in db.interfaces().iter() {
         let name = interface_def.name();
         for implements_interface in interface_def.implements_interfaces() {
-            if let Some(interface) = implements_interface.interface_definition(db) {
+            if let Some(interface) = implements_interface.interface_definition(db.upcast()) {
                 let i_name = (*interface.name()).to_string();
                 if name == i_name {
                     let offset = implements_interface
-                        .ast_node(db)
+                        .ast_node(db.upcast())
                         .text_range()
                         .start()
                         .into();
-                    let len: usize = implements_interface.ast_node(db).text_range().len().into();
+                    let len: usize = implements_interface
+                        .ast_node(db.upcast())
+                        .text_range()
+                        .len()
+                        .into();
                     diagnostics.push(ApolloDiagnostic::RecursiveDefinition(RecursiveDefinition {
                         message: format!("{} interface cannot implement itself", i_name),
                         definition: (offset, len).into(),
@@ -89,12 +93,14 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
             //
             // Returns Unique Value error.
             let field_name = field.name();
-            let offset: usize = field.ast_node(db).text_range().start().into();
-            let len: usize = field.ast_node(db).text_range().len().into();
+            let offset: usize = field.ast_node(db.upcast()).text_range().start().into();
+            let len: usize = field.ast_node(db.upcast()).text_range().len().into();
 
             if let Some(prev_field) = seen.get(&field_name) {
-                let prev_offset: usize = prev_field.ast_node(db).text_range().start().into();
-                let prev_node_len: usize = prev_field.ast_node(db).text_range().len().into();
+                let prev_offset: usize =
+                    prev_field.ast_node(db.upcast()).text_range().start().into();
+                let prev_node_len: usize =
+                    prev_field.ast_node(db.upcast()).text_range().len().into();
 
                 diagnostics.push(ApolloDiagnostic::UniqueField(UniqueField {
                     field: field_name.into(),
@@ -110,8 +116,8 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
             }
 
             // Field types in interface types must be of output type
-            if let Some(field_ty) = field.ty().ty(db) {
-                if !field.ty().is_output_type(db) {
+            if let Some(field_ty) = field.ty().ty(db.upcast()) {
+                if !field.ty().is_output_type(db.upcast()) {
                     diagnostics.push(ApolloDiagnostic::OutputType(OutputType {
                         name: field.name().into(),
                         ty: field_ty.ty(),
@@ -119,7 +125,7 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
                         definition: (offset, len).into(),
                     }))
                 }
-            } else if let Some(node) = field.ty().ast_node(db) {
+            } else if let Some(node) = field.ty().ast_node(db.upcast()) {
                 let field_ty_offset: usize = node.text_range().start().into();
                 let field_ty_len: usize = node.text_range().len().into();
                 diagnostics.push(ApolloDiagnostic::UndefinedDefinition(UndefinedDefinition {
@@ -142,7 +148,7 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
         .iter()
         .map(|interface| ValidationSet {
             name: interface.name().to_owned(),
-            node: interface.ast_node(db),
+            node: interface.ast_node(db.upcast()),
         })
         .collect();
     for interface_def in interfaces.iter() {
@@ -154,7 +160,7 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
             .iter()
             .map(|interface| ValidationSet {
                 name: interface.interface().to_owned(),
-                node: interface.ast_node(db),
+                node: interface.ast_node(db.upcast()),
             })
             .collect();
         let diff = implements_interfaces.difference(&defined_interfaces);
@@ -176,13 +182,13 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
             .implements_interfaces()
             .iter()
             .filter_map(|implements_interface| {
-                if let Some(interface) = implements_interface.interface_definition(db) {
+                if let Some(interface) = implements_interface.interface_definition(db.upcast()) {
                     let child_interfaces: HashSet<ValidationSet> = interface
                         .implements_interfaces()
                         .iter()
                         .map(|interface| ValidationSet {
                             name: interface.interface().to_owned(),
-                            node: implements_interface.ast_node(db),
+                            node: implements_interface.ast_node(db.upcast()),
                         })
                         .collect();
                     Some(child_interfaces)
@@ -215,29 +221,37 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
             .iter()
             .map(|field| ValidationSet {
                 name: field.name().into(),
-                node: field.ast_node(db),
+                node: field.ast_node(db.upcast()),
             })
             .collect();
         for implements_interface in interface_def.implements_interfaces().iter() {
-            if let Some(interface) = implements_interface.interface_definition(db) {
+            if let Some(interface) = implements_interface.interface_definition(db.upcast()) {
                 let implements_interface_fields: HashSet<ValidationSet> = interface
                     .fields_definition()
                     .iter()
                     .map(|field| ValidationSet {
                         name: field.name().into(),
-                        node: field.ast_node(db),
+                        node: field.ast_node(db.upcast()),
                     })
                     .collect();
 
                 let field_diff = implements_interface_fields.difference(&fields);
 
                 for missing_field in field_diff {
-                    let current_offset: usize =
-                        interface_def.ast_node(db).text_range().start().into();
-                    let current_len = interface_def.ast_node(db).text_range().len().into();
+                    let current_offset: usize = interface_def
+                        .ast_node(db.upcast())
+                        .text_range()
+                        .start()
+                        .into();
+                    let current_len = interface_def
+                        .ast_node(db.upcast())
+                        .text_range()
+                        .len()
+                        .into();
 
-                    let super_offset = interface.ast_node(db).text_range().start().into();
-                    let super_len: usize = interface.ast_node(db).text_range().len().into();
+                    let super_offset = interface.ast_node(db.upcast()).text_range().start().into();
+                    let super_len: usize =
+                        interface.ast_node(db.upcast()).text_range().len().into();
 
                     diagnostics.push(ApolloDiagnostic::MissingField(MissingField {
                         ty: missing_field.name.clone(),

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -1,41 +1,118 @@
-pub mod validation;
-
 // schema
 mod schema;
 
 // leaf nodes
-mod enums;
-mod scalars;
-mod unions;
+mod enum_;
+mod scalar;
+mod union_;
 
 // composite nodes
-mod directives;
-mod input_objects;
-mod interfaces;
-mod objects;
+mod directive;
+mod input_object;
+mod interface;
+mod object;
 
 // executable definitions
-mod operations;
+mod operation;
 
-mod unused_variables;
-
-use std::sync::Arc;
+mod unused_variable;
 
 use apollo_parser::SyntaxNode;
 
-use crate::{diagnostics, ApolloDiagnostic, Definitions, Document, DocumentParser, Inputs};
+use crate::{
+    database::db::Upcast, ApolloDiagnostic, AstDatabase, DocumentDatabase, HirDatabase,
+    InputDatabase,
+};
 
 #[salsa::query_group(ValidationStorage)]
-pub trait Validation: Document + Inputs + DocumentParser + Definitions {
-    fn validate(&self) -> Arc<Vec<ApolloDiagnostic>>;
+pub trait Validation:
+    Upcast<dyn DocumentDatabase> + InputDatabase + AstDatabase + HirDatabase
+{
+    fn validate(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_schema(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_scalar(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_enum(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_union(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_interface(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_directive(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_input_object(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_object(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_operation(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_unused_variable(&self) -> Vec<ApolloDiagnostic>;
 }
 
-pub fn validate(db: &dyn Validation) -> Arc<Vec<ApolloDiagnostic>> {
+pub fn validate(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
-    diagnostics.extend(schema::check(db));
+    diagnostics.extend(db.syntax_errors());
 
-    Arc::new(diagnostics)
+    diagnostics.extend(db.validate_schema());
+
+    diagnostics.extend(db.validate_scalar());
+    diagnostics.extend(db.validate_enum());
+    diagnostics.extend(db.validate_union());
+
+    diagnostics.extend(db.validate_interface());
+    diagnostics.extend(db.validate_directive());
+    diagnostics.extend(db.validate_input_object());
+    diagnostics.extend(db.validate_object());
+    diagnostics.extend(db.validate_operation());
+
+    diagnostics.extend(db.validate_unused_variable());
+
+    diagnostics
 }
+
+pub fn validate_schema(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    schema::check(db)
+}
+
+pub fn validate_scalar(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    scalar::check(db)
+}
+
+pub fn validate_enum(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    enum_::check(db)
+}
+
+pub fn validate_union(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    union_::check(db)
+}
+
+pub fn validate_interface(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    interface::check(db)
+}
+
+pub fn validate_directive(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    directive::check(db)
+}
+
+pub fn validate_input_object(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    input_object::check(db)
+}
+
+pub fn validate_object(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    object::check(db)
+}
+
+pub fn validate_operation(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    operation::check(db)
+}
+
+pub fn validate_unused_variable(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+    unused_variable::check(db)
+}
+
+// #[salsa::query_group(ValidationStorage)]
+// pub trait Validation: Document + Inputs + DocumentParser + Definitions {
+//     fn validate(&self) -> Arc<Vec<ApolloDiagnostic>>;
+// }
+//
+// pub fn validate(db: &dyn Validation) -> Arc<Vec<ApolloDiagnostic>> {
+//     let mut diagnostics = Vec::new();
+//     diagnostics.extend(schema::check(db));
+//
+//     Arc::new(diagnostics)
+// }
 
 #[derive(Debug, Eq)]
 struct ValidationSet {

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 #[salsa::query_group(ValidationStorage)]
-pub trait Validation:
+pub trait ValidationDatabase:
     Upcast<dyn DocumentDatabase> + InputDatabase + AstDatabase + HirDatabase
 {
     fn validate(&self) -> Vec<ApolloDiagnostic>;
@@ -41,7 +41,7 @@ pub trait Validation:
     fn validate_unused_variable(&self) -> Vec<ApolloDiagnostic>;
 }
 
-pub fn validate(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
     diagnostics.extend(db.syntax_errors());
 
@@ -62,43 +62,43 @@ pub fn validate(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     diagnostics
 }
 
-pub fn validate_schema(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_schema(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     schema::check(db)
 }
 
-pub fn validate_scalar(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_scalar(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     scalar::check(db)
 }
 
-pub fn validate_enum(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_enum(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     enum_::check(db)
 }
 
-pub fn validate_union(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_union(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     union_::check(db)
 }
 
-pub fn validate_interface(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_interface(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     interface::check(db)
 }
 
-pub fn validate_directive(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_directive(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     directive::check(db)
 }
 
-pub fn validate_input_object(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_input_object(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     input_object::check(db)
 }
 
-pub fn validate_object(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_object(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     object::check(db)
 }
 
-pub fn validate_operation(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_operation(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     operation::check(db)
 }
 
-pub fn validate_unused_variable(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn validate_unused_variable(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     unused_variable::check(db)
 }
 

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -7,10 +7,10 @@ use crate::{
     },
     hir::{FieldDefinition, ObjectTypeDefinition},
     validation::ValidationSet,
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     // Object Type definitions must have unique names.

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -5,11 +5,11 @@ use crate::{
         MissingIdent, SingleRootField, UndefinedField, UniqueDefinition, UnsupportedOperation,
     },
     hir::{OperationDefinition, Selection},
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 // use crate::{diagnostics::ErrorDiagnostic, ApolloDiagnostic, Document};
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
     // It is possible to have an unnamed (anonymous) operation definition only
     // if there is **one** operation definition.

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -5,11 +5,11 @@ use crate::{
         MissingIdent, SingleRootField, UndefinedField, UniqueDefinition, UnsupportedOperation,
     },
     hir::{OperationDefinition, Selection},
-    ApolloDiagnostic, Document,
+    ApolloDiagnostic, Validation,
 };
 // use crate::{diagnostics::ErrorDiagnostic, ApolloDiagnostic, Document};
 
-pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
     // It is possible to have an unnamed (anonymous) operation definition only
     // if there is **one** operation definition.
@@ -23,8 +23,8 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
             .iter()
             .filter_map(|op| {
                 if op.name().is_none() {
-                    let offset = op.ast_node(db).text_range().start().into();
-                    let len: usize = op.ast_node(db).text_range().len().into();
+                    let offset = op.ast_node(db.upcast()).text_range().start().into();
+                    let len: usize = op.ast_node(db.upcast()).text_range().len().into();
                     return Some(ApolloDiagnostic::MissingIdent(MissingIdent {
                         src: db.input(),
                         definition: (offset, len).into(),
@@ -44,11 +44,11 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     for op in db.operations().iter() {
         if let Some(name) = op.name() {
             if let Some(prev_def) = seen.get(&name) {
-                let prev_offset: usize = prev_def.ast_node(db).text_range().start().into();
-                let prev_node_len: usize = prev_def.ast_node(db).text_range().len().into();
+                let prev_offset: usize = prev_def.ast_node(db.upcast()).text_range().start().into();
+                let prev_node_len: usize = prev_def.ast_node(db.upcast()).text_range().len().into();
 
-                let current_offset: usize = op.ast_node(db).text_range().start().into();
-                let current_node_len: usize = op.ast_node(db).text_range().len().into();
+                let current_offset: usize = op.ast_node(db.upcast()).text_range().start().into();
+                let current_node_len: usize = op.ast_node(db.upcast()).text_range().len().into();
                 diagnostics.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
                     ty: "operation".into(),
                     name: name.into(),
@@ -67,18 +67,19 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
 
     // A Subscription operation definition can only have **one** root level
     // field.
-    if db.subscription_operations().len() >= 1 {
+    if db.upcast().subscription_operations().len() >= 1 {
         let single_root_field: Vec<ApolloDiagnostic> = db
+            .upcast()
             .subscription_operations()
             .iter()
             .filter_map(|op| {
-                let mut fields = op.fields(db).as_ref().clone();
-                fields.extend(op.fields_in_inline_fragments(db).as_ref().clone());
-                fields.extend(op.fields_in_fragment_spread(db).as_ref().clone());
+                let mut fields = op.fields(db.upcast()).as_ref().clone();
+                fields.extend(op.fields_in_inline_fragments(db.upcast()).as_ref().clone());
+                fields.extend(op.fields_in_fragment_spread(db.upcast()).as_ref().clone());
                 if fields.len() > 1 {
                     let field_names: Vec<&str> = fields.iter().map(|f| f.name()).collect();
-                    let offset = op.ast_node(db).text_range().start().into();
-                    let len: usize = op.ast_node(db).text_range().len().into();
+                    let offset = op.ast_node(db.upcast()).text_range().start().into();
+                    let len: usize = op.ast_node(db.upcast()).text_range().len().into();
                     Some(ApolloDiagnostic::SingleRootField(SingleRootField {
                         fields: fields.len(),
                         src: db.input(),
@@ -101,15 +102,18 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     // defined schema root operation types.
     //
     //   * subscription operation - subscription root operation
-    if db.subscription_operations().len() >= 1 && db.schema().subscription(db).is_none() {
+    if db.upcast().subscription_operations().len() >= 1
+        && db.schema().subscription(db.upcast()).is_none()
+    {
         let unsupported_ops: Vec<ApolloDiagnostic> = db
+            .upcast()
             .subscription_operations()
             .iter()
             .map(|op| {
-                let op_offset: usize = op.ast_node(db).text_range().start().into();
-                let op_len: usize = op.ast_node(db).text_range().len().into();
+                let op_offset: usize = op.ast_node(db.upcast()).text_range().start().into();
+                let op_len: usize = op.ast_node(db.upcast()).text_range().len().into();
 
-                if let Some(schema_node) = db.schema().ast_node(db) {
+                if let Some(schema_node) = db.schema().ast_node(db.upcast()) {
                     let schema_offset: usize = schema_node.text_range().start().into();
                     let schema_len: usize = schema_node.text_range().len().into();
                     ApolloDiagnostic::UnsupportedOperation(UnsupportedOperation {
@@ -137,15 +141,16 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     }
     //
     //   * query operation - query root operation
-    if db.query_operations().len() >= 1 && db.schema().query(db).is_none() {
+    if db.upcast().query_operations().len() >= 1 && db.schema().query(db.upcast()).is_none() {
         let unsupported_ops: Vec<ApolloDiagnostic> = db
+            .upcast()
             .query_operations()
             .iter()
             .map(|op| {
-                let op_offset: usize = op.ast_node(db).text_range().start().into();
-                let op_len: usize = op.ast_node(db).text_range().len().into();
+                let op_offset: usize = op.ast_node(db.upcast()).text_range().start().into();
+                let op_len: usize = op.ast_node(db.upcast()).text_range().len().into();
 
-                if let Some(schema_node) = db.schema().ast_node(db) {
+                if let Some(schema_node) = db.schema().ast_node(db.upcast()) {
                     let schema_offset: usize = schema_node.text_range().start().into();
                     let schema_len: usize = schema_node.text_range().len().into();
                     ApolloDiagnostic::UnsupportedOperation(UnsupportedOperation {
@@ -172,15 +177,16 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     }
 
     //   * mutation operation - mutation root operation
-    if db.mutation_operations().len() >= 1 && db.schema().mutation(db).is_none() {
+    if db.upcast().mutation_operations().len() >= 1 && db.schema().mutation(db.upcast()).is_none() {
         let unsupported_ops: Vec<ApolloDiagnostic> = db
+            .upcast()
             .mutation_operations()
             .iter()
             .map(|op| {
-                let op_offset: usize = op.ast_node(db).text_range().start().into();
-                let op_len: usize = op.ast_node(db).text_range().len().into();
+                let op_offset: usize = op.ast_node(db.upcast()).text_range().start().into();
+                let op_len: usize = op.ast_node(db.upcast()).text_range().len().into();
 
-                if let Some(schema_node) = db.schema().ast_node(db) {
+                if let Some(schema_node) = db.schema().ast_node(db.upcast()) {
                     let schema_offset: usize = schema_node.text_range().start().into();
                     let schema_len: usize = schema_node.text_range().len().into();
                     ApolloDiagnostic::UnsupportedOperation(UnsupportedOperation {
@@ -210,11 +216,11 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
     // Fields must exist on the type being queried.
     for op in db.operations().iter() {
         for selection in op.selection_set().selection() {
-            let obj_name = op.object_type(db).map(|obj| obj.name().to_owned());
+            let obj_name = op.object_type(db.upcast()).map(|obj| obj.name().to_owned());
             if let Selection::Field(field) = selection {
-                if field.ty(db).is_none() {
-                    let offset: usize = field.ast_node(db).text_range().start().into();
-                    let len: usize = field.ast_node(db).text_range().len().into();
+                if field.ty(db.upcast()).is_none() {
+                    let offset: usize = field.ast_node(db.upcast()).text_range().start().into();
+                    let len: usize = field.ast_node(db.upcast()).text_range().len().into();
                     let field_name = field.name().into();
                     let help = if let Some(obj_type) = obj_name {
                         format!("`{}` is not defined on `{}` type", field_name, obj_type)

--- a/crates/apollo-compiler/src/validation/scalar.rs
+++ b/crates/apollo-compiler/src/validation/scalar.rs
@@ -1,11 +1,11 @@
 use crate::{
     diagnostics::{BuiltInScalarDefinition, ScalarSpecificationURL},
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 
 const BUILT_IN_SCALARS: [&str; 5] = ["Int", "Float", "Boolean", "String", "ID"];
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     for scalar in db.scalars().iter() {

--- a/crates/apollo-compiler/src/validation/scalar.rs
+++ b/crates/apollo-compiler/src/validation/scalar.rs
@@ -1,16 +1,16 @@
 use crate::{
     diagnostics::{BuiltInScalarDefinition, ScalarSpecificationURL},
-    ApolloDiagnostic, Document,
+    ApolloDiagnostic, Validation,
 };
 
 const BUILT_IN_SCALARS: [&str; 5] = ["Int", "Float", "Boolean", "String", "ID"];
 
-pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     for scalar in db.scalars().iter() {
         let name = scalar.name();
-        if let Some(node) = scalar.ast_node(db) {
+        if let Some(node) = scalar.ast_node(db.upcast()) {
             let offset: usize = node.text_range().start().into();
             let len: usize = node.text_range().len().into();
 

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{QueryRootOperationType, UniqueDefinition},
     hir::RootOperationTypeDefinition,
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     // A GraphQL schema must have a Query root operation.

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{ObjectType, UndefinedDefinition, UniqueDefinition},
     hir::UnionMember,
-    ApolloDiagnostic, Validation,
+    ApolloDiagnostic, ValidationDatabase,
 };
 
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     for union_def in db.unions().iter() {

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -3,24 +3,28 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{ObjectType, UndefinedDefinition, UniqueDefinition},
     hir::UnionMember,
-    ApolloDiagnostic, Document,
+    ApolloDiagnostic, Validation,
 };
 
-pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     for union_def in db.unions().iter() {
         let mut seen: HashMap<&str, &UnionMember> = HashMap::new();
         for union_member in union_def.union_members().iter() {
             let name = union_member.name();
-            let offset: usize = union_member.ast_node(db).text_range().start().into();
-            let len: usize = union_member.ast_node(db).text_range().len().into();
+            let offset: usize = union_member
+                .ast_node(db.upcast())
+                .text_range()
+                .start()
+                .into();
+            let len: usize = union_member.ast_node(db.upcast()).text_range().len().into();
             // A Union type must include one or more unique member types.
             //
             // Return a Unique Value error in case of a duplicate member.
             if let Some(prev_def) = seen.get(&name) {
-                let prev_offset: usize = prev_def.ast_node(db).text_range().start().into();
-                let prev_node_len: usize = prev_def.ast_node(db).text_range().len().into();
+                let prev_offset: usize = prev_def.ast_node(db.upcast()).text_range().start().into();
+                let prev_node_len: usize = prev_def.ast_node(db.upcast()).text_range().len().into();
 
                 diagnostics.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
                     name: name.into(),
@@ -37,7 +41,9 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
             }
 
             // Union member must be defined.
-            let union_member_type = db.find_type_system_definition_by_name(name.to_string());
+            let union_member_type = db
+                .upcast()
+                .find_type_system_definition_by_name(name.to_string());
             if union_member_type.is_none() {
                 diagnostics.push(ApolloDiagnostic::UndefinedDefinition(UndefinedDefinition {
                     ty: name.into(),

--- a/crates/apollo-compiler/src/validation/unused_variable.rs
+++ b/crates/apollo-compiler/src/validation/unused_variable.rs
@@ -3,13 +3,13 @@ use std::collections::HashSet;
 use crate::{
     diagnostics::{ApolloDiagnostic, UndefinedDefinition, UnusedVariable},
     validation::ValidationSet,
-    Validation,
+    ValidationDatabase,
 };
 
 // check in scope
 // check in use
 // compare the two
-pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     db.operations()
         .iter()
         .flat_map(|op| {

--- a/crates/apollo-compiler/src/validation/unused_variable.rs
+++ b/crates/apollo-compiler/src/validation/unused_variable.rs
@@ -3,13 +3,13 @@ use std::collections::HashSet;
 use crate::{
     diagnostics::{ApolloDiagnostic, UndefinedDefinition, UnusedVariable},
     validation::ValidationSet,
-    Document,
+    Validation,
 };
 
 // check in scope
 // check in use
 // compare the two
-pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
+pub fn check(db: &dyn Validation) -> Vec<ApolloDiagnostic> {
     db.operations()
         .iter()
         .flat_map(|op| {
@@ -18,7 +18,7 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
                 .iter()
                 .map(|var| ValidationSet {
                     name: var.name().into(),
-                    node: var.ast_node(db),
+                    node: var.ast_node(db.upcast()),
                 })
                 .collect();
             let used_vars: HashSet<ValidationSet> = op
@@ -28,11 +28,11 @@ pub fn check(db: &dyn Document) -> Vec<ApolloDiagnostic> {
                 .iter()
                 .flat_map(|sel| {
                     let vars: HashSet<ValidationSet> = sel
-                        .variables(db)
+                        .variables(db.upcast())
                         .iter()
                         .map(|var| ValidationSet {
                             name: var.name().into(),
-                            node: var.ast_node(db),
+                            node: var.ast_node(db.upcast()),
                         })
                         .collect();
                     vars


### PR DESCRIPTION
Validation was its own module, which isn't as useful as having it be a salsa query group! We can now take advantage of memoised validation functions, as well as have a more succinct RootDatabase.

In this process, we've also renamed all query groups to match their associated storage names, as well as add `Database` to their naming. This ensures there is no confusion to `Document` or `Definition` being confused with ast's document or definition for the code reader. 

To allow `ValidationDatabase` to continue making calls to specific queries in `DocumentDatabase`, we've also added an `Upcast` trait. 