### PR TITLE
Expose directives from FragmentSpread types

### DIFF
--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -1113,6 +1113,11 @@ impl FragmentSpread {
         vars
     }
 
+    /// Get a reference to fragment spread directives.
+    pub fn directives(&self) -> &[Directive] {
+        self.directives.as_ref()
+    }
+
     /// Get a reference to SyntaxNodePtr of the current HIR node.
     pub fn ast_ptr(&self) -> &SyntaxNodePtr {
         &self.ast_ptr


### PR DESCRIPTION
There is currently no way to return the directives from a `FragmentSpread` definition, this PR adds one in the same manner that `InlineFragment` does.