### PR TITLE
Validate argument name uniqueness

### DIFF
--- a/crates/apollo-compiler/src/validation/arguments.rs
+++ b/crates/apollo-compiler/src/validation/arguments.rs
@@ -49,7 +49,8 @@ mod test {
     fn it_fails_validation_with_duplicate_argument_names() {
         let input = r#"
 type Query {
-  method(arg: Boolean, arg: Boolean): Int
+  single(arg: Boolean): Int
+  duplicate(arg: Boolean, arg: Boolean): Int
 }
 "#;
         let ctx = ApolloCompiler::new(input);

--- a/crates/apollo-compiler/src/validation/arguments.rs
+++ b/crates/apollo-compiler/src/validation/arguments.rs
@@ -1,7 +1,44 @@
-use crate::{ApolloDiagnostic, ValidationDatabase};
+use std::collections::HashMap;
+use crate::{
+    diagnostics::UniqueDefinition,
+    hir::InputValueDefinition,
+    ApolloDiagnostic, ValidationDatabase,
+};
 
-pub fn check(_db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
-    todo!()
+pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for object_type in db.object_types().iter() {
+        for field in object_type.fields_definition() {
+            let mut seen: HashMap<&str, &InputValueDefinition> = HashMap::new();
+            let input_values = field.arguments().input_values();
+            for input_value in input_values {
+                let name = input_value.name();
+                if let Some(prev_def) = seen.get(name) {
+                    let prev_offset: usize = prev_def.ast_node(db.upcast()).unwrap().text_range().start().into();
+                    let prev_node_len: usize = prev_def.ast_node(db.upcast()).unwrap().text_range().len().into();
+
+                    let current_offset: usize = input_value.ast_node(db.upcast()).unwrap().text_range().start().into();
+                    let current_node_len: usize = input_value.ast_node(db.upcast()).unwrap().text_range().len().into();
+
+                    diagnostics.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
+                        ty: "argument".into(),
+                        name: name.into(),
+                        src: db.input(),
+                        original_definition: (prev_offset, prev_node_len).into(),
+                        redefined_definition: (current_offset, current_node_len).into(),
+                        help: Some(format!(
+                            "`{name}` argument must only be defined once."
+                        )),
+                    }));
+                } else {
+                    seen.insert(name, &input_value);
+                }
+            }
+        }
+    }
+
+    diagnostics
 }
 
 #[cfg(test)]

--- a/crates/apollo-compiler/src/validation/arguments.rs
+++ b/crates/apollo-compiler/src/validation/arguments.rs
@@ -1,0 +1,25 @@
+use crate::{ApolloDiagnostic, ValidationDatabase};
+
+pub fn check(_db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
+    todo!()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ApolloCompiler;
+
+    #[test]
+    fn it_fails_validation_with_duplicate_argument_names() {
+        let input = r#"
+type Query {
+  method(arg: Boolean, arg: Boolean): Int
+}
+"#;
+        let ctx = ApolloCompiler::new(input);
+        let diagnostics = ctx.validate();
+        for diagnostic in &diagnostics {
+            println!("{}", diagnostic)
+        }
+        assert_eq!(diagnostics.len(), 1);
+    }
+}

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -15,6 +15,7 @@ mod object;
 // executable definitions
 mod operation;
 
+mod arguments;
 mod unused_variable;
 
 use apollo_parser::SyntaxNode;
@@ -38,6 +39,7 @@ pub trait ValidationDatabase:
     fn validate_input_object(&self) -> Vec<ApolloDiagnostic>;
     fn validate_object(&self) -> Vec<ApolloDiagnostic>;
     fn validate_operation(&self) -> Vec<ApolloDiagnostic>;
+    fn validate_arguments(&self) -> Vec<ApolloDiagnostic>;
     fn validate_unused_variable(&self) -> Vec<ApolloDiagnostic>;
 }
 
@@ -57,6 +59,7 @@ pub fn validate(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     diagnostics.extend(db.validate_object());
     diagnostics.extend(db.validate_operation());
 
+    diagnostics.extend(db.validate_arguments());
     diagnostics.extend(db.validate_unused_variable());
 
     diagnostics
@@ -96,6 +99,10 @@ pub fn validate_object(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
 
 pub fn validate_operation(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     operation::check(db)
+}
+
+pub fn validate_arguments(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
+    arguments::check(db)
 }
 
 pub fn validate_unused_variable(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {


### PR DESCRIPTION
One part of #308

It's an error to declare or provide multiple arguments by the same name, eg:
```graphql
type Query {
  things(offset: Int!, offset: Int!): [Thing]
  # ERR: duplicate argument definition: offset
}
```
```graphql
query GetThings {
  things(offset: 10, offset: 20) { id }
  # ERR: duplicate argument values: offset
}
```

I started with 1 specific case here, namely arguments in an object type field definition.
- [ ] the actual duplication check should be reused for directive arguments
- [ ] maybe also for `input` type definitions?
- [ ] similar check should apply when providing arguments to a field. as that's working with concrete values rather than types, it makes sense to have a separate check

some questions:
- `UniqueDefinition` is currently used for things that must be unique document-wide, so the error message is wrong for this case.
   ![image](https://user-images.githubusercontent.com/1006268/192788197-43bf9803-b5e9-4305-badc-aad305472fad.png)

   a `UniqueArgument` diagnostic may make sense, but UniqueDefinition is already used for a few different things, so maybe it can be made more flexible by adding another property?
- some `ast_node()` methods return a node reference, while others return an Option. what is the reason? it seems like we just always do `ast_node().unwrap()`, so it should actually not be None in practice?
- converting `text_range()` to a `SourceSpan` is a little verbose and could be done wrong (eg. by passing the wrong variable combination or calling `start()` twice instead of `start()`+`len()`). A From impl is infeasible as they are defined in different crates but a function could be nice, or an ext trait to add `.source_span()` to SyntaxNodes 😄 