### PR TITLE
Reduce token copying

### DIFF
--- a/crates/apollo-parser/src/lexer/mod.rs
+++ b/crates/apollo-parser/src/lexer/mod.rs
@@ -83,6 +83,11 @@ impl Lexer {
     pub fn errors(&self) -> Iter<'_, Error> {
         self.errors.iter()
     }
+
+    /// Consume the lexer and return the tokens and errors.
+    pub fn into_parts(self) -> (Vec<Token>, Vec<Error>) {
+        (self.tokens, self.errors)
+    }
 }
 
 impl Cursor<'_> {

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -202,8 +202,9 @@ impl Parser {
     /// otherwise.
     pub(crate) fn expect(&mut self, token: TokenKind, kind: SyntaxKind) {
         let current = self.current();
-        // TODO this allocation is only required if we have an error, but has to be done eagerly
-        // here as the &str reference gets invalidated by `self.at()`. Can we avoid that?
+        // TODO(@goto-bus-stop) this allocation is only required if we have an
+        // error, but has to be done eagerly here as the &str reference gets
+        // invalidated by `self.at()`. Can we avoid that?
         let data = current.data().to_string();
         let index = current.index();
 

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -86,18 +86,7 @@ pub struct Parser {
 impl Parser {
     /// Create a new instance of a parser given an input string.
     pub fn new(input: &str) -> Self {
-        let lexer = Lexer::new(input);
-
-        let mut tokens = Vec::new();
-        let mut errors = Vec::new();
-
-        for s in lexer.tokens().iter().cloned() {
-            tokens.push(s);
-        }
-
-        for e in lexer.errors().cloned() {
-            errors.push(e);
-        }
+        let (mut tokens, mut errors) = Lexer::new(input).into_parts();
 
         tokens.reverse();
         errors.reverse();

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -172,7 +172,7 @@ impl Parser {
     /// Note: After a limit error is pushed, any further errors pushed
     /// are silently discarded.
     pub(crate) fn limit_err<S: Into<String>>(&mut self, message: S) {
-        let current = self.current().clone();
+        let current = self.current();
         // this needs to be the computed location
         let err = Error::with_loc(message, current.data().to_string(), current.index());
         self.push_err(err);
@@ -181,7 +181,7 @@ impl Parser {
 
     /// Create a parser error and push it into the error vector.
     pub(crate) fn err(&mut self, message: &str) {
-        let current = self.current().clone();
+        let current = self.current();
         // this needs to be the computed location
         let err = Error::with_loc(message, current.data().to_string(), current.index());
         self.push_err(err);
@@ -201,8 +201,11 @@ impl Parser {
     /// Consume the next token if it is `kind` or emit an error
     /// otherwise.
     pub(crate) fn expect(&mut self, token: TokenKind, kind: SyntaxKind) {
-        let current = self.current().clone();
+        let current = self.current();
+        // TODO this allocation is only required if we have an error, but has to be done eagerly
+        // here as the &str reference gets invalidated by `self.at()`. Can we avoid that?
         let data = current.data().to_string();
+        let index = current.index();
 
         if self.at(token) {
             self.bump(kind);
@@ -212,7 +215,7 @@ impl Parser {
         let err = Error::with_loc(
             format!("expected {:?}, got {}", kind, data),
             data,
-            current.index(),
+            index,
         );
 
         self.push_err(err);


### PR DESCRIPTION
A little low-hanging fruit.

Since the Lexer instance isn't needed anymore after the lexing is complete,
we can take ownership of the tokens and errors vectors and reverse them
in-place without making a copy. Big schemas can have 100K+ tokens so
it's actually quite a lot of work to copy them.

As it is, maybe it makes sense to have the lexer just be
```rust
fn lex(input: &str) -> (Vec<Token>, Vec<Error>)
```
unless we're planning to add more features to it in the future?
(personally I also like the idea of a streaming lexer like in #115!)

Also spotted a few other clones in the parser that are not (or no longer)
necessary. Likely only the `expect` one has a chance of making a difference though.