### PR TITLE
fix(apollo-parser): handle unexpected tokens in document

### DIFF
--- a/crates/apollo-parser/src/parser/grammar/document.rs
+++ b/crates/apollo-parser/src/parser/grammar/document.rs
@@ -28,7 +28,7 @@ pub(crate) fn document(p: &mut Parser) {
                 select_definition(def, p);
             }
             TokenKind::Eof => break,
-            _ => p.err_and_pop("expected a String, Name or OperationDefinition"),
+            _ => p.err_and_pop("expected a StringValue, Name or OperationDefinition"),
         }
     }
 

--- a/crates/apollo-parser/src/parser/grammar/document.rs
+++ b/crates/apollo-parser/src/parser/grammar/document.rs
@@ -27,7 +27,8 @@ pub(crate) fn document(p: &mut Parser) {
                 let def = p.peek_data().unwrap();
                 select_definition(def, p);
             }
-            _ => break,
+            TokenKind::Eof => break,
+            _ => p.err_and_pop("expected a String, Name or OperationDefinition"),
         }
     }
 

--- a/crates/apollo-parser/src/parser/grammar/selection.rs
+++ b/crates/apollo-parser/src/parser/grammar/selection.rs
@@ -402,7 +402,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 2);
+        assert_eq!(ast.document().definitions().into_iter().count(), 4);
     }
 
     #[test]

--- a/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.graphql
@@ -1,5 +1,13 @@
 @
+# comment
 {
     pet
     faveSnack
-}}
+}
+
+# comment
+}
+
+type Query {
+    name: String
+}

--- a/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.graphql
@@ -1,0 +1,5 @@
+@
+{
+    pet
+    faveSnack
+}}

--- a/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
+++ b/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
@@ -1,0 +1,18 @@
+- DOCUMENT@0..26
+    - WHITESPACE@0..1 "\n"
+    - OPERATION_DEFINITION@1..26
+        - SELECTION_SET@1..26
+            - L_CURLY@1..2 "{"
+            - WHITESPACE@2..7 "\n    "
+            - FIELD@7..15
+                - NAME@7..15
+                    - IDENT@7..10 "pet"
+                    - WHITESPACE@10..15 "\n    "
+            - FIELD@15..25
+                - NAME@15..25
+                    - IDENT@15..24 "faveSnack"
+                    - WHITESPACE@24..25 "\n"
+            - R_CURLY@25..26 "}"
+- ERROR@0:1 "expected a String, Name or OperationDefinition" @
+- ERROR@27:28 "expected a String, Name or OperationDefinition" }
+recursion limit: 4096, high: 3

--- a/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
+++ b/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
@@ -1,18 +1,43 @@
-- DOCUMENT@0..26
+- DOCUMENT@0..81
     - WHITESPACE@0..1 "\n"
-    - OPERATION_DEFINITION@1..26
-        - SELECTION_SET@1..26
-            - L_CURLY@1..2 "{"
-            - WHITESPACE@2..7 "\n    "
-            - FIELD@7..15
-                - NAME@7..15
-                    - IDENT@7..10 "pet"
-                    - WHITESPACE@10..15 "\n    "
-            - FIELD@15..25
-                - NAME@15..25
-                    - IDENT@15..24 "faveSnack"
-                    - WHITESPACE@24..25 "\n"
-            - R_CURLY@25..26 "}"
+    - COMMENT@1..10 "# comment"
+    - WHITESPACE@10..11 "\n"
+    - OPERATION_DEFINITION@11..48
+        - SELECTION_SET@11..48
+            - L_CURLY@11..12 "{"
+            - WHITESPACE@12..17 "\n    "
+            - FIELD@17..25
+                - NAME@17..25
+                    - IDENT@17..20 "pet"
+                    - WHITESPACE@20..25 "\n    "
+            - FIELD@25..35
+                - NAME@25..35
+                    - IDENT@25..34 "faveSnack"
+                    - WHITESPACE@34..35 "\n"
+            - R_CURLY@35..36 "}"
+            - WHITESPACE@36..38 "\n\n"
+            - COMMENT@38..47 "# comment"
+            - WHITESPACE@47..48 "\n"
+    - WHITESPACE@48..50 "\n\n"
+    - OBJECT_TYPE_DEFINITION@50..81
+        - type_KW@50..54 "type"
+        - WHITESPACE@54..55 " "
+        - NAME@55..61
+            - IDENT@55..60 "Query"
+            - WHITESPACE@60..61 " "
+        - FIELDS_DEFINITION@61..81
+            - L_CURLY@61..62 "{"
+            - WHITESPACE@62..67 "\n    "
+            - FIELD_DEFINITION@67..80
+                - NAME@67..71
+                    - IDENT@67..71 "name"
+                - COLON@71..72 ":"
+                - WHITESPACE@72..73 " "
+                - NAMED_TYPE@73..79
+                    - NAME@73..79
+                        - IDENT@73..79 "String"
+                - WHITESPACE@79..80 "\n"
+            - R_CURLY@80..81 "}"
 - ERROR@0:1 "expected a String, Name or OperationDefinition" @
-- ERROR@27:28 "expected a String, Name or OperationDefinition" }
+- ERROR@49:50 "expected a String, Name or OperationDefinition" }
 recursion limit: 4096, high: 3

--- a/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
+++ b/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
@@ -38,6 +38,6 @@
                         - IDENT@73..79 "String"
                 - WHITESPACE@79..80 "\n"
             - R_CURLY@80..81 "}"
-- ERROR@0:1 "expected a String, Name or OperationDefinition" @
-- ERROR@49:50 "expected a String, Name or OperationDefinition" }
+- ERROR@0:1 "expected a StringValue, Name or OperationDefinition" @
+- ERROR@49:50 "expected a StringValue, Name or OperationDefinition" }
 recursion limit: 4096, high: 3


### PR DESCRIPTION
Unhandled tokens directly inside a document would break the loop in the parser. This resulted in the rest of the parsing to be skipped. An error would be expected here instead.