### PR TITLE
feat(encoder): provide TryFrom<parser types> for encoder types

### DIFF
--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -24,7 +24,6 @@ apollo-parser = { version = "0.2.12", optional = true }
 thiserror = "1.0.37"
 
 [features]
-# TODO(@goto-bus-stop) remove before merging, just easier this way while writing : )
 default = ["from-parser"]
 from-parser = ["apollo-parser"]
 

--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -19,6 +19,15 @@ categories = [
 ]
 edition = "2021"
 
+[dependencies]
+apollo-parser = { version = "0.2.12", optional = true }
+thiserror = "1.0.37"
+
+[features]
+# TODO(@goto-bus-stop) remove before merging, just easier this way while writing : )
+default = ["from-parser"]
+from-parser = ["apollo-parser"]
+
 [dev-dependencies]
 pretty_assertions = "0.7.1"
 indoc = "1.0.3"

--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -24,8 +24,7 @@ apollo-parser = { version = "0.2.12", optional = true }
 thiserror = "1.0.37"
 
 [features]
-default = ["from-parser"]
-from-parser = ["apollo-parser"]
+default = ["apollo-parser"]
 
 [dev-dependencies]
 pretty_assertions = "0.7.1"

--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -65,12 +65,12 @@ impl DirectiveDefinition {
         });
     }
 
-    /// Set the Directive's location.
+    /// Add a location where this Directive can be used.
     pub fn location(&mut self, location: String) {
         self.locations.push(location);
     }
 
-    /// Set the Directive's args.
+    /// Add an argument to this Directive.
     pub fn arg(&mut self, arg: InputValueDefinition) {
         self.args.input_value(arg);
     }

--- a/crates/apollo-encoder/src/fragment.rs
+++ b/crates/apollo-encoder/src/fragment.rs
@@ -43,7 +43,7 @@ pub struct FragmentDefinition {
 }
 
 impl FragmentDefinition {
-    /// Create an instance of FragmentDeg
+    /// Create an instance of FragmentDefinition.
     pub fn new(name: String, type_condition: TypeCondition, selection_set: SelectionSet) -> Self {
         Self {
             name,

--- a/crates/apollo-encoder/src/from_parser.rs
+++ b/crates/apollo-encoder/src/from_parser.rs
@@ -4,9 +4,10 @@ use apollo_parser::ast;
 use thiserror::Error;
 
 /// Errors that can occur when converting an apollo-parser AST to an apollo-encoder one.
-///
-/// TODO(@goto-bus-stop) Would be nice to have some way to show where the error
-/// occurred, as it's quite hard to figure out now.
+/// These errors don't give a lot of context at the moment. Before converting ASTs, you
+/// should make sure that your parse tree is complete and valid.
+// TODO(@goto-bus-stop) Would be nice to have some way to show where the error
+// occurred
 #[derive(Debug, Clone, Error)]
 pub enum FromError {
     #[error("parse tree is missing a node")]
@@ -20,6 +21,12 @@ pub enum FromError {
 impl TryFrom<ast::Value> for crate::Value {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::Value) -> Result<Self, Self::Error> {
         let encoder_node = match node {
             ast::Value::Variable(variable) => Self::Variable(variable.name().ok_or(FromError::MissingNode)?.text().to_string()),
@@ -54,6 +61,12 @@ impl TryFrom<ast::Value> for crate::Value {
 impl TryFrom<ast::DefaultValue> for crate::Value {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::DefaultValue) -> Result<Self, Self::Error> {
         node.value().ok_or(FromError::MissingNode)?.try_into()
     }
@@ -62,6 +75,12 @@ impl TryFrom<ast::DefaultValue> for crate::Value {
 impl TryFrom<ast::Directive> for crate::Directive {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::Directive) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut directive = Self::new(name);
@@ -79,6 +98,12 @@ impl TryFrom<ast::Directive> for crate::Directive {
 impl TryFrom<ast::Argument> for crate::Argument {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::Argument) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let value = node.value().ok_or(FromError::MissingNode)?.try_into()?;
@@ -88,6 +113,13 @@ impl TryFrom<ast::Argument> for crate::Argument {
 
 impl TryFrom<ast::NamedType> for crate::Type_ {
     type Error = FromError;
+
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::NamedType) -> Result<Self, Self::Error> {
         Ok(Self::NamedType {
             name: node.name().ok_or(FromError::MissingNode)?.text().to_string(),
@@ -97,6 +129,13 @@ impl TryFrom<ast::NamedType> for crate::Type_ {
 
 impl TryFrom<ast::ListType> for crate::Type_ {
     type Error = FromError;
+
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::ListType) -> Result<Self, Self::Error> {
         Ok(Self::List {
             ty: Box::new(node.ty().ok_or(FromError::MissingNode)?.try_into()?),
@@ -106,6 +145,13 @@ impl TryFrom<ast::ListType> for crate::Type_ {
 
 impl TryFrom<ast::NonNullType> for crate::Type_ {
     type Error = FromError;
+
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::NonNullType) -> Result<Self, Self::Error> {
         let named_type = node.named_type().ok_or(FromError::MissingNode).and_then(|ty| ty.try_into());
         let list_type = node.list_type().ok_or(FromError::MissingNode).and_then(|ty| ty.try_into());
@@ -119,6 +165,12 @@ impl TryFrom<ast::NonNullType> for crate::Type_ {
 impl TryFrom<ast::Type> for crate::Type_ {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::Type) -> Result<Self, Self::Error> {
         match node {
             ast::Type::NamedType(ty) => ty.try_into(),
@@ -131,6 +183,12 @@ impl TryFrom<ast::Type> for crate::Type_ {
 impl TryFrom<ast::InputValueDefinition> for crate::InputValueDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::InputValueDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let ty = node.ty().ok_or(FromError::MissingNode)?;
@@ -158,6 +216,12 @@ impl TryFrom<ast::InputValueDefinition> for crate::InputValueDefinition {
 impl TryFrom<ast::ArgumentsDefinition> for crate::ArgumentsDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::ArgumentsDefinition) -> Result<Self, Self::Error> {
         let input_values = node.input_value_definitions()
             .map(|input_value| input_value.try_into())
@@ -170,6 +234,12 @@ impl TryFrom<ast::ArgumentsDefinition> for crate::ArgumentsDefinition {
 impl TryFrom<ast::FieldDefinition> for crate::FieldDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::FieldDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let ty = node.ty().ok_or(FromError::MissingNode)?.try_into()?;
@@ -194,6 +264,12 @@ impl TryFrom<ast::FieldDefinition> for crate::FieldDefinition {
 impl TryFrom<ast::TypeCondition> for crate::TypeCondition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::TypeCondition) -> Result<Self, Self::Error> {
         let named_type = node.named_type().ok_or(FromError::MissingNode)?;
         let name = named_type.name().ok_or(FromError::MissingNode)?.text().to_string();
@@ -204,6 +280,12 @@ impl TryFrom<ast::TypeCondition> for crate::TypeCondition {
 impl TryFrom<ast::Field> for crate::Field {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::Field) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
 
@@ -236,6 +318,12 @@ impl TryFrom<ast::Field> for crate::Field {
 impl TryFrom<ast::FragmentSpread> for crate::FragmentSpread {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::FragmentSpread) -> Result<Self, Self::Error> {
         let name = node.fragment_name()
             .and_then(|fragment_name| fragment_name.name())
@@ -255,6 +343,12 @@ impl TryFrom<ast::FragmentSpread> for crate::FragmentSpread {
 impl TryFrom<ast::InlineFragment> for crate::InlineFragment {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::InlineFragment) -> Result<Self, Self::Error> {
         let selection_set = node.selection_set()
             .ok_or(FromError::MissingNode)?
@@ -279,6 +373,12 @@ impl TryFrom<ast::InlineFragment> for crate::InlineFragment {
 impl TryFrom<ast::Selection> for crate::Selection {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::Selection) -> Result<Self, Self::Error> {
         let encoder_node = match node {
             ast::Selection::Field(field) => Self::Field(field.try_into()?),
@@ -293,6 +393,12 @@ impl TryFrom<ast::Selection> for crate::Selection {
 impl TryFrom<ast::SelectionSet> for crate::SelectionSet {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::SelectionSet) -> Result<Self, Self::Error> {
         let selections = node.selections()
             .map(|selection| selection.try_into())
@@ -305,6 +411,12 @@ impl TryFrom<ast::SelectionSet> for crate::SelectionSet {
 impl TryFrom<ast::OperationType> for crate::OperationType {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::OperationType) -> Result<Self, Self::Error> {
         if node.query_token().is_some() {
             Ok(Self::Query)
@@ -321,6 +433,12 @@ impl TryFrom<ast::OperationType> for crate::OperationType {
 impl TryFrom<ast::VariableDefinition> for crate::VariableDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::VariableDefinition) -> Result<Self, Self::Error> {
         let name = node.variable()
             .ok_or(FromError::MissingNode)?
@@ -349,6 +467,12 @@ impl TryFrom<ast::VariableDefinition> for crate::VariableDefinition {
 impl TryFrom<ast::OperationDefinition> for crate::OperationDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::OperationDefinition) -> Result<Self, Self::Error> {
         let operation_type = node.operation_type().ok_or(FromError::MissingNode)?.try_into()?;
         let selection_set = node.selection_set().ok_or(FromError::MissingNode)?.try_into()?;
@@ -378,6 +502,12 @@ impl TryFrom<ast::OperationDefinition> for crate::OperationDefinition {
 impl TryFrom<ast::FragmentDefinition> for crate::FragmentDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::FragmentDefinition) -> Result<Self, Self::Error> {
         let name = node.fragment_name()
             .ok_or(FromError::MissingNode)?
@@ -406,6 +536,12 @@ impl TryFrom<ast::FragmentDefinition> for crate::FragmentDefinition {
 impl TryFrom<ast::DirectiveDefinition> for crate::DirectiveDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::DirectiveDefinition) -> Result<Self, Self::Error> {
         let name = node.name()
             .ok_or(FromError::MissingNode)?
@@ -474,6 +610,12 @@ fn apply_root_operation_type_definitions(encoder_node: &mut crate::SchemaDefinit
 impl TryFrom<ast::SchemaDefinition> for crate::SchemaDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::SchemaDefinition) -> Result<Self, Self::Error> {
         let mut encoder_node = Self::new();
 
@@ -499,6 +641,12 @@ impl TryFrom<ast::SchemaDefinition> for crate::SchemaDefinition {
 impl TryFrom<ast::ScalarTypeDefinition> for crate::ScalarDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::ScalarTypeDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -523,6 +671,12 @@ impl TryFrom<ast::ScalarTypeDefinition> for crate::ScalarDefinition {
 impl TryFrom<ast::ObjectTypeDefinition> for crate::ObjectDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::ObjectTypeDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -560,6 +714,12 @@ impl TryFrom<ast::ObjectTypeDefinition> for crate::ObjectDefinition {
 impl TryFrom<ast::InterfaceTypeDefinition> for crate::InterfaceDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::InterfaceTypeDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -597,6 +757,12 @@ impl TryFrom<ast::InterfaceTypeDefinition> for crate::InterfaceDefinition {
 impl TryFrom<ast::UnionTypeDefinition> for crate::UnionDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::UnionTypeDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -627,6 +793,12 @@ impl TryFrom<ast::UnionTypeDefinition> for crate::UnionDefinition {
 impl TryFrom<ast::EnumValueDefinition> for crate::EnumValue {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::EnumValueDefinition) -> Result<Self, Self::Error> {
         let name = node.enum_value()
             .ok_or(FromError::MissingNode)?
@@ -656,6 +828,12 @@ impl TryFrom<ast::EnumValueDefinition> for crate::EnumValue {
 impl TryFrom<ast::EnumTypeDefinition> for crate::EnumDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::EnumTypeDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -686,6 +864,12 @@ impl TryFrom<ast::EnumTypeDefinition> for crate::EnumDefinition {
 impl TryFrom<ast::InputValueDefinition> for crate::InputField {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::InputValueDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let ty = node.ty().ok_or(FromError::MissingNode)?;
@@ -713,6 +897,12 @@ impl TryFrom<ast::InputValueDefinition> for crate::InputField {
 impl TryFrom<ast::InputObjectTypeDefinition> for crate::InputObjectDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::InputObjectTypeDefinition) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -743,6 +933,12 @@ impl TryFrom<ast::InputObjectTypeDefinition> for crate::InputObjectDefinition {
 impl TryFrom<ast::SchemaExtension> for crate::SchemaDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::SchemaExtension) -> Result<Self, Self::Error> {
         let mut encoder_node = Self::new();
 
@@ -763,6 +959,12 @@ impl TryFrom<ast::SchemaExtension> for crate::SchemaDefinition {
 impl TryFrom<ast::ScalarTypeExtension> for crate::ScalarDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::ScalarTypeExtension) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -782,6 +984,12 @@ impl TryFrom<ast::ScalarTypeExtension> for crate::ScalarDefinition {
 impl TryFrom<ast::ObjectTypeExtension> for crate::ObjectDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::ObjectTypeExtension) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -814,6 +1022,12 @@ impl TryFrom<ast::ObjectTypeExtension> for crate::ObjectDefinition {
 impl TryFrom<ast::InterfaceTypeExtension> for crate::InterfaceDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::InterfaceTypeExtension) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -846,6 +1060,12 @@ impl TryFrom<ast::InterfaceTypeExtension> for crate::InterfaceDefinition {
 impl TryFrom<ast::UnionTypeExtension> for crate::UnionDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::UnionTypeExtension) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -871,6 +1091,12 @@ impl TryFrom<ast::UnionTypeExtension> for crate::UnionDefinition {
 impl TryFrom<ast::EnumTypeExtension> for crate::EnumDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::EnumTypeExtension) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -896,6 +1122,12 @@ impl TryFrom<ast::EnumTypeExtension> for crate::EnumDefinition {
 impl TryFrom<ast::InputObjectTypeExtension> for crate::InputObjectDefinition {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::InputObjectTypeExtension) -> Result<Self, Self::Error> {
         let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
         let mut encoder_node = Self::new(name);
@@ -921,6 +1153,12 @@ impl TryFrom<ast::InputObjectTypeExtension> for crate::InputObjectDefinition {
 impl TryFrom<ast::Document> for crate::Document {
     type Error = FromError;
 
+    /// Create an apollo-encoder node from an apollo-parser one.
+    ///
+    /// # Errors
+    /// This returns an error if the apollo-parser tree is not valid. The error
+    /// doesn't have much context due to TryFrom API constraints: validate the parse tree before
+    /// using TryFrom if granular errors are important to you.
     fn try_from(node: ast::Document) -> Result<Self, Self::Error> {
         let mut encoder_node = Self::new();
 

--- a/crates/apollo-encoder/src/from_parser.rs
+++ b/crates/apollo-encoder/src/from_parser.rs
@@ -366,6 +366,134 @@ impl TryFrom<ast::OperationDefinition> for crate::OperationDefinition {
     }
 }
 
+impl TryFrom<ast::FragmentDefinition> for crate::FragmentDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::FragmentDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::DirectiveDefinition> for crate::DirectiveDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::DirectiveDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::SchemaDefinition> for crate::SchemaDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::SchemaDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::ScalarTypeDefinition> for crate::ScalarDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::ScalarTypeDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::ObjectTypeDefinition> for crate::ObjectDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::ObjectTypeDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::InterfaceTypeDefinition> for crate::InterfaceDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::InterfaceTypeDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::UnionTypeDefinition> for crate::UnionDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::UnionTypeDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::EnumTypeDefinition> for crate::EnumDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::EnumTypeDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::InputObjectTypeDefinition> for crate::InputObjectDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::InputObjectTypeDefinition) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::SchemaExtension> for crate::SchemaDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::SchemaExtension) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::ScalarTypeExtension> for crate::ScalarDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::ScalarTypeExtension) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::ObjectTypeExtension> for crate::ObjectDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::ObjectTypeExtension) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::InterfaceTypeExtension> for crate::InterfaceDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::InterfaceTypeExtension) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::UnionTypeExtension> for crate::UnionDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::UnionTypeExtension) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::EnumTypeExtension> for crate::EnumDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::EnumTypeExtension) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<ast::InputObjectTypeExtension> for crate::InputObjectDefinition {
+    type Error = FromError;
+
+    fn try_from(_node: ast::InputObjectTypeExtension) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
 impl TryFrom<ast::Document> for crate::Document {
     type Error = FromError;
 
@@ -375,22 +503,22 @@ impl TryFrom<ast::Document> for crate::Document {
         for definition in node.definitions() {
             match definition {
                 ast::Definition::OperationDefinition(def) => encoder_node.operation(def.try_into()?),
-                ast::Definition::FragmentDefinition(_) => todo!(),
-                ast::Definition::DirectiveDefinition(_) => todo!(),
-                ast::Definition::SchemaDefinition(_) => todo!(),
-                ast::Definition::ScalarTypeDefinition(_) => todo!(),
-                ast::Definition::ObjectTypeDefinition(_) => todo!(),
-                ast::Definition::InterfaceTypeDefinition(_) => todo!(),
-                ast::Definition::UnionTypeDefinition(_) => todo!(),
-                ast::Definition::EnumTypeDefinition(_) => todo!(),
-                ast::Definition::InputObjectTypeDefinition(_) => todo!(),
-                ast::Definition::SchemaExtension(_) => todo!(),
-                ast::Definition::ScalarTypeExtension(_) => todo!(),
-                ast::Definition::ObjectTypeExtension(_) => todo!(),
-                ast::Definition::InterfaceTypeExtension(_) => todo!(),
-                ast::Definition::UnionTypeExtension(_) => todo!(),
-                ast::Definition::EnumTypeExtension(_) => todo!(),
-                ast::Definition::InputObjectTypeExtension(_) => todo!(),
+                ast::Definition::FragmentDefinition(def) => encoder_node.fragment(def.try_into()?),
+                ast::Definition::DirectiveDefinition(def) => encoder_node.directive(def.try_into()?),
+                ast::Definition::SchemaDefinition(def) => encoder_node.schema(def.try_into()?),
+                ast::Definition::ScalarTypeDefinition(def) => encoder_node.scalar(def.try_into()?),
+                ast::Definition::ObjectTypeDefinition(def) => encoder_node.object(def.try_into()?),
+                ast::Definition::InterfaceTypeDefinition(def) => encoder_node.interface(def.try_into()?),
+                ast::Definition::UnionTypeDefinition(def) => encoder_node.union(def.try_into()?),
+                ast::Definition::EnumTypeDefinition(def) => encoder_node.enum_(def.try_into()?),
+                ast::Definition::InputObjectTypeDefinition(def) => encoder_node.input_object(def.try_into()?),
+                ast::Definition::SchemaExtension(ext) => encoder_node.schema(ext.try_into()?),
+                ast::Definition::ScalarTypeExtension(ext) => encoder_node.scalar(ext.try_into()?),
+                ast::Definition::ObjectTypeExtension(ext) => encoder_node.object(ext.try_into()?),
+                ast::Definition::InterfaceTypeExtension(ext) => encoder_node.interface(ext.try_into()?),
+                ast::Definition::UnionTypeExtension(ext) => encoder_node.union(ext.try_into()?),
+                ast::Definition::EnumTypeExtension(ext) => encoder_node.enum_(ext.try_into()?),
+                ast::Definition::InputObjectTypeExtension(ext) => encoder_node.input_object(ext.try_into()?),
             }
         }
 

--- a/crates/apollo-encoder/src/from_parser.rs
+++ b/crates/apollo-encoder/src/from_parser.rs
@@ -782,40 +782,139 @@ impl TryFrom<ast::ScalarTypeExtension> for crate::ScalarDefinition {
 impl TryFrom<ast::ObjectTypeExtension> for crate::ObjectDefinition {
     type Error = FromError;
 
-    fn try_from(_node: ast::ObjectTypeExtension) -> Result<Self, Self::Error> {
-        todo!()
+    fn try_from(node: ast::ObjectTypeExtension) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
+        let mut encoder_node = Self::new(name);
+
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+
+        if let Some(implements_interfaces) = node.implements_interfaces() {
+            for implements in implements_interfaces.named_types() {
+                let name = implements.name().ok_or(FromError::MissingNode)?.text().to_string();
+                encoder_node.interface(name);
+            }
+        }
+
+        if let Some(field_definitions) = node.fields_definition() {
+            for field_definition in field_definitions.field_definitions() {
+                encoder_node.field(field_definition.try_into()?);
+            }
+        }
+
+        encoder_node.extend();
+
+        Ok(encoder_node)
     }
 }
 
 impl TryFrom<ast::InterfaceTypeExtension> for crate::InterfaceDefinition {
     type Error = FromError;
 
-    fn try_from(_node: ast::InterfaceTypeExtension) -> Result<Self, Self::Error> {
-        todo!()
+    fn try_from(node: ast::InterfaceTypeExtension) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
+        let mut encoder_node = Self::new(name);
+
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+
+        if let Some(implements_interfaces) = node.implements_interfaces() {
+            for implements in implements_interfaces.named_types() {
+                let name = implements.name().ok_or(FromError::MissingNode)?.text().to_string();
+                encoder_node.interface(name);
+            }
+        }
+
+        if let Some(field_definitions) = node.fields_definition() {
+            for field_definition in field_definitions.field_definitions() {
+                encoder_node.field(field_definition.try_into()?);
+            }
+        }
+
+        encoder_node.extend();
+
+        Ok(encoder_node)
     }
 }
 
 impl TryFrom<ast::UnionTypeExtension> for crate::UnionDefinition {
     type Error = FromError;
 
-    fn try_from(_node: ast::UnionTypeExtension) -> Result<Self, Self::Error> {
-        todo!()
+    fn try_from(node: ast::UnionTypeExtension) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
+        let mut encoder_node = Self::new(name);
+
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+
+        if let Some(members) = node.union_member_types() {
+            for member in members.named_types() {
+                encoder_node.member(member.name().ok_or(FromError::MissingNode)?.text().to_string());
+            }
+        }
+
+        encoder_node.extend();
+
+        Ok(encoder_node)
     }
 }
 
 impl TryFrom<ast::EnumTypeExtension> for crate::EnumDefinition {
     type Error = FromError;
 
-    fn try_from(_node: ast::EnumTypeExtension) -> Result<Self, Self::Error> {
-        todo!()
+    fn try_from(node: ast::EnumTypeExtension) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
+        let mut encoder_node = Self::new(name);
+
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+
+        if let Some(values) = node.enum_values_definition() {
+            for value in values.enum_value_definitions() {
+                encoder_node.value(value.try_into()?);
+            }
+        }
+
+        encoder_node.extend();
+
+        Ok(encoder_node)
     }
 }
 
 impl TryFrom<ast::InputObjectTypeExtension> for crate::InputObjectDefinition {
     type Error = FromError;
 
-    fn try_from(_node: ast::InputObjectTypeExtension) -> Result<Self, Self::Error> {
-        todo!()
+    fn try_from(node: ast::InputObjectTypeExtension) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.text().to_string();
+        let mut encoder_node = Self::new(name);
+
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+
+        if let Some(field_definitions) = node.input_fields_definition() {
+            for field_definition in field_definitions.input_value_definitions() {
+                encoder_node.field(field_definition.try_into()?);
+            }
+        }
+
+        encoder_node.extend();
+
+        Ok(encoder_node)
     }
 }
 

--- a/crates/apollo-encoder/src/from_parser.rs
+++ b/crates/apollo-encoder/src/from_parser.rs
@@ -1,0 +1,294 @@
+use std::convert::TryFrom;
+
+use apollo_parser::ast;
+use thiserror::Error;
+
+/// Errors that can occur when converting an apollo-parser AST to an apollo-encoder one.
+#[derive(Debug, Clone, Error)]
+pub enum FromError {
+    #[error("parse tree is missing a node")]
+    MissingNode,
+    #[error("invalid i32")]
+    ParseIntError(#[from] std::num::ParseIntError),
+    #[error("invalid f64")]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+}
+
+impl TryFrom<ast::Value> for crate::Value {
+    type Error = FromError;
+
+    fn try_from(node: ast::Value) -> Result<Self, Self::Error> {
+        let encoder_node = match node {
+            ast::Value::Variable(variable) => Self::Variable(variable.name().ok_or(FromError::MissingNode)?.to_string()),
+            ast::Value::StringValue(string) => Self::String(string.to_string()),
+            ast::Value::FloatValue(float) => Self::Float(float.float_token().ok_or(FromError::MissingNode)?.text().parse()?),
+            ast::Value::IntValue(int) => Self::Int(int.int_token().ok_or(FromError::MissingNode)?.text().parse()?),
+            ast::Value::BooleanValue(boolean) => Self::Boolean(boolean.true_token().is_some()),
+            ast::Value::NullValue(_) => Self::Null,
+            ast::Value::EnumValue(enum_) => Self::Enum(enum_.to_string()),
+            ast::Value::ListValue(list) => {
+                let encoder_list = list.values()
+                    .map(Self::try_from)
+                    .collect::<Result<Vec<_>, FromError>>()?;
+                Self::List(encoder_list)
+            },
+            ast::Value::ObjectValue(object) => {
+                let encoder_object = object.object_fields()
+                    .map(|field| {
+                        let name = field.name().ok_or(FromError::MissingNode)?.to_string();
+                        let value = field.value().ok_or(FromError::MissingNode)?.try_into()?;
+                        Ok((name, value))
+                    })
+                    .collect::<Result<Vec<_>, FromError>>()?;
+                Self::Object(encoder_object)
+            },
+        };
+
+        Ok(encoder_node)
+    }
+}
+
+impl TryFrom<ast::DefaultValue> for crate::Value {
+    type Error = FromError;
+
+    fn try_from(node: ast::DefaultValue) -> Result<Self, Self::Error> {
+        node.value().ok_or(FromError::MissingNode)?.try_into()
+    }
+}
+
+impl TryFrom<ast::Directive> for crate::Directive {
+    type Error = FromError;
+
+    fn try_from(node: ast::Directive) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.to_string();
+        let mut directive = Self::new(name);
+
+        let arguments = node.arguments()
+            .ok_or(FromError::MissingNode)?
+            .arguments()
+            .map(crate::Argument::try_from);
+        for argument in arguments {
+            directive.arg(argument?);
+        }
+
+        Ok(directive)
+    }
+}
+
+impl TryFrom<ast::Argument> for crate::Argument {
+    type Error = FromError;
+
+    fn try_from(node: ast::Argument) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.to_string();
+        let value = node.value().ok_or(FromError::MissingNode)?.try_into()?;
+        Ok(crate::Argument::new(name, value))
+    }
+}
+
+impl TryFrom<ast::NamedType> for crate::Type_ {
+    type Error = FromError;
+    fn try_from(node: ast::NamedType) -> Result<Self, Self::Error> {
+        Ok(Self::NamedType {
+            name: node.name().ok_or(FromError::MissingNode)?.to_string(),
+        })
+    }
+}
+
+impl TryFrom<ast::ListType> for crate::Type_ {
+    type Error = FromError;
+    fn try_from(node: ast::ListType) -> Result<Self, Self::Error> {
+        Ok(Self::List {
+            ty: Box::new(node.ty().ok_or(FromError::MissingNode)?.try_into()?),
+        })
+    }
+}
+
+impl TryFrom<ast::NonNullType> for crate::Type_ {
+    type Error = FromError;
+    fn try_from(node: ast::NonNullType) -> Result<Self, Self::Error> {
+        let named_type = node.named_type().ok_or(FromError::MissingNode).and_then(|ty| ty.try_into());
+        let list_type = node.list_type().ok_or(FromError::MissingNode).and_then(|ty| ty.try_into());
+
+        Ok(Self::NonNull {
+            ty: Box::new(named_type.or(list_type)?),
+        })
+    }
+}
+
+impl TryFrom<ast::Type> for crate::Type_ {
+    type Error = FromError;
+
+    fn try_from(node: ast::Type) -> Result<Self, Self::Error> {
+        match node {
+            ast::Type::NamedType(ty) => ty.try_into(),
+            ast::Type::ListType(ty) => ty.try_into(),
+            ast::Type::NonNullType(ty) => ty.try_into(),
+        }
+    }
+}
+
+impl TryFrom<ast::InputValueDefinition> for crate::InputValueDefinition {
+    type Error = FromError;
+
+    fn try_from(node: ast::InputValueDefinition) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.to_string();
+        let ty = node.ty().ok_or(FromError::MissingNode)?;
+        let mut encoder_node = Self::new(name, ty.try_into()?);
+        if let Some(description) = node.description() {
+            encoder_node.description(description.string_value().ok_or(FromError::MissingNode)?.to_string());
+        }
+        if let Some(default_value) = node.default_value() {
+            // TODO represent this as a Value enum in encoder?
+            encoder_node.default_value(default_value.value().ok_or(FromError::MissingNode)?.to_string());
+        }
+        Ok(encoder_node)
+    }
+}
+
+impl TryFrom<ast::ArgumentsDefinition> for crate::ArgumentsDefinition {
+    type Error = FromError;
+
+    fn try_from(node: ast::ArgumentsDefinition) -> Result<Self, Self::Error> {
+        let input_values = node.input_value_definitions()
+            .map(|input_value| input_value.try_into())
+            .collect::<Result<Vec<_>, FromError>>()?;
+
+        Ok(Self::with_values(input_values))
+    }
+}
+
+impl TryFrom<ast::FieldDefinition> for crate::FieldDefinition {
+    type Error = FromError;
+
+    fn try_from(node: ast::FieldDefinition) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.to_string();
+        let ty = node.ty().ok_or(FromError::MissingNode)?.try_into()?;
+        let mut encoder_node = Self::new(name, ty);
+
+        if let Some (arguments_definition) = node.arguments_definition() {
+            for input_value in arguments_definition.input_value_definitions() {
+                encoder_node.arg(input_value.try_into()?);
+            }
+        }
+
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+
+        Ok(encoder_node)
+    }
+}
+
+impl TryFrom<ast::TypeCondition> for crate::TypeCondition {
+    type Error = FromError;
+
+    fn try_from(node: ast::TypeCondition) -> Result<Self, Self::Error> {
+        let named_type = node.named_type().ok_or(FromError::MissingNode)?;
+        let name = named_type.name().ok_or(FromError::MissingNode)?.to_string();
+        Ok(Self::new(name))
+    }
+}
+
+impl TryFrom<ast::Field> for crate::Field {
+    type Error = FromError;
+
+    fn try_from(node: ast::Field) -> Result<Self, Self::Error> {
+        let name = node.name().ok_or(FromError::MissingNode)?.to_string();
+
+        let mut encoder_node = Self::new(name);
+
+        if let Some(alias) = node.alias() {
+            let alias = alias.name().ok_or(FromError::MissingNode)?.to_string();
+            encoder_node.alias(Some(alias));
+        }
+
+        let arguments = node.arguments()
+            .ok_or(FromError::MissingNode)?
+            .arguments()
+            .map(crate::Argument::try_from);
+        for argument in arguments {
+            encoder_node.argument(argument?);
+        }
+
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+
+        let selection_set = node.selection_set().map(|selection_set| selection_set.try_into()).transpose()?;
+        encoder_node.selection_set(selection_set);
+
+        Ok(encoder_node)
+    }
+}
+
+impl TryFrom<ast::FragmentSpread> for crate::FragmentSpread {
+    type Error = FromError;
+
+    fn try_from(node: ast::FragmentSpread) -> Result<Self, Self::Error> {
+        let name = node.fragment_name()
+            .and_then(|fragment_name| fragment_name.name())
+            .ok_or(FromError::MissingNode)?
+            .to_string();
+        let mut encoder_node = Self::new(name);
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+        Ok(encoder_node)
+    }
+}
+
+impl TryFrom<ast::InlineFragment> for crate::InlineFragment {
+    type Error = FromError;
+
+    fn try_from(node: ast::InlineFragment) -> Result<Self, Self::Error> {
+        let selection_set = node.selection_set()
+            .ok_or(FromError::MissingNode)?
+            .try_into()?;
+        let mut encoder_node = Self::new(selection_set);
+
+        let type_condition = node.type_condition()
+            .map(|condition| condition.try_into())
+            .transpose()?;
+        encoder_node.type_condition(type_condition);
+
+        if let Some(directives) = node.directives() {
+            for directive in directives.directives() {
+                encoder_node.directive(directive.try_into()?);
+            }
+        }
+
+        Ok(encoder_node)
+    }
+}
+
+impl TryFrom<ast::Selection> for crate::Selection {
+    type Error = FromError;
+
+    fn try_from(node: ast::Selection) -> Result<Self, Self::Error> {
+        let encoder_node = match node {
+            ast::Selection::Field(field) => Self::Field(field.try_into()?),
+            ast::Selection::FragmentSpread(fragment) => Self::FragmentSpread(fragment.try_into()?),
+            ast::Selection::InlineFragment(fragment) => Self::InlineFragment(fragment.try_into()?),
+        };
+
+        Ok(encoder_node)
+    }
+}
+
+impl TryFrom<ast::SelectionSet> for crate::SelectionSet {
+    type Error = FromError;
+
+    fn try_from(node: ast::SelectionSet) -> Result<Self, Self::Error> {
+        let selections = node.selections()
+            .map(|selection| selection.try_into())
+            .collect::<Result<Vec<_>, FromError>>()?;
+
+        Ok(Self::with_selections(selections))
+    }
+}

--- a/crates/apollo-encoder/src/lib.rs
+++ b/crates/apollo-encoder/src/lib.rs
@@ -25,6 +25,8 @@ mod ty;
 mod union_def;
 mod value;
 mod variable;
+#[cfg(feature = "from-parser")]
+mod from_parser;
 
 pub use argument::Argument;
 pub use argument::ArgumentsDefinition;

--- a/crates/apollo-encoder/src/lib.rs
+++ b/crates/apollo-encoder/src/lib.rs
@@ -25,7 +25,7 @@ mod ty;
 mod union_def;
 mod value;
 mod variable;
-#[cfg(feature = "from-parser")]
+#[cfg(feature = "apollo-parser")]
 mod from_parser;
 
 pub use argument::Argument;


### PR DESCRIPTION
Provides `TryFrom` impls for the apollo-encoder AST types.

The conversion effectively assumes that the apollo-parser AST is valid and complete. Otherwise you get an Err, but not a very useful one, because the TryFrom impl doesn't know anything about its parent (so we can't show source code where the error originated for example).

I put it behind a feature flag so apollo-encoder doesn't *have* to depend on apollo-parser, not sure if that is truly worth it, so i also enabled it by default 😛 .