### PR TITLE
fix(compiler): fix apollo-parser dependency version

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -17,7 +17,7 @@ categories = [
 edition = "2021"
 
 [dependencies]
-apollo-parser = { path = "../apollo-parser", apollo-parser = "0.2.11" }
+apollo-parser = { path = "../apollo-parser", version = "0.2.11" }
 rowan = "0.15.5"
 salsa = "0.16.1"
 uuid = { version = "1.1", features = ["serde", "v4"] }


### PR DESCRIPTION
I assume this was a typo. Caused warnings like:
```
warning: crates/apollo-compiler/Cargo.toml: unused manifest key: dependencies.apollo-parser.apollo-parser
```