### PR TITLE
chore(encoder): upgrade to apollo-parser@0.3.0

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -17,7 +17,7 @@ categories = [
 edition = "2021"
 
 [dependencies]
-apollo-parser = { path = "../apollo-parser", version = "0.3" }
+apollo-parser = { path = "../apollo-parser", version = "0.3.0" }
 rowan = "0.15.5"
 salsa = "0.16.1"
 uuid = { version = "1.1", features = ["serde", "v4"] }

--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -20,7 +20,7 @@ categories = [
 edition = "2021"
 
 [dependencies]
-apollo-parser = { version = "0.3", optional = true }
+apollo-parser = { version = "0.3.0", optional = true }
 thiserror = "1.0.37"
 
 [features]


### PR DESCRIPTION
uses `.source_string()` instead of the previously applicable `Display`