### PR TITLE
chore(apollo-rs): run cargo fmt check in CI's lint command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,9 @@ jobs:
       - run:
           name: Run cargo clippy
           command: cargo clippy --all-targets --all-features -- -D warnings && cargo clippy --benches
+      - run:
+          name: Run cargo fmt check
+          command: cargo fmt --all -- --check
 
   test:
     parameters:


### PR DESCRIPTION
What do we think? Is this going to be _very_ annoying?