### PR TITLE
docs(parser): example of modifying queries with parser + encoder

### DIFF
--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -20,7 +20,7 @@ categories = [
 edition = "2021"
 
 [dependencies]
-apollo-parser = { version = "0.3.0", optional = true }
+apollo-parser = { path = "../apollo-parser", version = "0.3.0", optional = true }
 thiserror = "1.0.37"
 
 [features]

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -21,7 +21,7 @@ rowan = "0.15.5"
 
 [dev-dependencies]
 miette = { version = "3.2.0", features = ["fancy"] }
-apollo-encoder = { version = "0.3.3", features = ["apollo-parser"] }
+apollo-encoder = { path = "../apollo-encoder", version = "0.3.3", features = ["apollo-parser"] }
 anyhow = "1.0.66"
 thiserror = "1.0.30"
 pretty_assertions = "0.7.1"

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -21,6 +21,8 @@ rowan = "0.15.5"
 
 [dev-dependencies]
 miette = { version = "3.2.0", features = ["fancy"] }
+apollo-encoder = { version = "0.3.3", features = ["apollo-parser"] }
+anyhow = "1.0.66"
 thiserror = "1.0.30"
 pretty_assertions = "0.7.1"
 annotate-snippets = "0.9.1"

--- a/crates/apollo-parser/examples/modify_query_using_parser_and_encoder.rs
+++ b/crates/apollo-parser/examples/modify_query_using_parser_and_encoder.rs
@@ -1,0 +1,95 @@
+use apollo_encoder::{self, Document, Field, OperationDefinition, Selection, SelectionSet};
+use apollo_parser::{
+    ast::{self, AstNode},
+    Parser,
+};
+
+use anyhow::Result;
+
+fn merge_queries() -> Result<Document> {
+    let query = r"#
+    query LaunchSite {
+      launches {
+        launches {
+          id
+          site
+        }
+      }
+    }
+
+    query AstronautInfo {
+      user
+      me
+    }
+    #";
+
+    let parser = Parser::new(query);
+    let ast = parser.parse();
+    assert_eq!(ast.errors().len(), 0);
+
+    let doc = ast.document();
+
+    let new_query = apollo_encoder::Document::new();
+    for def in doc.definitions() {
+        // We want to combine all of our operations into a single one.
+        if let ast::Definition::OperationDefinition(op) = def {
+            let sel_set: ast::SelectionSet = op.selection_set().unwrap();
+            let selection_set: SelectionSet = sel_set.try_into()?;
+        }
+    }
+
+    Ok(new_query)
+}
+
+fn omitted_fields() -> Result<Document> {
+    let query = r"#
+    query Products{
+      isbn @omitted
+      title
+      year @omitted
+      metadata @omitted
+      reviews
+    }
+
+    #";
+
+    let parser = Parser::new(query);
+    let ast = parser.parse();
+    assert_eq!(ast.errors().len(), 0);
+
+    let doc = ast.document();
+
+    let new_query = apollo_encoder::Document::new();
+    for def in doc.definitions() {
+        // We want to combine all of our operations into a single one.
+        if let ast::Definition::OperationDefinition(op) = def {
+            let selection_set = SelectionSet::new();
+            for selection in op.selection_set().unwrap().selections() {
+                if let ast::Selection::Field(field) = selection {
+                    let incl = field
+                        .directives()
+                        .unwrap()
+                        .directives()
+                        .into_iter()
+                        .filter(|d| d.name().unwrap().source_string() != "omitted");
+                    incl.for_each(|f| selection_set.selection(Selection::Field(field.try_into()?)));
+                } else {
+                    selection_set.selection(selection.try_into()?)
+                }
+            }
+            let op_def =
+                OperationDefinition::new(op.operation_type().unwrap().try_into()?, selection_set);
+        }
+    }
+
+    Ok(new_query)
+}
+
+fn main() -> Result<()> {
+    let merged = merge_queries()?;
+    println!("{}", merged);
+
+    let omitted_fields = omitted_fields()?;
+
+    Ok(())
+}

--- a/crates/apollo-parser/examples/modify_query_using_parser_and_encoder.rs
+++ b/crates/apollo-parser/examples/modify_query_using_parser_and_encoder.rs
@@ -1,7 +1,4 @@
-use apollo_parser::{
-    ast::{self, AstNode},
-    Parser,
-};
+use apollo_parser::{ast, Parser};
 
 use anyhow::Result;
 
@@ -84,7 +81,9 @@ fn omitted_fields() -> Result<apollo_encoder::Document> {
             for selection in op.selection_set().unwrap().selections() {
                 if let ast::Selection::Field(field) = selection {
                     if let Some(dir) = field.directives() {
-                        let omit = dir.directives().any(|dir| dir.name().unwrap().text() == "omitted");
+                        let omit = dir
+                            .directives()
+                            .any(|dir| dir.name().unwrap().text() == "omitted");
                         if !omit {
                             selection_set.selection(apollo_encoder::Selection::Field(
                                 field.clone().try_into()?,

--- a/crates/apollo-parser/examples/modify_query_using_parser_and_encoder.rs
+++ b/crates/apollo-parser/examples/modify_query_using_parser_and_encoder.rs
@@ -5,7 +5,7 @@ use apollo_parser::{
 
 use anyhow::Result;
 
-// This exampel merges the two operation definitions into a single one.
+// This example merges the two operation definitions into a single one.
 fn merge_queries() -> Result<apollo_encoder::Document> {
     let query = r"#
     query LaunchSite {
@@ -84,12 +84,11 @@ fn omitted_fields() -> Result<apollo_encoder::Document> {
             for selection in op.selection_set().unwrap().selections() {
                 if let ast::Selection::Field(field) = selection {
                     if let Some(dir) = field.directives() {
-                        for dir in dir.directives() {
-                            if dir.name().unwrap().source_string() != "omitted" {
-                                selection_set.selection(apollo_encoder::Selection::Field(
-                                    field.clone().try_into()?,
-                                ))
-                            }
+                        let omit = dir.directives().any(|dir| dir.name().unwrap().text() == "omitted");
+                        if !omit {
+                            selection_set.selection(apollo_encoder::Selection::Field(
+                                field.clone().try_into()?,
+                            ))
                         }
                     } else {
                         selection_set.selection(apollo_encoder::Selection::Field(field.try_into()?))


### PR DESCRIPTION
A few folks have been trying to modify/generate new schemas and queries using the AST provided with the parser. Given changes in #329, it's a bit easier generating SDL with the encoder using `ast_type.try_from()?`. 

This example outlines two possible modifications:
- merging two queries
- omitting certain fields in a query.