### PR TITLE
chore(parser): use `eat` in a loop instead of recursing `bump`

### DIFF
--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -140,13 +140,13 @@ impl<'a> Parser<'a> {
         while let Some(TokenKind::Comment | TokenKind::Whitespace | TokenKind::Comma) = self.peek()
         {
             if let Some(TokenKind::Comment) = self.peek() {
-                self.bump(SyntaxKind::COMMENT);
+                self.eat(SyntaxKind::COMMENT);
             }
             if let Some(TokenKind::Whitespace) = self.peek() {
-                self.bump(SyntaxKind::WHITESPACE);
+                self.eat(SyntaxKind::WHITESPACE);
             }
             if let Some(TokenKind::Comma) = self.peek() {
-                self.bump(SyntaxKind::COMMA);
+                self.eat(SyntaxKind::COMMA);
             }
         }
     }


### PR DESCRIPTION
A little simplification 😇 

We're inside `bump_ignored()` here, and `bump()` calls `bump_ignored()` again internally. So this loop didn't really do a lot: we end up doing just one iteration in the loop and recursing into `bump_ignored()` again to eat the next token.

Using `eat()` here is equivalent but without the recursion.