### PR TITLE
Fix injected `@include` directive locations to match spec

### DIFF
--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -1346,7 +1346,7 @@ fn include_directive() -> DirectiveDefinition {
         repeatable: false,
         directive_locations: Arc::new(vec![
             DirectiveLocation::Field,
-            DirectiveLocation::FragmentDefinition,
+            DirectiveLocation::FragmentSpread,
             DirectiveLocation::InlineFragment,
         ]),
         ast_ptr: None


### PR DESCRIPTION
Directive locations for the `@include` directive should include FragmentSpread as a location and not FragmentDefinition. Updating injected directive to match expectation.