### PR TITLE
feat(parser,smith): make the conversions to native types fallible

### DIFF
--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -940,9 +940,10 @@ fn value(val: ast::Value) -> Value {
             ast_ptr: SyntaxNodePtr::new(var.syntax()),
         }),
         ast::Value::StringValue(string_val) => Value::String(string_val.into()),
-        ast::Value::FloatValue(float) => Value::Float(Float::new(float.into())),
-        ast::Value::IntValue(int) => Value::Int(int.into()),
-        ast::Value::BooleanValue(bool) => Value::Boolean(bool.into()),
+        // TODO(@goto-bus-stop) do not unwrap
+        ast::Value::FloatValue(float) => Value::Float(Float::new(float.try_into().unwrap())),
+        ast::Value::IntValue(int) => Value::Int(int.try_into().unwrap()),
+        ast::Value::BooleanValue(bool) => Value::Boolean(bool.try_into().unwrap()),
         ast::Value::NullValue(_) => Value::Null,
         ast::Value::EnumValue(enum_) => Value::Enum(name(enum_.name())),
         ast::Value::ListValue(list) => {

--- a/crates/apollo-encoder/src/from_parser.rs
+++ b/crates/apollo-encoder/src/from_parser.rs
@@ -1067,7 +1067,7 @@ impl TryFrom<ast::InputObjectTypeDefinition> for crate::InputObjectDefinition {
         let description = node
             .description()
             .and_then(|description| description.string_value())
-            .map(|string| string.into());
+            .and_then(|string| string.try_into().ok());
         if let Some(description) = description {
             encoder_node.description(description);
         }

--- a/crates/apollo-parser/CHANGELOG.md
+++ b/crates/apollo-parser/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `apollo-parser` will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- # [x.x.x] (unreleased) - 2021-mm-dd
+<!-- # [x.x.x] (unreleased) - 2022-mm-dd
 
 > Important: X breaking changes below, indicated by **BREAKING**
 
@@ -17,6 +17,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 ## Documentation -->
+
+# [x.x.x] (unreleased) - 2022-mm-dd
+## BREAKING
+- **make conversions from GraphQL Values to Rust types fallible - [goto-bus-stop], [pull/xyz] fixing [issue/358]**
+
+  In the past you could do:
+  ```rust
+  let graphql_value: IntValue = get_a_value();
+  let x: i32 = graphql_value.into();
+  ```
+  But this `.into()` implementation could panic if the number was out of range.
+  Now, this conversion is implemented with the `TryFrom` trait, so you handle out-of-range errors however you want:
+  ```rust
+  let graphql_value: IntValue = get_a_value();
+  let x: i32 = graphql_value.try_into()?;
+  ```
+
+  [goto-bus-stop]: https://github.com/goto-bus-stop
+  [pull/xyz]: https://github.com/apollographql/apollo-rs/pull/xyz
+  [issue/358]: https://github.com/apollographql/apollo-rs/pull/358
+
 # [0.3.2](https://crates.io/crates/apollo-parser/0.3.2) - 2022-11-15
 ## Fixes
 - **lexing escaped and unicode characters in block strings - [lrlna], [pull/357] fixing [issue/341], [issue/342], [issue/343]**

--- a/crates/apollo-parser/CHANGELOG.md
+++ b/crates/apollo-parser/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 # [x.x.x] (unreleased) - 2022-mm-dd
 ## BREAKING
-- **make conversions from GraphQL Values to Rust types fallible - [goto-bus-stop], [pull/xyz] fixing [issue/358]**
+- **make conversions from GraphQL Values to Rust types fallible - [goto-bus-stop], [pull/371] fixing [issue/358]**
 
   In the past you could do:
   ```rust
@@ -34,8 +34,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   let x: i32 = graphql_value.try_into()?;
   ```
 
-  [goto-bus-stop]: https://github.com/goto-bus-stop
-  [pull/xyz]: https://github.com/apollographql/apollo-rs/pull/xyz
+  [goto-bus-stop]: https://github.com/goto-bus-stop 
+  [pull/371]: https://github.com/apollographql/apollo-rs/pull/371
   [issue/358]: https://github.com/apollographql/apollo-rs/pull/358
 
 # [0.3.2](https://crates.io/crates/apollo-parser/0.3.2) - 2022-11-15

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -26,7 +26,6 @@ apollo-encoder = { path = "../apollo-encoder", version = "0.3.3", features = [
     "apollo-parser",
 ] }
 anyhow = "1.0.66"
-thiserror = "1.0.30"
 pretty_assertions = "0.7.1"
 annotate-snippets = "0.9.1"
 expect-test = "1.1"

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -1,6 +1,7 @@
 use rowan::{GreenToken, SyntaxKind};
 
 use crate::{ast, ast::AstNode, SyntaxNode, TokenText};
+use std::num::{ParseFloatError, ParseIntError};
 
 impl ast::Name {
     pub fn text(&self) -> TokenText {
@@ -91,8 +92,6 @@ impl From<&'_ ast::StringValue> for String {
             .to_string()
     }
 }
-
-use std::num::{ParseIntError, ParseFloatError};
 
 impl TryFrom<ast::IntValue> for i32 {
     type Error = ParseIntError;

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -92,42 +92,73 @@ impl From<&'_ ast::StringValue> for String {
     }
 }
 
-impl From<ast::IntValue> for i32 {
-    fn from(val: ast::IntValue) -> Self {
-        Self::from(&val)
+use std::num::{ParseIntError, ParseFloatError};
+
+impl TryFrom<ast::IntValue> for i32 {
+    type Error = ParseIntError;
+
+    fn try_from(val: ast::IntValue) -> Result<Self, Self::Error> {
+        Self::try_from(&val)
     }
 }
 
-impl From<&'_ ast::IntValue> for i32 {
-    fn from(val: &'_ ast::IntValue) -> Self {
+impl TryFrom<&'_ ast::IntValue> for i32 {
+    type Error = ParseIntError;
+
+    fn try_from(val: &'_ ast::IntValue) -> Result<Self, Self::Error> {
         let text = text_of_first_token(val.syntax());
-        text.parse().expect("Cannot parse IntValue")
+        text.parse()
     }
 }
 
-impl From<ast::FloatValue> for f64 {
-    fn from(val: ast::FloatValue) -> Self {
-        Self::from(&val)
+impl TryFrom<ast::IntValue> for f64 {
+    type Error = ParseFloatError;
+
+    fn try_from(val: ast::IntValue) -> Result<Self, Self::Error> {
+        Self::try_from(&val)
     }
 }
 
-impl From<&'_ ast::FloatValue> for f64 {
-    fn from(val: &'_ ast::FloatValue) -> Self {
+impl TryFrom<&'_ ast::IntValue> for f64 {
+    type Error = ParseFloatError;
+
+    fn try_from(val: &'_ ast::IntValue) -> Result<Self, Self::Error> {
         let text = text_of_first_token(val.syntax());
-        text.parse().expect("Cannot parse FloatValue")
+        text.parse()
     }
 }
 
-impl From<ast::BooleanValue> for bool {
-    fn from(val: ast::BooleanValue) -> Self {
-        Self::from(&val)
+impl TryFrom<ast::FloatValue> for f64 {
+    type Error = ParseFloatError;
+
+    fn try_from(val: ast::FloatValue) -> Result<Self, Self::Error> {
+        Self::try_from(&val)
     }
 }
 
-impl From<&'_ ast::BooleanValue> for bool {
-    fn from(val: &'_ ast::BooleanValue) -> Self {
+impl TryFrom<&'_ ast::FloatValue> for f64 {
+    type Error = ParseFloatError;
+
+    fn try_from(val: &'_ ast::FloatValue) -> Result<Self, Self::Error> {
         let text = text_of_first_token(val.syntax());
-        text.parse().expect("Cannot parse BooleanValue")
+        text.parse()
+    }
+}
+
+impl TryFrom<ast::BooleanValue> for bool {
+    type Error = std::str::ParseBoolError;
+
+    fn try_from(val: ast::BooleanValue) -> Result<Self, Self::Error> {
+        Self::try_from(&val)
+    }
+}
+
+impl TryFrom<&'_ ast::BooleanValue> for bool {
+    type Error = std::str::ParseBoolError;
+
+    fn try_from(val: &'_ ast::BooleanValue) -> Result<Self, Self::Error> {
+        let text = text_of_first_token(val.syntax());
+        text.parse()
     }
 }
 

--- a/crates/apollo-parser/src/parser/grammar/value.rs
+++ b/crates/apollo-parser/src/parser/grammar/value.rs
@@ -206,7 +206,7 @@ enum Test @dir__one(int_value: -10) {
                         if let ast::Value::IntValue(val) =
                             argument.value().expect("Cannot get argument value.")
                         {
-                            let i: i32 = val.into();
+                            let i: i32 = val.try_into().unwrap();
                             assert_eq!(i, -10);
                         }
                     }
@@ -237,7 +237,7 @@ enum Test @dir__one(float_value: -1.123E4) {
                         if let ast::Value::FloatValue(val) =
                             argument.value().expect("Cannot get argument value.")
                         {
-                            let f: f64 = val.into();
+                            let f: f64 = val.try_into().unwrap();
                             assert_eq!(f, -1.123E4);
                         }
                     }
@@ -265,7 +265,7 @@ enum Test @dir__one(bool_value: false) {
                         if let ast::Value::BooleanValue(val) =
                             argument.value().expect("Cannot get argument value.")
                         {
-                            let b: bool = val.into();
+                            let b: bool = val.try_into().unwrap();
                             assert!(!b);
                         }
                     }

--- a/crates/apollo-smith/CHANGELOG.md
+++ b/crates/apollo-smith/CHANGELOG.md
@@ -18,6 +18,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 ## Documentation -->
+# [x.x.x] (unreleased) - 2022-mm-dd
+
+## BREAKING
+- **make conversions from apollo-parser types fallible - [goto-bus-stop], [pull/371]**
+
+  The `parser-impl` feature flag contains conversion code from apollo-parser AST node types
+  to apollo-smith types. With this change, those conversions now use the `TryFrom` trait
+  instead of the `From` trait, and return errors instead of panicking.
+
+  You now have to use the `try_from()` and `try_into()` methods instead of `from()` and
+  `into()`.
+
+  [goto-bus-stop]: https://github.com/goto-bus-stop
+  [pull/371]: https://github.com/apollographql/apollo-rs/pull/371
+
 # [0.2.0](https://crates.io/crates/apollo-smith/0.2.0) - 2022-11-08
 
 ## BREAKING

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -28,6 +28,7 @@ apollo-encoder = { path = "../apollo-encoder", version = "0.3.4" }
 apollo-parser = { path = "../apollo-parser", version = "0.3.1", optional = true }
 arbitrary = { version = "1.0.3", features = ["derive"] }
 once_cell = "1.9.0"
+thiserror = "1.0.37"
 
 [features]
 parser-impl = ["apollo-parser"]

--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -31,14 +31,16 @@ impl From<ArgumentsDef> for apollo_encoder::ArgumentsDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::ArgumentsDefinition> for ArgumentsDef {
-    fn from(args_def: apollo_parser::ast::ArgumentsDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::ArgumentsDefinition> for ArgumentsDef {
+    type Error = crate::FromError;
+
+    fn try_from(args_def: apollo_parser::ast::ArgumentsDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             input_value_definitions: args_def
                 .input_value_definitions()
-                .map(InputValueDef::from)
-                .collect(),
-        }
+                .map(InputValueDef::try_from)
+                .collect::<Result<_, _>>()?,
+        })
     }
 }
 
@@ -61,12 +63,14 @@ impl From<Argument> for apollo_encoder::Argument {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::Argument> for Argument {
-    fn from(argument: apollo_parser::ast::Argument) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::Argument> for Argument {
+    type Error = crate::FromError;
+
+    fn try_from(argument: apollo_parser::ast::Argument) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: argument.name().unwrap().into(),
-            value: argument.value().unwrap().into(),
-        }
+            value: argument.value().unwrap().try_into()?,
+        })
     }
 }
 

--- a/crates/apollo-smith/src/directive.rs
+++ b/crates/apollo-smith/src/directive.rs
@@ -49,15 +49,17 @@ impl From<DirectiveDef> for apollo_encoder::DirectiveDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::DirectiveDefinition> for DirectiveDef {
-    fn from(directive_def: apollo_parser::ast::DirectiveDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::DirectiveDefinition> for DirectiveDef {
+    type Error = crate::FromError;
+
+    fn try_from(directive_def: apollo_parser::ast::DirectiveDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             description: directive_def
                 .description()
                 .and_then(|d| d.string_value())
                 .map(|s| Description::from(Into::<String>::into(s))),
             name: directive_def.name().unwrap().into(),
-            arguments_definition: directive_def.arguments_definition().map(ArgumentsDef::from),
+            arguments_definition: directive_def.arguments_definition().map(ArgumentsDef::try_from).transpose()?,
             repeatable: directive_def.repeatable_token().is_some(),
             directive_locations: directive_def
                 .directive_locations()
@@ -67,7 +69,7 @@ impl From<apollo_parser::ast::DirectiveDefinition> for DirectiveDef {
                         .collect()
                 })
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 
@@ -96,15 +98,27 @@ impl From<Directive> for apollo_encoder::Directive {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::Directive> for Directive {
-    fn from(directive: apollo_parser::ast::Directive) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::Directive> for Directive {
+    type Error = crate::FromError;
+
+    fn try_from(directive: apollo_parser::ast::Directive) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: directive.name().unwrap().into(),
             arguments: directive
                 .arguments()
-                .map(|args| args.arguments().map(Argument::from).collect())
+                .map(|args| args.arguments().map(Argument::try_from).collect::<Result<_, _>>())
+                .transpose()?
                 .unwrap_or_default(),
-        }
+        })
+    }
+}
+
+#[cfg(feature = "parser-impl")]
+impl Directive {
+    pub(crate) fn convert_directives(directives: apollo_parser::ast::Directives) -> Result<HashMap<Name, Directive>, crate::FromError> {
+        directives.directives()
+            .map(|d| Ok((d.name().unwrap().into(), Directive::try_from(d)?)))
+            .collect()
     }
 }
 

--- a/crates/apollo-smith/src/document.rs
+++ b/crates/apollo-smith/src/document.rs
@@ -74,8 +74,10 @@ impl From<Document> for apollo_encoder::Document {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::Document> for Document {
-    fn from(doc: apollo_parser::ast::Document) -> Self {
+impl TryFrom<apollo_parser::ast::Document> for Document {
+    type Error = crate::FromError;
+
+    fn try_from(doc: apollo_parser::ast::Document) -> Result<Self, Self::Error> {
         let mut enum_defs = Vec::new();
         let mut object_defs = Vec::new();
         let mut schema_def = None;
@@ -90,60 +92,60 @@ impl From<apollo_parser::ast::Document> for Document {
         for definition in doc.definitions() {
             match definition {
                 apollo_parser::ast::Definition::EnumTypeDefinition(enum_def) => {
-                    enum_defs.push(EnumTypeDef::from(enum_def));
+                    enum_defs.push(EnumTypeDef::try_from(enum_def)?);
                 }
                 apollo_parser::ast::Definition::EnumTypeExtension(enum_def) => {
-                    enum_defs.push(EnumTypeDef::from(enum_def));
+                    enum_defs.push(EnumTypeDef::try_from(enum_def)?);
                 }
                 apollo_parser::ast::Definition::ObjectTypeDefinition(obj_def) => {
-                    object_defs.push(ObjectTypeDef::from(obj_def));
+                    object_defs.push(ObjectTypeDef::try_from(obj_def)?);
                 }
                 apollo_parser::ast::Definition::ObjectTypeExtension(obj_def) => {
-                    object_defs.push(ObjectTypeDef::from(obj_def));
+                    object_defs.push(ObjectTypeDef::try_from(obj_def)?);
                 }
                 apollo_parser::ast::Definition::SchemaDefinition(schema_definition) => {
-                    schema_def = Some(SchemaDef::from(schema_definition));
+                    schema_def = Some(SchemaDef::try_from(schema_definition)?);
                 }
                 apollo_parser::ast::Definition::SchemaExtension(schema_definition) => {
-                    schema_def = Some(SchemaDef::from(schema_definition));
+                    schema_def = Some(SchemaDef::try_from(schema_definition)?);
                 }
                 apollo_parser::ast::Definition::DirectiveDefinition(dir_def) => {
-                    directive_defs.push(DirectiveDef::from(dir_def));
+                    directive_defs.push(DirectiveDef::try_from(dir_def)?);
                 }
                 apollo_parser::ast::Definition::ScalarTypeDefinition(scalar_def) => {
-                    scalar_defs.push(ScalarTypeDef::from(scalar_def))
+                    scalar_defs.push(ScalarTypeDef::try_from(scalar_def)?)
                 }
                 apollo_parser::ast::Definition::ScalarTypeExtension(scalar_def) => {
-                    scalar_defs.push(ScalarTypeDef::from(scalar_def))
+                    scalar_defs.push(ScalarTypeDef::try_from(scalar_def)?)
                 }
                 apollo_parser::ast::Definition::OperationDefinition(operation_def) => {
-                    operation_defs.push(OperationDef::from(operation_def))
+                    operation_defs.push(OperationDef::try_from(operation_def)?)
                 }
                 apollo_parser::ast::Definition::InterfaceTypeDefinition(interface_def) => {
-                    interface_defs.push(InterfaceTypeDef::from(interface_def))
+                    interface_defs.push(InterfaceTypeDef::try_from(interface_def)?)
                 }
                 apollo_parser::ast::Definition::InterfaceTypeExtension(interface_def) => {
-                    interface_defs.push(InterfaceTypeDef::from(interface_def))
+                    interface_defs.push(InterfaceTypeDef::try_from(interface_def)?)
                 }
                 apollo_parser::ast::Definition::UnionTypeDefinition(union_def) => {
-                    union_defs.push(UnionTypeDef::from(union_def))
+                    union_defs.push(UnionTypeDef::try_from(union_def)?)
                 }
                 apollo_parser::ast::Definition::UnionTypeExtension(union_def) => {
-                    union_defs.push(UnionTypeDef::from(union_def))
+                    union_defs.push(UnionTypeDef::try_from(union_def)?)
                 }
                 apollo_parser::ast::Definition::InputObjectTypeDefinition(input_object_def) => {
-                    input_object_defs.push(InputObjectTypeDef::from(input_object_def))
+                    input_object_defs.push(InputObjectTypeDef::try_from(input_object_def)?)
                 }
                 apollo_parser::ast::Definition::InputObjectTypeExtension(input_object_def) => {
-                    input_object_defs.push(InputObjectTypeDef::from(input_object_def))
+                    input_object_defs.push(InputObjectTypeDef::try_from(input_object_def)?)
                 }
                 apollo_parser::ast::Definition::FragmentDefinition(fragment_def) => {
-                    fragment_defs.push(FragmentDef::from(fragment_def))
+                    fragment_defs.push(FragmentDef::try_from(fragment_def)?)
                 }
             }
         }
 
-        Self {
+        Ok(Self {
             operation_definitions: operation_defs,
             fragment_definitions: fragment_defs,
             schema_definition: schema_def,
@@ -154,7 +156,7 @@ impl From<apollo_parser::ast::Document> for Document {
             enum_type_definitions: enum_defs,
             input_object_type_definitions: input_object_defs,
             directive_definitions: directive_defs,
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/enum_.rs
+++ b/crates/apollo-smith/src/enum_.rs
@@ -133,7 +133,9 @@ impl From<EnumValueDefinition> for EnumValue {
 impl TryFrom<apollo_parser::ast::EnumValueDefinition> for EnumValueDefinition {
     type Error = crate::FromError;
 
-    fn try_from(enum_value_def: apollo_parser::ast::EnumValueDefinition) -> Result<Self, Self::Error> {
+    fn try_from(
+        enum_value_def: apollo_parser::ast::EnumValueDefinition,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             description: enum_value_def.description().map(Description::from),
             value: enum_value_def

--- a/crates/apollo-smith/src/enum_.rs
+++ b/crates/apollo-smith/src/enum_.rs
@@ -51,9 +51,11 @@ impl From<EnumTypeDef> for EnumDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::EnumTypeDefinition> for EnumTypeDef {
-    fn from(enum_def: apollo_parser::ast::EnumTypeDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::EnumTypeDefinition> for EnumTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(enum_def: apollo_parser::ast::EnumTypeDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             description: enum_def
                 .description()
                 .and_then(|d| d.string_value())
@@ -61,45 +63,41 @@ impl From<apollo_parser::ast::EnumTypeDefinition> for EnumTypeDef {
             name: enum_def.name().unwrap().into(),
             directives: enum_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             enum_values_def: enum_def
                 .enum_values_definition()
                 .expect("must have enum values definition")
                 .enum_value_definitions()
-                .map(EnumValueDefinition::from)
-                .collect(),
+                .map(EnumValueDefinition::try_from)
+                .collect::<Result<_, _>>()?,
             extend: false,
-        }
+        })
     }
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::EnumTypeExtension> for EnumTypeDef {
-    fn from(enum_def: apollo_parser::ast::EnumTypeExtension) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::EnumTypeExtension> for EnumTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(enum_def: apollo_parser::ast::EnumTypeExtension) -> Result<Self, Self::Error> {
+        Ok(Self {
             description: None,
             name: enum_def.name().unwrap().into(),
             directives: enum_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             enum_values_def: enum_def
                 .enum_values_definition()
                 .expect("must have enum values definition")
                 .enum_value_definitions()
-                .map(EnumValueDefinition::from)
-                .collect(),
+                .map(EnumValueDefinition::try_from)
+                .collect::<Result<_, _>>()?,
             extend: true,
-        }
+        })
     }
 }
 
@@ -132,9 +130,11 @@ impl From<EnumValueDefinition> for EnumValue {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::EnumValueDefinition> for EnumValueDefinition {
-    fn from(enum_value_def: apollo_parser::ast::EnumValueDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::EnumValueDefinition> for EnumValueDefinition {
+    type Error = crate::FromError;
+
+    fn try_from(enum_value_def: apollo_parser::ast::EnumValueDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             description: enum_value_def.description().map(Description::from),
             value: enum_value_def
                 .enum_value()
@@ -144,13 +144,10 @@ impl From<apollo_parser::ast::EnumValueDefinition> for EnumValueDefinition {
                 .into(),
             directives: enum_value_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/field.rs
+++ b/crates/apollo-smith/src/field.rs
@@ -47,25 +47,24 @@ impl From<FieldDef> for apollo_encoder::FieldDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::FieldDefinition> for FieldDef {
-    fn from(field_def: apollo_parser::ast::FieldDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::FieldDefinition> for FieldDef {
+    type Error = crate::FromError;
+
+    fn try_from(field_def: apollo_parser::ast::FieldDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             description: field_def.description().map(Description::from),
             name: field_def
                 .name()
                 .expect("field definition must have a name")
                 .into(),
-            arguments_definition: field_def.arguments_definition().map(ArgumentsDef::from),
+            arguments_definition: field_def.arguments_definition().map(ArgumentsDef::try_from).transpose()?,
             ty: field_def.ty().unwrap().into(),
             directives: field_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 
@@ -103,25 +102,25 @@ impl From<Field> for apollo_encoder::Field {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::Field> for Field {
-    fn from(field: apollo_parser::ast::Field) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::Field> for Field {
+    type Error = crate::FromError;
+
+    fn try_from(field: apollo_parser::ast::Field) -> Result<Self, Self::Error> {
+        Ok(Self {
             alias: field.alias().map(|alias| alias.name().unwrap().into()),
             name: field.name().unwrap().into(),
             args: field
                 .arguments()
-                .map(|arguments| arguments.arguments().map(Argument::from).collect())
+                .map(|arguments| arguments.arguments().map(Argument::try_from).collect::<Result<_, _>>())
+                .transpose()?
                 .unwrap_or_default(),
             directives: field
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
-            selection_set: field.selection_set().map(SelectionSet::from),
-        }
+            selection_set: field.selection_set().map(SelectionSet::try_from).transpose()?,
+        })
     }
 }
 

--- a/crates/apollo-smith/src/field.rs
+++ b/crates/apollo-smith/src/field.rs
@@ -57,7 +57,10 @@ impl TryFrom<apollo_parser::ast::FieldDefinition> for FieldDef {
                 .name()
                 .expect("field definition must have a name")
                 .into(),
-            arguments_definition: field_def.arguments_definition().map(ArgumentsDef::try_from).transpose()?,
+            arguments_definition: field_def
+                .arguments_definition()
+                .map(ArgumentsDef::try_from)
+                .transpose()?,
             ty: field_def.ty().unwrap().into(),
             directives: field_def
                 .directives()
@@ -111,7 +114,12 @@ impl TryFrom<apollo_parser::ast::Field> for Field {
             name: field.name().unwrap().into(),
             args: field
                 .arguments()
-                .map(|arguments| arguments.arguments().map(Argument::try_from).collect::<Result<_, _>>())
+                .map(|arguments| {
+                    arguments
+                        .arguments()
+                        .map(Argument::try_from)
+                        .collect::<Result<_, _>>()
+                })
                 .transpose()?
                 .unwrap_or_default(),
             directives: field
@@ -119,7 +127,10 @@ impl TryFrom<apollo_parser::ast::Field> for Field {
                 .map(Directive::convert_directives)
                 .transpose()?
                 .unwrap_or_default(),
-            selection_set: field.selection_set().map(SelectionSet::try_from).transpose()?,
+            selection_set: field
+                .selection_set()
+                .map(SelectionSet::try_from)
+                .transpose()?,
         })
     }
 }

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -41,21 +41,20 @@ impl From<FragmentDef> for apollo_encoder::FragmentDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::FragmentDefinition> for FragmentDef {
-    fn from(fragment_def: apollo_parser::ast::FragmentDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::FragmentDefinition> for FragmentDef {
+    type Error = crate::FromError;
+
+    fn try_from(fragment_def: apollo_parser::ast::FragmentDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: fragment_def.fragment_name().unwrap().name().unwrap().into(),
             directives: fragment_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             type_condition: fragment_def.type_condition().unwrap().into(),
-            selection_set: fragment_def.selection_set().unwrap().into(),
-        }
+            selection_set: fragment_def.selection_set().unwrap().try_into()?,
+        })
     }
 }
 
@@ -84,9 +83,11 @@ impl From<FragmentSpread> for apollo_encoder::FragmentSpread {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::FragmentSpread> for FragmentSpread {
-    fn from(fragment_spread: apollo_parser::ast::FragmentSpread) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::FragmentSpread> for FragmentSpread {
+    type Error = crate::FromError;
+
+    fn try_from(fragment_spread: apollo_parser::ast::FragmentSpread) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: fragment_spread
                 .fragment_name()
                 .unwrap()
@@ -95,13 +96,10 @@ impl From<apollo_parser::ast::FragmentSpread> for FragmentSpread {
                 .into(),
             directives: fragment_spread
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 
@@ -132,23 +130,22 @@ impl From<InlineFragment> for apollo_encoder::InlineFragment {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::InlineFragment> for InlineFragment {
-    fn from(inline_fragment: apollo_parser::ast::InlineFragment) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::InlineFragment> for InlineFragment {
+    type Error = crate::FromError;
+
+    fn try_from(inline_fragment: apollo_parser::ast::InlineFragment) -> Result<Self, Self::Error> {
+        Ok(Self {
             directives: inline_fragment
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             selection_set: inline_fragment
                 .selection_set()
-                .map(SelectionSet::from)
-                .unwrap(),
+                .unwrap()
+                .try_into()?,
             type_condition: inline_fragment.type_condition().map(TypeCondition::from),
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -140,10 +140,7 @@ impl TryFrom<apollo_parser::ast::InlineFragment> for InlineFragment {
                 .map(Directive::convert_directives)
                 .transpose()?
                 .unwrap_or_default(),
-            selection_set: inline_fragment
-                .selection_set()
-                .unwrap()
-                .try_into()?,
+            selection_set: inline_fragment.selection_set().unwrap().try_into()?,
             type_condition: inline_fragment.type_condition().map(TypeCondition::from),
         })
     }

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -58,7 +58,9 @@ impl From<InputObjectTypeDef> for apollo_encoder::InputObjectDefinition {
 impl TryFrom<apollo_parser::ast::InputObjectTypeDefinition> for InputObjectTypeDef {
     type Error = crate::FromError;
 
-    fn try_from(input_object: apollo_parser::ast::InputObjectTypeDefinition) -> Result<Self, Self::Error> {
+    fn try_from(
+        input_object: apollo_parser::ast::InputObjectTypeDefinition,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             name: input_object
                 .name()
@@ -89,7 +91,9 @@ impl TryFrom<apollo_parser::ast::InputObjectTypeDefinition> for InputObjectTypeD
 impl TryFrom<apollo_parser::ast::InputObjectTypeExtension> for InputObjectTypeDef {
     type Error = crate::FromError;
 
-    fn try_from(input_object: apollo_parser::ast::InputObjectTypeExtension) -> Result<Self, Self::Error> {
+    fn try_from(
+        input_object: apollo_parser::ast::InputObjectTypeExtension,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             name: input_object
                 .name()

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -55,9 +55,11 @@ impl From<InputObjectTypeDef> for apollo_encoder::InputObjectDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::InputObjectTypeDefinition> for InputObjectTypeDef {
-    fn from(input_object: apollo_parser::ast::InputObjectTypeDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::InputObjectTypeDefinition> for InputObjectTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(input_object: apollo_parser::ast::InputObjectTypeDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: input_object
                 .name()
                 .expect("object type definition must have a name")
@@ -65,11 +67,8 @@ impl From<apollo_parser::ast::InputObjectTypeDefinition> for InputObjectTypeDef 
             description: input_object.description().map(Description::from),
             directives: input_object
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             extend: false,
             fields: input_object
@@ -77,29 +76,29 @@ impl From<apollo_parser::ast::InputObjectTypeDefinition> for InputObjectTypeDef 
                 .map(|input_fields| {
                     input_fields
                         .input_value_definitions()
-                        .map(InputValueDef::from)
-                        .collect()
+                        .map(InputValueDef::try_from)
+                        .collect::<Result<_, _>>()
                 })
+                .transpose()?
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::InputObjectTypeExtension> for InputObjectTypeDef {
-    fn from(input_object: apollo_parser::ast::InputObjectTypeExtension) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::InputObjectTypeExtension> for InputObjectTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(input_object: apollo_parser::ast::InputObjectTypeExtension) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: input_object
                 .name()
                 .expect("object type definition must have a name")
                 .into(),
             directives: input_object
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             extend: true,
             fields: input_object
@@ -107,12 +106,13 @@ impl From<apollo_parser::ast::InputObjectTypeExtension> for InputObjectTypeDef {
                 .map(|input_fields| {
                     input_fields
                         .input_value_definitions()
-                        .map(InputValueDef::from)
-                        .collect()
+                        .map(InputValueDef::try_from)
+                        .collect::<Result<Vec<_>, crate::FromError>>()
                 })
+                .transpose()?
                 .unwrap_or_default(),
             description: None,
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -10,7 +10,6 @@ use crate::{
 use arbitrary::Result;
 
 #[derive(Debug, Clone, PartialEq)]
-
 pub enum InputValue {
     Variable(Name),
     Int(i32),
@@ -42,34 +41,39 @@ impl From<InputValue> for apollo_encoder::Value {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::DefaultValue> for InputValue {
-    fn from(default_val: apollo_parser::ast::DefaultValue) -> Self {
-        default_val.value().unwrap().into()
+impl TryFrom<apollo_parser::ast::DefaultValue> for InputValue {
+    type Error = crate::FromError;
+
+    fn try_from(default_val: apollo_parser::ast::DefaultValue) -> Result<Self, Self::Error> {
+        default_val.value().unwrap().try_into()
     }
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::Value> for InputValue {
-    fn from(value: apollo_parser::ast::Value) -> Self {
-        match value {
+impl TryFrom<apollo_parser::ast::Value> for InputValue {
+    type Error = crate::FromError;
+
+    fn try_from(value: apollo_parser::ast::Value) -> Result<Self, Self::Error> {
+        let smith_value = match value {
             apollo_parser::ast::Value::Variable(variable) => {
                 Self::Variable(variable.name().unwrap().into())
             }
             apollo_parser::ast::Value::StringValue(val) => Self::String(val.try_into().unwrap()),
-            apollo_parser::ast::Value::FloatValue(val) => Self::Float(val.try_into().unwrap()),
-            apollo_parser::ast::Value::IntValue(val) => Self::Int(val.try_into().unwrap()),
-            apollo_parser::ast::Value::BooleanValue(val) => Self::Boolean(val.try_into().unwrap()),
+            apollo_parser::ast::Value::FloatValue(val) => Self::Float(val.try_into()?),
+            apollo_parser::ast::Value::IntValue(val) => Self::Int(val.try_into()?),
+            apollo_parser::ast::Value::BooleanValue(val) => Self::Boolean(val.try_into()?),
             apollo_parser::ast::Value::NullValue(_val) => Self::Null,
             apollo_parser::ast::Value::EnumValue(val) => Self::Enum(val.name().unwrap().into()),
             apollo_parser::ast::Value::ListValue(val) => {
-                Self::List(val.values().map(Self::from).collect())
+                Self::List(val.values().map(Self::try_from).collect::<Result<Vec<_>, _>>()?)
             }
             apollo_parser::ast::Value::ObjectValue(val) => Self::Object(
                 val.object_fields()
-                    .map(|of| (of.name().unwrap().into(), of.value().unwrap().into()))
-                    .collect(),
-            ),
-        }
+                .map(|of| Ok((of.name().unwrap().into(), of.value().unwrap().try_into()?)))
+                .collect::<Result<Vec<_>, crate::FromError>>()?,
+                ),
+        };
+        Ok(smith_value)
     }
 }
 
@@ -135,22 +139,21 @@ impl From<InputValueDef> for apollo_encoder::InputValueDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::InputValueDefinition> for InputValueDef {
-    fn from(input_val_def: apollo_parser::ast::InputValueDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::InputValueDefinition> for InputValueDef {
+    type Error = crate::FromError;
+
+    fn try_from(input_val_def: apollo_parser::ast::InputValueDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             description: input_val_def.description().map(Description::from),
             name: input_val_def.name().unwrap().into(),
             ty: input_val_def.ty().unwrap().into(),
-            default_value: input_val_def.default_value().map(InputValue::from),
+            default_value: input_val_def.default_value().map(InputValue::try_from).transpose()?,
             directives: input_val_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -55,10 +55,10 @@ impl From<apollo_parser::ast::Value> for InputValue {
             apollo_parser::ast::Value::Variable(variable) => {
                 Self::Variable(variable.name().unwrap().into())
             }
-            apollo_parser::ast::Value::StringValue(val) => Self::String(val.into()),
-            apollo_parser::ast::Value::FloatValue(val) => Self::Float(val.into()),
-            apollo_parser::ast::Value::IntValue(val) => Self::Int(val.into()),
-            apollo_parser::ast::Value::BooleanValue(val) => Self::Boolean(val.into()),
+            apollo_parser::ast::Value::StringValue(val) => Self::String(val.try_into().unwrap()),
+            apollo_parser::ast::Value::FloatValue(val) => Self::Float(val.try_into().unwrap()),
+            apollo_parser::ast::Value::IntValue(val) => Self::Int(val.try_into().unwrap()),
+            apollo_parser::ast::Value::BooleanValue(val) => Self::Boolean(val.try_into().unwrap()),
             apollo_parser::ast::Value::NullValue(_val) => Self::Null,
             apollo_parser::ast::Value::EnumValue(val) => Self::Enum(val.name().unwrap().into()),
             apollo_parser::ast::Value::ListValue(val) => {

--- a/crates/apollo-smith/src/interface.rs
+++ b/crates/apollo-smith/src/interface.rs
@@ -58,7 +58,9 @@ impl From<InterfaceTypeDef> for InterfaceDefinition {
 impl TryFrom<apollo_parser::ast::InterfaceTypeDefinition> for InterfaceTypeDef {
     type Error = crate::FromError;
 
-    fn try_from(interface_def: apollo_parser::ast::InterfaceTypeDefinition) -> Result<Self, Self::Error> {
+    fn try_from(
+        interface_def: apollo_parser::ast::InterfaceTypeDefinition,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             name: interface_def
                 .name()
@@ -93,7 +95,9 @@ impl TryFrom<apollo_parser::ast::InterfaceTypeDefinition> for InterfaceTypeDef {
 impl TryFrom<apollo_parser::ast::InterfaceTypeExtension> for InterfaceTypeDef {
     type Error = crate::FromError;
 
-    fn try_from(interface_def: apollo_parser::ast::InterfaceTypeExtension) -> Result<Self, Self::Error> {
+    fn try_from(
+        interface_def: apollo_parser::ast::InterfaceTypeExtension,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             name: interface_def
                 .name()

--- a/crates/apollo-smith/src/interface.rs
+++ b/crates/apollo-smith/src/interface.rs
@@ -55,9 +55,11 @@ impl From<InterfaceTypeDef> for InterfaceDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::InterfaceTypeDefinition> for InterfaceTypeDef {
-    fn from(interface_def: apollo_parser::ast::InterfaceTypeDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::InterfaceTypeDefinition> for InterfaceTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(interface_def: apollo_parser::ast::InterfaceTypeDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: interface_def
                 .name()
                 .expect("object type definition must have a name")
@@ -65,19 +67,16 @@ impl From<apollo_parser::ast::InterfaceTypeDefinition> for InterfaceTypeDef {
             description: interface_def.description().map(Description::from),
             directives: interface_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             extend: false,
             fields_def: interface_def
                 .fields_definition()
                 .expect("object type definition must have fields definition")
                 .field_definitions()
-                .map(FieldDef::from)
-                .collect(),
+                .map(FieldDef::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
             interfaces: interface_def
                 .implements_interfaces()
                 .map(|itfs| {
@@ -86,14 +85,16 @@ impl From<apollo_parser::ast::InterfaceTypeDefinition> for InterfaceTypeDef {
                         .collect()
                 })
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::InterfaceTypeExtension> for InterfaceTypeDef {
-    fn from(interface_def: apollo_parser::ast::InterfaceTypeExtension) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::InterfaceTypeExtension> for InterfaceTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(interface_def: apollo_parser::ast::InterfaceTypeExtension) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: interface_def
                 .name()
                 .expect("object type definition must have a name")
@@ -101,19 +102,16 @@ impl From<apollo_parser::ast::InterfaceTypeExtension> for InterfaceTypeDef {
             description: None,
             directives: interface_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             extend: true,
             fields_def: interface_def
                 .fields_definition()
                 .expect("object type definition must have fields definition")
                 .field_definitions()
-                .map(FieldDef::from)
-                .collect(),
+                .map(FieldDef::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
             interfaces: interface_def
                 .implements_interfaces()
                 .map(|itfs| {
@@ -122,7 +120,7 @@ impl From<apollo_parser::ast::InterfaceTypeExtension> for InterfaceTypeDef {
                         .collect()
                 })
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -24,6 +24,19 @@ use std::{collections::HashMap, fmt::Debug};
 
 use arbitrary::Unstructured;
 
+#[cfg(feature = "parser-impl")]
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum FromError {
+    #[error("parse tree is missing a node")]
+    MissingNode,
+    #[error("invalid i32")]
+    ParseIntError(#[from] std::num::ParseIntError),
+    #[error("invalid f64")]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+    #[error("invalid boolean")]
+    ParseBoolError(#[from] std::str::ParseBoolError),
+}
+
 pub use arbitrary::Result;
 use argument::Argument;
 pub use directive::DirectiveDef;

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -51,26 +51,25 @@ impl From<OperationDef> for String {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::OperationDefinition> for OperationDef {
-    fn from(operation_def: apollo_parser::ast::OperationDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::OperationDefinition> for OperationDef {
+    type Error = crate::FromError;
+
+    fn try_from(operation_def: apollo_parser::ast::OperationDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: operation_def.name().map(Name::from),
             directives: operation_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             operation_type: operation_def
                 .operation_type()
                 .map(OperationType::from)
                 .unwrap_or(OperationType::Query),
             variable_definitions: Vec::new(),
-            selection_set: operation_def.selection_set().unwrap().into(),
+            selection_set: operation_def.selection_set().unwrap().try_into()?,
             shorthand: operation_def.operation_type().is_none(),
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -54,7 +54,9 @@ impl From<OperationDef> for String {
 impl TryFrom<apollo_parser::ast::OperationDefinition> for OperationDef {
     type Error = crate::FromError;
 
-    fn try_from(operation_def: apollo_parser::ast::OperationDefinition) -> Result<Self, Self::Error> {
+    fn try_from(
+        operation_def: apollo_parser::ast::OperationDefinition,
+    ) -> Result<Self, Self::Error> {
         Ok(Self {
             name: operation_def.name().map(Name::from),
             directives: operation_def

--- a/crates/apollo-smith/src/scalar.rs
+++ b/crates/apollo-smith/src/scalar.rs
@@ -43,9 +43,11 @@ impl From<ScalarTypeDef> for apollo_encoder::ScalarDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::ScalarTypeDefinition> for ScalarTypeDef {
-    fn from(scalar_def: apollo_parser::ast::ScalarTypeDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::ScalarTypeDefinition> for ScalarTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(scalar_def: apollo_parser::ast::ScalarTypeDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             description: scalar_def
                 .description()
                 .and_then(|d| d.string_value())
@@ -53,33 +55,29 @@ impl From<apollo_parser::ast::ScalarTypeDefinition> for ScalarTypeDef {
             name: scalar_def.name().unwrap().into(),
             directives: scalar_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             extend: false,
-        }
+        })
     }
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::ScalarTypeExtension> for ScalarTypeDef {
-    fn from(scalar_def: apollo_parser::ast::ScalarTypeExtension) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::ScalarTypeExtension> for ScalarTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(scalar_def: apollo_parser::ast::ScalarTypeExtension) -> Result<Self, Self::Error> {
+        Ok(Self {
             description: None,
             name: scalar_def.name().unwrap().into(),
             directives: scalar_def
                 .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             extend: true,
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/selection_set.rs
+++ b/crates/apollo-smith/src/selection_set.rs
@@ -31,11 +31,13 @@ impl From<SelectionSet> for apollo_encoder::SelectionSet {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::SelectionSet> for SelectionSet {
-    fn from(selection_set: apollo_parser::ast::SelectionSet) -> Self {
-        Self {
-            selections: selection_set.selections().map(Selection::from).collect(),
-        }
+impl TryFrom<apollo_parser::ast::SelectionSet> for SelectionSet {
+    type Error = crate::FromError;
+
+    fn try_from(selection_set: apollo_parser::ast::SelectionSet) -> Result<Self, Self::Error> {
+        Ok(Self {
+            selections: selection_set.selections().map(Selection::try_from).collect::<Result<_, _>>()?,
+        })
     }
 }
 
@@ -69,15 +71,17 @@ impl From<Selection> for apollo_encoder::Selection {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::Selection> for Selection {
-    fn from(selection: apollo_parser::ast::Selection) -> Self {
+impl TryFrom<apollo_parser::ast::Selection> for Selection {
+    type Error = crate::FromError;
+
+    fn try_from(selection: apollo_parser::ast::Selection) -> Result<Self, Self::Error> {
         match selection {
-            apollo_parser::ast::Selection::Field(field) => Self::Field(field.into()),
+            apollo_parser::ast::Selection::Field(field) => field.try_into().map(Self::Field),
             apollo_parser::ast::Selection::FragmentSpread(fragment_spread) => {
-                Self::FragmentSpread(fragment_spread.into())
+                fragment_spread.try_into().map(Self::FragmentSpread)
             }
             apollo_parser::ast::Selection::InlineFragment(inline_fragment) => {
-                Self::InlineFragment(inline_fragment.into())
+                inline_fragment.try_into().map(Self::InlineFragment)
             }
         }
     }

--- a/crates/apollo-smith/src/selection_set.rs
+++ b/crates/apollo-smith/src/selection_set.rs
@@ -36,7 +36,10 @@ impl TryFrom<apollo_parser::ast::SelectionSet> for SelectionSet {
 
     fn try_from(selection_set: apollo_parser::ast::SelectionSet) -> Result<Self, Self::Error> {
         Ok(Self {
-            selections: selection_set.selections().map(Selection::try_from).collect::<Result<_, _>>()?,
+            selections: selection_set
+                .selections()
+                .map(Selection::try_from)
+                .collect::<Result<_, _>>()?,
         })
     }
 }

--- a/crates/apollo-smith/src/union.rs
+++ b/crates/apollo-smith/src/union.rs
@@ -50,21 +50,19 @@ impl From<UnionTypeDef> for UnionDefinition {
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::UnionTypeDefinition> for UnionTypeDef {
-    fn from(union_def: apollo_parser::ast::UnionTypeDefinition) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::UnionTypeDefinition> for UnionTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(union_def: apollo_parser::ast::UnionTypeDefinition) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: union_def
                 .name()
                 .expect("object type definition must have a name")
                 .into(),
             description: union_def.description().map(Description::from),
-            directives: union_def
-                .directives()
-                .map(|d| {
-                    d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
-                })
+            directives: union_def.directives()
+                .map(Directive::convert_directives)
+                .transpose()?
                 .unwrap_or_default(),
             extend: false,
             members: union_def
@@ -76,14 +74,16 @@ impl From<apollo_parser::ast::UnionTypeDefinition> for UnionTypeDef {
                         .collect()
                 })
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 
 #[cfg(feature = "parser-impl")]
-impl From<apollo_parser::ast::UnionTypeExtension> for UnionTypeDef {
-    fn from(union_def: apollo_parser::ast::UnionTypeExtension) -> Self {
-        Self {
+impl TryFrom<apollo_parser::ast::UnionTypeExtension> for UnionTypeDef {
+    type Error = crate::FromError;
+
+    fn try_from(union_def: apollo_parser::ast::UnionTypeExtension) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: union_def
                 .name()
                 .expect("object type definition must have a name")
@@ -93,9 +93,10 @@ impl From<apollo_parser::ast::UnionTypeExtension> for UnionTypeDef {
                 .directives()
                 .map(|d| {
                     d.directives()
-                        .map(|d| (d.name().unwrap().into(), Directive::from(d)))
-                        .collect()
+                        .map(|d| Ok((d.name().unwrap().into(), Directive::try_from(d)?)))
+                        .collect::<Result<_, crate::FromError>>()
                 })
+                .transpose()?
                 .unwrap_or_default(),
             extend: true,
             members: union_def
@@ -107,7 +108,7 @@ impl From<apollo_parser::ast::UnionTypeExtension> for UnionTypeDef {
                         .collect()
                 })
                 .unwrap_or_default(),
-        }
+        })
     }
 }
 

--- a/crates/apollo-smith/src/union.rs
+++ b/crates/apollo-smith/src/union.rs
@@ -60,7 +60,8 @@ impl TryFrom<apollo_parser::ast::UnionTypeDefinition> for UnionTypeDef {
                 .expect("object type definition must have a name")
                 .into(),
             description: union_def.description().map(Description::from),
-            directives: union_def.directives()
+            directives: union_def
+                .directives()
                 .map(Directive::convert_directives)
                 .transpose()?
                 .unwrap_or_default(),


### PR DESCRIPTION
This PR changes the `From<$ParserNode> for $RustType` implementations to `TryFrom`, so that user input cannot cause panics as easily. For example, `i32::from(node)` could panic if `node` contains a very large integer.

This PR also adds an `impl TryFrom<IntValue> for f64` implementation, as you are allowed to write integers when a schema expects a float.

closes #358

These are still todos but could be done later:
- [ ] compiler is still panicky, we would have to make it store `Result`s
- [ ] now that `apollo-smith` uses `TryFrom`, it could use the `FromError::MissingNode` type just like apollo-encoder, instead of panicking on missing nodes.