### PR TITLE
AST int → HIR float  when expected by type system (best effort)

### DIFF
--- a/crates/apollo-compiler/test_data/ok/0014_float_values.graphql
+++ b/crates/apollo-compiler/test_data/ok/0014_float_values.graphql
@@ -1,0 +1,6 @@
+input WithAllKindsOfFloats {
+  a_regular_float: Float = 1.2
+  an_integer_float: Float = 1234
+  a_float_that_doesnt_fit_an_int: Float = 9876543210
+  list_of_floats: [Float] = [4, 9876543210]
+}

--- a/crates/apollo-compiler/test_data/ok/0014_float_values.txt
+++ b/crates/apollo-compiler/test_data/ok/0014_float_values.txt
@@ -1,0 +1,83 @@
+- DOCUMENT@0..192
+    - INPUT_OBJECT_TYPE_DEFINITION@0..192
+        - input_KW@0..5 "input"
+        - WHITESPACE@5..6 " "
+        - NAME@6..27
+            - IDENT@6..26 "WithAllKindsOfFloats"
+            - WHITESPACE@26..27 " "
+        - INPUT_FIELDS_DEFINITION@27..192
+            - L_CURLY@27..28 "{"
+            - WHITESPACE@28..31 "\n  "
+            - INPUT_VALUE_DEFINITION@31..62
+                - NAME@31..46
+                    - IDENT@31..46 "a_regular_float"
+                - COLON@46..47 ":"
+                - WHITESPACE@47..48 " "
+                - NAMED_TYPE@48..53
+                    - NAME@48..53
+                        - IDENT@48..53 "Float"
+                - WHITESPACE@53..54 " "
+                - DEFAULT_VALUE@54..62
+                    - EQ@54..55 "="
+                    - WHITESPACE@55..56 " "
+                    - FLOAT_VALUE@56..62
+                        - FLOAT@56..59 "1.2"
+                        - WHITESPACE@59..62 "\n  "
+            - INPUT_VALUE_DEFINITION@62..95
+                - NAME@62..78
+                    - IDENT@62..78 "an_integer_float"
+                - COLON@78..79 ":"
+                - WHITESPACE@79..80 " "
+                - NAMED_TYPE@80..85
+                    - NAME@80..85
+                        - IDENT@80..85 "Float"
+                - WHITESPACE@85..86 " "
+                - DEFAULT_VALUE@86..95
+                    - EQ@86..87 "="
+                    - WHITESPACE@87..88 " "
+                    - INT_VALUE@88..95
+                        - INT@88..92 "1234"
+                        - WHITESPACE@92..95 "\n  "
+            - INPUT_VALUE_DEFINITION@95..148
+                - NAME@95..125
+                    - IDENT@95..125 "a_float_that_doesnt_fit_an_int"
+                - COLON@125..126 ":"
+                - WHITESPACE@126..127 " "
+                - NAMED_TYPE@127..132
+                    - NAME@127..132
+                        - IDENT@127..132 "Float"
+                - WHITESPACE@132..133 " "
+                - DEFAULT_VALUE@133..148
+                    - EQ@133..134 "="
+                    - WHITESPACE@134..135 " "
+                    - INT_VALUE@135..148
+                        - INT@135..145 "9876543210"
+                        - WHITESPACE@145..148 "\n  "
+            - INPUT_VALUE_DEFINITION@148..190
+                - NAME@148..162
+                    - IDENT@148..162 "list_of_floats"
+                - COLON@162..163 ":"
+                - WHITESPACE@163..164 " "
+                - LIST_TYPE@164..171
+                    - L_BRACK@164..165 "["
+                    - NAMED_TYPE@165..170
+                        - NAME@165..170
+                            - IDENT@165..170 "Float"
+                    - R_BRACK@170..171 "]"
+                - WHITESPACE@171..172 " "
+                - DEFAULT_VALUE@172..190
+                    - EQ@172..173 "="
+                    - WHITESPACE@173..174 " "
+                    - LIST_VALUE@174..190
+                        - L_BRACK@174..175 "["
+                        - INT_VALUE@175..178
+                            - INT@175..176 "4"
+                            - COMMA@176..177 ","
+                            - WHITESPACE@177..178 " "
+                        - INT_VALUE@178..188
+                            - INT@178..188 "9876543210"
+                        - R_BRACK@188..189 "]"
+                        - WHITESPACE@189..190 "\n"
+            - R_CURLY@190..191 "}"
+            - WHITESPACE@191..192 "\n"
+recursion limit: 4096, high: 0

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -131,6 +131,19 @@ impl From<&'_ ast::BooleanValue> for bool {
     }
 }
 
+impl ast::IntValue {
+    /// A value literal that is syntactically an integer can be used
+    /// in contexts where the type system expects a Float.
+    ///
+    /// This method should be used in such cases since it
+    /// correctly handle some values that would overflow
+    /// when converting through `i32`.
+    pub fn as_float(&self) -> f64 {
+        let text = text_of_first_token(self.syntax());
+        text.parse().expect("Cannot parse IntValue as Float")
+    }
+}
+
 fn text_of_first_token(node: &SyntaxNode) -> TokenText {
     let first_token = node
         .green()


### PR DESCRIPTION
The syntax for an integer value is also valid for a float value, but the latter has a wider range of accepted values (~53 bits v.s. 32 bits). This adds support for such "extra" values during HIR creation by returning a `hir::Value::Float` for an `ast::IntValue` when type system definitions indicate that a float is expected.

In some cases, type system definitions would have enough information but this does not yet implement all lookups necessary.

In other cases it truly does not have sufficient information. Either way, `hir::Value::Int` is used as a fallback as before.