### PR TITLE
fix(compiler,parser): do not panic during HIR creation

### DIFF
--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -2359,4 +2359,19 @@ mod tests {
         assert_eq!(default_values[2], "98765432109876540000");
         assert_eq!(default_values[3], "98765432109876540000");
     }
+
+    #[test]
+    fn syntax_errors() {
+        let compiler = ApolloCompiler::new(
+            "type Person {
+                id: ID!
+                name: String
+                appearedIn: [Film]s
+                directed: [Film]
+            }",
+        );
+        let person = compiler.db.find_object_type_by_name("Person".into()).unwrap();
+        let hir_field_names: Vec<_> = person.fields_definition.iter().map(|field| field.name()).collect();
+        assert_eq!(hir_field_names, ["id", "name", "appearedIn", "directed"]);
+    }
 }

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -2370,8 +2370,15 @@ mod tests {
                 directed: [Film]
             }",
         );
-        let person = compiler.db.find_object_type_by_name("Person".into()).unwrap();
-        let hir_field_names: Vec<_> = person.fields_definition.iter().map(|field| field.name()).collect();
+        let person = compiler
+            .db
+            .find_object_type_by_name("Person".into())
+            .unwrap();
+        let hir_field_names: Vec<_> = person
+            .fields_definition
+            .iter()
+            .map(|field| field.name())
+            .collect();
         assert_eq!(hir_field_names, ["id", "name", "appearedIn", "directed"]);
     }
 }

--- a/crates/apollo-parser/src/parser/grammar/field.rs
+++ b/crates/apollo-parser/src/parser/grammar/field.rs
@@ -63,7 +63,14 @@ pub(crate) fn field(p: &mut Parser) {
 pub(crate) fn fields_definition(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::FIELDS_DEFINITION);
     p.bump(S!['{']);
-    field_definition(p);
+    loop {
+        field_definition(p);
+        // If we reach the end of the file or the end of the field definitions,
+        // break the loop.
+        if matches!(p.peek(), None | Some(T!['}']) | Some(TokenKind::Eof)) {
+            break;
+        }
+    }
     p.expect(T!['}'], S!['}']);
 }
 
@@ -73,7 +80,7 @@ pub(crate) fn fields_definition(p: &mut Parser) {
 ///     Description? Name ArgumentsDefinition? **:** Type Directives?
 pub(crate) fn field_definition(p: &mut Parser) {
     if let Some(TokenKind::Name | TokenKind::StringValue) = p.peek() {
-        let guard = p.start_node(SyntaxKind::FIELD_DEFINITION);
+        let _guard = p.start_node(SyntaxKind::FIELD_DEFINITION);
 
         if let Some(TokenKind::StringValue) = p.peek() {
             description::description(p);
@@ -94,8 +101,7 @@ pub(crate) fn field_definition(p: &mut Parser) {
                         directive::directives(p);
                     }
                     if p.peek().is_some() {
-                        guard.finish_node();
-                        return field_definition(p);
+                        return;
                     }
                 }
                 _ => {
@@ -105,9 +111,5 @@ pub(crate) fn field_definition(p: &mut Parser) {
         } else {
             p.err("expected a type");
         }
-    }
-
-    if let Some(T!['}']) = p.peek() {
-        return;
     }
 }

--- a/crates/apollo-parser/src/parser/grammar/ty.rs
+++ b/crates/apollo-parser/src/parser/grammar/ty.rs
@@ -19,8 +19,10 @@ use crate::{parser::grammar::name, Parser, SyntaxKind, Token, TokenKind, S, T};
 // unwrap them once the last possible child has been parsed. Nodes are then
 // created in the processing stage of this parsing rule.
 pub(crate) fn ty(p: &mut Parser) {
-    let ty = parse(p);
-    process(ty, p);
+    match parse(p) {
+        Ok(ty) => process(ty, p),
+        Err(_token) => p.err("expected a type"),
+    }
 }
 
 #[derive(Debug)]
@@ -29,7 +31,7 @@ enum TokenTy {
         nullable: Option<Token>,
         open_token: Token,
         close_token: Option<Token>,
-        inner: Box<TokenTy>,
+        inner: Option<Box<TokenTy>>,
         comma: Option<Token>,
         trailing_ws: Option<Token>,
     },
@@ -41,11 +43,22 @@ enum TokenTy {
     },
 }
 
-fn parse(p: &mut Parser) -> TokenTy {
+/// Returns the type on success, or the TokenKind that caused an error.
+///
+/// When errors occur deeper inside nested types like lists, this function
+/// pushes errors *inside* the list to the parser, and returns an Ok() with
+/// an incomplete type.
+fn parse(p: &mut Parser) -> Result<TokenTy, TokenKind> {
     let token = p.pop();
     let mut types = match token.kind() {
         T!['['] => {
-            let inner = parse(p);
+            let inner = match parse(p) {
+                Ok(ty) => Some(Box::new(ty)),
+                Err(_token) => {
+                    p.err("expected item type");
+                    None
+                }
+            };
             let close_token = if let Some(T![']']) = p.peek() {
                 Some(p.pop())
             } else {
@@ -53,7 +66,7 @@ fn parse(p: &mut Parser) -> TokenTy {
             };
 
             TokenTy::List {
-                inner: Box::new(inner),
+                inner,
                 open_token: token,
                 close_token,
                 nullable: None,
@@ -67,8 +80,7 @@ fn parse(p: &mut Parser) -> TokenTy {
             comma: None,
             trailing_ws: None,
         },
-        // TODO(@lrlna): this should not panic
-        token => panic!("unexpected token, {:?}", token),
+        token => return Err(token),
     };
 
     // Deal with nullable types
@@ -94,7 +106,7 @@ fn parse(p: &mut Parser) -> TokenTy {
         };
     }
 
-    types
+    Ok(types)
 }
 
 fn process(ty: TokenTy, p: &mut Parser) {
@@ -109,12 +121,12 @@ fn process(ty: TokenTy, p: &mut Parser) {
         } => match nullable {
             Some(nullable_token) => {
                 let _non_null_g = p.start_node(SyntaxKind::NON_NULL_TYPE);
-                process_list(p, open_token, *inner, close_token);
+                process_list(p, open_token, inner, close_token);
                 p.push_ast(S![!], nullable_token);
                 process_ignored_tokens(comma, p, trailing_ws);
             }
             None => {
-                process_list(p, open_token, *inner, close_token);
+                process_list(p, open_token, inner, close_token);
                 process_ignored_tokens(comma, p, trailing_ws);
             }
         },
@@ -148,10 +160,12 @@ fn process_ignored_tokens(comma: Option<Token>, p: &mut Parser, whitespace: Opti
     }
 }
 
-fn process_list(p: &mut Parser, open_token: Token, inner: TokenTy, close_token: Option<Token>) {
+fn process_list(p: &mut Parser, open_token: Token, inner: Option<Box<TokenTy>>, close_token: Option<Token>) {
     let _list_g = p.start_node(SyntaxKind::LIST_TYPE);
     p.push_ast(S!['['], open_token);
-    process(inner, p);
+    if let Some(inner) = inner {
+        process(*inner, p);
+    }
     if let Some(close_token) = close_token {
         p.push_ast(S![']'], close_token);
     }

--- a/crates/apollo-parser/src/parser/grammar/ty.rs
+++ b/crates/apollo-parser/src/parser/grammar/ty.rs
@@ -162,7 +162,12 @@ fn process_ignored_tokens(comma: Option<Token>, p: &mut Parser, whitespace: Opti
     }
 }
 
-fn process_list(p: &mut Parser, open_token: Token, inner: Option<Box<TokenTy>>, close_token: Option<Token>) {
+fn process_list(
+    p: &mut Parser,
+    open_token: Token,
+    inner: Option<Box<TokenTy>>,
+    close_token: Option<Token>,
+) {
     let _list_g = p.start_node(SyntaxKind::LIST_TYPE);
     p.push_ast(S!['['], open_token);
     if let Some(inner) = inner {

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -189,7 +189,18 @@ impl<'a> Parser<'a> {
         self.accept_errors = false;
     }
 
-    /// Create a parser error and push it into the error vector.
+    /// Create a parser error at a given location and push it into the error vector.
+    pub(crate) fn err_at_token(&mut self, current: &Token, message: &str) {
+        let err = if current.kind == TokenKind::Eof {
+            Error::eof(message, current.index())
+        } else {
+            // this needs to be the computed location
+            Error::with_loc(message, current.data().to_string(), current.index())
+        };
+        self.push_err(err);
+    }
+
+    /// Create a parser error at the current location and push it into the error vector.
     pub(crate) fn err(&mut self, message: &str) {
         let current = if let Some(current) = self.current() {
             current
@@ -205,7 +216,7 @@ impl<'a> Parser<'a> {
         self.push_err(err);
     }
 
-    /// Create a parser error and push it into the error vector.
+    /// Create a parser error at the current location and eat the responsible token.
     pub(crate) fn err_and_pop(&mut self, message: &str) {
         if self.current().is_none() {
             return;

--- a/crates/apollo-parser/test_data/parser/err/0043_type_with_trailing_garbage.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0043_type_with_trailing_garbage.graphql
@@ -1,0 +1,6 @@
+type Person {
+  id: ID!
+  appearedIn: [Film]s
+  name: String
+  directed: [Film]
+}

--- a/crates/apollo-parser/test_data/parser/err/0043_type_with_trailing_garbage.txt
+++ b/crates/apollo-parser/test_data/parser/err/0043_type_with_trailing_garbage.txt
@@ -1,0 +1,61 @@
+- DOCUMENT@0..82
+    - OBJECT_TYPE_DEFINITION@0..82
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..5 " "
+        - NAME@5..12
+            - IDENT@5..11 "Person"
+            - WHITESPACE@11..12 " "
+        - FIELDS_DEFINITION@12..82
+            - L_CURLY@12..13 "{"
+            - WHITESPACE@13..16 "\n  "
+            - FIELD_DEFINITION@16..26
+                - NAME@16..18
+                    - IDENT@16..18 "id"
+                - COLON@18..19 ":"
+                - WHITESPACE@19..20 " "
+                - NON_NULL_TYPE@20..26
+                    - NAMED_TYPE@20..22
+                        - NAME@20..22
+                            - IDENT@20..22 "ID"
+                    - BANG@22..23 "!"
+                    - WHITESPACE@23..26 "\n  "
+            - FIELD_DEFINITION@26..44
+                - NAME@26..36
+                    - IDENT@26..36 "appearedIn"
+                - COLON@36..37 ":"
+                - WHITESPACE@37..38 " "
+                - LIST_TYPE@38..44
+                    - L_BRACK@38..39 "["
+                    - NAMED_TYPE@39..43
+                        - NAME@39..43
+                            - IDENT@39..43 "Film"
+                    - R_BRACK@43..44 "]"
+            - FIELD_DEFINITION@44..48
+                - NAME@44..48
+                    - IDENT@44..45 "s"
+                    - WHITESPACE@45..48 "\n  "
+            - FIELD_DEFINITION@48..63
+                - NAME@48..52
+                    - IDENT@48..52 "name"
+                - COLON@52..53 ":"
+                - WHITESPACE@53..54 " "
+                - NAMED_TYPE@54..60
+                    - NAME@54..60
+                        - IDENT@54..60 "String"
+                - WHITESPACE@60..63 "\n  "
+            - FIELD_DEFINITION@63..80
+                - NAME@63..71
+                    - IDENT@63..71 "directed"
+                - COLON@71..72 ":"
+                - WHITESPACE@72..73 " "
+                - LIST_TYPE@73..79
+                    - L_BRACK@73..74 "["
+                    - NAMED_TYPE@74..78
+                        - NAME@74..78
+                            - IDENT@74..78 "Film"
+                    - R_BRACK@78..79 "]"
+                - WHITESPACE@79..80 "\n"
+            - R_CURLY@80..81 "}"
+            - WHITESPACE@81..82 "\n"
+- ERROR@48:52 "expected a type" name
+recursion limit: 4096, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0044_list_type_with_no_type.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0044_list_type_with_no_type.graphql
@@ -1,0 +1,4 @@
+type List {
+  field: [] @coolDirective
+  deepError: [[[Item Type]]]
+}

--- a/crates/apollo-parser/test_data/parser/err/0044_list_type_with_no_type.txt
+++ b/crates/apollo-parser/test_data/parser/err/0044_list_type_with_no_type.txt
@@ -1,0 +1,52 @@
+- DOCUMENT@0..65
+    - OBJECT_TYPE_DEFINITION@0..63
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..5 " "
+        - NAME@5..10
+            - IDENT@5..9 "List"
+            - WHITESPACE@9..10 " "
+        - FIELDS_DEFINITION@10..63
+            - L_CURLY@10..11 "{"
+            - WHITESPACE@11..14 "\n  "
+            - FIELD_DEFINITION@14..40
+                - NAME@14..19
+                    - IDENT@14..19 "field"
+                - COLON@19..20 ":"
+                - WHITESPACE@20..21 " "
+                - LIST_TYPE@21..22
+                    - L_BRACK@21..22 "["
+                - WHITESPACE@22..23 " "
+                - DIRECTIVES@23..40
+                    - DIRECTIVE@23..40
+                        - AT@23..24 "@"
+                        - NAME@24..40
+                            - IDENT@24..37 "coolDirective"
+                            - WHITESPACE@37..40 "\n  "
+            - FIELD_DEFINITION@40..59
+                - NAME@40..49
+                    - IDENT@40..49 "deepError"
+                - COLON@49..50 ":"
+                - WHITESPACE@50..51 " "
+                - LIST_TYPE@51..59
+                    - L_BRACK@51..52 "["
+                    - LIST_TYPE@52..59
+                        - L_BRACK@52..53 "["
+                        - LIST_TYPE@53..59
+                            - L_BRACK@53..54 "["
+                            - NAMED_TYPE@54..58
+                                - NAME@54..58
+                                    - IDENT@54..58 "Item"
+                            - WHITESPACE@58..59 " "
+            - FIELD_DEFINITION@59..63
+                - NAME@59..63
+                    - IDENT@59..63 "Type"
+    - WHITESPACE@63..64 "\n"
+    - WHITESPACE@64..65 "\n"
+- ERROR@23:24 "expected item type"  
+- ERROR@64:65 "expected a type" ]
+- ERROR@64:65 "expected R_CURLY, got ]" ]
+- ERROR@64:65 "expected a StringValue, Name or OperationDefinition" ]
+- ERROR@65:66 "expected a StringValue, Name or OperationDefinition" ]
+- ERROR@66:67 "expected a StringValue, Name or OperationDefinition" ]
+- ERROR@68:69 "expected a StringValue, Name or OperationDefinition" }
+recursion limit: 4096, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0044_list_type_with_no_type.txt
+++ b/crates/apollo-parser/test_data/parser/err/0044_list_type_with_no_type.txt
@@ -42,7 +42,7 @@
                     - IDENT@59..63 "Type"
     - WHITESPACE@63..64 "\n"
     - WHITESPACE@64..65 "\n"
-- ERROR@23:24 "expected item type"  
+- ERROR@22:23 "expected item type" ]
 - ERROR@64:65 "expected a type" ]
 - ERROR@64:65 "expected R_CURLY, got ]" ]
 - ERROR@64:65 "expected a StringValue, Name or OperationDefinition" ]


### PR DESCRIPTION
Ref #256, probably not a *full* fix yet, but that issue is quite broad.

I set out to simply change every panic in HIR creation to returning a `None`, but while writing tests I triggered panics in the parser, so I tried to address those too.

- This removes some panics from type name parsing. For example, `field: []` does not panic anymore. Instead it produces a syntax error and an incomplete List type.
- Fixes the parser completely bailing out of parsing a list of field definitions when encountering a syntax error in one field.
   ```graphql
   type A {
      fieldA: [] # ← has error, missing item type
      fieldB: Int
      fieldC: Int
   }
   ```
   Previously fieldB and fieldC would not be parsed, now they are.
- Replaces panics when creating the HIR with `Option`s. This means that AST nodes with errors are *ignored* by the HIR. *Most* cases where AST nodes are missing already cause syntax errors in the parser, so users can still tell that something is wrong, and the validation etc. should not be expected to be perfect if there are syntax errors anyways.

   There are some cases where we ignore more of the tree than we need to. eg. if an object type definition is missing a name, we ignore the entire thing, even though we could still do useful validation on the directives and fields. We could add that stuff in the future by allowing for certain optional or invalid values in the HIR. As it is, silently ignoring those cases is still an improvement over panicking, I think (+ it's not actually silent because you do get a parse error already).