### PR TITLE
Add some accessors or convenience public APIs

### DIFF
--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -23,6 +23,8 @@ pub trait DocumentDatabase: InputDatabase + AstDatabase + HirDatabase {
 
     fn find_union_by_name(&self, name: String) -> Option<Arc<UnionTypeDefinition>>;
 
+    fn find_enum_by_name(&self, name: String) -> Option<Arc<EnumTypeDefinition>>;
+
     fn find_interface(&self, id: Uuid) -> Option<Arc<InterfaceTypeDefinition>>;
 
     fn find_interface_by_name(&self, name: String) -> Option<Arc<InterfaceTypeDefinition>>;
@@ -169,6 +171,15 @@ fn find_union_by_name(db: &dyn DocumentDatabase, name: String) -> Option<Arc<Uni
     db.unions().iter().find_map(|union| {
         if name == union.name() {
             return Some(Arc::new(union.clone()));
+        }
+        None
+    })
+}
+
+fn find_enum_by_name(db: &dyn DocumentDatabase, name: String) -> Option<Arc<EnumTypeDefinition>> {
+    db.enums().iter().find_map(|enum_def| {
+        if name == enum_def.name() {
+            return Some(Arc::new(enum_def.clone()));
         }
         None
     })


### PR DESCRIPTION
* `DocumentDatabase::find_enum_by_name`, similar to existing `find_union_by_name`
* `Directive::argument_by_name`
* `impl Copy for hir::Float`
* `Float::get`
* `Float::to_i32_checked` (naming pattern from std’s to_int_unchecked)
* `ScalarTypeDefiniton::is_built_in`