### PR TITLE
feat(compiler): Name-indexed maps + inlined extensions

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2021"
 
 [dependencies]
 apollo-parser = { path = "../apollo-parser", version = "0.4.0" }
+indexmap = "1.9.2"
 rowan = "0.15.5"
 salsa = "0.16.1"
 uuid = { version = "1.1", features = ["serde", "v4"] }

--- a/crates/apollo-compiler/examples/hello_world.rs
+++ b/crates/apollo-compiler/examples/hello_world.rs
@@ -1,8 +1,8 @@
-use std::{fs, path::Path};
+use std::{fs, path::Path, sync::Arc};
 
 use apollo_compiler::{hir, ApolloCompiler, HirDatabase};
 
-fn compile_query() -> Option<hir::FragmentDefinition> {
+fn compile_query() -> Option<Arc<hir::FragmentDefinition>> {
     let file = Path::new("crates/apollo-compiler/examples/query_with_errors.graphql");
     let src = fs::read_to_string(file).expect("Could not read schema file.");
 
@@ -14,7 +14,7 @@ fn compile_query() -> Option<hir::FragmentDefinition> {
     let operation_names: Vec<_> = operations.iter().filter_map(|op| op.name()).collect();
     assert_eq!(["ExampleQuery"], operation_names.as_slice());
     let frags = compiler.db.fragments(document_id);
-    let fragments: Vec<_> = frags.iter().map(|frag| frag.name()).collect();
+    let fragments: Vec<_> = frags.keys().map(|name| &**name).collect();
     assert_eq!(["vipCustomer"], fragments.as_slice());
 
     let operation_variables: Vec<&str> = operations
@@ -29,8 +29,7 @@ fn compile_query() -> Option<hir::FragmentDefinition> {
     compiler
         .db
         .fragments(document_id)
-        .iter()
-        .find(|op| op.name() == "vipCustomer")
+        .get("vipCustomer")
         .cloned()
 }
 

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -285,7 +285,7 @@ scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
         assert_eq!(["ExampleQuery"], operation_names.as_slice());
 
         let fragments = compiler.db.fragments(document_id);
-        let fragment_names: Vec<_> = fragments.iter().map(|fragment| fragment.name()).collect();
+        let fragment_names: Vec<_> = fragments.keys().map(|name| &**name).collect();
         assert_eq!(["vipCustomer"], fragment_names.as_slice());
 
         let operation_variables: Vec<String> = match operations
@@ -694,10 +694,7 @@ scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 
         let scalars = compiler.db.scalars();
 
-        let directives: Vec<&str> = scalars
-            .iter()
-            .find(|scalar| scalar.name() == "URL")
-            .unwrap()
+        let directives: Vec<&str> = scalars["URL"]
             .directives()
             .iter()
             .map(|directive| directive.name())
@@ -729,10 +726,7 @@ enum Pet {
         assert!(diagnostics.is_empty());
 
         let enums = compiler.db.enums();
-        let enum_values: Vec<&str> = enums
-            .iter()
-            .find(|enum_def| enum_def.name() == "Pet")
-            .unwrap()
+        let enum_values: Vec<&str> = enums["Pet"]
             .enum_values_definition()
             .iter()
             .map(|enum_val| enum_val.enum_value())
@@ -774,20 +768,14 @@ type SearchQuery {
         assert!(diagnostics.is_empty());
 
         let unions = compiler.db.unions();
-        let union_members: Vec<&str> = unions
-            .iter()
-            .find(|def| def.name() == "SearchResult")
-            .unwrap()
+        let union_members: Vec<&str> = unions["SearchResult"]
             .union_members()
             .iter()
             .map(|member| member.name())
             .collect();
         assert_eq!(union_members, ["Photo", "Person"]);
 
-        let photo_object = unions
-            .iter()
-            .find(|def| def.name() == "SearchResult")
-            .unwrap()
+        let photo_object = unions["SearchResult"]
             .union_members()
             .iter()
             .find(|mem| mem.name() == "Person")
@@ -828,21 +816,10 @@ type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
         assert!(diagnostics.is_empty());
 
         let directives = compiler.db.directive_definitions();
-        let locations: Vec<String> = directives
+        let locations: Vec<String> = directives["delegateField"]
+            .directive_locations()
             .iter()
-            .filter_map(|dir| {
-                if dir.name() == "delegateField" {
-                    let locations: Vec<String> = dir
-                        .directive_locations()
-                        .iter()
-                        .map(|loc| loc.clone().into())
-                        .collect();
-                    Some(locations)
-                } else {
-                    None
-                }
-            })
-            .flatten()
+            .map(|loc| loc.clone().into())
             .collect();
 
         assert_eq!(locations, ["OBJECT", "INTERFACE"]);
@@ -874,21 +851,10 @@ input Point2D {
         assert!(diagnostics.is_empty());
 
         let input_objects = compiler.db.input_objects();
-        let fields: Vec<&str> = input_objects
+        let fields: Vec<&str> = input_objects["Point2D"]
+            .input_fields_definition()
             .iter()
-            .filter_map(|input| {
-                if input.name() == "Point2D" {
-                    let fields: Vec<&str> = input
-                        .input_fields_definition()
-                        .iter()
-                        .map(|val| val.name())
-                        .collect();
-                    Some(fields)
-                } else {
-                    None
-                }
-            })
-            .flatten()
+            .map(|val| val.name())
             .collect();
 
         assert_eq!(fields, ["x", "y"]);
@@ -955,7 +921,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
                 .filter_map(|f| {
                     // get access to the actual definition the field is using
                     if let Some(field_ty) = f.ty().ty(&compiler.db) {
-                        match field_ty.as_ref() {
+                        match field_ty {
                             // get that definition's directives, for example
                             Definition::ScalarTypeDefinition(scalar) => {
                                 let dir_names: Vec<String> = scalar
@@ -984,7 +950,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
                         .iter()
                         .filter_map(|val| {
                             if let Some(input_ty) = val.ty().ty(&compiler.db) {
-                                match input_ty.as_ref() {
+                                match input_ty {
                                     // get that definition's directives, for example
                                     Definition::EnumTypeDefinition(enum_) => {
                                         let dir_names: Vec<String> = enum_
@@ -1036,7 +1002,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
                 .iter()
                 .filter_map(|f| {
                     if let Some(field_ty) = f.ty().ty(&compiler.db) {
-                        match field_ty.as_ref() {
+                        match field_ty {
                             Definition::ScalarTypeDefinition(scalar) => {
                                 let dir_names: Vec<String> = scalar
                                     .directives()
@@ -1145,7 +1111,7 @@ type User
         assert_eq!(diagnostics.len(), 1);
 
         let object_types = compiler.db.object_types();
-        let object_names: Vec<_> = object_types.iter().map(|op| op.name()).collect();
+        let object_names: Vec<_> = object_types.keys().map(|name| &**name).collect();
         assert_eq!(
             ["Mutation", "Product", "Query", "Review", "User"],
             object_names.as_slice()

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
-
 use crate::{
     diagnostics::{RecursiveDefinition, UniqueDefinition},
-    hir::DirectiveDefinition,
+    validation::type_definitions,
     ApolloDiagnostic, ValidationDatabase,
 };
+use apollo_parser::ast;
 
 pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut errors = Vec::new();
@@ -12,29 +11,28 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     // Directive definitions must have unique names.
     //
     // Return a Unique Definition error in case of a duplicate name.
-    let mut seen: HashMap<&str, &DirectiveDefinition> = HashMap::new();
-    for dir_def in db.directive_definitions().iter() {
-        let name = dir_def.name();
-        if let Some(prev_def) = seen.get(&name) {
-            if prev_def.loc.is_some() && dir_def.loc.is_some() {
-                let prev_offset: usize = prev_def.loc().unwrap().offset();
-                let prev_node_len: usize = prev_def.loc().unwrap().node_len();
-
-                let current_offset: usize = dir_def.loc().unwrap().offset();
-                let current_node_len: usize = dir_def.loc().unwrap().node_len();
-                errors.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
-                    ty: "directive".into(),
-                    name: name.into(),
-                    src: db.source_code(prev_def.loc().unwrap().file_id()),
-                    original_definition: (prev_offset, prev_node_len).into(),
-                    redefined_definition: (current_offset, current_node_len).into(),
-                    help: Some(format!(
-                        "`{name}` must only be defined once in this document."
-                    )),
-                }));
+    let hir = db.directive_definitions();
+    for (file_id, ast_def) in type_definitions::<ast::DirectiveDefinition>(db) {
+        if let Some(name) = ast_def.name() {
+            let name = &*name.text();
+            let hir_def = &hir[name];
+            if let Some(hir_loc) = hir_def.loc() {
+                let ast_loc = (file_id, &ast_def).into();
+                if *hir_loc == ast_loc {
+                    // The HIR node was built from this AST node. This is fine.
+                } else {
+                    errors.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
+                        ty: "directive".into(),
+                        name: name.to_owned(),
+                        src: db.source_code(hir_loc.file_id()),
+                        original_definition: hir_loc.into(),
+                        redefined_definition: ast_loc.into(),
+                        help: Some(format!(
+                            "`{name}` must only be defined once in this document."
+                        )),
+                    }));
+                }
             }
-        } else {
-            seen.insert(name, dir_def);
         }
     }
 
@@ -42,17 +40,14 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     // references itself directly.
     //
     // Returns Recursive Definition error.
-    for directive_def in db.directive_definitions().iter() {
-        let name = directive_def.name();
+    for (name, directive_def) in db.directive_definitions().iter() {
         for input_values in directive_def.arguments().input_values() {
             for directive in input_values.directives().iter() {
                 let directive_name = directive.name();
                 if name == directive_name {
-                    let offset = directive.loc().offset();
-                    let len: usize = directive.loc().node_len();
                     errors.push(ApolloDiagnostic::RecursiveDefinition(RecursiveDefinition {
                         message: format!("{} directive definition cannot reference itself", name),
-                        definition: (offset, len).into(),
+                        definition: directive.loc().into(),
                         src: db.source_code(directive.loc().file_id()),
                         definition_label: "recursive directive definition".into(),
                     }));

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -12,7 +12,7 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     // An Enum type must define one or more unique enum values.
     //
     // Return a Unique Value error in case of a duplicate value.
-    for enum_def in db.enums().iter() {
+    for enum_def in db.enums().values() {
         let mut seen: HashMap<&str, &EnumValueDefinition> = HashMap::new();
         for enum_value in enum_def.enum_values_definition().iter() {
             let value = enum_value.enum_value();
@@ -39,7 +39,7 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     // (convention) Values in an Enum Definition should be capitalized.
     //
     // Return a Capitalized Value warning if enum value is not capitalized.
-    for enum_def in db.enums().iter() {
+    for enum_def in db.enums().values() {
         for enum_value in enum_def.enum_values_definition().iter() {
             let value = enum_value.enum_value();
             let offset = enum_value.loc().offset();

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 
 use crate::{
     diagnostics::{UniqueDefinition, UniqueField},
-    hir::{InputObjectTypeDefinition, InputValueDefinition},
+    hir::InputValueDefinition,
+    validation::type_definitions,
     ApolloDiagnostic, ValidationDatabase,
 };
+use apollo_parser::ast;
 
 pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
@@ -12,34 +14,33 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     // Input Object Definitions must have unique names.
     //
     // Return a Unique Definition error in case of a duplicate name.
-    let mut seen: HashMap<&str, &InputObjectTypeDefinition> = HashMap::new();
-    for input_object in db.input_objects().iter() {
-        let name = input_object.name();
-        if let Some(prev_def) = seen.get(name) {
-            let prev_offset = prev_def.loc().offset();
-            let prev_node_len = prev_def.loc().node_len();
-
-            let current_offset = input_object.loc().offset();
-            let current_node_len = input_object.loc().node_len();
-            diagnostics.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
-                ty: "input object".into(),
-                name: name.into(),
-                src: db.source_code(prev_def.loc().file_id()),
-                original_definition: (prev_offset, prev_node_len).into(),
-                redefined_definition: (current_offset, current_node_len).into(),
-                help: Some(format!(
-                    "`{name}` must only be defined once in this document."
-                )),
-            }));
-        } else {
-            seen.insert(name, input_object);
+    let hir = db.input_objects();
+    for (file_id, ast_def) in type_definitions::<ast::InputObjectTypeDefinition>(db) {
+        if let Some(name) = ast_def.name() {
+            let name = &*name.text();
+            let hir_def = &hir[name];
+            let ast_loc = (file_id, &ast_def).into();
+            if *hir_def.loc() == ast_loc {
+                // The HIR node was built from this AST node. This is fine.
+            } else {
+                diagnostics.push(ApolloDiagnostic::UniqueDefinition(UniqueDefinition {
+                    ty: "input object".into(),
+                    name: name.to_owned(),
+                    src: db.source_code(hir_def.loc().file_id()),
+                    original_definition: hir_def.loc().into(),
+                    redefined_definition: ast_loc.into(),
+                    help: Some(format!(
+                        "`{name}` must only be defined once in this document."
+                    )),
+                }));
+            }
         }
     }
 
     // Fields in an Input Object Definition must be unique
     //
     // Returns Unique Value error.
-    for input_objects in db.input_objects().iter() {
+    for input_objects in db.input_objects().values() {
         let mut seen: HashMap<&str, &InputValueDefinition> = HashMap::new();
 
         let input_fields = input_objects.input_fields_definition();

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -13,7 +13,8 @@ mod unused_variable;
 
 pub use validation_db::{ValidationDatabase, ValidationStorage};
 
-use crate::hir::HirNodeLocation;
+use crate::{hir::HirNodeLocation, FileId};
+use apollo_parser::ast::AstNode;
 
 #[derive(Debug, Eq)]
 struct ValidationSet {
@@ -31,4 +32,23 @@ impl PartialEq for ValidationSet {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
     }
+}
+
+/// Finds top-level AST nodes of a given type in type definition files.
+pub(crate) fn type_definitions<'db, AstType>(
+    db: &'db dyn ValidationDatabase,
+) -> impl Iterator<Item = (FileId, AstType)> + 'db
+where
+    AstType: 'db + AstNode,
+{
+    db.type_definition_files()
+        .into_iter()
+        .flat_map(move |file_id| {
+            db.ast(file_id)
+                .document()
+                .syntax()
+                .children()
+                .filter_map(AstNode::cast)
+                .map(move |def| (file_id, def))
+        })
 }

--- a/crates/apollo-compiler/src/validation/scalar.rs
+++ b/crates/apollo-compiler/src/validation/scalar.rs
@@ -8,14 +8,13 @@ const BUILT_IN_SCALARS: [&str; 5] = ["Int", "Float", "Boolean", "String", "ID"];
 pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
-    for scalar in db.scalars().iter() {
-        let name = scalar.name();
+    for (name, scalar) in db.scalars().iter() {
         if let Some(loc) = scalar.loc() {
             let offset = loc.offset();
             let len = loc.node_len();
 
             // All built-in scalars must be omitted for brevity.
-            if BUILT_IN_SCALARS.contains(&name) && !scalar.is_built_in() {
+            if BUILT_IN_SCALARS.contains(&&**name) && !scalar.is_built_in() {
                 diagnostics.push(ApolloDiagnostic::BuiltInScalarDefinition(
                     BuiltInScalarDefinition {
                         scalar: (offset, len).into(),

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -9,7 +9,7 @@ use crate::{
 pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
-    for union_def in db.unions().iter() {
+    for union_def in db.unions().values() {
         let mut seen: HashMap<&str, &UnionMember> = HashMap::new();
         for union_member in union_def.union_members().iter() {
             let name = union_member.name();

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -36,29 +36,29 @@ pub trait ValidationDatabase:
 
     fn check_directive_definition(
         &self,
-        directive: hir::DirectiveDefinition,
+        def: Arc<hir::DirectiveDefinition>,
     ) -> Vec<ApolloDiagnostic>;
     fn check_object_type_definition(
         &self,
-        object_type: hir::ObjectTypeDefinition,
+        def: Arc<hir::ObjectTypeDefinition>,
     ) -> Vec<ApolloDiagnostic>;
     fn check_interface_type_definition(
         &self,
-        object_type: hir::InterfaceTypeDefinition,
+        def: Arc<hir::InterfaceTypeDefinition>,
     ) -> Vec<ApolloDiagnostic>;
     fn check_union_type_definition(
         &self,
-        object_type: hir::UnionTypeDefinition,
+        def: Arc<hir::UnionTypeDefinition>,
     ) -> Vec<ApolloDiagnostic>;
     fn check_enum_type_definition(
         &self,
-        object_type: hir::EnumTypeDefinition,
+        def: Arc<hir::EnumTypeDefinition>,
     ) -> Vec<ApolloDiagnostic>;
     fn check_input_object_type_definition(
         &self,
-        object_type: hir::InputObjectTypeDefinition,
+        def: Arc<hir::InputObjectTypeDefinition>,
     ) -> Vec<ApolloDiagnostic>;
-    fn check_schema_definition(&self, object_type: hir::SchemaDefinition) -> Vec<ApolloDiagnostic>;
+    fn check_schema_definition(&self, def: Arc<hir::SchemaDefinition>) -> Vec<ApolloDiagnostic>;
     fn check_selection_set(&self, selection_set: hir::SelectionSet) -> Vec<ApolloDiagnostic>;
     fn check_arguments_definition(
         &self,
@@ -78,18 +78,18 @@ pub trait ValidationDatabase:
 
 pub fn check_directive_definition(
     db: &dyn ValidationDatabase,
-    directive: hir::DirectiveDefinition,
+    directive: Arc<hir::DirectiveDefinition>,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
-    diagnostics.extend(db.check_arguments_definition(directive.arguments));
+    diagnostics.extend(db.check_arguments_definition(directive.arguments.clone()));
 
     diagnostics
 }
 
 pub fn check_object_type_definition(
     db: &dyn ValidationDatabase,
-    object_type: hir::ObjectTypeDefinition,
+    object_type: Arc<hir::ObjectTypeDefinition>,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -102,7 +102,7 @@ pub fn check_object_type_definition(
 
 pub fn check_interface_type_definition(
     db: &dyn ValidationDatabase,
-    interface_type: hir::InterfaceTypeDefinition,
+    interface_type: Arc<hir::InterfaceTypeDefinition>,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -115,21 +115,21 @@ pub fn check_interface_type_definition(
 
 pub fn check_union_type_definition(
     _db: &dyn ValidationDatabase,
-    _union_type: hir::UnionTypeDefinition,
+    _union_type: Arc<hir::UnionTypeDefinition>,
 ) -> Vec<ApolloDiagnostic> {
     vec![]
 }
 
 pub fn check_enum_type_definition(
     _db: &dyn ValidationDatabase,
-    _enum_type: hir::EnumTypeDefinition,
+    _enum_type: Arc<hir::EnumTypeDefinition>,
 ) -> Vec<ApolloDiagnostic> {
     vec![]
 }
 
 pub fn check_input_object_type_definition(
     _db: &dyn ValidationDatabase,
-    _input_object_type: hir::InputObjectTypeDefinition,
+    _input_object_type: Arc<hir::InputObjectTypeDefinition>,
 ) -> Vec<ApolloDiagnostic> {
     // Not checking the `input_values` here as those are checked as fields elsewhere.
     vec![]
@@ -137,7 +137,7 @@ pub fn check_input_object_type_definition(
 
 pub fn check_schema_definition(
     db: &dyn ValidationDatabase,
-    schema_def: hir::SchemaDefinition,
+    schema_def: Arc<hir::SchemaDefinition>,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -236,6 +236,7 @@ pub fn check_db_definitions(
             diagnostics.extend(db.check_directive(directive.clone()));
         }
 
+        // TODO: validate extensions too
         use hir::Definition::*;
         match definition {
             OperationDefinition(def) => {
@@ -266,14 +267,6 @@ pub fn check_db_definitions(
             SchemaDefinition(def) => {
                 diagnostics.extend(db.check_schema_definition(def.clone()));
             }
-            // FIXME: what validation is needed for extensions?
-            SchemaExtension(_) => {}
-            ScalarTypeExtension(_) => {}
-            ObjectTypeExtension(_) => {}
-            InterfaceTypeExtension(_) => {}
-            UnionTypeExtension(_) => {}
-            EnumTypeExtension(_) => {}
-            InputObjectTypeExtension(_) => {}
         }
     }
 


### PR DESCRIPTION
* For all kinds of definitions that have a mandatory name, keep them in source-order-preserving `IndexMap` instead of a `Vec` to speed up name lookup.

* Remove type extensions as independent HIR items, instead store them in a new `extensions` struct field on the respective definitions they extend.

* Wrap more HIR components in Arc, to reduce cost of Salsa’s cloning.