### PR TITLE
chore(smith): avoid using arbitrary::Result where std Result is intended

### DIFF
--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -1,4 +1,4 @@
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     input_value::{InputValue, InputValueDef},
@@ -76,28 +76,31 @@ impl TryFrom<apollo_parser::ast::Argument> for Argument {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary vector of `Argument`
-    pub fn arguments(&mut self) -> Result<Vec<Argument>> {
+    pub fn arguments(&mut self) -> ArbitraryResult<Vec<Argument>> {
         let num_arguments = self.u.int_in_range(0..=4)?;
         let arguments = (0..num_arguments)
             .map(|_| self.argument())
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<ArbitraryResult<Vec<_>>>()?;
 
         Ok(arguments)
     }
 
     /// Create an arbitrary vector of `Argument` given ArgumentsDef
-    pub fn arguments_with_def(&mut self, args_def: &ArgumentsDef) -> Result<Vec<Argument>> {
+    pub fn arguments_with_def(
+        &mut self,
+        args_def: &ArgumentsDef,
+    ) -> ArbitraryResult<Vec<Argument>> {
         let arguments = args_def
             .input_value_definitions
             .iter()
             .map(|input_val_def| self.argument_with_def(input_val_def))
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<ArbitraryResult<Vec<_>>>()?;
 
         Ok(arguments)
     }
 
     /// Create an arbitrary `Argument`
-    pub fn argument(&mut self) -> Result<Argument> {
+    pub fn argument(&mut self) -> ArbitraryResult<Argument> {
         let name = self.name()?;
         let value = self.input_value()?;
 
@@ -105,7 +108,10 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `Argument`
-    pub fn argument_with_def(&mut self, input_val_def: &InputValueDef) -> Result<Argument> {
+    pub fn argument_with_def(
+        &mut self,
+        input_val_def: &InputValueDef,
+    ) -> ArbitraryResult<Argument> {
         let name = input_val_def.name.clone();
         let value = self.input_value_for_type(&input_val_def.ty)?;
 
@@ -113,7 +119,7 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `ArgumentsDef`
-    pub fn arguments_definition(&mut self) -> Result<ArgumentsDef> {
+    pub fn arguments_definition(&mut self) -> ArbitraryResult<ArgumentsDef> {
         Ok(ArgumentsDef {
             input_value_definitions: self.input_values_def()?,
         })

--- a/crates/apollo-smith/src/description.rs
+++ b/crates/apollo-smith/src/description.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use arbitrary::{Arbitrary, Result, Unstructured};
+use arbitrary::{Arbitrary, Result as ArbitraryResult, Unstructured};
 
 use crate::DocumentBuilder;
 
@@ -82,7 +82,7 @@ impl From<String> for StringValue {
 }
 
 impl Arbitrary<'_> for StringValue {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> Result<Self> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> ArbitraryResult<Self> {
         let mut arbitrary_str = limited_string_desc(u, 100)?;
         if arbitrary_str.trim_matches('"').is_empty() {
             let _ = write!(arbitrary_str, "{}", u.arbitrary::<usize>()?);
@@ -100,12 +100,12 @@ impl Arbitrary<'_> for StringValue {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `Description`
-    pub fn description(&mut self) -> Result<Description> {
+    pub fn description(&mut self) -> ArbitraryResult<Description> {
         self.u.arbitrary()
     }
 }
 
-fn limited_string_desc(u: &mut Unstructured<'_>, max_size: usize) -> Result<String> {
+fn limited_string_desc(u: &mut Unstructured<'_>, max_size: usize) -> ArbitraryResult<String> {
     let size = u.int_in_range(0..=max_size)?;
 
     let gen_str = String::from_utf8(
@@ -117,7 +117,7 @@ fn limited_string_desc(u: &mut Unstructured<'_>, max_size: usize) -> Result<Stri
 
                 Ok(CHARSET[idx])
             })
-            .collect::<Result<Vec<u8>>>()?,
+            .collect::<ArbitraryResult<Vec<u8>>>()?,
     )
     .unwrap();
 

--- a/crates/apollo-smith/src/directive.rs
+++ b/crates/apollo-smith/src/directive.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use arbitrary::{Arbitrary, Result};
+use arbitrary::{Arbitrary, Result as ArbitraryResult};
 
 use crate::{
     argument::{Argument, ArgumentsDef},
@@ -139,7 +139,7 @@ impl<'a> DocumentBuilder<'a> {
     pub fn directives(
         &mut self,
         directive_location: DirectiveLocation,
-    ) -> Result<HashMap<Name, Directive>> {
+    ) -> ArbitraryResult<HashMap<Name, Directive>> {
         if self.directive_defs.is_empty() {
             return Ok(HashMap::new());
         }
@@ -147,7 +147,7 @@ impl<'a> DocumentBuilder<'a> {
         let num_directives = self.u.int_in_range(0..=(self.directive_defs.len() - 1))?;
         let directives = (0..num_directives)
             .map(|_| self.directive(directive_location))
-            .collect::<Result<Vec<_>>>()?
+            .collect::<ArbitraryResult<Vec<_>>>()?
             .into_iter()
             .flat_map(|d| d.map(|d| (d.name.clone(), d)))
             .collect();
@@ -159,7 +159,7 @@ impl<'a> DocumentBuilder<'a> {
     pub fn directive(
         &mut self,
         directive_location: DirectiveLocation,
-    ) -> Result<Option<Directive>> {
+    ) -> ArbitraryResult<Option<Directive>> {
         let available_directive_defs: Vec<&DirectiveDef> = self
             .directive_defs
             .iter()
@@ -184,7 +184,7 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `DirectiveDef`
-    pub fn directive_def(&mut self) -> Result<DirectiveDef> {
+    pub fn directive_def(&mut self) -> ArbitraryResult<DirectiveDef> {
         let description = self
             .u
             .arbitrary()
@@ -211,10 +211,10 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `HashSet` of `DirectiveLocation`
-    pub fn directive_locations(&mut self) -> Result<HashSet<DirectiveLocation>> {
+    pub fn directive_locations(&mut self) -> ArbitraryResult<HashSet<DirectiveLocation>> {
         (1..self.u.int_in_range(2..=5usize)?)
             .map(|_| self.u.arbitrary())
-            .collect::<Result<HashSet<_>>>()
+            .collect::<ArbitraryResult<HashSet<_>>>()
     }
 }
 

--- a/crates/apollo-smith/src/field.rs
+++ b/crates/apollo-smith/src/field.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     argument::{Argument, ArgumentsDef},
@@ -137,7 +137,7 @@ impl TryFrom<apollo_parser::ast::Field> for Field {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary list of `FieldDef`
-    pub fn fields_definition(&mut self, exclude: &[&Name]) -> Result<Vec<FieldDef>> {
+    pub fn fields_definition(&mut self, exclude: &[&Name]) -> ArbitraryResult<Vec<FieldDef>> {
         let num_fields = self.u.int_in_range(2..=50usize)?;
         let mut fields_names = HashSet::with_capacity(num_fields);
 
@@ -176,7 +176,7 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `Field` given an object type
-    pub fn field(&mut self, index: usize) -> Result<Field> {
+    pub fn field(&mut self, index: usize) -> ArbitraryResult<Field> {
         let fields_defs = self
             .stack
             .last()

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     directive::{Directive, DirectiveLocation},
@@ -174,7 +174,7 @@ impl From<apollo_parser::ast::TypeCondition> for TypeCondition {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `FragmentDef`
-    pub fn fragment_definition(&mut self) -> Result<FragmentDef> {
+    pub fn fragment_definition(&mut self) -> ArbitraryResult<FragmentDef> {
         // TODO: also choose between enum/scalars/object
         let selected_object_type_name = self.u.choose(&self.object_type_defs)?.name.clone();
         let _ = self.stack_ty(&Ty::Named(selected_object_type_name));
@@ -193,7 +193,10 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `FragmentSpread`, returns `None` if no fragment definition was previously created
-    pub fn fragment_spread(&mut self, excludes: &mut Vec<Name>) -> Result<Option<FragmentSpread>> {
+    pub fn fragment_spread(
+        &mut self,
+        excludes: &mut Vec<Name>,
+    ) -> ArbitraryResult<Option<FragmentSpread>> {
         let available_fragment: Vec<&FragmentDef> = self
             .fragment_defs
             .iter()
@@ -212,7 +215,7 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `InlineFragment`
-    pub fn inline_fragment(&mut self) -> Result<InlineFragment> {
+    pub fn inline_fragment(&mut self) -> ArbitraryResult<InlineFragment> {
         let type_condition = self
             .u
             .arbitrary()
@@ -230,7 +233,7 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `TypeCondition`
-    pub fn type_condition(&mut self) -> Result<TypeCondition> {
+    pub fn type_condition(&mut self) -> ArbitraryResult<TypeCondition> {
         let last_element = self.stack.last();
         match last_element {
             Some(last_element) => Ok(TypeCondition {

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     description::Description,
@@ -122,7 +122,7 @@ impl TryFrom<apollo_parser::ast::InputObjectTypeExtension> for InputObjectTypeDe
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `InputObjectTypeDef`
-    pub fn input_object_type_definition(&mut self) -> Result<InputObjectTypeDef> {
+    pub fn input_object_type_definition(&mut self) -> ArbitraryResult<InputObjectTypeDef> {
         let extend = !self.input_object_type_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
         let name = if extend {
             let available_input_objects: Vec<&Name> = self

--- a/crates/apollo-smith/src/interface.rs
+++ b/crates/apollo-smith/src/interface.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use apollo_encoder::InterfaceDefinition;
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     description::Description,
@@ -130,7 +130,7 @@ impl TryFrom<apollo_parser::ast::InterfaceTypeExtension> for InterfaceTypeDef {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `InterfaceTypeDef`
-    pub fn interface_type_definition(&mut self) -> Result<InterfaceTypeDef> {
+    pub fn interface_type_definition(&mut self) -> ArbitraryResult<InterfaceTypeDef> {
         let extend = !self.interface_type_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
         let description = self
             .u
@@ -163,7 +163,7 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `HashSet` of implemented interfaces
-    pub fn implements_interfaces(&mut self) -> Result<HashSet<Name>> {
+    pub fn implements_interfaces(&mut self) -> ArbitraryResult<HashSet<Name>> {
         if self.interface_type_defs.is_empty() {
             return Ok(HashSet::new());
         }

--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::DocumentBuilder;
 
@@ -62,12 +62,12 @@ impl Name {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `Name`
-    pub fn name(&mut self) -> Result<Name> {
+    pub fn name(&mut self) -> ArbitraryResult<Name> {
         Ok(Name::new(self.limited_string(30)?))
     }
 
     /// Create an arbitrary type `Name`
-    pub fn type_name(&mut self) -> Result<Name> {
+    pub fn type_name(&mut self) -> ArbitraryResult<Name> {
         let mut new_name = self.limited_string(30)?;
         if self.list_existing_type_names().any(|n| n.name == new_name) {
             let _ = write!(
@@ -80,7 +80,7 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `Name` with an index included in the name (to avoid name conflict)
-    pub fn name_with_index(&mut self, index: usize) -> Result<Name> {
+    pub fn name_with_index(&mut self, index: usize) -> ArbitraryResult<Name> {
         let mut name = self.limited_string(30)?;
         let _ = write!(name, "{}", index);
 
@@ -88,7 +88,7 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     // Mirror what happens in `Arbitrary for String`, but do so with a clamped size.
-    pub(crate) fn limited_string(&mut self, max_size: usize) -> Result<String> {
+    pub(crate) fn limited_string(&mut self, max_size: usize) -> ArbitraryResult<String> {
         loop {
             let size = self.u.int_in_range(0..=max_size)?;
 
@@ -112,7 +112,7 @@ impl<'a> DocumentBuilder<'a> {
 
                         Ok(ch)
                     })
-                    .collect::<Result<Vec<u8>>>()?,
+                    .collect::<ArbitraryResult<Vec<u8>>>()?,
             )
             .unwrap();
             let new_gen = gen_str.trim_end_matches('_');

--- a/crates/apollo-smith/src/object.rs
+++ b/crates/apollo-smith/src/object.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use apollo_encoder::ObjectDefinition;
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     description::Description,
@@ -128,7 +128,7 @@ impl TryFrom<apollo_parser::ast::ObjectTypeExtension> for ObjectTypeDef {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `ObjectTypeDef`
-    pub fn object_type_definition(&mut self) -> Result<ObjectTypeDef> {
+    pub fn object_type_definition(&mut self) -> ArbitraryResult<ObjectTypeDef> {
         let extend = !self.object_type_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
         let description = self
             .u

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use arbitrary::{Arbitrary, Result};
+use arbitrary::{Arbitrary, Result as ArbitraryResult};
 
 use crate::{
     directive::{Directive, DirectiveLocation},
@@ -115,7 +115,7 @@ impl From<apollo_parser::ast::OperationType> for OperationType {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `OperationDef` taking the last `SchemaDef`
-    pub fn operation_definition(&mut self) -> Result<Option<OperationDef>> {
+    pub fn operation_definition(&mut self) -> ArbitraryResult<Option<OperationDef>> {
         let schema = match self.schema_def.clone() {
             Some(schema_def) => schema_def,
             None => return Ok(None),

--- a/crates/apollo-smith/src/scalar.rs
+++ b/crates/apollo-smith/src/scalar.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     description::Description,
@@ -83,7 +83,7 @@ impl TryFrom<apollo_parser::ast::ScalarTypeExtension> for ScalarTypeDef {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `ScalarTypeDef`
-    pub fn scalar_type_definition(&mut self) -> Result<ScalarTypeDef> {
+    pub fn scalar_type_definition(&mut self) -> ArbitraryResult<ScalarTypeDef> {
         let extend = !self.scalar_type_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
         let name = if extend {
             let available_scalars: Vec<&Name> = self

--- a/crates/apollo-smith/src/schema.rs
+++ b/crates/apollo-smith/src/schema.rs
@@ -7,7 +7,7 @@ use crate::{
     ty::Ty,
     DocumentBuilder,
 };
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 /// A GraphQL service’s collective type system capabilities are referred to as that service’s “schema”.
 ///
@@ -126,7 +126,7 @@ impl TryFrom<apollo_parser::ast::SchemaExtension> for SchemaDef {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `SchemaDef`
-    pub fn schema_definition(&mut self) -> Result<SchemaDef> {
+    pub fn schema_definition(&mut self) -> ArbitraryResult<SchemaDef> {
         let description = self
             .u
             .arbitrary()

--- a/crates/apollo-smith/src/selection_set.rs
+++ b/crates/apollo-smith/src/selection_set.rs
@@ -1,4 +1,4 @@
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     field::Field,
@@ -92,7 +92,7 @@ impl TryFrom<apollo_parser::ast::Selection> for Selection {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `SelectionSet`
-    pub fn selection_set(&mut self) -> Result<SelectionSet> {
+    pub fn selection_set(&mut self) -> ArbitraryResult<SelectionSet> {
         let mut exclude_names = Vec::new();
         let selection_nb = std::cmp::max(
             self.stack.last().map(|o| o.fields_def().len()).unwrap_or(7),
@@ -100,12 +100,16 @@ impl<'a> DocumentBuilder<'a> {
         );
         let selections = (0..self.u.int_in_range(2..=selection_nb)?)
             .map(|index| self.selection(index, &mut exclude_names)) // TODO do not generate duplication variable name
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<ArbitraryResult<Vec<_>>>()?;
         Ok(SelectionSet { selections })
     }
 
     /// Create an arbitrary `Selection`
-    pub fn selection(&mut self, index: usize, excludes: &mut Vec<Name>) -> Result<Selection> {
+    pub fn selection(
+        &mut self,
+        index: usize,
+        excludes: &mut Vec<Name>,
+    ) -> ArbitraryResult<Selection> {
         let selection = match self.u.int_in_range(0..=2usize)? {
             0 => Selection::Field(self.field(index)?),
             1 => match self.fragment_spread(excludes)? {

--- a/crates/apollo-smith/src/ty.rs
+++ b/crates/apollo-smith/src/ty.rs
@@ -1,5 +1,5 @@
 use apollo_encoder::Type_;
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 use once_cell::sync::Lazy;
 
 use crate::{input_value::InputValue, name::Name, DocumentBuilder};
@@ -95,17 +95,17 @@ impl Ty {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `Ty`
-    pub fn ty(&mut self) -> Result<Ty> {
+    pub fn ty(&mut self) -> ArbitraryResult<Ty> {
         self.generate_ty(true)
     }
 
     /// Choose an arbitrary existing `Ty` given a slice of existing types
-    pub fn choose_ty(&mut self, existing_types: &[Ty]) -> Result<Ty> {
+    pub fn choose_ty(&mut self, existing_types: &[Ty]) -> ArbitraryResult<Ty> {
         self.choose_ty_given_nullable(existing_types, true)
     }
 
     /// Choose an arbitrary existing named `Ty` given a slice of existing types
-    pub fn choose_named_ty(&mut self, existing_types: &[Ty]) -> Result<Ty> {
+    pub fn choose_named_ty(&mut self, existing_types: &[Ty]) -> ArbitraryResult<Ty> {
         let used_type_names: Vec<&Ty> = existing_types
             .iter()
             .chain(BUILTIN_SCALAR_NAMES.iter())
@@ -114,7 +114,11 @@ impl<'a> DocumentBuilder<'a> {
         Ok(self.u.choose(&used_type_names)?.to_owned().clone())
     }
 
-    fn choose_ty_given_nullable(&mut self, existing_types: &[Ty], is_nullable: bool) -> Result<Ty> {
+    fn choose_ty_given_nullable(
+        &mut self,
+        existing_types: &[Ty],
+        is_nullable: bool,
+    ) -> ArbitraryResult<Ty> {
         let ty: Ty = match self.u.int_in_range(0..=2usize)? {
             // Named type
             0 => {
@@ -145,7 +149,7 @@ impl<'a> DocumentBuilder<'a> {
         Ok(ty)
     }
 
-    fn generate_ty(&mut self, is_nullable: bool) -> Result<Ty> {
+    fn generate_ty(&mut self, is_nullable: bool) -> ArbitraryResult<Ty> {
         let ty = match self.u.int_in_range(0..=2usize)? {
             // Named type
             0 => Ty::Named(self.name()?),

--- a/crates/apollo-smith/src/union.rs
+++ b/crates/apollo-smith/src/union.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use apollo_encoder::UnionDefinition;
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     description::Description,
@@ -115,7 +115,7 @@ impl TryFrom<apollo_parser::ast::UnionTypeExtension> for UnionTypeDef {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `UnionTypeDef`
-    pub fn union_type_definition(&mut self) -> Result<UnionTypeDef> {
+    pub fn union_type_definition(&mut self) -> ArbitraryResult<UnionTypeDef> {
         let extend = !self.union_type_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
         let name = if extend {
             let available_unions: Vec<&Name> = self
@@ -150,7 +150,7 @@ impl<'a> DocumentBuilder<'a> {
 
         let members = (0..self.u.int_in_range(2..=10)?)
             .map(|_| Ok(self.choose_named_ty(&existing_types)?.name().clone()))
-            .collect::<Result<HashSet<_>>>()?;
+            .collect::<ArbitraryResult<HashSet<_>>>()?;
 
         Ok(UnionTypeDef {
             name,

--- a/crates/apollo-smith/src/variable.rs
+++ b/crates/apollo-smith/src/variable.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use arbitrary::Result;
+use arbitrary::Result as ArbitraryResult;
 
 use crate::{
     directive::{Directive, DirectiveLocation},
@@ -41,14 +41,14 @@ impl From<VariableDef> for apollo_encoder::VariableDefinition {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary list of `VariableDef`
-    pub fn variable_definitions(&mut self) -> Result<Vec<VariableDef>> {
+    pub fn variable_definitions(&mut self) -> ArbitraryResult<Vec<VariableDef>> {
         (0..self.u.int_in_range(0..=7usize)?)
             .map(|_| self.variable_definition()) // TODO do not generate duplication variable name
             .collect()
     }
 
     /// Create an arbitrary `VariableDef`
-    pub fn variable_definition(&mut self) -> Result<VariableDef> {
+    pub fn variable_definition(&mut self) -> ArbitraryResult<VariableDef> {
         let name = self.type_name()?;
         let ty = self.choose_ty(&self.list_existing_types())?;
         let default_value = self


### PR DESCRIPTION
fixes https://github.com/apollographql/apollo-rs/issues/388

I think renaming or writing out `arbitrary::Result` is better here than aliasing `arbitrary::Result` to the name thats already in the rust prelude. I accidentally used the wrong `Result` type because of the name collision.