### PR TITLE
Document that only latest Stable Rust is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ make sure we account for them early on.
 
 ## Rust versions
 
-`apollo-rs` is tested with the latest Stable version of Rust.
+`apollo-rs` is tested on the latest stable version of Rust.
 Older version may or may not be compatible.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ or writing out query planning and composition algorithms in Rust. These all have
 quite different requirements when it comes to AST manipulation. We wanted to
 make sure we account for them early on.
 
+## Rust versions
+
+`apollo-rs` is tested with the latest Stable version of Rust.
+Older version may or may not be compatible.
+
 ## License
 Licensed under either of
 

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -37,7 +37,7 @@ cargo add apollo-compiler
 
 ## Rust versions
 
-`apollo-compiler` is tested with the latest Stable version of Rust.
+`apollo-compiler` is tested on the latest stable version of Rust.
 Older version may or may not be compatible.
 
 ## Usage

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -35,6 +35,11 @@ Or using [cargo-edit]:
 cargo add apollo-compiler
 ```
 
+## Rust versions
+
+`apollo-compiler` is tested with the latest Stable version of Rust.
+Older version may or may not be compatible.
+
 ## Usage
 `apollo-compiler` is built using [`salsa`] to provide a
 memoised query system on top of the AST produced by `apollo-parser`.

--- a/crates/apollo-encoder/README.md
+++ b/crates/apollo-encoder/README.md
@@ -35,7 +35,7 @@ cargo add apollo-encoder
 
 ## Rust versions
 
-`apollo-encoder` is tested with the latest Stable version of Rust.
+`apollo-encoder` is tested on the latest stable version of Rust.
 Older version may or may not be compatible.
 
 ## Examples

--- a/crates/apollo-encoder/README.md
+++ b/crates/apollo-encoder/README.md
@@ -33,6 +33,11 @@ Or using [cargo-edit]:
 cargo add apollo-encoder
 ```
 
+## Rust versions
+
+`apollo-encoder` is tested with the latest Stable version of Rust.
+Older version may or may not be compatible.
+
 ## Examples
 
 ### Create executable definitions

--- a/crates/apollo-parser/README.md
+++ b/crates/apollo-parser/README.md
@@ -37,6 +37,11 @@ Or using [cargo-edit]:
 cargo add apollo-parser
 ```
 
+## Rust versions
+
+`apollo-parser` is tested with the latest Stable version of Rust.
+Older version may or may not be compatible.
+
 ## Usage
 `apollo-parser` is built to parse both GraphQL schemas and queries according to
 the latest [October 2021 specification]. It produces a typed syntax tree that

--- a/crates/apollo-parser/README.md
+++ b/crates/apollo-parser/README.md
@@ -39,7 +39,7 @@ cargo add apollo-parser
 
 ## Rust versions
 
-`apollo-parser` is tested with the latest Stable version of Rust.
+`apollo-parser` is tested on the latest stable version of Rust.
 Older version may or may not be compatible.
 
 ## Usage

--- a/crates/apollo-smith/README.md
+++ b/crates/apollo-smith/README.md
@@ -29,6 +29,12 @@ anything that requires GraphQL document generation.
 
 This is still a work in progress, for outstanding issues, checkout out the
 [apollo-smith label] in our issue tracker.
+
+## Rust versions
+
+`apollo-smith` is tested with the latest Stable version of Rust.
+Older version may or may not be compatible.
+
 ## Using `apollo-smith` with `cargo fuzz`
 
 Define a new target with [`cargo fuzz`],

--- a/crates/apollo-smith/README.md
+++ b/crates/apollo-smith/README.md
@@ -32,7 +32,7 @@ This is still a work in progress, for outstanding issues, checkout out the
 
 ## Rust versions
 
-`apollo-smith` is tested with the latest Stable version of Rust.
+`apollo-smith` is tested on the latest stable version of Rust.
 Older version may or may not be compatible.
 
 ## Using `apollo-smith` with `cargo fuzz`


### PR DESCRIPTION
In the root readme to be visible on the repo’s home page on github, and repeated in crate-specific readmes to be visible on crates.io