### PR TITLE
feat(compiler): make `FileId`s unique per-process

### DIFF
--- a/crates/apollo-compiler/examples/extend_db.rs
+++ b/crates/apollo-compiler/examples/extend_db.rs
@@ -11,7 +11,6 @@ use thiserror::Error;
 #[derive(Default)]
 pub struct Linter {
     pub db: LinterDatabase,
-    next_file_id: u32,
 }
 
 impl Linter {
@@ -21,9 +20,7 @@ impl Linter {
     }
 
     pub fn document(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
-        let id = FileId(self.next_file_id);
-        self.next_file_id += 1;
-
+        let id = FileId::new();
         self.db.set_input(
             id,
             Source::document(path.as_ref().to_owned(), input.to_string()),

--- a/crates/apollo-compiler/src/database/sources.rs
+++ b/crates/apollo-compiler/src/database/sources.rs
@@ -1,6 +1,6 @@
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{atomic, Arc},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -63,4 +63,17 @@ impl Source {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct FileId(pub u32);
+pub struct FileId {
+    id: u64,
+}
+
+impl FileId {
+    // Returning a different value every time does not sound like good `impl Default`
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        static NEXT: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+        Self {
+            id: NEXT.fetch_add(1, atomic::Ordering::Relaxed),
+        }
+    }
+}

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -16,7 +16,6 @@ pub use diagnostics::ApolloDiagnostic;
 
 pub struct ApolloCompiler {
     pub db: RootDatabase,
-    next_file_id: FileId,
 }
 
 /// Apollo compiler creates a context around your GraphQL. It creates refernces
@@ -81,9 +80,7 @@ impl ApolloCompiler {
     }
 
     fn add_input(&mut self, source: Source) -> FileId {
-        let next_file_id = FileId(self.next_file_id.0 + 1);
-        let file_id = std::mem::replace(&mut self.next_file_id, next_file_id);
-
+        let file_id = FileId::new();
         let mut sources = self.db.source_files();
         sources.push(file_id);
         self.db.set_input(file_id, source);
@@ -196,10 +193,7 @@ impl Default for ApolloCompiler {
         db.set_recursion_limit(None);
         db.set_source_files(vec![]);
 
-        Self {
-            db,
-            next_file_id: FileId(0),
-        }
+        Self { db }
     }
 }
 


### PR DESCRIPTION
When we add an alternative kind of compiler input that contains already-parsed HIR nodes, this will allows `FileId` in these nodes to stay meaningful across multiple compiler instances in the same address space.