### PR TITLE
feat(compiler): introduce pre-computed type system input

### DIFF
--- a/crates/apollo-compiler/src/database/ast.rs
+++ b/crates/apollo-compiler/src/database/ast.rs
@@ -20,7 +20,10 @@ pub trait AstDatabase: InputDatabase {
 }
 
 fn ast(db: &dyn AstDatabase, file_id: FileId) -> SyntaxTree {
-    let input = db.source_code(file_id);
+    // Do not use `db.source_code(file_id)` here
+    // as that would also include sources of for pre-computed input,
+    // which we don’t want to re-parse.
+    let input = db.input(file_id).text();
 
     let parser = ApolloParser::new(&input);
     let parser = if let Some(limit) = db.recursion_limit() {

--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -10,6 +10,7 @@ pub(crate) fn types_definitions_by_name(
     db: &dyn HirDatabase,
 ) -> Arc<IndexMap<String, TypeDefinition>> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.type_definitions_by_name.clone();
     }
     let mut map = IndexMap::new();
@@ -265,6 +266,7 @@ pub(crate) fn operation_definition_variables(
 
 pub(crate) fn subtype_map(db: &dyn HirDatabase) -> Arc<HashMap<String, HashSet<String>>> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.subtype_map.clone();
     }
     let mut map = HashMap::<String, HashSet<String>>::new();

--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -45,6 +45,16 @@ pub(crate) fn find_operation_by_name(
         .cloned()
 }
 
+pub(crate) fn find_unnamed_operation(
+    db: &dyn HirDatabase,
+    file_id: FileId,
+) -> Option<Arc<OperationDefinition>> {
+    db.operations(file_id)
+        .iter()
+        .find(|def| def.name().is_none())
+        .cloned()
+}
+
 pub(crate) fn find_fragment_by_name(
     db: &dyn HirDatabase,
     file_id: FileId,

--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 pub(crate) fn types_definitions_by_name(
     db: &dyn HirDatabase,
 ) -> Arc<IndexMap<String, TypeDefinition>> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.type_definitions_by_name.clone();
     }
     let mut map = IndexMap::new();
@@ -264,7 +264,7 @@ pub(crate) fn operation_definition_variables(
 }
 
 pub(crate) fn subtype_map(db: &dyn HirDatabase) -> Arc<HashMap<String, HashSet<String>>> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.subtype_map.clone();
     }
     let mut map = HashMap::<String, HashSet<String>>::new();

--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -48,7 +48,7 @@ pub(crate) fn find_operation_by_name(
         .cloned()
 }
 
-pub(crate) fn find_unnamed_operation(
+pub(crate) fn find_anonymous_operation(
     db: &dyn HirDatabase,
     file_id: FileId,
 ) -> Option<Arc<OperationDefinition>> {

--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -9,6 +9,9 @@ use indexmap::IndexMap;
 pub(crate) fn types_definitions_by_name(
     db: &dyn HirDatabase,
 ) -> Arc<IndexMap<String, TypeDefinition>> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.type_definitions_by_name.clone();
+    }
     let mut map = IndexMap::new();
     macro_rules! add {
         ($get: ident, $variant: ident) => {
@@ -261,6 +264,9 @@ pub(crate) fn operation_definition_variables(
 }
 
 pub(crate) fn subtype_map(db: &dyn HirDatabase) -> Arc<HashMap<String, HashSet<String>>> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.subtype_map.clone();
+    }
     let mut map = HashMap::<String, HashSet<String>>::new();
     let mut add = |key: &str, value: &str| {
         map.entry(key.to_owned())

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -25,7 +25,7 @@ pub struct TypeSystemDefinitions {
     pub directives: ByName<DirectiveDefinition>,
 }
 
-/// Contains a `TypeSystemDefinition` together with:
+/// Contains `TypeSystemDefinitions` together with:
 ///
 /// * Other data that can be derived from it.
 /// * Relevant inputs

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -1,9 +1,12 @@
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use apollo_parser::{ast, SyntaxNode};
 use ordered_float::{self, OrderedFloat};
 
-use crate::HirDatabase;
+use crate::{HirDatabase, Source};
 
 use super::FileId;
 use indexmap::IndexMap;
@@ -20,6 +23,18 @@ pub struct TypeSystemDefinitions {
     pub enums: ByName<EnumTypeDefinition>,
     pub input_objects: ByName<InputObjectTypeDefinition>,
     pub directives: ByName<DirectiveDefinition>,
+}
+
+/// Contains a `TypeSystemDefinition` together with:
+///
+/// * Other data that can be derived from it.
+/// * Relevant inputs
+#[derive(PartialEq, Eq, Debug)]
+pub struct PrecomputedTypeSystem {
+    pub definitions: Arc<TypeSystemDefinitions>,
+    pub inputs: IndexMap<FileId, Source>,
+    pub type_definitions_by_name: Arc<IndexMap<String, TypeDefinition>>,
+    pub subtype_map: Arc<HashMap<String, HashSet<String>>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -27,10 +27,13 @@ pub struct TypeSystemDefinitions {
 
 /// Contains `TypeSystemDefinitions` together with:
 ///
-/// * Other data that can be derived from it.
-/// * Relevant inputs
+/// * Other data that can be derived from it, computed eagerly
+/// * Relevant inputs, so that diagnostics can print context
+///
+/// This can be used with [`set_type_system_hir`][crate::ApolloCompiler::set_type_system_hir]
+/// on another compiler.
 #[derive(PartialEq, Eq, Debug)]
-pub struct PrecomputedTypeSystem {
+pub struct TypeSystem {
     pub definitions: Arc<TypeSystemDefinitions>,
     pub inputs: IndexMap<FileId, Source>,
     pub type_definitions_by_name: Arc<IndexMap<String, TypeDefinition>>,

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -225,6 +225,7 @@ fn type_system_definitions(db: &dyn HirDatabase) -> Arc<TypeSystemDefinitions> {
 
 fn type_system(db: &dyn HirDatabase) -> Arc<TypeSystem> {
     if let Some(precomputed_input) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed_input;
     }
     Arc::new(TypeSystem {
@@ -319,6 +320,7 @@ where
 // means we can't really diagnose the "multiple schema definitions" errors.
 fn schema(db: &dyn HirDatabase) -> Arc<SchemaDefinition> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.definitions.schema.clone();
     }
     let mut schema_def = type_definitions(db, schema_definition)
@@ -368,6 +370,7 @@ macro_rules! by_name_extensible {
 
 fn object_types(db: &dyn HirDatabase) -> ByName<ObjectTypeDefinition> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.definitions.objects.clone();
     }
     Arc::new(by_name_extensible!(
@@ -379,6 +382,7 @@ fn object_types(db: &dyn HirDatabase) -> ByName<ObjectTypeDefinition> {
 
 fn scalars(db: &dyn HirDatabase) -> ByName<ScalarTypeDefinition> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.definitions.scalars.clone();
     }
     Arc::new(built_in_scalars(by_name_extensible!(
@@ -390,6 +394,7 @@ fn scalars(db: &dyn HirDatabase) -> ByName<ScalarTypeDefinition> {
 
 fn enums(db: &dyn HirDatabase) -> ByName<EnumTypeDefinition> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.definitions.enums.clone();
     }
     Arc::new(by_name_extensible!(db, enum_definition, enum_extension))
@@ -397,6 +402,7 @@ fn enums(db: &dyn HirDatabase) -> ByName<EnumTypeDefinition> {
 
 fn unions(db: &dyn HirDatabase) -> ByName<UnionTypeDefinition> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.definitions.unions.clone();
     }
     Arc::new(by_name_extensible!(db, union_definition, union_extension))
@@ -412,6 +418,7 @@ fn interfaces(db: &dyn HirDatabase) -> ByName<InterfaceTypeDefinition> {
 
 fn input_objects(db: &dyn HirDatabase) -> ByName<InputObjectTypeDefinition> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.definitions.input_objects.clone();
     }
     Arc::new(by_name_extensible!(
@@ -423,6 +430,7 @@ fn input_objects(db: &dyn HirDatabase) -> ByName<InputObjectTypeDefinition> {
 
 fn directive_definitions(db: &dyn HirDatabase) -> ByName<DirectiveDefinition> {
     if let Some(precomputed) = db.type_system_hir_input() {
+        // Panics in `ApolloCompiler` methods ensure `type_definition_files().is_empty()`
         return precomputed.definitions.directives.clone();
     }
     Arc::new(built_in_directives(by_name!(db, directive_definition)))

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -22,8 +22,11 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
     /// Return all type system definitions defined in the compiler.
     fn type_system_definitions(&self) -> Arc<TypeSystemDefinitions>;
 
-    /// Return a `PrecomputedTypeSystem` which can be used to add a type system to a new instance of `ApolloCompiler`.
-    fn precomputed_type_system(&self) -> Arc<TypeSystem>;
+    /// Return a [`TypeSystem`] containing definitions and more.
+    ///
+    /// This can be used with [`set_type_system_hir`][crate::ApolloCompiler::set_type_system_hir]
+    /// on another compiler.
+    fn type_system(&self) -> Arc<TypeSystem>;
 
     /// Return all the operations defined in a file.
     fn operations(&self, file_id: FileId) -> Arc<Vec<Arc<OperationDefinition>>>;
@@ -220,8 +223,8 @@ fn type_system_definitions(db: &dyn HirDatabase) -> Arc<TypeSystemDefinitions> {
     })
 }
 
-fn precomputed_type_system(db: &dyn HirDatabase) -> Arc<TypeSystem> {
-    if let Some(precomputed_input) = db.precomputed_input() {
+fn type_system(db: &dyn HirDatabase) -> Arc<TypeSystem> {
+    if let Some(precomputed_input) = db.type_system_hir_input() {
         return precomputed_input;
     }
     Arc::new(TypeSystem {
@@ -315,7 +318,7 @@ where
 // This implementation currently just finds the first schema definition, which
 // means we can't really diagnose the "multiple schema definitions" errors.
 fn schema(db: &dyn HirDatabase) -> Arc<SchemaDefinition> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.definitions.schema.clone();
     }
     let mut schema_def = type_definitions(db, schema_definition)
@@ -364,7 +367,7 @@ macro_rules! by_name_extensible {
 }
 
 fn object_types(db: &dyn HirDatabase) -> ByName<ObjectTypeDefinition> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.definitions.objects.clone();
     }
     Arc::new(by_name_extensible!(
@@ -375,7 +378,7 @@ fn object_types(db: &dyn HirDatabase) -> ByName<ObjectTypeDefinition> {
 }
 
 fn scalars(db: &dyn HirDatabase) -> ByName<ScalarTypeDefinition> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.definitions.scalars.clone();
     }
     Arc::new(built_in_scalars(by_name_extensible!(
@@ -386,14 +389,14 @@ fn scalars(db: &dyn HirDatabase) -> ByName<ScalarTypeDefinition> {
 }
 
 fn enums(db: &dyn HirDatabase) -> ByName<EnumTypeDefinition> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.definitions.enums.clone();
     }
     Arc::new(by_name_extensible!(db, enum_definition, enum_extension))
 }
 
 fn unions(db: &dyn HirDatabase) -> ByName<UnionTypeDefinition> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.definitions.unions.clone();
     }
     Arc::new(by_name_extensible!(db, union_definition, union_extension))
@@ -408,7 +411,7 @@ fn interfaces(db: &dyn HirDatabase) -> ByName<InterfaceTypeDefinition> {
 }
 
 fn input_objects(db: &dyn HirDatabase) -> ByName<InputObjectTypeDefinition> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.definitions.input_objects.clone();
     }
     Arc::new(by_name_extensible!(
@@ -419,7 +422,7 @@ fn input_objects(db: &dyn HirDatabase) -> ByName<InputObjectTypeDefinition> {
 }
 
 fn directive_definitions(db: &dyn HirDatabase) -> ByName<DirectiveDefinition> {
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         return precomputed.definitions.directives.clone();
     }
     Arc::new(built_in_directives(by_name!(db, directive_definition)))

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -68,8 +68,8 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
         name: String,
     ) -> Option<Arc<OperationDefinition>>;
 
-    /// Return an operation definition without a name corresponding to the file id.
-    fn find_unnamed_operation(&self, file_id: FileId) -> Option<Arc<OperationDefinition>>;
+    /// Return an operation definition without a name, corresponding to the file id.
+    fn find_anonymous_operation(&self, file_id: FileId) -> Option<Arc<OperationDefinition>>;
 
     /// Return an fragment definition corresponding to the name and file id.
     /// Result of this query is not cached internally.

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -22,6 +22,7 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
     /// Return all type system definitions defined in the compiler.
     fn type_system_definitions(&self) -> Arc<TypeSystemDefinitions>;
 
+    /// Return a `PrecomputedTypeSystem` which can be used to add a type system to a new instance of `ApolloCompiler`.
     fn precomputed_type_system(&self) -> Arc<PrecomputedTypeSystem>;
 
     /// Return all the operations defined in a file.

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -23,7 +23,7 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
     fn type_system_definitions(&self) -> Arc<TypeSystemDefinitions>;
 
     /// Return a `PrecomputedTypeSystem` which can be used to add a type system to a new instance of `ApolloCompiler`.
-    fn precomputed_type_system(&self) -> Arc<PrecomputedTypeSystem>;
+    fn precomputed_type_system(&self) -> Arc<TypeSystem>;
 
     /// Return all the operations defined in a file.
     fn operations(&self, file_id: FileId) -> Arc<Vec<Arc<OperationDefinition>>>;
@@ -220,11 +220,11 @@ fn type_system_definitions(db: &dyn HirDatabase) -> Arc<TypeSystemDefinitions> {
     })
 }
 
-fn precomputed_type_system(db: &dyn HirDatabase) -> Arc<PrecomputedTypeSystem> {
+fn precomputed_type_system(db: &dyn HirDatabase) -> Arc<TypeSystem> {
     if let Some(precomputed_input) = db.precomputed_input() {
         return precomputed_input;
     }
-    Arc::new(PrecomputedTypeSystem {
+    Arc::new(TypeSystem {
         definitions: db.type_system_definitions(),
         type_definitions_by_name: db.types_definitions_by_name(),
         subtype_map: db.subtype_map(),

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -68,6 +68,7 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
         name: String,
     ) -> Option<Arc<OperationDefinition>>;
 
+    /// Return an operation definition without a name corresponding to the file id.
     fn find_unnamed_operation(&self, file_id: FileId) -> Option<Arc<OperationDefinition>>;
 
     /// Return an fragment definition corresponding to the name and file id.

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -1,19 +1,18 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
 
-use apollo_parser::{
-    ast::{self, AstChildren, AstNode},
-    SyntaxNode,
-};
-
-use crate::{
-    database::{document::*, FileId},
-    hir::*,
-    AstDatabase, InputDatabase,
-};
+use apollo_parser::ast::AstChildren;
+use apollo_parser::ast::AstNode;
+use apollo_parser::ast::{self};
+use apollo_parser::SyntaxNode;
 use indexmap::IndexMap;
+
+use crate::database::document::*;
+use crate::database::FileId;
+use crate::hir::*;
+use crate::AstDatabase;
+use crate::InputDatabase;
 
 // HIR creators *ignore* missing data entirely. *Only* missing data
 // as a result of parser errors should be ignored.
@@ -22,6 +21,8 @@ use indexmap::IndexMap;
 pub trait HirDatabase: InputDatabase + AstDatabase {
     /// Return all type system definitions defined in the compiler.
     fn type_system_definitions(&self) -> Arc<TypeSystemDefinitions>;
+
+    fn precomputed_type_system(&self) -> Arc<PrecomputedTypeSystem>;
 
     /// Return all the operations defined in a file.
     fn operations(&self, file_id: FileId) -> Arc<Vec<Arc<OperationDefinition>>>;
@@ -66,6 +67,8 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
         file_id: FileId,
         name: String,
     ) -> Option<Arc<OperationDefinition>>;
+
+    fn find_unnamed_operation(&self, file_id: FileId) -> Option<Arc<OperationDefinition>>;
 
     /// Return an fragment definition corresponding to the name and file id.
     /// Result of this query is not cached internally.
@@ -215,6 +218,22 @@ fn type_system_definitions(db: &dyn HirDatabase) -> Arc<TypeSystemDefinitions> {
     })
 }
 
+fn precomputed_type_system(db: &dyn HirDatabase) -> Arc<PrecomputedTypeSystem> {
+    if let Some(precomputed_input) = db.precomputed_input() {
+        return precomputed_input;
+    }
+    Arc::new(PrecomputedTypeSystem {
+        definitions: db.type_system_definitions(),
+        type_definitions_by_name: db.types_definitions_by_name(),
+        subtype_map: db.subtype_map(),
+        inputs: db
+            .type_definition_files()
+            .into_iter()
+            .map(|file_id| (file_id, db.input(file_id)))
+            .collect(),
+    })
+}
+
 fn operations(db: &dyn HirDatabase, file_id: FileId) -> Arc<Vec<Arc<OperationDefinition>>> {
     Arc::new(
         db.ast(file_id)
@@ -294,6 +313,9 @@ where
 // This implementation currently just finds the first schema definition, which
 // means we can't really diagnose the "multiple schema definitions" errors.
 fn schema(db: &dyn HirDatabase) -> Arc<SchemaDefinition> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.definitions.schema.clone();
+    }
     let mut schema_def = type_definitions(db, schema_definition)
         .next()
         .unwrap_or_default();
@@ -340,6 +362,9 @@ macro_rules! by_name_extensible {
 }
 
 fn object_types(db: &dyn HirDatabase) -> ByName<ObjectTypeDefinition> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.definitions.objects.clone();
+    }
     Arc::new(by_name_extensible!(
         db,
         object_type_definition,
@@ -348,6 +373,9 @@ fn object_types(db: &dyn HirDatabase) -> ByName<ObjectTypeDefinition> {
 }
 
 fn scalars(db: &dyn HirDatabase) -> ByName<ScalarTypeDefinition> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.definitions.scalars.clone();
+    }
     Arc::new(built_in_scalars(by_name_extensible!(
         db,
         scalar_definition,
@@ -356,10 +384,16 @@ fn scalars(db: &dyn HirDatabase) -> ByName<ScalarTypeDefinition> {
 }
 
 fn enums(db: &dyn HirDatabase) -> ByName<EnumTypeDefinition> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.definitions.enums.clone();
+    }
     Arc::new(by_name_extensible!(db, enum_definition, enum_extension))
 }
 
 fn unions(db: &dyn HirDatabase) -> ByName<UnionTypeDefinition> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.definitions.unions.clone();
+    }
     Arc::new(by_name_extensible!(db, union_definition, union_extension))
 }
 
@@ -372,6 +406,9 @@ fn interfaces(db: &dyn HirDatabase) -> ByName<InterfaceTypeDefinition> {
 }
 
 fn input_objects(db: &dyn HirDatabase) -> ByName<InputObjectTypeDefinition> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.definitions.input_objects.clone();
+    }
     Arc::new(by_name_extensible!(
         db,
         input_object_definition,
@@ -380,6 +417,9 @@ fn input_objects(db: &dyn HirDatabase) -> ByName<InputObjectTypeDefinition> {
 }
 
 fn directive_definitions(db: &dyn HirDatabase) -> ByName<DirectiveDefinition> {
+    if let Some(precomputed) = db.precomputed_input() {
+        return precomputed.definitions.directives.clone();
+    }
     Arc::new(built_in_directives(by_name!(db, directive_definition)))
 }
 

--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -1,5 +1,5 @@
 use super::sources::{FileId, Source, SourceType};
-use crate::hir::PrecomputedTypeSystem;
+use crate::hir::TypeSystem;
 use std::sync::Arc;
 
 #[salsa::query_group(InputStorage)]
@@ -10,7 +10,7 @@ pub trait InputDatabase {
 
     /// Get input source of the corresponding file.
     #[salsa::input]
-    fn precomputed_input(&self) -> Option<Arc<PrecomputedTypeSystem>>;
+    fn precomputed_input(&self) -> Option<Arc<TypeSystem>>;
 
     #[salsa::input]
     fn input(&self, file_id: FileId) -> Source;

--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -1,4 +1,5 @@
 use super::sources::{FileId, Source, SourceType};
+use crate::hir::PrecomputedTypeSystem;
 use std::sync::Arc;
 
 #[salsa::query_group(InputStorage)]
@@ -8,6 +9,9 @@ pub trait InputDatabase {
     fn recursion_limit(&self) -> Option<usize>;
 
     /// Get input source of the corresponding file.
+    #[salsa::input]
+    fn precomputed_input(&self) -> Option<Arc<PrecomputedTypeSystem>>;
+
     #[salsa::input]
     fn input(&self, file_id: FileId) -> Source;
 
@@ -29,6 +33,12 @@ pub trait InputDatabase {
 }
 
 fn source_code(db: &dyn InputDatabase, file_id: FileId) -> Arc<str> {
+    // For diagnostics, also include sources for a precomputed input.
+    if let Some(precomputed) = db.precomputed_input() {
+        if let Some(source) = precomputed.inputs.get(&file_id) {
+            return source.text();
+        }
+    }
     db.input(file_id).text()
 }
 

--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -10,7 +10,7 @@ pub trait InputDatabase {
 
     /// Get input source of the corresponding file.
     #[salsa::input]
-    fn precomputed_input(&self) -> Option<Arc<TypeSystem>>;
+    fn type_system_hir_input(&self) -> Option<Arc<TypeSystem>>;
 
     #[salsa::input]
     fn input(&self, file_id: FileId) -> Source;
@@ -34,7 +34,7 @@ pub trait InputDatabase {
 
 fn source_code(db: &dyn InputDatabase, file_id: FileId) -> Arc<str> {
     // For diagnostics, also include sources for a precomputed input.
-    if let Some(precomputed) = db.precomputed_input() {
+    if let Some(precomputed) = db.type_system_hir_input() {
         if let Some(source) = precomputed.inputs.get(&file_id) {
             return source.text();
         }

--- a/crates/apollo-compiler/src/database/sources.rs
+++ b/crates/apollo-compiler/src/database/sources.rs
@@ -11,7 +11,7 @@ pub enum SourceType {
 }
 
 /// Represents a GraphQL source file.
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Source {
     ty: SourceType,
     filename: PathBuf,

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -90,7 +90,7 @@ impl ApolloCompiler {
                  for type system definitions is not supported"
             )
         }
-        self.db.set_precomputed_input(Some(schema))
+        self.db.set_type_system_hir_input(Some(schema))
     }
 
     fn add_input(&mut self, source: Source) -> FileId {
@@ -112,7 +112,7 @@ impl ApolloCompiler {
     ///
     /// Returns a `FileId` that you can use to update the source text of this document.
     pub fn add_document(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
-        if self.db.precomputed_input().is_some() {
+        if self.db.type_system_hir_input().is_some() {
             panic!(
                 "Having both string inputs and pre-computed inputs \
                  for type system definitions is not supported"
@@ -130,7 +130,7 @@ impl ApolloCompiler {
     ///
     /// Returns a `FileId` that you can use to update the source text of this document.
     pub fn add_type_system(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
-        if self.db.precomputed_input().is_some() {
+        if self.db.type_system_hir_input().is_some() {
             panic!(
                 "Having both string inputs and pre-computed inputs \
                  for type system definitions is not supported"
@@ -216,7 +216,7 @@ impl Default for ApolloCompiler {
         let mut db = RootDatabase::default();
         // TODO(@goto-bus-stop) can we make salsa fill in these defaults for us…?
         db.set_recursion_limit(None);
-        db.set_precomputed_input(None);
+        db.set_type_system_hir_input(None);
         db.set_source_files(vec![]);
 
         Self { db }
@@ -1213,11 +1213,11 @@ type Query {
 
         let mut compiler = ApolloCompiler::new();
         compiler.add_type_system(schema, "schema.graphql");
-        let precomputed = compiler.db.precomputed_type_system();
+        let type_system = compiler.db.type_system();
 
         let handles: Vec<_> = (0..2)
             .map(|_| {
-                let cloned = std::sync::Arc::clone(&precomputed);
+                let cloned = std::sync::Arc::clone(&type_system); // cheap refcount increment
                 std::thread::spawn(move || {
                     let mut compiler = ApolloCompiler::new();
                     let query_id = compiler.add_executable(query, "query.graphql");

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -11,7 +11,6 @@ use std::{path::Path, sync::Arc};
 use salsa::ParallelDatabase;
 use validation::ValidationDatabase;
 
-use database::hir::PrecomputedTypeSystem;
 pub use database::{hir, AstDatabase, FileId, HirDatabase, InputDatabase, RootDatabase, Source};
 pub use diagnostics::ApolloDiagnostic;
 
@@ -84,7 +83,7 @@ impl ApolloCompiler {
     }
 
     /// Add or update a pre-computed input for type system definitions
-    pub fn set_precomputed_schema(&mut self, schema: Arc<PrecomputedTypeSystem>) {
+    pub fn set_type_system_hir(&mut self, schema: Arc<hir::TypeSystem>) {
         if !self.db.type_definition_files().is_empty() {
             panic!(
                 "Having both string inputs and pre-computed inputs \
@@ -1222,7 +1221,7 @@ type Query {
                 std::thread::spawn(move || {
                     let mut compiler = ApolloCompiler::new();
                     let query_id = compiler.add_executable(query, "query.graphql");
-                    compiler.set_precomputed_schema(cloned);
+                    compiler.set_type_system_hir(cloned);
                     compiler
                         .db
                         .find_anonymous_operation(query_id)

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -1225,7 +1225,7 @@ type Query {
                     compiler.set_precomputed_schema(cloned);
                     compiler
                         .db
-                        .find_unnamed_operation(query_id)
+                        .find_anonymous_operation(query_id)
                         .unwrap()
                         .fields(&compiler.db)[0]
                         .ty(&compiler.db)

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -1,6 +1,6 @@
 use crate::{
     diagnostics::{RecursiveDefinition, UniqueDefinition},
-    validation::type_definitions,
+    validation::ast_type_definitions,
     ApolloDiagnostic, ValidationDatabase,
 };
 use apollo_parser::ast;
@@ -12,7 +12,7 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     //
     // Return a Unique Definition error in case of a duplicate name.
     let hir = db.directive_definitions();
-    for (file_id, ast_def) in type_definitions::<ast::DirectiveDefinition>(db) {
+    for (file_id, ast_def) in ast_type_definitions::<ast::DirectiveDefinition>(db) {
         if let Some(name) = ast_def.name() {
             let name = &*name.text();
             let hir_def = &hir[name];

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     diagnostics::{UniqueDefinition, UniqueField},
     hir::InputValueDefinition,
-    validation::type_definitions,
+    validation::ast_type_definitions,
     ApolloDiagnostic, ValidationDatabase,
 };
 use apollo_parser::ast;
@@ -15,7 +15,7 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     //
     // Return a Unique Definition error in case of a duplicate name.
     let hir = db.input_objects();
-    for (file_id, ast_def) in type_definitions::<ast::InputObjectTypeDefinition>(db) {
+    for (file_id, ast_def) in ast_type_definitions::<ast::InputObjectTypeDefinition>(db) {
         if let Some(name) = ast_def.name() {
             let name = &*name.text();
             let hir_def = &hir[name];

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -6,7 +6,7 @@ use crate::{
         UndefinedDefinition, UniqueDefinition, UniqueField,
     },
     hir::FieldDefinition,
-    validation::{type_definitions, ValidationSet},
+    validation::{ast_type_definitions, ValidationSet},
     ApolloDiagnostic, ValidationDatabase,
 };
 use apollo_parser::ast;
@@ -18,7 +18,7 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     //
     // Return a Unique Definition error in case of a duplicate name.
     let hir = db.interfaces();
-    for (file_id, ast_def) in type_definitions::<ast::InterfaceTypeDefinition>(db) {
+    for (file_id, ast_def) in ast_type_definitions::<ast::InterfaceTypeDefinition>(db) {
         if let Some(name) = ast_def.name() {
             let name = &*name.text();
             let hir_def = &hir[name];

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -35,7 +35,9 @@ impl PartialEq for ValidationSet {
 }
 
 /// Finds top-level AST nodes of a given type in type definition files.
-pub(crate) fn type_definitions<'db, AstType>(
+///
+/// This ignores pre-computed inputs.
+pub(crate) fn ast_type_definitions<'db, AstType>(
     db: &'db dyn ValidationDatabase,
 ) -> impl Iterator<Item = (FileId, AstType)> + 'db
 where

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -6,7 +6,7 @@ use crate::{
         UniqueDefinition, UniqueField,
     },
     hir::FieldDefinition,
-    validation::{type_definitions, ValidationSet},
+    validation::{ast_type_definitions, ValidationSet},
     ApolloDiagnostic, ValidationDatabase,
 };
 use apollo_parser::ast;
@@ -18,7 +18,7 @@ pub fn check(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     //
     // Return a Unique Definition error in case of a duplicate name.
     let hir = db.object_types();
-    for (file_id, ast_def) in type_definitions::<ast::ObjectTypeDefinition>(db) {
+    for (file_id, ast_def) in ast_type_definitions::<ast::ObjectTypeDefinition>(db) {
         if let Some(name) = ast_def.name() {
             let name = &*name.text();
             let hir_def = &hir[name];


### PR DESCRIPTION
This allows extracting a parsed type system from Salsa
into read-only data that can be shared across threads,
with each thread using it as input to new compiler instances.

Fixes https://github.com/apollographql/apollo-rs/issues/406