### PR TITLE
feat(compiler): add type alias for `compiler.snapshot()`

### DIFF
--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -19,7 +19,7 @@ pub struct ApolloCompiler {
 }
 
 /// A read-only, `Sync` snapshot of the database.
-type Snapshot = salsa::Snapshot<RootDatabase>;
+pub type Snapshot = salsa::Snapshot<RootDatabase>;
 
 /// Apollo compiler creates a context around your GraphQL. It creates refernces
 /// between various GraphQL types in scope.

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -18,6 +18,9 @@ pub struct ApolloCompiler {
     pub db: RootDatabase,
 }
 
+/// A read-only, `Sync` snapshot of the database.
+type Snapshot = salsa::Snapshot<RootDatabase>;
+
 /// Apollo compiler creates a context around your GraphQL. It creates refernces
 /// between various GraphQL types in scope.
 ///
@@ -156,7 +159,7 @@ impl ApolloCompiler {
     }
 
     /// Get a snapshot of the current database.
-    pub fn snapshot(&self) -> salsa::Snapshot<RootDatabase> {
+    pub fn snapshot(&self) -> Snapshot {
         self.db.snapshot()
     }
 


### PR DESCRIPTION
This allows naming the return type of `ApolloCompiler::snapshot` without importing `salsa` separately.