### PR TITLE
breaking(compiler): rename create_* methods to add_*

### DIFF
--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -79,7 +79,7 @@ let input = r#"
 "#;
 
 let mut compiler = ApolloCompiler::new();
-compiler.create_document(input, "document.graphql");
+compiler.add_document(input, "document.graphql");
 
 let diagnostics = compiler.validate();
 for diagnostic in &diagnostics {
@@ -133,8 +133,8 @@ fn main() -> Result<()> {
     "#;
 
     let mut compiler = ApolloCompiler::new();
-    let _schema_id = compiler.create_schema(schema_input, "schema.graphql");
-    let query_id = compiler.create_executable(query_input, "query.graphql");
+    let _schema_id = compiler.add_schema(schema_input, "schema.graphql");
+    let query_id = compiler.add_executable(query_input, "query.graphql");
 
     let diagnostics = compiler.validate();
     for diagnostic in &diagnostics {
@@ -195,8 +195,8 @@ fn main() -> Result<()> {
 
 
     let mut compiler = ApolloCompiler::new();
-    compiler.create_schema(schema_input, "schema.graphql");
-    let query_id = compiler.create_executable(query_input, "query.graphql");
+    compiler.add_schema(schema_input, "schema.graphql");
+    let query_id = compiler.add_executable(query_input, "query.graphql");
 
     let diagnostics = compiler.validate();
     for diagnostic in &diagnostics {
@@ -291,7 +291,7 @@ union CatOrDog = Cat | Dog
 "#;
 
 let mut compiler = ApolloCompiler::new();
-compiler.create_document(input, "document.graphql");
+compiler.add_document(input, "document.graphql");
 
 let diagnostics = compiler.validate();
 for diagnostic in &diagnostics {

--- a/crates/apollo-compiler/benches/multi_source.rs
+++ b/crates/apollo-compiler/benches/multi_source.rs
@@ -3,8 +3,8 @@ use criterion::*;
 
 fn compile(schema: &str, query: &str) -> ApolloCompiler {
     let mut compiler = ApolloCompiler::new();
-    compiler.create_schema(schema, "schema.graphql");
-    let executable_id = compiler.create_executable(query, "query.graphql");
+    compiler.add_schema(schema, "schema.graphql");
+    let executable_id = compiler.add_executable(query, "query.graphql");
 
     compiler.db.operations(executable_id);
     compiler.db.object_types();

--- a/crates/apollo-compiler/examples/file_watcher.rs
+++ b/crates/apollo-compiler/examples/file_watcher.rs
@@ -32,7 +32,7 @@ impl FileWatcher {
 
     // The `watch` fn first goes over every document in a given directory and
     // creates it as a new document with compiler's
-    // `compiler.create_document()`.
+    // `compiler.add_document()`.
     //
     // We then watch for file changes, and update
     // each changed document with `compiler.update_document()`.
@@ -122,7 +122,7 @@ impl FileWatcher {
         proposed_document: String,
         src_path: PathBuf,
     ) -> Result<(), anyhow::Error> {
-        let file_id = self.compiler.create_document(&proposed_document, &src_path);
+        let file_id = self.compiler.add_document(&proposed_document, &src_path);
         let full_path = fs::canonicalize(src_path)?;
         self.manifest.insert(full_path, file_id);
         Ok(())

--- a/crates/apollo-compiler/examples/hello_world.rs
+++ b/crates/apollo-compiler/examples/hello_world.rs
@@ -7,7 +7,7 @@ fn compile_query() -> Option<Arc<hir::FragmentDefinition>> {
     let src = fs::read_to_string(file).expect("Could not read schema file.");
 
     let mut compiler = ApolloCompiler::new();
-    let document_id = compiler.create_document(&src, file);
+    let document_id = compiler.add_document(&src, file);
     // let errors = ctx.validate();
 
     let operations = compiler.db.operations(document_id);

--- a/crates/apollo-compiler/examples/multi_source_validation.rs
+++ b/crates/apollo-compiler/examples/multi_source_validation.rs
@@ -18,7 +18,7 @@ fn compile_from_dir() -> io::Result<()> {
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
             let src = fs::read_to_string(entry.path()).expect("Could not read document file.");
-            compiler.create_document(&src, entry.path());
+            compiler.add_document(&src, entry.path());
         }
     }
 
@@ -37,18 +37,18 @@ fn compile_schema_and_query_files() -> io::Result<()> {
     // add a schema file
     let schema = Path::new("crates/apollo-compiler/examples/documents/schema.graphql");
     let src = fs::read_to_string(schema).expect("Could not read schema file.");
-    compiler.create_schema(&src, schema);
+    compiler.add_schema(&src, schema);
 
-    // schema_extension is still a file containing a type system, and it also gets added under .create_schema API
+    // schema_extension is still a file containing a type system, and it also gets added under .add_schema API
     let schema_ext =
         Path::new("crates/apollo-compiler/examples/documents/schema_extension.graphql");
     let src = fs::read_to_string(schema_ext).expect("Could not read schema ext file.");
-    compiler.create_schema(&src, schema_ext);
+    compiler.add_schema(&src, schema_ext);
 
-    // get_dog_name is a query-only file and gets added with a .create_executable API
+    // get_dog_name is a query-only file and gets added with a .add_executable API
     let query = Path::new("crates/apollo-compiler/examples/documents/get_dog_name.graphql");
     let src = fs::read_to_string(query).expect("Could not read query file.");
-    compiler.create_executable(&src, query);
+    compiler.add_executable(&src, query);
 
     let diagnostics = compiler.validate();
     for diagnostic in &diagnostics {
@@ -132,8 +132,8 @@ query getDogName {
 }
     "#;
     let mut compiler = ApolloCompiler::new();
-    compiler.create_schema(schema, "schema.graphl");
-    compiler.create_executable(query, "query.graphql");
+    compiler.add_schema(schema, "schema.graphl");
+    compiler.add_executable(query, "query.graphql");
 
     let diagnostics = compiler.validate();
     for diagnostic in &diagnostics {

--- a/crates/apollo-compiler/src/database/ast.rs
+++ b/crates/apollo-compiler/src/database/ast.rs
@@ -69,7 +69,7 @@ mod tests {
         }
         "#;
         let mut compiler = ApolloCompiler::with_recursion_limit(1);
-        let doc_id = compiler.create_document(schema, "schema.graphql");
+        let doc_id = compiler.add_document(schema, "schema.graphql");
 
         let ast = compiler.db.ast(doc_id);
 
@@ -88,7 +88,7 @@ mod tests {
         }
         "#;
         let mut compiler = ApolloCompiler::with_recursion_limit(7);
-        let doc_id = compiler.create_document(schema, "schema.graphql");
+        let doc_id = compiler.add_document(schema, "schema.graphql");
 
         let ast = compiler.db.ast(doc_id);
 

--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -324,7 +324,7 @@ mod tests {
         "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(schema, "schema.graphql");
+        compiler.add_document(schema, "schema.graphql");
 
         let key_definitions = compiler.db.find_types_with_directive(String::from("key"));
         let mut key_definition_names: Vec<&str> =
@@ -356,7 +356,7 @@ mod tests {
             );
             let schema = format!("{}\n{}", base_schema, schema);
             let mut compiler = ApolloCompiler::new();
-            compiler.create_document(&schema, "schema.graphql");
+            compiler.add_document(&schema, "schema.graphql");
             compiler
         }
 
@@ -382,7 +382,7 @@ mod tests {
             );
             let schema = format!("{}\n{}", base_schema, schema);
             let mut compiler = ApolloCompiler::new();
-            compiler.create_document(&schema, "schema.graphql");
+            compiler.add_document(&schema, "schema.graphql");
             compiler
         }
 

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -2033,7 +2033,7 @@ mod tests {
     #[test]
     fn huge_floats() {
         let mut compiler = ApolloCompiler::new();
-        compiler.create_schema(
+        compiler.add_schema(
             "input HugeFloats {
                 a: Float = 9876543210
                 b: Float = 9876543210.0
@@ -2067,7 +2067,7 @@ mod tests {
     #[test]
     fn syntax_errors() {
         let mut compiler = ApolloCompiler::new();
-        compiler.create_schema(
+        compiler.add_schema(
             "type Person {
                 id: ID!
                 name: String

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -56,7 +56,7 @@ pub struct ApolloCompiler {
 /// "#;
 ///
 /// let mut compiler = ApolloCompiler::new();
-/// compiler.create_schema(input, "schema.graphql");
+/// compiler.add_schema(input, "schema.graphql");
 ///
 /// let diagnostics = compiler.validate();
 /// for diagnostic in &diagnostics {
@@ -97,7 +97,7 @@ impl ApolloCompiler {
     /// It does not need to be unique.
     ///
     /// Returns a `FileId` that you can use to update the source text of this document.
-    pub fn create_document(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
+    pub fn add_document(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
         let filename = path.as_ref().to_owned();
         self.add_input(Source::document(filename, input))
     }
@@ -110,7 +110,7 @@ impl ApolloCompiler {
     /// It does not need to be unique.
     ///
     /// Returns a `FileId` that you can use to update the source text of this document.
-    pub fn create_schema(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
+    pub fn add_schema(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
         let filename = path.as_ref().to_owned();
         self.add_input(Source::schema(filename, input))
     }
@@ -122,7 +122,7 @@ impl ApolloCompiler {
     /// It does not need to be unique.
     ///
     /// Returns a `FileId` that you can use to update the source text of this document.
-    pub fn create_executable(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
+    pub fn add_executable(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
         let filename = path.as_ref().to_owned();
         self.add_input(Source::executable(filename, input))
     }
@@ -173,7 +173,7 @@ impl ApolloCompiler {
     /// "#;
     ///
     /// let mut compiler = ApolloCompiler::new();
-    /// compiler.create_document(input, "document.graphql");
+    /// compiler.add_document(input, "document.graphql");
     ///
     /// let diagnostics = compiler.validate();
     /// for diagnostic in &diagnostics {
@@ -224,8 +224,8 @@ query ExampleQuery {
       "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(schema, "schema.graphql");
-        compiler.create_executable(query, "query.graphql");
+        compiler.add_document(schema, "schema.graphql");
+        compiler.add_executable(query, "query.graphql");
     }
 
     #[test]
@@ -264,7 +264,7 @@ scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        let document_id = compiler.create_document(input, "document.graphql");
+        let document_id = compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -318,7 +318,7 @@ type Query {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        let document_id = compiler.create_document(input, "document.graphql");
+        let document_id = compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -377,7 +377,7 @@ union Union = Concrete
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        let document_id = compiler.create_document(input, "document.graphql");
+        let document_id = compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         assert!(diagnostics.is_empty());
@@ -467,7 +467,7 @@ type Product {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        let document_id = compiler.create_document(input, "document.graphql");
+        let document_id = compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -549,10 +549,10 @@ scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
         let colliding_query = r#"query getProduct { topProducts { type, price } }"#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_schema(schema, "schema.graphql");
-        compiler.create_executable(product_query, "query.graphql");
-        compiler.create_executable(customer_query, "query.graphql");
-        compiler.create_executable(colliding_query, "query.graphql");
+        compiler.add_schema(schema, "schema.graphql");
+        compiler.add_executable(product_query, "query.graphql");
+        compiler.add_executable(customer_query, "query.graphql");
+        compiler.add_executable(colliding_query, "query.graphql");
 
         assert_eq!(compiler.validate(), &[]);
     }
@@ -594,8 +594,8 @@ fragment vipCustomer on User {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_schema(schema, "schema.graphql");
-        let query_id = compiler.create_executable(query, "query.graphql");
+        compiler.add_schema(schema, "schema.graphql");
+        let query_id = compiler.add_executable(query, "query.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -655,7 +655,7 @@ type Result {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -676,7 +676,7 @@ scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -709,7 +709,7 @@ enum Pet {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -751,7 +751,7 @@ type SearchQuery {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -799,7 +799,7 @@ type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -834,7 +834,7 @@ input Point2D {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -862,7 +862,7 @@ type Book @directiveA(name: "pageCount") @directiveB(name: "author") {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -896,7 +896,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -978,7 +978,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -1093,7 +1093,7 @@ type User
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -1122,7 +1122,7 @@ scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -1151,7 +1151,7 @@ type Query {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        let input_id = compiler.create_document(input, "document.graphql");
+        let input_id = compiler.add_document(input, "document.graphql");
 
         let object_type = compiler
             .db

--- a/crates/apollo-compiler/src/tests.rs
+++ b/crates/apollo-compiler/src/tests.rs
@@ -26,7 +26,7 @@ use crate::{ApolloCompiler, ApolloDiagnostic, AstDatabase};
 fn compiler_tests() {
     dir_tests(&test_data_dir(), &["ok"], "txt", |text, path| {
         let mut compiler = ApolloCompiler::new();
-        let file_id = compiler.create_document(text, path);
+        let file_id = compiler.add_document(text, path);
 
         let errors = compiler.validate();
         let ast = compiler.db.ast(file_id);
@@ -36,7 +36,7 @@ fn compiler_tests() {
 
     dir_tests(&test_data_dir(), &["diagnostics"], "txt", |text, path| {
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(text, path);
+        compiler.add_document(text, path);
 
         let diagnostics = compiler.validate();
         assert_diagnostics_are_present(&diagnostics, path);

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -275,7 +275,7 @@ interface NamedEntity {
 scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -309,7 +309,7 @@ interface NamedEntity {
 scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -337,7 +337,7 @@ interface NamedEntity implements NamedEntity {
 scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -358,7 +358,7 @@ interface NamedEntity implements NewEntity {
 scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -389,7 +389,7 @@ interface Image implements Resource & Node {
 }
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -452,7 +452,7 @@ input Point2D {
 scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -274,7 +274,7 @@ input Point2D {
 scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -301,7 +301,7 @@ type Cat implements Pet {
 union CatOrDog = Cat | Dog
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -350,7 +350,7 @@ type Cat implements Pet {
 }
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -399,7 +399,7 @@ type Cat implements Pet {
 }
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         assert!(diagnostics.is_empty());
@@ -438,7 +438,7 @@ type Cat implements Pet {
 }
 "#;
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {
@@ -468,7 +468,7 @@ type Product {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "schema.graphql");
+        compiler.add_document(input, "schema.graphql");
 
         let diagnostics = compiler.validate();
         for diagnostic in &diagnostics {

--- a/crates/apollo-compiler/src/validation/unused_variable.rs
+++ b/crates/apollo-compiler/src/validation/unused_variable.rs
@@ -101,7 +101,7 @@ type Products {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
 
@@ -133,7 +133,7 @@ type Product {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
 
@@ -174,7 +174,7 @@ type Product {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.create_document(input, "document.graphql");
+        compiler.add_document(input, "document.graphql");
 
         let diagnostics = compiler.validate();
 


### PR DESCRIPTION
Methods of `ApolloCompiler`:

* `create_document` → `add_document`
* `create_schema` → `add_schema`
* `create_executable` → `add_executable`

As discussed in https://github.com/apollographql/apollo-rs/pull/407#discussion_r1064512416