### PR TITLE
breaking(compiler): rename `{add,update}_schema` to `*_type_system`

### DIFF
--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -133,7 +133,7 @@ fn main() -> Result<()> {
     "#;
 
     let mut compiler = ApolloCompiler::new();
-    let _schema_id = compiler.add_schema(schema_input, "schema.graphql");
+    let _schema_id = compiler.add_type_system(schema_input, "schema.graphql");
     let query_id = compiler.add_executable(query_input, "query.graphql");
 
     let diagnostics = compiler.validate();
@@ -195,7 +195,7 @@ fn main() -> Result<()> {
 
 
     let mut compiler = ApolloCompiler::new();
-    compiler.add_schema(schema_input, "schema.graphql");
+    compiler.add_type_system(schema_input, "schema.graphql");
     let query_id = compiler.add_executable(query_input, "query.graphql");
 
     let diagnostics = compiler.validate();

--- a/crates/apollo-compiler/benches/multi_source.rs
+++ b/crates/apollo-compiler/benches/multi_source.rs
@@ -3,7 +3,7 @@ use criterion::*;
 
 fn compile(schema: &str, query: &str) -> ApolloCompiler {
     let mut compiler = ApolloCompiler::new();
-    compiler.add_schema(schema, "schema.graphql");
+    compiler.add_type_system(schema, "schema.graphql");
     let executable_id = compiler.add_executable(query, "query.graphql");
 
     compiler.db.operations(executable_id);

--- a/crates/apollo-compiler/examples/multi_source_validation.rs
+++ b/crates/apollo-compiler/examples/multi_source_validation.rs
@@ -37,13 +37,13 @@ fn compile_schema_and_query_files() -> io::Result<()> {
     // add a schema file
     let schema = Path::new("crates/apollo-compiler/examples/documents/schema.graphql");
     let src = fs::read_to_string(schema).expect("Could not read schema file.");
-    compiler.add_schema(&src, schema);
+    compiler.add_type_system(&src, schema);
 
-    // schema_extension is still a file containing a type system, and it also gets added under .add_schema API
+    // schema_extension is still a file containing a type system, and it also gets added under .add_type_system API
     let schema_ext =
         Path::new("crates/apollo-compiler/examples/documents/schema_extension.graphql");
     let src = fs::read_to_string(schema_ext).expect("Could not read schema ext file.");
-    compiler.add_schema(&src, schema_ext);
+    compiler.add_type_system(&src, schema_ext);
 
     // get_dog_name is a query-only file and gets added with a .add_executable API
     let query = Path::new("crates/apollo-compiler/examples/documents/get_dog_name.graphql");
@@ -132,7 +132,7 @@ query getDogName {
 }
     "#;
     let mut compiler = ApolloCompiler::new();
-    compiler.add_schema(schema, "schema.graphl");
+    compiler.add_type_system(schema, "schema.graphl");
     compiler.add_executable(query, "query.graphql");
 
     let diagnostics = compiler.validate();

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -2033,7 +2033,7 @@ mod tests {
     #[test]
     fn huge_floats() {
         let mut compiler = ApolloCompiler::new();
-        compiler.add_schema(
+        compiler.add_type_system(
             "input HugeFloats {
                 a: Float = 9876543210
                 b: Float = 9876543210.0
@@ -2067,7 +2067,7 @@ mod tests {
     #[test]
     fn syntax_errors() {
         let mut compiler = ApolloCompiler::new();
-        compiler.add_schema(
+        compiler.add_type_system(
             "type Person {
                 id: ID!
                 name: String

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -59,7 +59,7 @@ pub type Snapshot = salsa::Snapshot<RootDatabase>;
 /// "#;
 ///
 /// let mut compiler = ApolloCompiler::new();
-/// compiler.add_schema(input, "schema.graphql");
+/// compiler.add_type_system(input, "schema.graphql");
 ///
 /// let diagnostics = compiler.validate();
 /// for diagnostic in &diagnostics {
@@ -105,15 +105,14 @@ impl ApolloCompiler {
         self.add_input(Source::document(filename, input))
     }
 
-    /// Add a schema - a document with type system definitions and extensions only
-    /// - to the compiler.
+    /// Add a document with type system definitions and extensions only to the compiler.
     ///
     /// The `path` argument is used to display diagnostics. If your GraphQL document
     /// doesn't come from a file, you can make up a name or provide the empty string.
     /// It does not need to be unique.
     ///
     /// Returns a `FileId` that you can use to update the source text of this document.
-    pub fn add_schema(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
+    pub fn add_type_system(&mut self, input: &str, path: impl AsRef<Path>) -> FileId {
         let filename = path.as_ref().to_owned();
         self.add_input(Source::schema(filename, input))
     }
@@ -142,7 +141,7 @@ impl ApolloCompiler {
 
     /// Update an existing GraphQL document with new source text. Queries that depend
     /// on this document will be recomputed.
-    pub fn update_schema(&mut self, file_id: FileId, input: &str) {
+    pub fn update_type_system(&mut self, file_id: FileId, input: &str) {
         let schema = self.db.input(file_id);
         self.db
             .set_input(file_id, Source::schema(schema.filename().to_owned(), input))
@@ -552,7 +551,7 @@ scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
         let colliding_query = r#"query getProduct { topProducts { type, price } }"#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.add_schema(schema, "schema.graphql");
+        compiler.add_type_system(schema, "schema.graphql");
         compiler.add_executable(product_query, "query.graphql");
         compiler.add_executable(customer_query, "query.graphql");
         compiler.add_executable(colliding_query, "query.graphql");
@@ -597,7 +596,7 @@ fragment vipCustomer on User {
 "#;
 
         let mut compiler = ApolloCompiler::new();
-        compiler.add_schema(schema, "schema.graphql");
+        compiler.add_type_system(schema, "schema.graphql");
         let query_id = compiler.add_executable(query, "query.graphql");
 
         let diagnostics = compiler.validate();


### PR DESCRIPTION
For consistency with https://github.com/apollographql/apollo-rs/pull/407 and avoiding confusion with `compiler.db.schema()` which returns a `SchemaDefinition`.