### PR TITLE
feat(compiler): validate directive locations + undefined directives

### DIFF
--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -182,6 +182,8 @@ fn main() -> Result<()> {
       upc: String!
       weight: Int
     }
+
+    directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
     "#;
     let query_input = r#"
     query getProduct {

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -323,6 +323,18 @@ impl<'a> From<&'a str> for OperationType {
     }
 }
 
+impl From<OperationType> for DirectiveLocation {
+    fn from(op_type: OperationType) -> Self {
+        if op_type.is_subscription() {
+            DirectiveLocation::Subscription
+        } else if op_type.is_mutation() {
+            DirectiveLocation::Mutation
+        } else {
+            DirectiveLocation::Query
+        }
+    }
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct VariableDefinition {
     pub(crate) name: Name,

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -24,6 +24,7 @@ pub enum ApolloDiagnostic {
     UnusedVariable(UnusedVariable),
     OutputType(OutputType),
     ObjectType(ObjectType),
+    UnsupportedLocation(UnsupportedLocation),
 }
 
 impl ApolloDiagnostic {
@@ -46,6 +47,7 @@ impl ApolloDiagnostic {
                 | ApolloDiagnostic::BuiltInScalarDefinition(_)
                 | ApolloDiagnostic::OutputType(_)
                 | ApolloDiagnostic::ObjectType(_)
+                | ApolloDiagnostic::UnsupportedLocation(_)
         )
     }
 
@@ -85,6 +87,7 @@ impl ApolloDiagnostic {
             ApolloDiagnostic::ObjectType(diagnostic) => Report::new(diagnostic.clone()),
             ApolloDiagnostic::UndefinedField(diagnostic) => Report::new(diagnostic.clone()),
             ApolloDiagnostic::UniqueArgument(diagnostic) => Report::new(diagnostic.clone()),
+            ApolloDiagnostic::UnsupportedLocation(diagnostic) => Report::new(diagnostic.clone()),
         }
     }
 }
@@ -394,6 +397,29 @@ pub struct UniqueArgument {
 
     #[label("`{}` is redefined here", self.name)]
     pub redefined_definition: SourceSpan,
+
+    #[help]
+    pub help: Option<String>,
+}
+
+#[derive(Diagnostic, Debug, Error, Clone, Hash, PartialEq, Eq)]
+#[error("{} directive is not supported for {} location", self.ty, self.dir_loc)]
+#[diagnostic(code("apollo-compiler validation error"))]
+pub struct UnsupportedLocation {
+    // current directive definition
+    pub ty: String,
+
+    // current location where the directive is used
+    pub dir_loc: String,
+
+    #[source_code]
+    pub src: Arc<str>,
+
+    #[label("{} is not a valid location", self.dir_loc)]
+    pub directive: SourceSpan,
+
+    #[label("consider adding {} directive location here", self.dir_loc)]
+    pub directive_def: Option<SourceSpan>,
 
     #[help]
     pub help: Option<String>,

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -466,6 +466,8 @@ type Product {
   upc: String!
   weight: Int
 }
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
 "#;
 
         let mut compiler = ApolloCompiler::new();
@@ -861,6 +863,9 @@ input Point2D {
 type Book @directiveA(name: "pageCount") @directiveB(name: "author") {
   id: ID!
 }
+
+directive @directiveA(name: String) on OBJECT | INTERFACE
+directive @directiveB(name: String) on OBJECT | INTERFACE
 "#;
 
         let mut compiler = ApolloCompiler::new();

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -465,6 +465,8 @@ type Product {
   inStock: Boolean @join__field(graph: INVENTORY)
   name: String @join__field(graph: PRODUCTS)
 }
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
 "#;
 
         let mut compiler = ApolloCompiler::new();

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -185,7 +185,7 @@ pub fn check_input_object_type_definition(
     let mut diagnostics = Vec::new();
 
     diagnostics.extend(db.check_input_values(
-        (*input_obj).clone().input_fields_definition,
+        input_obj.input_fields_definition.clone(),
         hir::DirectiveLocation::InputFieldDefinition,
     ));
 

--- a/crates/apollo-compiler/test_data/diagnostics/0031_input_object_with_duplicate_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0031_input_object_with_duplicate_fields.txt
@@ -24,4 +24,29 @@
             ),
         },
     ),
+    UniqueArgument(
+        UniqueArgument {
+            name: "x",
+            src: "type Query {\n  website: URL,\n  amount: Int\n}\n\nscalar URL @specifiedBy(url: \"https://tools.ietf.org/html/rfc3986\")\n\ninput Point2D {\n  x: Float\n  x: Float\n}",
+            original_definition: SourceSpan {
+                offset: SourceOffset(
+                    133,
+                ),
+                length: SourceOffset(
+                    11,
+                ),
+            },
+            redefined_definition: SourceSpan {
+                offset: SourceOffset(
+                    144,
+                ),
+                length: SourceOffset(
+                    9,
+                ),
+            },
+            help: Some(
+                "`x` argument must only be defined once.",
+            ),
+        },
+    ),
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.graphql
@@ -12,3 +12,5 @@ type Product {
   inStock: Boolean @join__field(graph: INVENTORY)
   name: String @join__field(graph: PRODUCTS)
 }
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION

--- a/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.txt
@@ -2,7 +2,7 @@
     UndefinedField(
         UndefinedField {
             field: "size",
-            src: "query getProduct {\n  size\n  weight\n}\n\ntype Query {\n  name: String\n  topProducts: Product\n}\n\ntype Product {\n  inStock: Boolean @join__field(graph: INVENTORY)\n  name: String @join__field(graph: PRODUCTS)\n}",
+            src: "query getProduct {\n  size\n  weight\n}\n\ntype Query {\n  name: String\n  topProducts: Product\n}\n\ntype Product {\n  inStock: Boolean @join__field(graph: INVENTORY)\n  name: String @join__field(graph: PRODUCTS)\n}\n\ndirective @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION",
             definition: SourceSpan {
                 offset: SourceOffset(
                     21,
@@ -17,7 +17,7 @@
     UndefinedField(
         UndefinedField {
             field: "weight",
-            src: "query getProduct {\n  size\n  weight\n}\n\ntype Query {\n  name: String\n  topProducts: Product\n}\n\ntype Product {\n  inStock: Boolean @join__field(graph: INVENTORY)\n  name: String @join__field(graph: PRODUCTS)\n}",
+            src: "query getProduct {\n  size\n  weight\n}\n\ntype Query {\n  name: String\n  topProducts: Product\n}\n\ntype Product {\n  inStock: Boolean @join__field(graph: INVENTORY)\n  name: String @join__field(graph: PRODUCTS)\n}\n\ndirective @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION",
             definition: SourceSpan {
                 offset: SourceOffset(
                     28,

--- a/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.graphql
@@ -1,4 +1,4 @@
-type X @deprecated(reason: "as a test", reason: "just for fun") {}
+scalar @specifiedBy(url: "https://tools.ietf.org/html/rfc4122", url: "https://tools.ietf.org/html/rfc4125") {}
 type Query {
   something: X @skip(if: false, if: true)
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.graphql
@@ -1,4 +1,8 @@
-scalar @specifiedBy(url: "https://tools.ietf.org/html/rfc4122", url: "https://tools.ietf.org/html/rfc4125") {}
+scalar newScalar @specifiedBy(url: "https://tools.ietf.org/html/rfc4122", url: "https://tools.ietf.org/html/rfc4125")
+
 type Query {
-  something: X @skip(if: false, if: true)
+  status: String,
+  response: String @example(if: false, if: true)
 }
+
+directive @example(if: Boolean) on FIELD_DEFINITION

--- a/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.txt
@@ -1,53 +1,36 @@
 [
-    SyntaxError(
-        SyntaxError {
-            message: "expected a Name",
-            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
-            span: SourceSpan {
+    UniqueArgument(
+        UniqueArgument {
+            name: "url",
+            src: "scalar newScalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\")\n\ntype Query {\n  status: String,\n  response: String @example(if: false, if: true)\n}\n\ndirective @example(if: Boolean) on FIELD_DEFINITION",
+            original_definition: SourceSpan {
                 offset: SourceOffset(
-                    7,
+                    30,
                 ),
                 length: SourceOffset(
-                    1,
+                    44,
                 ),
             },
-        },
-    ),
-    SyntaxError(
-        SyntaxError {
-            message: "expected at least one Selection in Selection Set",
-            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
-            span: SourceSpan {
+            redefined_definition: SourceSpan {
                 offset: SourceOffset(
-                    109,
+                    74,
                 ),
                 length: SourceOffset(
-                    1,
+                    42,
                 ),
             },
-        },
-    ),
-    UndefinedDefinition(
-        UndefinedDefinition {
-            ty: "X",
-            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
-            definition: SourceSpan {
-                offset: SourceOffset(
-                    137,
-                ),
-                length: SourceOffset(
-                    1,
-                ),
-            },
+            help: Some(
+                "`url` argument must only be provided once.",
+            ),
         },
     ),
     UniqueArgument(
         UniqueArgument {
             name: "if",
-            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
+            src: "scalar newScalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\")\n\ntype Query {\n  status: String,\n  response: String @example(if: false, if: true)\n}\n\ndirective @example(if: Boolean) on FIELD_DEFINITION",
             original_definition: SourceSpan {
                 offset: SourceOffset(
-                    145,
+                    178,
                 ),
                 length: SourceOffset(
                     11,
@@ -55,7 +38,7 @@
             },
             redefined_definition: SourceSpan {
                 offset: SourceOffset(
-                    156,
+                    189,
                 ),
                 length: SourceOffset(
                     8,
@@ -63,25 +46,6 @@
             },
             help: Some(
                 "`if` argument must only be provided once.",
-            ),
-        },
-    ),
-    UnsupportedLocation(
-        UnsupportedLocation {
-            ty: "skip",
-            dir_loc: "FIELD_DEFINITION",
-            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
-            directive: SourceSpan {
-                offset: SourceOffset(
-                    139,
-                ),
-                length: SourceOffset(
-                    27,
-                ),
-            },
-            directive_def: None,
-            help: Some(
-                "the directive must be used in a location that the service has declared support for",
             ),
         },
     ),

--- a/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.txt
@@ -1,36 +1,53 @@
 [
-    UniqueArgument(
-        UniqueArgument {
-            name: "reason",
-            src: "type X @deprecated(reason: \"as a test\", reason: \"just for fun\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
-            original_definition: SourceSpan {
+    SyntaxError(
+        SyntaxError {
+            message: "expected a Name",
+            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
+            span: SourceSpan {
                 offset: SourceOffset(
-                    19,
+                    7,
                 ),
                 length: SourceOffset(
-                    21,
+                    1,
                 ),
             },
-            redefined_definition: SourceSpan {
+        },
+    ),
+    SyntaxError(
+        SyntaxError {
+            message: "expected at least one Selection in Selection Set",
+            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
+            span: SourceSpan {
                 offset: SourceOffset(
-                    40,
+                    109,
                 ),
                 length: SourceOffset(
-                    22,
+                    1,
                 ),
             },
-            help: Some(
-                "`reason` argument must only be provided once.",
-            ),
+        },
+    ),
+    UndefinedDefinition(
+        UndefinedDefinition {
+            ty: "X",
+            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    137,
+                ),
+                length: SourceOffset(
+                    1,
+                ),
+            },
         },
     ),
     UniqueArgument(
         UniqueArgument {
             name: "if",
-            src: "type X @deprecated(reason: \"as a test\", reason: \"just for fun\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
+            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
             original_definition: SourceSpan {
                 offset: SourceOffset(
-                    101,
+                    145,
                 ),
                 length: SourceOffset(
                     11,
@@ -38,7 +55,7 @@
             },
             redefined_definition: SourceSpan {
                 offset: SourceOffset(
-                    112,
+                    156,
                 ),
                 length: SourceOffset(
                     8,
@@ -46,6 +63,25 @@
             },
             help: Some(
                 "`if` argument must only be provided once.",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "skip",
+            dir_loc: "FIELD_DEFINITION",
+            src: "scalar @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\", url: \"https://tools.ietf.org/html/rfc4125\") {}\ntype Query {\n  something: X @skip(if: false, if: true)\n}\n",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    139,
+                ),
+                length: SourceOffset(
+                    27,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
             ),
         },
     ),

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.graphql
@@ -1,0 +1,3 @@
+query @skip(if: $foo) {
+  field
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.graphql
@@ -1,3 +1,8 @@
 query @skip(if: $foo) {
   field
 }
+
+type Query @deprecated {
+  field: String
+  response(status: String @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")): Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.graphql
@@ -1,8 +1,89 @@
-query @skip(if: $foo) {
+query queryA($status: String @skip) @skip(if: $foo){
   field
+  response(status: $status) @deprecated
+  human {
+    ... pet @directiveB
+  }
+}
+
+fragment pet on Cat @directiveB{
+  meowVolume
+  ... on Pet @directiveA {
+    name
+  }
+}
+
+subscription subscriptionA @directiveA {
+  newMessage {
+    body
+    sender
+  }
+}
+
+mutation @skip(if: true) {
+  setMessage (message: "Hello, World! Yours, GraphQL.")
+}
+
+interface Pet @skip {
+  name: String
+}
+
+type Dog implements Pet {
+  name: String @directiveB
+  nickname: String
+  barkVolume: Int
+}
+
+type Cat implements Pet {
+  name: String
+  nickname: String
+  meowVolume: Int
+}
+
+input Example @include {
+  self: Example @include
+  value: String
+}
+
+union CatOrDog @directiveB = Cat | Dog
+
+type Human {
+  name: String
+  pets: [Pet]
+}
+
+enum Status @directiveA {
+  GREEN @directiveA,
+  RED,
+  YELLOW
 }
 
 type Query @deprecated {
-  field: String
-  response(status: String @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")): Int
+  human: Human
+  field: String,
+  response(status: String @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")): Status
 }
+
+type Subscription {
+  newMessage: Result
+}
+
+type Mutation {
+  setMessage(message: String): String
+}
+
+schema @include {
+  query: Query
+  subscription: Subscription
+  mutation: Mutation
+}
+
+type Result {
+  body: String,
+  sender: String
+}
+
+scalar spec @directiveB @specifiedBy(url: "https://spec.graphql.org/")
+
+directive @directiveA on UNION
+directive @directiveB on ENUM

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
@@ -3,10 +3,123 @@
         UnsupportedLocation {
             ty: "skip",
             dir_loc: "QUERY",
-            src: "query @skip(if: $foo) {\n  field\n}\n\ntype Query @deprecated {\n  field: String\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Int\n}",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
-                    6,
+                    36,
+                ),
+                length: SourceOffset(
+                    15,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "skip",
+            dir_loc: "VARIABLE_DEFINITION",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    29,
+                ),
+                length: SourceOffset(
+                    5,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "deprecated",
+            dir_loc: "FIELD",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    89,
+                ),
+                length: SourceOffset(
+                    14,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "directiveB",
+            dir_loc: "FRAGMENT_SPREAD",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    123,
+                ),
+                length: SourceOffset(
+                    14,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1326,
+                    ),
+                    length: SourceOffset(
+                        29,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "directiveA",
+            dir_loc: "SUBSCRIPTION",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    258,
+                ),
+                length: SourceOffset(
+                    12,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1295,
+                    ),
+                    length: SourceOffset(
+                        31,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "skip",
+            dir_loc: "MUTATION",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    323,
                 ),
                 length: SourceOffset(
                     16,
@@ -20,12 +133,124 @@
     ),
     UnsupportedLocation(
         UnsupportedLocation {
-            ty: "deprecated",
-            dir_loc: "OBJECT",
-            src: "query @skip(if: $foo) {\n  field\n}\n\ntype Query @deprecated {\n  field: String\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Int\n}",
+            ty: "directiveB",
+            dir_loc: "FRAGMENT_DEFINITION",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
-                    46,
+                    162,
+                ),
+                length: SourceOffset(
+                    11,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1326,
+                    ),
+                    length: SourceOffset(
+                        29,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "directiveA",
+            dir_loc: "INLINE_FRAGMENT",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    201,
+                ),
+                length: SourceOffset(
+                    12,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1295,
+                    ),
+                    length: SourceOffset(
+                        31,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "directiveB",
+            dir_loc: "SCALAR",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    1235,
+                ),
+                length: SourceOffset(
+                    12,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1326,
+                    ),
+                    length: SourceOffset(
+                        29,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "directiveB",
+            dir_loc: "FIELD_DEFINITION",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    481,
+                ),
+                length: SourceOffset(
+                    14,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1326,
+                    ),
+                    length: SourceOffset(
+                        29,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "deprecated",
+            dir_loc: "OBJECT",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    845,
                 ),
                 length: SourceOffset(
                     12,
@@ -41,10 +266,10 @@
         UnsupportedLocation {
             ty: "specifiedBy",
             dir_loc: "ARGUMENT_DEFINITION",
-            src: "query @skip(if: $foo) {\n  field\n}\n\ntype Query @deprecated {\n  field: String\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Int\n}",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
-                    102,
+                    917,
                 ),
                 length: SourceOffset(
                     56,
@@ -53,6 +278,182 @@
             directive_def: None,
             help: Some(
                 "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "skip",
+            dir_loc: "INTERFACE",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    414,
+                ),
+                length: SourceOffset(
+                    6,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "directiveB",
+            dir_loc: "UNION",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    698,
+                ),
+                length: SourceOffset(
+                    12,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1326,
+                    ),
+                    length: SourceOffset(
+                        29,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "directiveA",
+            dir_loc: "ENUM",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    780,
+                ),
+                length: SourceOffset(
+                    12,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1295,
+                    ),
+                    length: SourceOffset(
+                        31,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "directiveA",
+            dir_loc: "ENUM_VALUE",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    802,
+                ),
+                length: SourceOffset(
+                    15,
+                ),
+            },
+            directive_def: Some(
+                SourceSpan {
+                    offset: SourceOffset(
+                        1295,
+                    ),
+                    length: SourceOffset(
+                        31,
+                    ),
+                },
+            ),
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "include",
+            dir_loc: "INPUT_OBJECT",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    628,
+                ),
+                length: SourceOffset(
+                    9,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "include",
+            dir_loc: "INPUT_FIELD_DEFINITION",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    655,
+                ),
+                length: SourceOffset(
+                    11,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "include",
+            dir_loc: "SCHEMA",
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    1094,
+                ),
+                length: SourceOffset(
+                    9,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    MissingIdent(
+        MissingIdent {
+            src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    314,
+                ),
+                length: SourceOffset(
+                    86,
+                ),
+            },
+            help: Some(
+                "GraphQL allows a short-hand form for defining query operations when only that one operation exists in the document. There are 3 operations in this document.",
             ),
         },
     ),

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
@@ -1,0 +1,59 @@
+[
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "skip",
+            dir_loc: "QUERY",
+            src: "query @skip(if: $foo) {\n  field\n}\n\ntype Query @deprecated {\n  field: String\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Int\n}",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    6,
+                ),
+                length: SourceOffset(
+                    16,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "deprecated",
+            dir_loc: "OBJECT",
+            src: "query @skip(if: $foo) {\n  field\n}\n\ntype Query @deprecated {\n  field: String\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Int\n}",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    46,
+                ),
+                length: SourceOffset(
+                    12,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+    UnsupportedLocation(
+        UnsupportedLocation {
+            ty: "specifiedBy",
+            dir_loc: "ARGUMENT_DEFINITION",
+            src: "query @skip(if: $foo) {\n  field\n}\n\ntype Query @deprecated {\n  field: String\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Int\n}",
+            directive: SourceSpan {
+                offset: SourceOffset(
+                    102,
+                ),
+                length: SourceOffset(
+                    56,
+                ),
+            },
+            directive_def: None,
+            help: Some(
+                "the directive must be used in a location that the service has declared support for",
+            ),
+        },
+    ),
+]

--- a/crates/apollo-compiler/test_data/diagnostics/0051_undefined_directive.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0051_undefined_directive.graphql
@@ -1,0 +1,6 @@
+type Query {
+    name: String
+    status: Int @directiveA
+}
+
+directive @directiveB on FIELD_DEFINITION

--- a/crates/apollo-compiler/test_data/diagnostics/0051_undefined_directive.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0051_undefined_directive.txt
@@ -1,0 +1,16 @@
+[
+    UndefinedDefinition(
+        UndefinedDefinition {
+            ty: "directiveA",
+            src: "type Query {\n    name: String\n    status: Int @directiveA\n}\n\ndirective @directiveB on FIELD_DEFINITION\n",
+            definition: SourceSpan {
+                offset: SourceOffset(
+                    46,
+                ),
+                length: SourceOffset(
+                    12,
+                ),
+            },
+        },
+    ),
+]

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.graphql
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.graphql
@@ -20,3 +20,5 @@ type Product {
   upc: String!
   weight: Int
 }
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -1,4 +1,4 @@
-- DOCUMENT@0..313
+- DOCUMENT@0..429
     - OPERATION_DEFINITION@0..70
         - OPERATION_TYPE@0..6
             - query_KW@0..5 "query"
@@ -70,13 +70,13 @@
                 - WHITESPACE@132..133 "\n"
             - R_CURLY@133..134 "}"
             - WHITESPACE@134..136 "\n\n"
-    - OBJECT_TYPE_DEFINITION@136..313
+    - OBJECT_TYPE_DEFINITION@136..315
         - type_KW@136..140 "type"
         - WHITESPACE@140..141 " "
         - NAME@141..149
             - IDENT@141..148 "Product"
             - WHITESPACE@148..149 " "
-        - FIELDS_DEFINITION@149..313
+        - FIELDS_DEFINITION@149..315
             - L_CURLY@149..150 "{"
             - WHITESPACE@150..153 "\n  "
             - FIELD_DEFINITION@153..203
@@ -170,4 +170,48 @@
                         - IDENT@308..311 "Int"
                 - WHITESPACE@311..312 "\n"
             - R_CURLY@312..313 "}"
+            - WHITESPACE@313..315 "\n\n"
+    - DIRECTIVE_DEFINITION@315..429
+        - directive_KW@315..324 "directive"
+        - WHITESPACE@324..325 " "
+        - AT@325..326 "@"
+        - NAME@326..337
+            - IDENT@326..337 "join__field"
+        - ARGUMENTS_DEFINITION@337..410
+            - L_PAREN@337..338 "("
+            - INPUT_VALUE_DEFINITION@338..358
+                - NAME@338..343
+                    - IDENT@338..343 "graph"
+                - COLON@343..344 ":"
+                - WHITESPACE@344..345 " "
+                - NAMED_TYPE@345..356
+                    - NAME@345..356
+                        - IDENT@345..356 "join__Graph"
+                - COMMA@356..357 ","
+                - WHITESPACE@357..358 " "
+            - INPUT_VALUE_DEFINITION@358..384
+                - NAME@358..366
+                    - IDENT@358..366 "requires"
+                - COLON@366..367 ":"
+                - WHITESPACE@367..368 " "
+                - NAMED_TYPE@368..382
+                    - NAME@368..382
+                        - IDENT@368..382 "join__FieldSet"
+                - COMMA@382..383 ","
+                - WHITESPACE@383..384 " "
+            - INPUT_VALUE_DEFINITION@384..408
+                - NAME@384..392
+                    - IDENT@384..392 "provides"
+                - COLON@392..393 ":"
+                - WHITESPACE@393..394 " "
+                - NAMED_TYPE@394..408
+                    - NAME@394..408
+                        - IDENT@394..408 "join__FieldSet"
+            - R_PAREN@408..409 ")"
+            - WHITESPACE@409..410 " "
+        - on_KW@410..412 "on"
+        - WHITESPACE@412..413 " "
+        - DIRECTIVE_LOCATIONS@413..429
+            - DIRECTIVE_LOCATION@413..429
+                - FIELD_DEFINITION_KW@413..429 "FIELD_DEFINITION"
 recursion limit: 4096, high: 6

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.graphql
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.graphql
@@ -1,0 +1,266 @@
+schema
+@core(feature: "https://specs.apollo.dev/core/v0.1"),
+@core(feature: "https://specs.apollo.dev/join/v0.1")
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @core(feature: String!) repeatable on SCHEMA
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+directive @stream on FIELD
+directive @transform(from: String!) on FIELD
+
+union AccountType = PasswordAccount | SMSAccount
+
+type Amazon {
+  referrer: String
+}
+
+union Body = Image | Text
+
+type Book implements Product
+@join__owner(graph: BOOKS)
+@join__type(graph: BOOKS, key: "isbn")
+@join__type(graph: INVENTORY, key: "isbn")
+@join__type(graph: PRODUCT, key: "isbn")
+@join__type(graph: REVIEWS, key: "isbn")
+{
+  isbn: String! @join__field(graph: BOOKS)
+  title: String @join__field(graph: BOOKS)
+  year: Int @join__field(graph: BOOKS)
+  similarBooks: [Book]! @join__field(graph: BOOKS)
+  metadata: [MetadataOrError] @join__field(graph: BOOKS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  isCheckedOut: Boolean @join__field(graph: INVENTORY)
+  upc: String! @join__field(graph: PRODUCT)
+  sku: String! @join__field(graph: PRODUCT)
+  name(delimeter: String = " "): String @join__field(graph: PRODUCT, requires: "title year")
+  price: String @join__field(graph: PRODUCT)
+  details: ProductDetailsBook @join__field(graph: PRODUCT)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  relatedReviews: [Review!]! @join__field(graph: REVIEWS, requires: "similarBooks{isbn}")
+}
+
+union Brand = Ikea | Amazon
+
+type Car implements Vehicle
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id")
+{
+  id: String! @join__field(graph: PRODUCT)
+  description: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  retailPrice: String @join__field(graph: REVIEWS, requires: "price")
+}
+
+type Error {
+  code: Int
+  message: String
+}
+
+type Furniture implements Product
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "upc")
+@join__type(graph: PRODUCT, key: "sku")
+@join__type(graph: INVENTORY, key: "sku")
+@join__type(graph: REVIEWS, key: "upc")
+{
+  upc: String! @join__field(graph: PRODUCT)
+  sku: String! @join__field(graph: PRODUCT)
+  name: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  brand: Brand @join__field(graph: PRODUCT)
+  metadata: [MetadataOrError] @join__field(graph: PRODUCT)
+  details: ProductDetailsFurniture @join__field(graph: PRODUCT)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  isHeavy: Boolean @join__field(graph: INVENTORY)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}
+
+type Ikea {
+  asile: Int
+}
+
+type Image implements NamedObject {
+  name: String!
+  attributes: ImageAttributes!
+}
+
+type ImageAttributes {
+  url: String!
+}
+
+scalar join__FieldSet @specifiedBy(url: "https://spec.graphql.org/")
+
+enum join__Graph {
+ACCOUNTS @join__graph(name: "accounts" url: "")
+BOOKS @join__graph(name: "books" url: "")
+DOCUMENTS @join__graph(name: "documents" url: "")
+INVENTORY @join__graph(name: "inventory" url: "")
+PRODUCT @join__graph(name: "product" url: "")
+REVIEWS @join__graph(name: "reviews" url: "")
+}
+
+type KeyValue {
+  key: String!
+  value: String!
+}
+
+type Library
+@join__owner(graph: BOOKS)
+@join__type(graph: BOOKS, key: "id")
+@join__type(graph: ACCOUNTS, key: "id")
+{
+  id: ID! @join__field(graph: BOOKS)
+  name: String @join__field(graph: BOOKS)
+  userAccount(id: ID! = 1): User @join__field(graph: ACCOUNTS, requires: "name")
+}
+
+union MetadataOrError = KeyValue | Error
+
+type Mutation {
+  login(username: String!, password: String!): User @join__field(graph: ACCOUNTS)
+  reviewProduct(upc: String!, body: String!): Product @join__field(graph: REVIEWS)
+  updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
+  deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
+}
+
+type Name {
+  first: String
+  last: String
+}
+
+interface NamedObject {
+  name: String!
+}
+
+type PasswordAccount
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "email")
+{
+  email: String! @join__field(graph: ACCOUNTS)
+}
+
+interface Product {
+  upc: String!
+  sku: String!
+  name: String
+  price: String
+  details: ProductDetails
+  inStock: Boolean
+  reviews: [Review]
+}
+
+interface ProductDetails {
+  country: String
+}
+
+type ProductDetailsBook implements ProductDetails {
+  country: String
+  pages: Int
+}
+
+type ProductDetailsFurniture implements ProductDetails {
+  country: String
+  color: String
+}
+
+type Query {
+  user(id: ID!): User @join__field(graph: ACCOUNTS)
+  me: User @join__field(graph: ACCOUNTS)
+  book(isbn: String!): Book @join__field(graph: BOOKS)
+  books: [Book] @join__field(graph: BOOKS)
+  library(id: ID!): Library @join__field(graph: BOOKS)
+  body: Body! @join__field(graph: DOCUMENTS)
+  product(upc: String!): Product @join__field(graph: PRODUCT)
+  vehicle(id: String!): Vehicle @join__field(graph: PRODUCT)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCT)
+  topCars(first: Int = 5): [Car] @join__field(graph: PRODUCT)
+  topReviews(first: Int = 5): [Review] @join__field(graph: REVIEWS)
+}
+
+type Review
+@join__owner(graph: REVIEWS)
+@join__type(graph: REVIEWS, key: "id")
+{
+  id: ID! @join__field(graph: REVIEWS)
+  body(format: Boolean = false): String @join__field(graph: REVIEWS)
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  product: Product @join__field(graph: REVIEWS)
+  metadata: [MetadataOrError] @join__field(graph: REVIEWS)
+}
+
+type SMSAccount
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "number")
+{
+  number: String @join__field(graph: ACCOUNTS)
+}
+
+type Text implements NamedObject {
+  name: String!
+  attributes: TextAttributes!
+}
+
+type TextAttributes {
+  bold: Boolean
+  text: String
+}
+
+union Thing = Car | Ikea
+
+input UpdateReviewInput {
+  id: ID!
+  body: String
+}
+
+type User
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "id")
+@join__type(graph: ACCOUNTS, key: "username name{first last}")
+@join__type(graph: INVENTORY, key: "id")
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id")
+{
+  id: ID! @join__field(graph: ACCOUNTS)
+  name: Name @join__field(graph: ACCOUNTS)
+  username: String @join__field(graph: ACCOUNTS)
+  birthDate(locale: String): String @join__field(graph: ACCOUNTS)
+  account: AccountType @join__field(graph: ACCOUNTS)
+  metadata: [UserMetadata] @join__field(graph: ACCOUNTS)
+  goodDescription: Boolean @join__field(graph: INVENTORY, requires: "metadata{description}")
+  vehicle: Vehicle @join__field(graph: PRODUCT)
+  thing: Thing @join__field(graph: PRODUCT)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  numberOfReviews: Int! @join__field(graph: REVIEWS)
+  goodAddress: Boolean @join__field(graph: REVIEWS, requires: "metadata{address}")
+}
+
+type UserMetadata {
+  name: String
+  address: String
+  description: String
+}
+
+type Van implements Vehicle
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id")
+{
+  id: String! @join__field(graph: PRODUCT)
+  description: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  retailPrice: String @join__field(graph: REVIEWS, requires: "price")
+}
+
+interface Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
@@ -1,0 +1,4203 @@
+- DOCUMENT@0..7541
+    - SCHEMA_DEFINITION@0..155
+        - schema_KW@0..6 "schema"
+        - WHITESPACE@6..7 "\n"
+        - DIRECTIVES@7..114
+            - DIRECTIVE@7..61
+                - AT@7..8 "@"
+                - NAME@8..12
+                    - IDENT@8..12 "core"
+                - ARGUMENTS@12..61
+                    - L_PAREN@12..13 "("
+                    - ARGUMENT@13..58
+                        - NAME@13..20
+                            - IDENT@13..20 "feature"
+                        - COLON@20..21 ":"
+                        - WHITESPACE@21..22 " "
+                        - STRING_VALUE@22..58
+                            - STRING@22..58 "\"https://specs.apollo.dev/core/v0.1\""
+                    - R_PAREN@58..59 ")"
+                    - COMMA@59..60 ","
+                    - WHITESPACE@60..61 "\n"
+            - DIRECTIVE@61..114
+                - AT@61..62 "@"
+                - NAME@62..66
+                    - IDENT@62..66 "core"
+                - ARGUMENTS@66..114
+                    - L_PAREN@66..67 "("
+                    - ARGUMENT@67..112
+                        - NAME@67..74
+                            - IDENT@67..74 "feature"
+                        - COLON@74..75 ":"
+                        - WHITESPACE@75..76 " "
+                        - STRING_VALUE@76..112
+                            - STRING@76..112 "\"https://specs.apollo.dev/join/v0.1\""
+                    - R_PAREN@112..113 ")"
+                    - WHITESPACE@113..114 "\n"
+        - L_CURLY@114..115 "{"
+        - WHITESPACE@115..118 "\n  "
+        - ROOT_OPERATION_TYPE_DEFINITION@118..133
+            - OPERATION_TYPE@118..123
+                - query_KW@118..123 "query"
+            - COLON@123..124 ":"
+            - WHITESPACE@124..125 " "
+            - NAMED_TYPE@125..133
+                - NAME@125..133
+                    - IDENT@125..130 "Query"
+                    - WHITESPACE@130..133 "\n  "
+        - ROOT_OPERATION_TYPE_DEFINITION@133..152
+            - OPERATION_TYPE@133..141
+                - mutation_KW@133..141 "mutation"
+            - COLON@141..142 ":"
+            - WHITESPACE@142..143 " "
+            - NAMED_TYPE@143..152
+                - NAME@143..152
+                    - IDENT@143..151 "Mutation"
+                    - WHITESPACE@151..152 "\n"
+        - R_CURLY@152..153 "}"
+        - WHITESPACE@153..155 "\n\n"
+    - DIRECTIVE_DEFINITION@155..210
+        - directive_KW@155..164 "directive"
+        - WHITESPACE@164..165 " "
+        - AT@165..166 "@"
+        - NAME@166..170
+            - IDENT@166..170 "core"
+        - ARGUMENTS_DEFINITION@170..189
+            - L_PAREN@170..171 "("
+            - INPUT_VALUE_DEFINITION@171..187
+                - NAME@171..178
+                    - IDENT@171..178 "feature"
+                - COLON@178..179 ":"
+                - WHITESPACE@179..180 " "
+                - NON_NULL_TYPE@180..187
+                    - NAMED_TYPE@180..186
+                        - NAME@180..186
+                            - IDENT@180..186 "String"
+                    - BANG@186..187 "!"
+            - R_PAREN@187..188 ")"
+            - WHITESPACE@188..189 " "
+        - repeatable_KW@189..199 "repeatable"
+        - WHITESPACE@199..200 " "
+        - on_KW@200..202 "on"
+        - WHITESPACE@202..203 " "
+        - DIRECTIVE_LOCATIONS@203..210
+            - DIRECTIVE_LOCATION@203..210
+                - SCHEMA_KW@203..209 "SCHEMA"
+                - WHITESPACE@209..210 "\n"
+    - DIRECTIVE_DEFINITION@210..325
+        - directive_KW@210..219 "directive"
+        - WHITESPACE@219..220 " "
+        - AT@220..221 "@"
+        - NAME@221..232
+            - IDENT@221..232 "join__field"
+        - ARGUMENTS_DEFINITION@232..305
+            - L_PAREN@232..233 "("
+            - INPUT_VALUE_DEFINITION@233..253
+                - NAME@233..238
+                    - IDENT@233..238 "graph"
+                - COLON@238..239 ":"
+                - WHITESPACE@239..240 " "
+                - NAMED_TYPE@240..251
+                    - NAME@240..251
+                        - IDENT@240..251 "join__Graph"
+                - COMMA@251..252 ","
+                - WHITESPACE@252..253 " "
+            - INPUT_VALUE_DEFINITION@253..279
+                - NAME@253..261
+                    - IDENT@253..261 "requires"
+                - COLON@261..262 ":"
+                - WHITESPACE@262..263 " "
+                - NAMED_TYPE@263..277
+                    - NAME@263..277
+                        - IDENT@263..277 "join__FieldSet"
+                - COMMA@277..278 ","
+                - WHITESPACE@278..279 " "
+            - INPUT_VALUE_DEFINITION@279..303
+                - NAME@279..287
+                    - IDENT@279..287 "provides"
+                - COLON@287..288 ":"
+                - WHITESPACE@288..289 " "
+                - NAMED_TYPE@289..303
+                    - NAME@289..303
+                        - IDENT@289..303 "join__FieldSet"
+            - R_PAREN@303..304 ")"
+            - WHITESPACE@304..305 " "
+        - on_KW@305..307 "on"
+        - WHITESPACE@307..308 " "
+        - DIRECTIVE_LOCATIONS@308..325
+            - DIRECTIVE_LOCATION@308..325
+                - FIELD_DEFINITION_KW@308..324 "FIELD_DEFINITION"
+                - WHITESPACE@324..325 "\n"
+    - DIRECTIVE_DEFINITION@325..422
+        - directive_KW@325..334 "directive"
+        - WHITESPACE@334..335 " "
+        - AT@335..336 "@"
+        - NAME@336..346
+            - IDENT@336..346 "join__type"
+        - ARGUMENTS_DEFINITION@346..389
+            - L_PAREN@346..347 "("
+            - INPUT_VALUE_DEFINITION@347..368
+                - NAME@347..352
+                    - IDENT@347..352 "graph"
+                - COLON@352..353 ":"
+                - WHITESPACE@353..354 " "
+                - NON_NULL_TYPE@354..368
+                    - NAMED_TYPE@354..365
+                        - NAME@354..365
+                            - IDENT@354..365 "join__Graph"
+                    - BANG@365..366 "!"
+                    - COMMA@366..367 ","
+                    - WHITESPACE@367..368 " "
+            - INPUT_VALUE_DEFINITION@368..387
+                - NAME@368..371
+                    - IDENT@368..371 "key"
+                - COLON@371..372 ":"
+                - WHITESPACE@372..373 " "
+                - NAMED_TYPE@373..387
+                    - NAME@373..387
+                        - IDENT@373..387 "join__FieldSet"
+            - R_PAREN@387..388 ")"
+            - WHITESPACE@388..389 " "
+        - repeatable_KW@389..399 "repeatable"
+        - WHITESPACE@399..400 " "
+        - on_KW@400..402 "on"
+        - WHITESPACE@402..403 " "
+        - DIRECTIVE_LOCATIONS@403..422
+            - DIRECTIVE_LOCATION@403..410
+                - OBJECT_KW@403..409 "OBJECT"
+                - WHITESPACE@409..410 " "
+            - PIPE@410..411 "|"
+            - WHITESPACE@411..412 " "
+            - DIRECTIVE_LOCATION@412..422
+                - INTERFACE_KW@412..421 "INTERFACE"
+                - WHITESPACE@421..422 "\n"
+    - DIRECTIVE_DEFINITION@422..488
+        - directive_KW@422..431 "directive"
+        - WHITESPACE@431..432 " "
+        - AT@432..433 "@"
+        - NAME@433..444
+            - IDENT@433..444 "join__owner"
+        - ARGUMENTS_DEFINITION@444..466
+            - L_PAREN@444..445 "("
+            - INPUT_VALUE_DEFINITION@445..464
+                - NAME@445..450
+                    - IDENT@445..450 "graph"
+                - COLON@450..451 ":"
+                - WHITESPACE@451..452 " "
+                - NON_NULL_TYPE@452..464
+                    - NAMED_TYPE@452..463
+                        - NAME@452..463
+                            - IDENT@452..463 "join__Graph"
+                    - BANG@463..464 "!"
+            - R_PAREN@464..465 ")"
+            - WHITESPACE@465..466 " "
+        - on_KW@466..468 "on"
+        - WHITESPACE@468..469 " "
+        - DIRECTIVE_LOCATIONS@469..488
+            - DIRECTIVE_LOCATION@469..476
+                - OBJECT_KW@469..475 "OBJECT"
+                - WHITESPACE@475..476 " "
+            - PIPE@476..477 "|"
+            - WHITESPACE@477..478 " "
+            - DIRECTIVE_LOCATION@478..488
+                - INTERFACE_KW@478..487 "INTERFACE"
+                - WHITESPACE@487..488 "\n"
+    - DIRECTIVE_DEFINITION@488..554
+        - directive_KW@488..497 "directive"
+        - WHITESPACE@497..498 " "
+        - AT@498..499 "@"
+        - NAME@499..510
+            - IDENT@499..510 "join__graph"
+        - ARGUMENTS_DEFINITION@510..540
+            - L_PAREN@510..511 "("
+            - INPUT_VALUE_DEFINITION@511..526
+                - NAME@511..515
+                    - IDENT@511..515 "name"
+                - COLON@515..516 ":"
+                - WHITESPACE@516..517 " "
+                - NON_NULL_TYPE@517..526
+                    - NAMED_TYPE@517..523
+                        - NAME@517..523
+                            - IDENT@517..523 "String"
+                    - BANG@523..524 "!"
+                    - COMMA@524..525 ","
+                    - WHITESPACE@525..526 " "
+            - INPUT_VALUE_DEFINITION@526..538
+                - NAME@526..529
+                    - IDENT@526..529 "url"
+                - COLON@529..530 ":"
+                - WHITESPACE@530..531 " "
+                - NON_NULL_TYPE@531..538
+                    - NAMED_TYPE@531..537
+                        - NAME@531..537
+                            - IDENT@531..537 "String"
+                    - BANG@537..538 "!"
+            - R_PAREN@538..539 ")"
+            - WHITESPACE@539..540 " "
+        - on_KW@540..542 "on"
+        - WHITESPACE@542..543 " "
+        - DIRECTIVE_LOCATIONS@543..554
+            - DIRECTIVE_LOCATION@543..554
+                - ENUM_VALUE_KW@543..553 "ENUM_VALUE"
+                - WHITESPACE@553..554 "\n"
+    - DIRECTIVE_DEFINITION@554..581
+        - directive_KW@554..563 "directive"
+        - WHITESPACE@563..564 " "
+        - AT@564..565 "@"
+        - NAME@565..572
+            - IDENT@565..571 "stream"
+            - WHITESPACE@571..572 " "
+        - on_KW@572..574 "on"
+        - WHITESPACE@574..575 " "
+        - DIRECTIVE_LOCATIONS@575..581
+            - DIRECTIVE_LOCATION@575..581
+                - FIELD_KW@575..580 "FIELD"
+                - WHITESPACE@580..581 "\n"
+    - DIRECTIVE_DEFINITION@581..627
+        - directive_KW@581..590 "directive"
+        - WHITESPACE@590..591 " "
+        - AT@591..592 "@"
+        - NAME@592..601
+            - IDENT@592..601 "transform"
+        - ARGUMENTS_DEFINITION@601..617
+            - L_PAREN@601..602 "("
+            - INPUT_VALUE_DEFINITION@602..615
+                - NAME@602..606
+                    - IDENT@602..606 "from"
+                - COLON@606..607 ":"
+                - WHITESPACE@607..608 " "
+                - NON_NULL_TYPE@608..615
+                    - NAMED_TYPE@608..614
+                        - NAME@608..614
+                            - IDENT@608..614 "String"
+                    - BANG@614..615 "!"
+            - R_PAREN@615..616 ")"
+            - WHITESPACE@616..617 " "
+        - on_KW@617..619 "on"
+        - WHITESPACE@619..620 " "
+        - DIRECTIVE_LOCATIONS@620..627
+            - DIRECTIVE_LOCATION@620..627
+                - FIELD_KW@620..625 "FIELD"
+                - WHITESPACE@625..627 "\n\n"
+    - UNION_TYPE_DEFINITION@627..677
+        - union_KW@627..632 "union"
+        - WHITESPACE@632..633 " "
+        - NAME@633..645
+            - IDENT@633..644 "AccountType"
+            - WHITESPACE@644..645 " "
+        - UNION_MEMBER_TYPES@645..677
+            - EQ@645..646 "="
+            - WHITESPACE@646..647 " "
+            - NAMED_TYPE@647..663
+                - NAME@647..663
+                    - IDENT@647..662 "PasswordAccount"
+                    - WHITESPACE@662..663 " "
+            - PIPE@663..664 "|"
+            - WHITESPACE@664..665 " "
+            - NAMED_TYPE@665..677
+                - NAME@665..677
+                    - IDENT@665..675 "SMSAccount"
+                    - WHITESPACE@675..677 "\n\n"
+    - OBJECT_TYPE_DEFINITION@677..713
+        - type_KW@677..681 "type"
+        - WHITESPACE@681..682 " "
+        - NAME@682..689
+            - IDENT@682..688 "Amazon"
+            - WHITESPACE@688..689 " "
+        - FIELDS_DEFINITION@689..713
+            - L_CURLY@689..690 "{"
+            - WHITESPACE@690..693 "\n  "
+            - FIELD_DEFINITION@693..710
+                - NAME@693..701
+                    - IDENT@693..701 "referrer"
+                - COLON@701..702 ":"
+                - WHITESPACE@702..703 " "
+                - NAMED_TYPE@703..709
+                    - NAME@703..709
+                        - IDENT@703..709 "String"
+                - WHITESPACE@709..710 "\n"
+            - R_CURLY@710..711 "}"
+            - WHITESPACE@711..713 "\n\n"
+    - UNION_TYPE_DEFINITION@713..740
+        - union_KW@713..718 "union"
+        - WHITESPACE@718..719 " "
+        - NAME@719..724
+            - IDENT@719..723 "Body"
+            - WHITESPACE@723..724 " "
+        - UNION_MEMBER_TYPES@724..740
+            - EQ@724..725 "="
+            - WHITESPACE@725..726 " "
+            - NAMED_TYPE@726..732
+                - NAME@726..732
+                    - IDENT@726..731 "Image"
+                    - WHITESPACE@731..732 " "
+            - PIPE@732..733 "|"
+            - WHITESPACE@733..734 " "
+            - NAMED_TYPE@734..740
+                - NAME@734..740
+                    - IDENT@734..738 "Text"
+                    - WHITESPACE@738..740 "\n\n"
+    - OBJECT_TYPE_DEFINITION@740..1727
+        - type_KW@740..744 "type"
+        - WHITESPACE@744..745 " "
+        - NAME@745..750
+            - IDENT@745..749 "Book"
+            - WHITESPACE@749..750 " "
+        - IMPLEMENTS_INTERFACES@750..769
+            - implements_KW@750..760 "implements"
+            - WHITESPACE@760..761 " "
+            - NAMED_TYPE@761..769
+                - NAME@761..769
+                    - IDENT@761..768 "Product"
+                    - WHITESPACE@768..769 "\n"
+        - DIRECTIVES@769..960
+            - DIRECTIVE@769..796
+                - AT@769..770 "@"
+                - NAME@770..781
+                    - IDENT@770..781 "join__owner"
+                - ARGUMENTS@781..796
+                    - L_PAREN@781..782 "("
+                    - ARGUMENT@782..794
+                        - NAME@782..787
+                            - IDENT@782..787 "graph"
+                        - COLON@787..788 ":"
+                        - WHITESPACE@788..789 " "
+                        - ENUM_VALUE@789..794
+                            - NAME@789..794
+                                - IDENT@789..794 "BOOKS"
+                    - R_PAREN@794..795 ")"
+                    - WHITESPACE@795..796 "\n"
+            - DIRECTIVE@796..835
+                - AT@796..797 "@"
+                - NAME@797..807
+                    - IDENT@797..807 "join__type"
+                - ARGUMENTS@807..835
+                    - L_PAREN@807..808 "("
+                    - ARGUMENT@808..822
+                        - NAME@808..813
+                            - IDENT@808..813 "graph"
+                        - COLON@813..814 ":"
+                        - WHITESPACE@814..815 " "
+                        - ENUM_VALUE@815..822
+                            - NAME@815..822
+                                - IDENT@815..820 "BOOKS"
+                                - COMMA@820..821 ","
+                                - WHITESPACE@821..822 " "
+                    - ARGUMENT@822..833
+                        - NAME@822..825
+                            - IDENT@822..825 "key"
+                        - COLON@825..826 ":"
+                        - WHITESPACE@826..827 " "
+                        - STRING_VALUE@827..833
+                            - STRING@827..833 "\"isbn\""
+                    - R_PAREN@833..834 ")"
+                    - WHITESPACE@834..835 "\n"
+            - DIRECTIVE@835..878
+                - AT@835..836 "@"
+                - NAME@836..846
+                    - IDENT@836..846 "join__type"
+                - ARGUMENTS@846..878
+                    - L_PAREN@846..847 "("
+                    - ARGUMENT@847..865
+                        - NAME@847..852
+                            - IDENT@847..852 "graph"
+                        - COLON@852..853 ":"
+                        - WHITESPACE@853..854 " "
+                        - ENUM_VALUE@854..865
+                            - NAME@854..865
+                                - IDENT@854..863 "INVENTORY"
+                                - COMMA@863..864 ","
+                                - WHITESPACE@864..865 " "
+                    - ARGUMENT@865..876
+                        - NAME@865..868
+                            - IDENT@865..868 "key"
+                        - COLON@868..869 ":"
+                        - WHITESPACE@869..870 " "
+                        - STRING_VALUE@870..876
+                            - STRING@870..876 "\"isbn\""
+                    - R_PAREN@876..877 ")"
+                    - WHITESPACE@877..878 "\n"
+            - DIRECTIVE@878..919
+                - AT@878..879 "@"
+                - NAME@879..889
+                    - IDENT@879..889 "join__type"
+                - ARGUMENTS@889..919
+                    - L_PAREN@889..890 "("
+                    - ARGUMENT@890..906
+                        - NAME@890..895
+                            - IDENT@890..895 "graph"
+                        - COLON@895..896 ":"
+                        - WHITESPACE@896..897 " "
+                        - ENUM_VALUE@897..906
+                            - NAME@897..906
+                                - IDENT@897..904 "PRODUCT"
+                                - COMMA@904..905 ","
+                                - WHITESPACE@905..906 " "
+                    - ARGUMENT@906..917
+                        - NAME@906..909
+                            - IDENT@906..909 "key"
+                        - COLON@909..910 ":"
+                        - WHITESPACE@910..911 " "
+                        - STRING_VALUE@911..917
+                            - STRING@911..917 "\"isbn\""
+                    - R_PAREN@917..918 ")"
+                    - WHITESPACE@918..919 "\n"
+            - DIRECTIVE@919..960
+                - AT@919..920 "@"
+                - NAME@920..930
+                    - IDENT@920..930 "join__type"
+                - ARGUMENTS@930..960
+                    - L_PAREN@930..931 "("
+                    - ARGUMENT@931..947
+                        - NAME@931..936
+                            - IDENT@931..936 "graph"
+                        - COLON@936..937 ":"
+                        - WHITESPACE@937..938 " "
+                        - ENUM_VALUE@938..947
+                            - NAME@938..947
+                                - IDENT@938..945 "REVIEWS"
+                                - COMMA@945..946 ","
+                                - WHITESPACE@946..947 " "
+                    - ARGUMENT@947..958
+                        - NAME@947..950
+                            - IDENT@947..950 "key"
+                        - COLON@950..951 ":"
+                        - WHITESPACE@951..952 " "
+                        - STRING_VALUE@952..958
+                            - STRING@952..958 "\"isbn\""
+                    - R_PAREN@958..959 ")"
+                    - WHITESPACE@959..960 "\n"
+        - FIELDS_DEFINITION@960..1727
+            - L_CURLY@960..961 "{"
+            - WHITESPACE@961..964 "\n  "
+            - FIELD_DEFINITION@964..1007
+                - NAME@964..968
+                    - IDENT@964..968 "isbn"
+                - COLON@968..969 ":"
+                - WHITESPACE@969..970 " "
+                - NON_NULL_TYPE@970..978
+                    - NAMED_TYPE@970..976
+                        - NAME@970..976
+                            - IDENT@970..976 "String"
+                    - BANG@976..977 "!"
+                    - WHITESPACE@977..978 " "
+                - DIRECTIVES@978..1007
+                    - DIRECTIVE@978..1007
+                        - AT@978..979 "@"
+                        - NAME@979..990
+                            - IDENT@979..990 "join__field"
+                        - ARGUMENTS@990..1007
+                            - L_PAREN@990..991 "("
+                            - ARGUMENT@991..1003
+                                - NAME@991..996
+                                    - IDENT@991..996 "graph"
+                                - COLON@996..997 ":"
+                                - WHITESPACE@997..998 " "
+                                - ENUM_VALUE@998..1003
+                                    - NAME@998..1003
+                                        - IDENT@998..1003 "BOOKS"
+                            - R_PAREN@1003..1004 ")"
+                            - WHITESPACE@1004..1007 "\n  "
+            - FIELD_DEFINITION@1007..1050
+                - NAME@1007..1012
+                    - IDENT@1007..1012 "title"
+                - COLON@1012..1013 ":"
+                - WHITESPACE@1013..1014 " "
+                - NAMED_TYPE@1014..1020
+                    - NAME@1014..1020
+                        - IDENT@1014..1020 "String"
+                - WHITESPACE@1020..1021 " "
+                - DIRECTIVES@1021..1050
+                    - DIRECTIVE@1021..1050
+                        - AT@1021..1022 "@"
+                        - NAME@1022..1033
+                            - IDENT@1022..1033 "join__field"
+                        - ARGUMENTS@1033..1050
+                            - L_PAREN@1033..1034 "("
+                            - ARGUMENT@1034..1046
+                                - NAME@1034..1039
+                                    - IDENT@1034..1039 "graph"
+                                - COLON@1039..1040 ":"
+                                - WHITESPACE@1040..1041 " "
+                                - ENUM_VALUE@1041..1046
+                                    - NAME@1041..1046
+                                        - IDENT@1041..1046 "BOOKS"
+                            - R_PAREN@1046..1047 ")"
+                            - WHITESPACE@1047..1050 "\n  "
+            - FIELD_DEFINITION@1050..1089
+                - NAME@1050..1054
+                    - IDENT@1050..1054 "year"
+                - COLON@1054..1055 ":"
+                - WHITESPACE@1055..1056 " "
+                - NAMED_TYPE@1056..1059
+                    - NAME@1056..1059
+                        - IDENT@1056..1059 "Int"
+                - WHITESPACE@1059..1060 " "
+                - DIRECTIVES@1060..1089
+                    - DIRECTIVE@1060..1089
+                        - AT@1060..1061 "@"
+                        - NAME@1061..1072
+                            - IDENT@1061..1072 "join__field"
+                        - ARGUMENTS@1072..1089
+                            - L_PAREN@1072..1073 "("
+                            - ARGUMENT@1073..1085
+                                - NAME@1073..1078
+                                    - IDENT@1073..1078 "graph"
+                                - COLON@1078..1079 ":"
+                                - WHITESPACE@1079..1080 " "
+                                - ENUM_VALUE@1080..1085
+                                    - NAME@1080..1085
+                                        - IDENT@1080..1085 "BOOKS"
+                            - R_PAREN@1085..1086 ")"
+                            - WHITESPACE@1086..1089 "\n  "
+            - FIELD_DEFINITION@1089..1140
+                - NAME@1089..1101
+                    - IDENT@1089..1101 "similarBooks"
+                - COLON@1101..1102 ":"
+                - WHITESPACE@1102..1103 " "
+                - NON_NULL_TYPE@1103..1111
+                    - LIST_TYPE@1103..1109
+                        - L_BRACK@1103..1104 "["
+                        - NAMED_TYPE@1104..1108
+                            - NAME@1104..1108
+                                - IDENT@1104..1108 "Book"
+                        - R_BRACK@1108..1109 "]"
+                    - BANG@1109..1110 "!"
+                    - WHITESPACE@1110..1111 " "
+                - DIRECTIVES@1111..1140
+                    - DIRECTIVE@1111..1140
+                        - AT@1111..1112 "@"
+                        - NAME@1112..1123
+                            - IDENT@1112..1123 "join__field"
+                        - ARGUMENTS@1123..1140
+                            - L_PAREN@1123..1124 "("
+                            - ARGUMENT@1124..1136
+                                - NAME@1124..1129
+                                    - IDENT@1124..1129 "graph"
+                                - COLON@1129..1130 ":"
+                                - WHITESPACE@1130..1131 " "
+                                - ENUM_VALUE@1131..1136
+                                    - NAME@1131..1136
+                                        - IDENT@1131..1136 "BOOKS"
+                            - R_PAREN@1136..1137 ")"
+                            - WHITESPACE@1137..1140 "\n  "
+            - FIELD_DEFINITION@1140..1197
+                - NAME@1140..1148
+                    - IDENT@1140..1148 "metadata"
+                - COLON@1148..1149 ":"
+                - WHITESPACE@1149..1150 " "
+                - LIST_TYPE@1150..1167
+                    - L_BRACK@1150..1151 "["
+                    - NAMED_TYPE@1151..1166
+                        - NAME@1151..1166
+                            - IDENT@1151..1166 "MetadataOrError"
+                    - R_BRACK@1166..1167 "]"
+                - WHITESPACE@1167..1168 " "
+                - DIRECTIVES@1168..1197
+                    - DIRECTIVE@1168..1197
+                        - AT@1168..1169 "@"
+                        - NAME@1169..1180
+                            - IDENT@1169..1180 "join__field"
+                        - ARGUMENTS@1180..1197
+                            - L_PAREN@1180..1181 "("
+                            - ARGUMENT@1181..1193
+                                - NAME@1181..1186
+                                    - IDENT@1181..1186 "graph"
+                                - COLON@1186..1187 ":"
+                                - WHITESPACE@1187..1188 " "
+                                - ENUM_VALUE@1188..1193
+                                    - NAME@1188..1193
+                                        - IDENT@1188..1193 "BOOKS"
+                            - R_PAREN@1193..1194 ")"
+                            - WHITESPACE@1194..1197 "\n  "
+            - FIELD_DEFINITION@1197..1247
+                - NAME@1197..1204
+                    - IDENT@1197..1204 "inStock"
+                - COLON@1204..1205 ":"
+                - WHITESPACE@1205..1206 " "
+                - NAMED_TYPE@1206..1213
+                    - NAME@1206..1213
+                        - IDENT@1206..1213 "Boolean"
+                - WHITESPACE@1213..1214 " "
+                - DIRECTIVES@1214..1247
+                    - DIRECTIVE@1214..1247
+                        - AT@1214..1215 "@"
+                        - NAME@1215..1226
+                            - IDENT@1215..1226 "join__field"
+                        - ARGUMENTS@1226..1247
+                            - L_PAREN@1226..1227 "("
+                            - ARGUMENT@1227..1243
+                                - NAME@1227..1232
+                                    - IDENT@1227..1232 "graph"
+                                - COLON@1232..1233 ":"
+                                - WHITESPACE@1233..1234 " "
+                                - ENUM_VALUE@1234..1243
+                                    - NAME@1234..1243
+                                        - IDENT@1234..1243 "INVENTORY"
+                            - R_PAREN@1243..1244 ")"
+                            - WHITESPACE@1244..1247 "\n  "
+            - FIELD_DEFINITION@1247..1302
+                - NAME@1247..1259
+                    - IDENT@1247..1259 "isCheckedOut"
+                - COLON@1259..1260 ":"
+                - WHITESPACE@1260..1261 " "
+                - NAMED_TYPE@1261..1268
+                    - NAME@1261..1268
+                        - IDENT@1261..1268 "Boolean"
+                - WHITESPACE@1268..1269 " "
+                - DIRECTIVES@1269..1302
+                    - DIRECTIVE@1269..1302
+                        - AT@1269..1270 "@"
+                        - NAME@1270..1281
+                            - IDENT@1270..1281 "join__field"
+                        - ARGUMENTS@1281..1302
+                            - L_PAREN@1281..1282 "("
+                            - ARGUMENT@1282..1298
+                                - NAME@1282..1287
+                                    - IDENT@1282..1287 "graph"
+                                - COLON@1287..1288 ":"
+                                - WHITESPACE@1288..1289 " "
+                                - ENUM_VALUE@1289..1298
+                                    - NAME@1289..1298
+                                        - IDENT@1289..1298 "INVENTORY"
+                            - R_PAREN@1298..1299 ")"
+                            - WHITESPACE@1299..1302 "\n  "
+            - FIELD_DEFINITION@1302..1346
+                - NAME@1302..1305
+                    - IDENT@1302..1305 "upc"
+                - COLON@1305..1306 ":"
+                - WHITESPACE@1306..1307 " "
+                - NON_NULL_TYPE@1307..1315
+                    - NAMED_TYPE@1307..1313
+                        - NAME@1307..1313
+                            - IDENT@1307..1313 "String"
+                    - BANG@1313..1314 "!"
+                    - WHITESPACE@1314..1315 " "
+                - DIRECTIVES@1315..1346
+                    - DIRECTIVE@1315..1346
+                        - AT@1315..1316 "@"
+                        - NAME@1316..1327
+                            - IDENT@1316..1327 "join__field"
+                        - ARGUMENTS@1327..1346
+                            - L_PAREN@1327..1328 "("
+                            - ARGUMENT@1328..1342
+                                - NAME@1328..1333
+                                    - IDENT@1328..1333 "graph"
+                                - COLON@1333..1334 ":"
+                                - WHITESPACE@1334..1335 " "
+                                - ENUM_VALUE@1335..1342
+                                    - NAME@1335..1342
+                                        - IDENT@1335..1342 "PRODUCT"
+                            - R_PAREN@1342..1343 ")"
+                            - WHITESPACE@1343..1346 "\n  "
+            - FIELD_DEFINITION@1346..1390
+                - NAME@1346..1349
+                    - IDENT@1346..1349 "sku"
+                - COLON@1349..1350 ":"
+                - WHITESPACE@1350..1351 " "
+                - NON_NULL_TYPE@1351..1359
+                    - NAMED_TYPE@1351..1357
+                        - NAME@1351..1357
+                            - IDENT@1351..1357 "String"
+                    - BANG@1357..1358 "!"
+                    - WHITESPACE@1358..1359 " "
+                - DIRECTIVES@1359..1390
+                    - DIRECTIVE@1359..1390
+                        - AT@1359..1360 "@"
+                        - NAME@1360..1371
+                            - IDENT@1360..1371 "join__field"
+                        - ARGUMENTS@1371..1390
+                            - L_PAREN@1371..1372 "("
+                            - ARGUMENT@1372..1386
+                                - NAME@1372..1377
+                                    - IDENT@1372..1377 "graph"
+                                - COLON@1377..1378 ":"
+                                - WHITESPACE@1378..1379 " "
+                                - ENUM_VALUE@1379..1386
+                                    - NAME@1379..1386
+                                        - IDENT@1379..1386 "PRODUCT"
+                            - R_PAREN@1386..1387 ")"
+                            - WHITESPACE@1387..1390 "\n  "
+            - FIELD_DEFINITION@1390..1483
+                - NAME@1390..1394
+                    - IDENT@1390..1394 "name"
+                - ARGUMENTS_DEFINITION@1394..1419
+                    - L_PAREN@1394..1395 "("
+                    - INPUT_VALUE_DEFINITION@1395..1418
+                        - NAME@1395..1404
+                            - IDENT@1395..1404 "delimeter"
+                        - COLON@1404..1405 ":"
+                        - WHITESPACE@1405..1406 " "
+                        - NAMED_TYPE@1406..1412
+                            - NAME@1406..1412
+                                - IDENT@1406..1412 "String"
+                        - WHITESPACE@1412..1413 " "
+                        - DEFAULT_VALUE@1413..1418
+                            - EQ@1413..1414 "="
+                            - WHITESPACE@1414..1415 " "
+                            - STRING_VALUE@1415..1418
+                                - STRING@1415..1418 "\" \""
+                    - R_PAREN@1418..1419 ")"
+                - COLON@1419..1420 ":"
+                - WHITESPACE@1420..1421 " "
+                - NAMED_TYPE@1421..1427
+                    - NAME@1421..1427
+                        - IDENT@1421..1427 "String"
+                - WHITESPACE@1427..1428 " "
+                - DIRECTIVES@1428..1483
+                    - DIRECTIVE@1428..1483
+                        - AT@1428..1429 "@"
+                        - NAME@1429..1440
+                            - IDENT@1429..1440 "join__field"
+                        - ARGUMENTS@1440..1483
+                            - L_PAREN@1440..1441 "("
+                            - ARGUMENT@1441..1457
+                                - NAME@1441..1446
+                                    - IDENT@1441..1446 "graph"
+                                - COLON@1446..1447 ":"
+                                - WHITESPACE@1447..1448 " "
+                                - ENUM_VALUE@1448..1457
+                                    - NAME@1448..1457
+                                        - IDENT@1448..1455 "PRODUCT"
+                                        - COMMA@1455..1456 ","
+                                        - WHITESPACE@1456..1457 " "
+                            - ARGUMENT@1457..1479
+                                - NAME@1457..1465
+                                    - IDENT@1457..1465 "requires"
+                                - COLON@1465..1466 ":"
+                                - WHITESPACE@1466..1467 " "
+                                - STRING_VALUE@1467..1479
+                                    - STRING@1467..1479 "\"title year\""
+                            - R_PAREN@1479..1480 ")"
+                            - WHITESPACE@1480..1483 "\n  "
+            - FIELD_DEFINITION@1483..1528
+                - NAME@1483..1488
+                    - IDENT@1483..1488 "price"
+                - COLON@1488..1489 ":"
+                - WHITESPACE@1489..1490 " "
+                - NAMED_TYPE@1490..1496
+                    - NAME@1490..1496
+                        - IDENT@1490..1496 "String"
+                - WHITESPACE@1496..1497 " "
+                - DIRECTIVES@1497..1528
+                    - DIRECTIVE@1497..1528
+                        - AT@1497..1498 "@"
+                        - NAME@1498..1509
+                            - IDENT@1498..1509 "join__field"
+                        - ARGUMENTS@1509..1528
+                            - L_PAREN@1509..1510 "("
+                            - ARGUMENT@1510..1524
+                                - NAME@1510..1515
+                                    - IDENT@1510..1515 "graph"
+                                - COLON@1515..1516 ":"
+                                - WHITESPACE@1516..1517 " "
+                                - ENUM_VALUE@1517..1524
+                                    - NAME@1517..1524
+                                        - IDENT@1517..1524 "PRODUCT"
+                            - R_PAREN@1524..1525 ")"
+                            - WHITESPACE@1525..1528 "\n  "
+            - FIELD_DEFINITION@1528..1587
+                - NAME@1528..1535
+                    - IDENT@1528..1535 "details"
+                - COLON@1535..1536 ":"
+                - WHITESPACE@1536..1537 " "
+                - NAMED_TYPE@1537..1555
+                    - NAME@1537..1555
+                        - IDENT@1537..1555 "ProductDetailsBook"
+                - WHITESPACE@1555..1556 " "
+                - DIRECTIVES@1556..1587
+                    - DIRECTIVE@1556..1587
+                        - AT@1556..1557 "@"
+                        - NAME@1557..1568
+                            - IDENT@1557..1568 "join__field"
+                        - ARGUMENTS@1568..1587
+                            - L_PAREN@1568..1569 "("
+                            - ARGUMENT@1569..1583
+                                - NAME@1569..1574
+                                    - IDENT@1569..1574 "graph"
+                                - COLON@1574..1575 ":"
+                                - WHITESPACE@1575..1576 " "
+                                - ENUM_VALUE@1576..1583
+                                    - NAME@1576..1583
+                                        - IDENT@1576..1583 "PRODUCT"
+                            - R_PAREN@1583..1584 ")"
+                            - WHITESPACE@1584..1587 "\n  "
+            - FIELD_DEFINITION@1587..1636
+                - NAME@1587..1594
+                    - IDENT@1587..1594 "reviews"
+                - COLON@1594..1595 ":"
+                - WHITESPACE@1595..1596 " "
+                - LIST_TYPE@1596..1604
+                    - L_BRACK@1596..1597 "["
+                    - NAMED_TYPE@1597..1603
+                        - NAME@1597..1603
+                            - IDENT@1597..1603 "Review"
+                    - R_BRACK@1603..1604 "]"
+                - WHITESPACE@1604..1605 " "
+                - DIRECTIVES@1605..1636
+                    - DIRECTIVE@1605..1636
+                        - AT@1605..1606 "@"
+                        - NAME@1606..1617
+                            - IDENT@1606..1617 "join__field"
+                        - ARGUMENTS@1617..1636
+                            - L_PAREN@1617..1618 "("
+                            - ARGUMENT@1618..1632
+                                - NAME@1618..1623
+                                    - IDENT@1618..1623 "graph"
+                                - COLON@1623..1624 ":"
+                                - WHITESPACE@1624..1625 " "
+                                - ENUM_VALUE@1625..1632
+                                    - NAME@1625..1632
+                                        - IDENT@1625..1632 "REVIEWS"
+                            - R_PAREN@1632..1633 ")"
+                            - WHITESPACE@1633..1636 "\n  "
+            - FIELD_DEFINITION@1636..1724
+                - NAME@1636..1650
+                    - IDENT@1636..1650 "relatedReviews"
+                - COLON@1650..1651 ":"
+                - WHITESPACE@1651..1652 " "
+                - NON_NULL_TYPE@1652..1663
+                    - LIST_TYPE@1652..1661
+                        - L_BRACK@1652..1653 "["
+                        - NON_NULL_TYPE@1653..1660
+                            - NAMED_TYPE@1653..1659
+                                - NAME@1653..1659
+                                    - IDENT@1653..1659 "Review"
+                            - BANG@1659..1660 "!"
+                        - R_BRACK@1660..1661 "]"
+                    - BANG@1661..1662 "!"
+                    - WHITESPACE@1662..1663 " "
+                - DIRECTIVES@1663..1724
+                    - DIRECTIVE@1663..1724
+                        - AT@1663..1664 "@"
+                        - NAME@1664..1675
+                            - IDENT@1664..1675 "join__field"
+                        - ARGUMENTS@1675..1724
+                            - L_PAREN@1675..1676 "("
+                            - ARGUMENT@1676..1692
+                                - NAME@1676..1681
+                                    - IDENT@1676..1681 "graph"
+                                - COLON@1681..1682 ":"
+                                - WHITESPACE@1682..1683 " "
+                                - ENUM_VALUE@1683..1692
+                                    - NAME@1683..1692
+                                        - IDENT@1683..1690 "REVIEWS"
+                                        - COMMA@1690..1691 ","
+                                        - WHITESPACE@1691..1692 " "
+                            - ARGUMENT@1692..1722
+                                - NAME@1692..1700
+                                    - IDENT@1692..1700 "requires"
+                                - COLON@1700..1701 ":"
+                                - WHITESPACE@1701..1702 " "
+                                - STRING_VALUE@1702..1722
+                                    - STRING@1702..1722 "\"similarBooks{isbn}\""
+                            - R_PAREN@1722..1723 ")"
+                            - WHITESPACE@1723..1724 "\n"
+            - R_CURLY@1724..1725 "}"
+            - WHITESPACE@1725..1727 "\n\n"
+    - UNION_TYPE_DEFINITION@1727..1756
+        - union_KW@1727..1732 "union"
+        - WHITESPACE@1732..1733 " "
+        - NAME@1733..1739
+            - IDENT@1733..1738 "Brand"
+            - WHITESPACE@1738..1739 " "
+        - UNION_MEMBER_TYPES@1739..1756
+            - EQ@1739..1740 "="
+            - WHITESPACE@1740..1741 " "
+            - NAMED_TYPE@1741..1746
+                - NAME@1741..1746
+                    - IDENT@1741..1745 "Ikea"
+                    - WHITESPACE@1745..1746 " "
+            - PIPE@1746..1747 "|"
+            - WHITESPACE@1747..1748 " "
+            - NAMED_TYPE@1748..1756
+                - NAME@1748..1756
+                    - IDENT@1748..1754 "Amazon"
+                    - WHITESPACE@1754..1756 "\n\n"
+    - OBJECT_TYPE_DEFINITION@1756..2105
+        - type_KW@1756..1760 "type"
+        - WHITESPACE@1760..1761 " "
+        - NAME@1761..1765
+            - IDENT@1761..1764 "Car"
+            - WHITESPACE@1764..1765 " "
+        - IMPLEMENTS_INTERFACES@1765..1784
+            - implements_KW@1765..1775 "implements"
+            - WHITESPACE@1775..1776 " "
+            - NAMED_TYPE@1776..1784
+                - NAME@1776..1784
+                    - IDENT@1776..1783 "Vehicle"
+                    - WHITESPACE@1783..1784 "\n"
+        - DIRECTIVES@1784..1891
+            - DIRECTIVE@1784..1813
+                - AT@1784..1785 "@"
+                - NAME@1785..1796
+                    - IDENT@1785..1796 "join__owner"
+                - ARGUMENTS@1796..1813
+                    - L_PAREN@1796..1797 "("
+                    - ARGUMENT@1797..1811
+                        - NAME@1797..1802
+                            - IDENT@1797..1802 "graph"
+                        - COLON@1802..1803 ":"
+                        - WHITESPACE@1803..1804 " "
+                        - ENUM_VALUE@1804..1811
+                            - NAME@1804..1811
+                                - IDENT@1804..1811 "PRODUCT"
+                    - R_PAREN@1811..1812 ")"
+                    - WHITESPACE@1812..1813 "\n"
+            - DIRECTIVE@1813..1852
+                - AT@1813..1814 "@"
+                - NAME@1814..1824
+                    - IDENT@1814..1824 "join__type"
+                - ARGUMENTS@1824..1852
+                    - L_PAREN@1824..1825 "("
+                    - ARGUMENT@1825..1841
+                        - NAME@1825..1830
+                            - IDENT@1825..1830 "graph"
+                        - COLON@1830..1831 ":"
+                        - WHITESPACE@1831..1832 " "
+                        - ENUM_VALUE@1832..1841
+                            - NAME@1832..1841
+                                - IDENT@1832..1839 "PRODUCT"
+                                - COMMA@1839..1840 ","
+                                - WHITESPACE@1840..1841 " "
+                    - ARGUMENT@1841..1850
+                        - NAME@1841..1844
+                            - IDENT@1841..1844 "key"
+                        - COLON@1844..1845 ":"
+                        - WHITESPACE@1845..1846 " "
+                        - STRING_VALUE@1846..1850
+                            - STRING@1846..1850 "\"id\""
+                    - R_PAREN@1850..1851 ")"
+                    - WHITESPACE@1851..1852 "\n"
+            - DIRECTIVE@1852..1891
+                - AT@1852..1853 "@"
+                - NAME@1853..1863
+                    - IDENT@1853..1863 "join__type"
+                - ARGUMENTS@1863..1891
+                    - L_PAREN@1863..1864 "("
+                    - ARGUMENT@1864..1880
+                        - NAME@1864..1869
+                            - IDENT@1864..1869 "graph"
+                        - COLON@1869..1870 ":"
+                        - WHITESPACE@1870..1871 " "
+                        - ENUM_VALUE@1871..1880
+                            - NAME@1871..1880
+                                - IDENT@1871..1878 "REVIEWS"
+                                - COMMA@1878..1879 ","
+                                - WHITESPACE@1879..1880 " "
+                    - ARGUMENT@1880..1889
+                        - NAME@1880..1883
+                            - IDENT@1880..1883 "key"
+                        - COLON@1883..1884 ":"
+                        - WHITESPACE@1884..1885 " "
+                        - STRING_VALUE@1885..1889
+                            - STRING@1885..1889 "\"id\""
+                    - R_PAREN@1889..1890 ")"
+                    - WHITESPACE@1890..1891 "\n"
+        - FIELDS_DEFINITION@1891..2105
+            - L_CURLY@1891..1892 "{"
+            - WHITESPACE@1892..1895 "\n  "
+            - FIELD_DEFINITION@1895..1938
+                - NAME@1895..1897
+                    - IDENT@1895..1897 "id"
+                - COLON@1897..1898 ":"
+                - WHITESPACE@1898..1899 " "
+                - NON_NULL_TYPE@1899..1907
+                    - NAMED_TYPE@1899..1905
+                        - NAME@1899..1905
+                            - IDENT@1899..1905 "String"
+                    - BANG@1905..1906 "!"
+                    - WHITESPACE@1906..1907 " "
+                - DIRECTIVES@1907..1938
+                    - DIRECTIVE@1907..1938
+                        - AT@1907..1908 "@"
+                        - NAME@1908..1919
+                            - IDENT@1908..1919 "join__field"
+                        - ARGUMENTS@1919..1938
+                            - L_PAREN@1919..1920 "("
+                            - ARGUMENT@1920..1934
+                                - NAME@1920..1925
+                                    - IDENT@1920..1925 "graph"
+                                - COLON@1925..1926 ":"
+                                - WHITESPACE@1926..1927 " "
+                                - ENUM_VALUE@1927..1934
+                                    - NAME@1927..1934
+                                        - IDENT@1927..1934 "PRODUCT"
+                            - R_PAREN@1934..1935 ")"
+                            - WHITESPACE@1935..1938 "\n  "
+            - FIELD_DEFINITION@1938..1989
+                - NAME@1938..1949
+                    - IDENT@1938..1949 "description"
+                - COLON@1949..1950 ":"
+                - WHITESPACE@1950..1951 " "
+                - NAMED_TYPE@1951..1957
+                    - NAME@1951..1957
+                        - IDENT@1951..1957 "String"
+                - WHITESPACE@1957..1958 " "
+                - DIRECTIVES@1958..1989
+                    - DIRECTIVE@1958..1989
+                        - AT@1958..1959 "@"
+                        - NAME@1959..1970
+                            - IDENT@1959..1970 "join__field"
+                        - ARGUMENTS@1970..1989
+                            - L_PAREN@1970..1971 "("
+                            - ARGUMENT@1971..1985
+                                - NAME@1971..1976
+                                    - IDENT@1971..1976 "graph"
+                                - COLON@1976..1977 ":"
+                                - WHITESPACE@1977..1978 " "
+                                - ENUM_VALUE@1978..1985
+                                    - NAME@1978..1985
+                                        - IDENT@1978..1985 "PRODUCT"
+                            - R_PAREN@1985..1986 ")"
+                            - WHITESPACE@1986..1989 "\n  "
+            - FIELD_DEFINITION@1989..2034
+                - NAME@1989..1994
+                    - IDENT@1989..1994 "price"
+                - COLON@1994..1995 ":"
+                - WHITESPACE@1995..1996 " "
+                - NAMED_TYPE@1996..2002
+                    - NAME@1996..2002
+                        - IDENT@1996..2002 "String"
+                - WHITESPACE@2002..2003 " "
+                - DIRECTIVES@2003..2034
+                    - DIRECTIVE@2003..2034
+                        - AT@2003..2004 "@"
+                        - NAME@2004..2015
+                            - IDENT@2004..2015 "join__field"
+                        - ARGUMENTS@2015..2034
+                            - L_PAREN@2015..2016 "("
+                            - ARGUMENT@2016..2030
+                                - NAME@2016..2021
+                                    - IDENT@2016..2021 "graph"
+                                - COLON@2021..2022 ":"
+                                - WHITESPACE@2022..2023 " "
+                                - ENUM_VALUE@2023..2030
+                                    - NAME@2023..2030
+                                        - IDENT@2023..2030 "PRODUCT"
+                            - R_PAREN@2030..2031 ")"
+                            - WHITESPACE@2031..2034 "\n  "
+            - FIELD_DEFINITION@2034..2102
+                - NAME@2034..2045
+                    - IDENT@2034..2045 "retailPrice"
+                - COLON@2045..2046 ":"
+                - WHITESPACE@2046..2047 " "
+                - NAMED_TYPE@2047..2053
+                    - NAME@2047..2053
+                        - IDENT@2047..2053 "String"
+                - WHITESPACE@2053..2054 " "
+                - DIRECTIVES@2054..2102
+                    - DIRECTIVE@2054..2102
+                        - AT@2054..2055 "@"
+                        - NAME@2055..2066
+                            - IDENT@2055..2066 "join__field"
+                        - ARGUMENTS@2066..2102
+                            - L_PAREN@2066..2067 "("
+                            - ARGUMENT@2067..2083
+                                - NAME@2067..2072
+                                    - IDENT@2067..2072 "graph"
+                                - COLON@2072..2073 ":"
+                                - WHITESPACE@2073..2074 " "
+                                - ENUM_VALUE@2074..2083
+                                    - NAME@2074..2083
+                                        - IDENT@2074..2081 "REVIEWS"
+                                        - COMMA@2081..2082 ","
+                                        - WHITESPACE@2082..2083 " "
+                            - ARGUMENT@2083..2100
+                                - NAME@2083..2091
+                                    - IDENT@2083..2091 "requires"
+                                - COLON@2091..2092 ":"
+                                - WHITESPACE@2092..2093 " "
+                                - STRING_VALUE@2093..2100
+                                    - STRING@2093..2100 "\"price\""
+                            - R_PAREN@2100..2101 ")"
+                            - WHITESPACE@2101..2102 "\n"
+            - R_CURLY@2102..2103 "}"
+            - WHITESPACE@2103..2105 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2105..2151
+        - type_KW@2105..2109 "type"
+        - WHITESPACE@2109..2110 " "
+        - NAME@2110..2116
+            - IDENT@2110..2115 "Error"
+            - WHITESPACE@2115..2116 " "
+        - FIELDS_DEFINITION@2116..2151
+            - L_CURLY@2116..2117 "{"
+            - WHITESPACE@2117..2120 "\n  "
+            - FIELD_DEFINITION@2120..2132
+                - NAME@2120..2124
+                    - IDENT@2120..2124 "code"
+                - COLON@2124..2125 ":"
+                - WHITESPACE@2125..2126 " "
+                - NAMED_TYPE@2126..2129
+                    - NAME@2126..2129
+                        - IDENT@2126..2129 "Int"
+                - WHITESPACE@2129..2132 "\n  "
+            - FIELD_DEFINITION@2132..2148
+                - NAME@2132..2139
+                    - IDENT@2132..2139 "message"
+                - COLON@2139..2140 ":"
+                - WHITESPACE@2140..2141 " "
+                - NAMED_TYPE@2141..2147
+                    - NAME@2141..2147
+                        - IDENT@2141..2147 "String"
+                - WHITESPACE@2147..2148 "\n"
+            - R_CURLY@2148..2149 "}"
+            - WHITESPACE@2149..2151 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2151..2874
+        - type_KW@2151..2155 "type"
+        - WHITESPACE@2155..2156 " "
+        - NAME@2156..2166
+            - IDENT@2156..2165 "Furniture"
+            - WHITESPACE@2165..2166 " "
+        - IMPLEMENTS_INTERFACES@2166..2185
+            - implements_KW@2166..2176 "implements"
+            - WHITESPACE@2176..2177 " "
+            - NAMED_TYPE@2177..2185
+                - NAME@2177..2185
+                    - IDENT@2177..2184 "Product"
+                    - WHITESPACE@2184..2185 "\n"
+        - DIRECTIVES@2185..2376
+            - DIRECTIVE@2185..2214
+                - AT@2185..2186 "@"
+                - NAME@2186..2197
+                    - IDENT@2186..2197 "join__owner"
+                - ARGUMENTS@2197..2214
+                    - L_PAREN@2197..2198 "("
+                    - ARGUMENT@2198..2212
+                        - NAME@2198..2203
+                            - IDENT@2198..2203 "graph"
+                        - COLON@2203..2204 ":"
+                        - WHITESPACE@2204..2205 " "
+                        - ENUM_VALUE@2205..2212
+                            - NAME@2205..2212
+                                - IDENT@2205..2212 "PRODUCT"
+                    - R_PAREN@2212..2213 ")"
+                    - WHITESPACE@2213..2214 "\n"
+            - DIRECTIVE@2214..2254
+                - AT@2214..2215 "@"
+                - NAME@2215..2225
+                    - IDENT@2215..2225 "join__type"
+                - ARGUMENTS@2225..2254
+                    - L_PAREN@2225..2226 "("
+                    - ARGUMENT@2226..2242
+                        - NAME@2226..2231
+                            - IDENT@2226..2231 "graph"
+                        - COLON@2231..2232 ":"
+                        - WHITESPACE@2232..2233 " "
+                        - ENUM_VALUE@2233..2242
+                            - NAME@2233..2242
+                                - IDENT@2233..2240 "PRODUCT"
+                                - COMMA@2240..2241 ","
+                                - WHITESPACE@2241..2242 " "
+                    - ARGUMENT@2242..2252
+                        - NAME@2242..2245
+                            - IDENT@2242..2245 "key"
+                        - COLON@2245..2246 ":"
+                        - WHITESPACE@2246..2247 " "
+                        - STRING_VALUE@2247..2252
+                            - STRING@2247..2252 "\"upc\""
+                    - R_PAREN@2252..2253 ")"
+                    - WHITESPACE@2253..2254 "\n"
+            - DIRECTIVE@2254..2294
+                - AT@2254..2255 "@"
+                - NAME@2255..2265
+                    - IDENT@2255..2265 "join__type"
+                - ARGUMENTS@2265..2294
+                    - L_PAREN@2265..2266 "("
+                    - ARGUMENT@2266..2282
+                        - NAME@2266..2271
+                            - IDENT@2266..2271 "graph"
+                        - COLON@2271..2272 ":"
+                        - WHITESPACE@2272..2273 " "
+                        - ENUM_VALUE@2273..2282
+                            - NAME@2273..2282
+                                - IDENT@2273..2280 "PRODUCT"
+                                - COMMA@2280..2281 ","
+                                - WHITESPACE@2281..2282 " "
+                    - ARGUMENT@2282..2292
+                        - NAME@2282..2285
+                            - IDENT@2282..2285 "key"
+                        - COLON@2285..2286 ":"
+                        - WHITESPACE@2286..2287 " "
+                        - STRING_VALUE@2287..2292
+                            - STRING@2287..2292 "\"sku\""
+                    - R_PAREN@2292..2293 ")"
+                    - WHITESPACE@2293..2294 "\n"
+            - DIRECTIVE@2294..2336
+                - AT@2294..2295 "@"
+                - NAME@2295..2305
+                    - IDENT@2295..2305 "join__type"
+                - ARGUMENTS@2305..2336
+                    - L_PAREN@2305..2306 "("
+                    - ARGUMENT@2306..2324
+                        - NAME@2306..2311
+                            - IDENT@2306..2311 "graph"
+                        - COLON@2311..2312 ":"
+                        - WHITESPACE@2312..2313 " "
+                        - ENUM_VALUE@2313..2324
+                            - NAME@2313..2324
+                                - IDENT@2313..2322 "INVENTORY"
+                                - COMMA@2322..2323 ","
+                                - WHITESPACE@2323..2324 " "
+                    - ARGUMENT@2324..2334
+                        - NAME@2324..2327
+                            - IDENT@2324..2327 "key"
+                        - COLON@2327..2328 ":"
+                        - WHITESPACE@2328..2329 " "
+                        - STRING_VALUE@2329..2334
+                            - STRING@2329..2334 "\"sku\""
+                    - R_PAREN@2334..2335 ")"
+                    - WHITESPACE@2335..2336 "\n"
+            - DIRECTIVE@2336..2376
+                - AT@2336..2337 "@"
+                - NAME@2337..2347
+                    - IDENT@2337..2347 "join__type"
+                - ARGUMENTS@2347..2376
+                    - L_PAREN@2347..2348 "("
+                    - ARGUMENT@2348..2364
+                        - NAME@2348..2353
+                            - IDENT@2348..2353 "graph"
+                        - COLON@2353..2354 ":"
+                        - WHITESPACE@2354..2355 " "
+                        - ENUM_VALUE@2355..2364
+                            - NAME@2355..2364
+                                - IDENT@2355..2362 "REVIEWS"
+                                - COMMA@2362..2363 ","
+                                - WHITESPACE@2363..2364 " "
+                    - ARGUMENT@2364..2374
+                        - NAME@2364..2367
+                            - IDENT@2364..2367 "key"
+                        - COLON@2367..2368 ":"
+                        - WHITESPACE@2368..2369 " "
+                        - STRING_VALUE@2369..2374
+                            - STRING@2369..2374 "\"upc\""
+                    - R_PAREN@2374..2375 ")"
+                    - WHITESPACE@2375..2376 "\n"
+        - FIELDS_DEFINITION@2376..2874
+            - L_CURLY@2376..2377 "{"
+            - WHITESPACE@2377..2380 "\n  "
+            - FIELD_DEFINITION@2380..2424
+                - NAME@2380..2383
+                    - IDENT@2380..2383 "upc"
+                - COLON@2383..2384 ":"
+                - WHITESPACE@2384..2385 " "
+                - NON_NULL_TYPE@2385..2393
+                    - NAMED_TYPE@2385..2391
+                        - NAME@2385..2391
+                            - IDENT@2385..2391 "String"
+                    - BANG@2391..2392 "!"
+                    - WHITESPACE@2392..2393 " "
+                - DIRECTIVES@2393..2424
+                    - DIRECTIVE@2393..2424
+                        - AT@2393..2394 "@"
+                        - NAME@2394..2405
+                            - IDENT@2394..2405 "join__field"
+                        - ARGUMENTS@2405..2424
+                            - L_PAREN@2405..2406 "("
+                            - ARGUMENT@2406..2420
+                                - NAME@2406..2411
+                                    - IDENT@2406..2411 "graph"
+                                - COLON@2411..2412 ":"
+                                - WHITESPACE@2412..2413 " "
+                                - ENUM_VALUE@2413..2420
+                                    - NAME@2413..2420
+                                        - IDENT@2413..2420 "PRODUCT"
+                            - R_PAREN@2420..2421 ")"
+                            - WHITESPACE@2421..2424 "\n  "
+            - FIELD_DEFINITION@2424..2468
+                - NAME@2424..2427
+                    - IDENT@2424..2427 "sku"
+                - COLON@2427..2428 ":"
+                - WHITESPACE@2428..2429 " "
+                - NON_NULL_TYPE@2429..2437
+                    - NAMED_TYPE@2429..2435
+                        - NAME@2429..2435
+                            - IDENT@2429..2435 "String"
+                    - BANG@2435..2436 "!"
+                    - WHITESPACE@2436..2437 " "
+                - DIRECTIVES@2437..2468
+                    - DIRECTIVE@2437..2468
+                        - AT@2437..2438 "@"
+                        - NAME@2438..2449
+                            - IDENT@2438..2449 "join__field"
+                        - ARGUMENTS@2449..2468
+                            - L_PAREN@2449..2450 "("
+                            - ARGUMENT@2450..2464
+                                - NAME@2450..2455
+                                    - IDENT@2450..2455 "graph"
+                                - COLON@2455..2456 ":"
+                                - WHITESPACE@2456..2457 " "
+                                - ENUM_VALUE@2457..2464
+                                    - NAME@2457..2464
+                                        - IDENT@2457..2464 "PRODUCT"
+                            - R_PAREN@2464..2465 ")"
+                            - WHITESPACE@2465..2468 "\n  "
+            - FIELD_DEFINITION@2468..2512
+                - NAME@2468..2472
+                    - IDENT@2468..2472 "name"
+                - COLON@2472..2473 ":"
+                - WHITESPACE@2473..2474 " "
+                - NAMED_TYPE@2474..2480
+                    - NAME@2474..2480
+                        - IDENT@2474..2480 "String"
+                - WHITESPACE@2480..2481 " "
+                - DIRECTIVES@2481..2512
+                    - DIRECTIVE@2481..2512
+                        - AT@2481..2482 "@"
+                        - NAME@2482..2493
+                            - IDENT@2482..2493 "join__field"
+                        - ARGUMENTS@2493..2512
+                            - L_PAREN@2493..2494 "("
+                            - ARGUMENT@2494..2508
+                                - NAME@2494..2499
+                                    - IDENT@2494..2499 "graph"
+                                - COLON@2499..2500 ":"
+                                - WHITESPACE@2500..2501 " "
+                                - ENUM_VALUE@2501..2508
+                                    - NAME@2501..2508
+                                        - IDENT@2501..2508 "PRODUCT"
+                            - R_PAREN@2508..2509 ")"
+                            - WHITESPACE@2509..2512 "\n  "
+            - FIELD_DEFINITION@2512..2557
+                - NAME@2512..2517
+                    - IDENT@2512..2517 "price"
+                - COLON@2517..2518 ":"
+                - WHITESPACE@2518..2519 " "
+                - NAMED_TYPE@2519..2525
+                    - NAME@2519..2525
+                        - IDENT@2519..2525 "String"
+                - WHITESPACE@2525..2526 " "
+                - DIRECTIVES@2526..2557
+                    - DIRECTIVE@2526..2557
+                        - AT@2526..2527 "@"
+                        - NAME@2527..2538
+                            - IDENT@2527..2538 "join__field"
+                        - ARGUMENTS@2538..2557
+                            - L_PAREN@2538..2539 "("
+                            - ARGUMENT@2539..2553
+                                - NAME@2539..2544
+                                    - IDENT@2539..2544 "graph"
+                                - COLON@2544..2545 ":"
+                                - WHITESPACE@2545..2546 " "
+                                - ENUM_VALUE@2546..2553
+                                    - NAME@2546..2553
+                                        - IDENT@2546..2553 "PRODUCT"
+                            - R_PAREN@2553..2554 ")"
+                            - WHITESPACE@2554..2557 "\n  "
+            - FIELD_DEFINITION@2557..2601
+                - NAME@2557..2562
+                    - IDENT@2557..2562 "brand"
+                - COLON@2562..2563 ":"
+                - WHITESPACE@2563..2564 " "
+                - NAMED_TYPE@2564..2569
+                    - NAME@2564..2569
+                        - IDENT@2564..2569 "Brand"
+                - WHITESPACE@2569..2570 " "
+                - DIRECTIVES@2570..2601
+                    - DIRECTIVE@2570..2601
+                        - AT@2570..2571 "@"
+                        - NAME@2571..2582
+                            - IDENT@2571..2582 "join__field"
+                        - ARGUMENTS@2582..2601
+                            - L_PAREN@2582..2583 "("
+                            - ARGUMENT@2583..2597
+                                - NAME@2583..2588
+                                    - IDENT@2583..2588 "graph"
+                                - COLON@2588..2589 ":"
+                                - WHITESPACE@2589..2590 " "
+                                - ENUM_VALUE@2590..2597
+                                    - NAME@2590..2597
+                                        - IDENT@2590..2597 "PRODUCT"
+                            - R_PAREN@2597..2598 ")"
+                            - WHITESPACE@2598..2601 "\n  "
+            - FIELD_DEFINITION@2601..2660
+                - NAME@2601..2609
+                    - IDENT@2601..2609 "metadata"
+                - COLON@2609..2610 ":"
+                - WHITESPACE@2610..2611 " "
+                - LIST_TYPE@2611..2628
+                    - L_BRACK@2611..2612 "["
+                    - NAMED_TYPE@2612..2627
+                        - NAME@2612..2627
+                            - IDENT@2612..2627 "MetadataOrError"
+                    - R_BRACK@2627..2628 "]"
+                - WHITESPACE@2628..2629 " "
+                - DIRECTIVES@2629..2660
+                    - DIRECTIVE@2629..2660
+                        - AT@2629..2630 "@"
+                        - NAME@2630..2641
+                            - IDENT@2630..2641 "join__field"
+                        - ARGUMENTS@2641..2660
+                            - L_PAREN@2641..2642 "("
+                            - ARGUMENT@2642..2656
+                                - NAME@2642..2647
+                                    - IDENT@2642..2647 "graph"
+                                - COLON@2647..2648 ":"
+                                - WHITESPACE@2648..2649 " "
+                                - ENUM_VALUE@2649..2656
+                                    - NAME@2649..2656
+                                        - IDENT@2649..2656 "PRODUCT"
+                            - R_PAREN@2656..2657 ")"
+                            - WHITESPACE@2657..2660 "\n  "
+            - FIELD_DEFINITION@2660..2724
+                - NAME@2660..2667
+                    - IDENT@2660..2667 "details"
+                - COLON@2667..2668 ":"
+                - WHITESPACE@2668..2669 " "
+                - NAMED_TYPE@2669..2692
+                    - NAME@2669..2692
+                        - IDENT@2669..2692 "ProductDetailsFurniture"
+                - WHITESPACE@2692..2693 " "
+                - DIRECTIVES@2693..2724
+                    - DIRECTIVE@2693..2724
+                        - AT@2693..2694 "@"
+                        - NAME@2694..2705
+                            - IDENT@2694..2705 "join__field"
+                        - ARGUMENTS@2705..2724
+                            - L_PAREN@2705..2706 "("
+                            - ARGUMENT@2706..2720
+                                - NAME@2706..2711
+                                    - IDENT@2706..2711 "graph"
+                                - COLON@2711..2712 ":"
+                                - WHITESPACE@2712..2713 " "
+                                - ENUM_VALUE@2713..2720
+                                    - NAME@2713..2720
+                                        - IDENT@2713..2720 "PRODUCT"
+                            - R_PAREN@2720..2721 ")"
+                            - WHITESPACE@2721..2724 "\n  "
+            - FIELD_DEFINITION@2724..2774
+                - NAME@2724..2731
+                    - IDENT@2724..2731 "inStock"
+                - COLON@2731..2732 ":"
+                - WHITESPACE@2732..2733 " "
+                - NAMED_TYPE@2733..2740
+                    - NAME@2733..2740
+                        - IDENT@2733..2740 "Boolean"
+                - WHITESPACE@2740..2741 " "
+                - DIRECTIVES@2741..2774
+                    - DIRECTIVE@2741..2774
+                        - AT@2741..2742 "@"
+                        - NAME@2742..2753
+                            - IDENT@2742..2753 "join__field"
+                        - ARGUMENTS@2753..2774
+                            - L_PAREN@2753..2754 "("
+                            - ARGUMENT@2754..2770
+                                - NAME@2754..2759
+                                    - IDENT@2754..2759 "graph"
+                                - COLON@2759..2760 ":"
+                                - WHITESPACE@2760..2761 " "
+                                - ENUM_VALUE@2761..2770
+                                    - NAME@2761..2770
+                                        - IDENT@2761..2770 "INVENTORY"
+                            - R_PAREN@2770..2771 ")"
+                            - WHITESPACE@2771..2774 "\n  "
+            - FIELD_DEFINITION@2774..2824
+                - NAME@2774..2781
+                    - IDENT@2774..2781 "isHeavy"
+                - COLON@2781..2782 ":"
+                - WHITESPACE@2782..2783 " "
+                - NAMED_TYPE@2783..2790
+                    - NAME@2783..2790
+                        - IDENT@2783..2790 "Boolean"
+                - WHITESPACE@2790..2791 " "
+                - DIRECTIVES@2791..2824
+                    - DIRECTIVE@2791..2824
+                        - AT@2791..2792 "@"
+                        - NAME@2792..2803
+                            - IDENT@2792..2803 "join__field"
+                        - ARGUMENTS@2803..2824
+                            - L_PAREN@2803..2804 "("
+                            - ARGUMENT@2804..2820
+                                - NAME@2804..2809
+                                    - IDENT@2804..2809 "graph"
+                                - COLON@2809..2810 ":"
+                                - WHITESPACE@2810..2811 " "
+                                - ENUM_VALUE@2811..2820
+                                    - NAME@2811..2820
+                                        - IDENT@2811..2820 "INVENTORY"
+                            - R_PAREN@2820..2821 ")"
+                            - WHITESPACE@2821..2824 "\n  "
+            - FIELD_DEFINITION@2824..2871
+                - NAME@2824..2831
+                    - IDENT@2824..2831 "reviews"
+                - COLON@2831..2832 ":"
+                - WHITESPACE@2832..2833 " "
+                - LIST_TYPE@2833..2841
+                    - L_BRACK@2833..2834 "["
+                    - NAMED_TYPE@2834..2840
+                        - NAME@2834..2840
+                            - IDENT@2834..2840 "Review"
+                    - R_BRACK@2840..2841 "]"
+                - WHITESPACE@2841..2842 " "
+                - DIRECTIVES@2842..2871
+                    - DIRECTIVE@2842..2871
+                        - AT@2842..2843 "@"
+                        - NAME@2843..2854
+                            - IDENT@2843..2854 "join__field"
+                        - ARGUMENTS@2854..2871
+                            - L_PAREN@2854..2855 "("
+                            - ARGUMENT@2855..2869
+                                - NAME@2855..2860
+                                    - IDENT@2855..2860 "graph"
+                                - COLON@2860..2861 ":"
+                                - WHITESPACE@2861..2862 " "
+                                - ENUM_VALUE@2862..2869
+                                    - NAME@2862..2869
+                                        - IDENT@2862..2869 "REVIEWS"
+                            - R_PAREN@2869..2870 ")"
+                            - WHITESPACE@2870..2871 "\n"
+            - R_CURLY@2871..2872 "}"
+            - WHITESPACE@2872..2874 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2874..2902
+        - type_KW@2874..2878 "type"
+        - WHITESPACE@2878..2879 " "
+        - NAME@2879..2884
+            - IDENT@2879..2883 "Ikea"
+            - WHITESPACE@2883..2884 " "
+        - FIELDS_DEFINITION@2884..2902
+            - L_CURLY@2884..2885 "{"
+            - WHITESPACE@2885..2888 "\n  "
+            - FIELD_DEFINITION@2888..2899
+                - NAME@2888..2893
+                    - IDENT@2888..2893 "asile"
+                - COLON@2893..2894 ":"
+                - WHITESPACE@2894..2895 " "
+                - NAMED_TYPE@2895..2898
+                    - NAME@2895..2898
+                        - IDENT@2895..2898 "Int"
+                - WHITESPACE@2898..2899 "\n"
+            - R_CURLY@2899..2900 "}"
+            - WHITESPACE@2900..2902 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2902..2988
+        - type_KW@2902..2906 "type"
+        - WHITESPACE@2906..2907 " "
+        - NAME@2907..2913
+            - IDENT@2907..2912 "Image"
+            - WHITESPACE@2912..2913 " "
+        - IMPLEMENTS_INTERFACES@2913..2936
+            - implements_KW@2913..2923 "implements"
+            - WHITESPACE@2923..2924 " "
+            - NAMED_TYPE@2924..2936
+                - NAME@2924..2936
+                    - IDENT@2924..2935 "NamedObject"
+                    - WHITESPACE@2935..2936 " "
+        - FIELDS_DEFINITION@2936..2988
+            - L_CURLY@2936..2937 "{"
+            - WHITESPACE@2937..2940 "\n  "
+            - FIELD_DEFINITION@2940..2956
+                - NAME@2940..2944
+                    - IDENT@2940..2944 "name"
+                - COLON@2944..2945 ":"
+                - WHITESPACE@2945..2946 " "
+                - NON_NULL_TYPE@2946..2956
+                    - NAMED_TYPE@2946..2952
+                        - NAME@2946..2952
+                            - IDENT@2946..2952 "String"
+                    - BANG@2952..2953 "!"
+                    - WHITESPACE@2953..2956 "\n  "
+            - FIELD_DEFINITION@2956..2985
+                - NAME@2956..2966
+                    - IDENT@2956..2966 "attributes"
+                - COLON@2966..2967 ":"
+                - WHITESPACE@2967..2968 " "
+                - NON_NULL_TYPE@2968..2985
+                    - NAMED_TYPE@2968..2983
+                        - NAME@2968..2983
+                            - IDENT@2968..2983 "ImageAttributes"
+                    - BANG@2983..2984 "!"
+                    - WHITESPACE@2984..2985 "\n"
+            - R_CURLY@2985..2986 "}"
+            - WHITESPACE@2986..2988 "\n\n"
+    - OBJECT_TYPE_DEFINITION@2988..3029
+        - type_KW@2988..2992 "type"
+        - WHITESPACE@2992..2993 " "
+        - NAME@2993..3009
+            - IDENT@2993..3008 "ImageAttributes"
+            - WHITESPACE@3008..3009 " "
+        - FIELDS_DEFINITION@3009..3029
+            - L_CURLY@3009..3010 "{"
+            - WHITESPACE@3010..3013 "\n  "
+            - FIELD_DEFINITION@3013..3026
+                - NAME@3013..3016
+                    - IDENT@3013..3016 "url"
+                - COLON@3016..3017 ":"
+                - WHITESPACE@3017..3018 " "
+                - NON_NULL_TYPE@3018..3026
+                    - NAMED_TYPE@3018..3024
+                        - NAME@3018..3024
+                            - IDENT@3018..3024 "String"
+                    - BANG@3024..3025 "!"
+                    - WHITESPACE@3025..3026 "\n"
+            - R_CURLY@3026..3027 "}"
+            - WHITESPACE@3027..3029 "\n\n"
+    - SCALAR_TYPE_DEFINITION@3029..3099
+        - scalar_KW@3029..3035 "scalar"
+        - WHITESPACE@3035..3036 " "
+        - NAME@3036..3051
+            - IDENT@3036..3050 "join__FieldSet"
+            - WHITESPACE@3050..3051 " "
+        - DIRECTIVES@3051..3099
+            - DIRECTIVE@3051..3099
+                - AT@3051..3052 "@"
+                - NAME@3052..3063
+                    - IDENT@3052..3063 "specifiedBy"
+                - ARGUMENTS@3063..3099
+                    - L_PAREN@3063..3064 "("
+                    - ARGUMENT@3064..3096
+                        - NAME@3064..3067
+                            - IDENT@3064..3067 "url"
+                        - COLON@3067..3068 ":"
+                        - WHITESPACE@3068..3069 " "
+                        - STRING_VALUE@3069..3096
+                            - STRING@3069..3096 "\"https://spec.graphql.org/\""
+                    - R_PAREN@3096..3097 ")"
+                    - WHITESPACE@3097..3099 "\n\n"
+    - ENUM_TYPE_DEFINITION@3099..3403
+        - enum_KW@3099..3103 "enum"
+        - WHITESPACE@3103..3104 " "
+        - NAME@3104..3116
+            - IDENT@3104..3115 "join__Graph"
+            - WHITESPACE@3115..3116 " "
+        - ENUM_VALUES_DEFINITION@3116..3403
+            - L_CURLY@3116..3117 "{"
+            - WHITESPACE@3117..3118 "\n"
+            - ENUM_VALUE_DEFINITION@3118..3166
+                - ENUM_VALUE@3118..3127
+                    - NAME@3118..3127
+                        - IDENT@3118..3126 "ACCOUNTS"
+                        - WHITESPACE@3126..3127 " "
+                - DIRECTIVES@3127..3166
+                    - DIRECTIVE@3127..3166
+                        - AT@3127..3128 "@"
+                        - NAME@3128..3139
+                            - IDENT@3128..3139 "join__graph"
+                        - ARGUMENTS@3139..3166
+                            - L_PAREN@3139..3140 "("
+                            - ARGUMENT@3140..3157
+                                - NAME@3140..3144
+                                    - IDENT@3140..3144 "name"
+                                - COLON@3144..3145 ":"
+                                - WHITESPACE@3145..3146 " "
+                                - STRING_VALUE@3146..3157
+                                    - STRING@3146..3156 "\"accounts\""
+                                    - WHITESPACE@3156..3157 " "
+                            - ARGUMENT@3157..3164
+                                - NAME@3157..3160
+                                    - IDENT@3157..3160 "url"
+                                - COLON@3160..3161 ":"
+                                - WHITESPACE@3161..3162 " "
+                                - STRING_VALUE@3162..3164
+                                    - STRING@3162..3164 "\"\""
+                            - R_PAREN@3164..3165 ")"
+                            - WHITESPACE@3165..3166 "\n"
+            - ENUM_VALUE_DEFINITION@3166..3208
+                - ENUM_VALUE@3166..3172
+                    - NAME@3166..3172
+                        - IDENT@3166..3171 "BOOKS"
+                        - WHITESPACE@3171..3172 " "
+                - DIRECTIVES@3172..3208
+                    - DIRECTIVE@3172..3208
+                        - AT@3172..3173 "@"
+                        - NAME@3173..3184
+                            - IDENT@3173..3184 "join__graph"
+                        - ARGUMENTS@3184..3208
+                            - L_PAREN@3184..3185 "("
+                            - ARGUMENT@3185..3199
+                                - NAME@3185..3189
+                                    - IDENT@3185..3189 "name"
+                                - COLON@3189..3190 ":"
+                                - WHITESPACE@3190..3191 " "
+                                - STRING_VALUE@3191..3199
+                                    - STRING@3191..3198 "\"books\""
+                                    - WHITESPACE@3198..3199 " "
+                            - ARGUMENT@3199..3206
+                                - NAME@3199..3202
+                                    - IDENT@3199..3202 "url"
+                                - COLON@3202..3203 ":"
+                                - WHITESPACE@3203..3204 " "
+                                - STRING_VALUE@3204..3206
+                                    - STRING@3204..3206 "\"\""
+                            - R_PAREN@3206..3207 ")"
+                            - WHITESPACE@3207..3208 "\n"
+            - ENUM_VALUE_DEFINITION@3208..3258
+                - ENUM_VALUE@3208..3218
+                    - NAME@3208..3218
+                        - IDENT@3208..3217 "DOCUMENTS"
+                        - WHITESPACE@3217..3218 " "
+                - DIRECTIVES@3218..3258
+                    - DIRECTIVE@3218..3258
+                        - AT@3218..3219 "@"
+                        - NAME@3219..3230
+                            - IDENT@3219..3230 "join__graph"
+                        - ARGUMENTS@3230..3258
+                            - L_PAREN@3230..3231 "("
+                            - ARGUMENT@3231..3249
+                                - NAME@3231..3235
+                                    - IDENT@3231..3235 "name"
+                                - COLON@3235..3236 ":"
+                                - WHITESPACE@3236..3237 " "
+                                - STRING_VALUE@3237..3249
+                                    - STRING@3237..3248 "\"documents\""
+                                    - WHITESPACE@3248..3249 " "
+                            - ARGUMENT@3249..3256
+                                - NAME@3249..3252
+                                    - IDENT@3249..3252 "url"
+                                - COLON@3252..3253 ":"
+                                - WHITESPACE@3253..3254 " "
+                                - STRING_VALUE@3254..3256
+                                    - STRING@3254..3256 "\"\""
+                            - R_PAREN@3256..3257 ")"
+                            - WHITESPACE@3257..3258 "\n"
+            - ENUM_VALUE_DEFINITION@3258..3308
+                - ENUM_VALUE@3258..3268
+                    - NAME@3258..3268
+                        - IDENT@3258..3267 "INVENTORY"
+                        - WHITESPACE@3267..3268 " "
+                - DIRECTIVES@3268..3308
+                    - DIRECTIVE@3268..3308
+                        - AT@3268..3269 "@"
+                        - NAME@3269..3280
+                            - IDENT@3269..3280 "join__graph"
+                        - ARGUMENTS@3280..3308
+                            - L_PAREN@3280..3281 "("
+                            - ARGUMENT@3281..3299
+                                - NAME@3281..3285
+                                    - IDENT@3281..3285 "name"
+                                - COLON@3285..3286 ":"
+                                - WHITESPACE@3286..3287 " "
+                                - STRING_VALUE@3287..3299
+                                    - STRING@3287..3298 "\"inventory\""
+                                    - WHITESPACE@3298..3299 " "
+                            - ARGUMENT@3299..3306
+                                - NAME@3299..3302
+                                    - IDENT@3299..3302 "url"
+                                - COLON@3302..3303 ":"
+                                - WHITESPACE@3303..3304 " "
+                                - STRING_VALUE@3304..3306
+                                    - STRING@3304..3306 "\"\""
+                            - R_PAREN@3306..3307 ")"
+                            - WHITESPACE@3307..3308 "\n"
+            - ENUM_VALUE_DEFINITION@3308..3354
+                - ENUM_VALUE@3308..3316
+                    - NAME@3308..3316
+                        - IDENT@3308..3315 "PRODUCT"
+                        - WHITESPACE@3315..3316 " "
+                - DIRECTIVES@3316..3354
+                    - DIRECTIVE@3316..3354
+                        - AT@3316..3317 "@"
+                        - NAME@3317..3328
+                            - IDENT@3317..3328 "join__graph"
+                        - ARGUMENTS@3328..3354
+                            - L_PAREN@3328..3329 "("
+                            - ARGUMENT@3329..3345
+                                - NAME@3329..3333
+                                    - IDENT@3329..3333 "name"
+                                - COLON@3333..3334 ":"
+                                - WHITESPACE@3334..3335 " "
+                                - STRING_VALUE@3335..3345
+                                    - STRING@3335..3344 "\"product\""
+                                    - WHITESPACE@3344..3345 " "
+                            - ARGUMENT@3345..3352
+                                - NAME@3345..3348
+                                    - IDENT@3345..3348 "url"
+                                - COLON@3348..3349 ":"
+                                - WHITESPACE@3349..3350 " "
+                                - STRING_VALUE@3350..3352
+                                    - STRING@3350..3352 "\"\""
+                            - R_PAREN@3352..3353 ")"
+                            - WHITESPACE@3353..3354 "\n"
+            - ENUM_VALUE_DEFINITION@3354..3400
+                - ENUM_VALUE@3354..3362
+                    - NAME@3354..3362
+                        - IDENT@3354..3361 "REVIEWS"
+                        - WHITESPACE@3361..3362 " "
+                - DIRECTIVES@3362..3400
+                    - DIRECTIVE@3362..3400
+                        - AT@3362..3363 "@"
+                        - NAME@3363..3374
+                            - IDENT@3363..3374 "join__graph"
+                        - ARGUMENTS@3374..3400
+                            - L_PAREN@3374..3375 "("
+                            - ARGUMENT@3375..3391
+                                - NAME@3375..3379
+                                    - IDENT@3375..3379 "name"
+                                - COLON@3379..3380 ":"
+                                - WHITESPACE@3380..3381 " "
+                                - STRING_VALUE@3381..3391
+                                    - STRING@3381..3390 "\"reviews\""
+                                    - WHITESPACE@3390..3391 " "
+                            - ARGUMENT@3391..3398
+                                - NAME@3391..3394
+                                    - IDENT@3391..3394 "url"
+                                - COLON@3394..3395 ":"
+                                - WHITESPACE@3395..3396 " "
+                                - STRING_VALUE@3396..3398
+                                    - STRING@3396..3398 "\"\""
+                            - R_PAREN@3398..3399 ")"
+                            - WHITESPACE@3399..3400 "\n"
+            - R_CURLY@3400..3401 "}"
+            - WHITESPACE@3401..3403 "\n\n"
+    - OBJECT_TYPE_DEFINITION@3403..3454
+        - type_KW@3403..3407 "type"
+        - WHITESPACE@3407..3408 " "
+        - NAME@3408..3417
+            - IDENT@3408..3416 "KeyValue"
+            - WHITESPACE@3416..3417 " "
+        - FIELDS_DEFINITION@3417..3454
+            - L_CURLY@3417..3418 "{"
+            - WHITESPACE@3418..3421 "\n  "
+            - FIELD_DEFINITION@3421..3436
+                - NAME@3421..3424
+                    - IDENT@3421..3424 "key"
+                - COLON@3424..3425 ":"
+                - WHITESPACE@3425..3426 " "
+                - NON_NULL_TYPE@3426..3436
+                    - NAMED_TYPE@3426..3432
+                        - NAME@3426..3432
+                            - IDENT@3426..3432 "String"
+                    - BANG@3432..3433 "!"
+                    - WHITESPACE@3433..3436 "\n  "
+            - FIELD_DEFINITION@3436..3451
+                - NAME@3436..3441
+                    - IDENT@3436..3441 "value"
+                - COLON@3441..3442 ":"
+                - WHITESPACE@3442..3443 " "
+                - NON_NULL_TYPE@3443..3451
+                    - NAMED_TYPE@3443..3449
+                        - NAME@3443..3449
+                            - IDENT@3443..3449 "String"
+                    - BANG@3449..3450 "!"
+                    - WHITESPACE@3450..3451 "\n"
+            - R_CURLY@3451..3452 "}"
+            - WHITESPACE@3452..3454 "\n\n"
+    - OBJECT_TYPE_DEFINITION@3454..3736
+        - type_KW@3454..3458 "type"
+        - WHITESPACE@3458..3459 " "
+        - NAME@3459..3467
+            - IDENT@3459..3466 "Library"
+            - WHITESPACE@3466..3467 "\n"
+        - DIRECTIVES@3467..3571
+            - DIRECTIVE@3467..3494
+                - AT@3467..3468 "@"
+                - NAME@3468..3479
+                    - IDENT@3468..3479 "join__owner"
+                - ARGUMENTS@3479..3494
+                    - L_PAREN@3479..3480 "("
+                    - ARGUMENT@3480..3492
+                        - NAME@3480..3485
+                            - IDENT@3480..3485 "graph"
+                        - COLON@3485..3486 ":"
+                        - WHITESPACE@3486..3487 " "
+                        - ENUM_VALUE@3487..3492
+                            - NAME@3487..3492
+                                - IDENT@3487..3492 "BOOKS"
+                    - R_PAREN@3492..3493 ")"
+                    - WHITESPACE@3493..3494 "\n"
+            - DIRECTIVE@3494..3531
+                - AT@3494..3495 "@"
+                - NAME@3495..3505
+                    - IDENT@3495..3505 "join__type"
+                - ARGUMENTS@3505..3531
+                    - L_PAREN@3505..3506 "("
+                    - ARGUMENT@3506..3520
+                        - NAME@3506..3511
+                            - IDENT@3506..3511 "graph"
+                        - COLON@3511..3512 ":"
+                        - WHITESPACE@3512..3513 " "
+                        - ENUM_VALUE@3513..3520
+                            - NAME@3513..3520
+                                - IDENT@3513..3518 "BOOKS"
+                                - COMMA@3518..3519 ","
+                                - WHITESPACE@3519..3520 " "
+                    - ARGUMENT@3520..3529
+                        - NAME@3520..3523
+                            - IDENT@3520..3523 "key"
+                        - COLON@3523..3524 ":"
+                        - WHITESPACE@3524..3525 " "
+                        - STRING_VALUE@3525..3529
+                            - STRING@3525..3529 "\"id\""
+                    - R_PAREN@3529..3530 ")"
+                    - WHITESPACE@3530..3531 "\n"
+            - DIRECTIVE@3531..3571
+                - AT@3531..3532 "@"
+                - NAME@3532..3542
+                    - IDENT@3532..3542 "join__type"
+                - ARGUMENTS@3542..3571
+                    - L_PAREN@3542..3543 "("
+                    - ARGUMENT@3543..3560
+                        - NAME@3543..3548
+                            - IDENT@3543..3548 "graph"
+                        - COLON@3548..3549 ":"
+                        - WHITESPACE@3549..3550 " "
+                        - ENUM_VALUE@3550..3560
+                            - NAME@3550..3560
+                                - IDENT@3550..3558 "ACCOUNTS"
+                                - COMMA@3558..3559 ","
+                                - WHITESPACE@3559..3560 " "
+                    - ARGUMENT@3560..3569
+                        - NAME@3560..3563
+                            - IDENT@3560..3563 "key"
+                        - COLON@3563..3564 ":"
+                        - WHITESPACE@3564..3565 " "
+                        - STRING_VALUE@3565..3569
+                            - STRING@3565..3569 "\"id\""
+                    - R_PAREN@3569..3570 ")"
+                    - WHITESPACE@3570..3571 "\n"
+        - FIELDS_DEFINITION@3571..3736
+            - L_CURLY@3571..3572 "{"
+            - WHITESPACE@3572..3575 "\n  "
+            - FIELD_DEFINITION@3575..3612
+                - NAME@3575..3577
+                    - IDENT@3575..3577 "id"
+                - COLON@3577..3578 ":"
+                - WHITESPACE@3578..3579 " "
+                - NON_NULL_TYPE@3579..3583
+                    - NAMED_TYPE@3579..3581
+                        - NAME@3579..3581
+                            - IDENT@3579..3581 "ID"
+                    - BANG@3581..3582 "!"
+                    - WHITESPACE@3582..3583 " "
+                - DIRECTIVES@3583..3612
+                    - DIRECTIVE@3583..3612
+                        - AT@3583..3584 "@"
+                        - NAME@3584..3595
+                            - IDENT@3584..3595 "join__field"
+                        - ARGUMENTS@3595..3612
+                            - L_PAREN@3595..3596 "("
+                            - ARGUMENT@3596..3608
+                                - NAME@3596..3601
+                                    - IDENT@3596..3601 "graph"
+                                - COLON@3601..3602 ":"
+                                - WHITESPACE@3602..3603 " "
+                                - ENUM_VALUE@3603..3608
+                                    - NAME@3603..3608
+                                        - IDENT@3603..3608 "BOOKS"
+                            - R_PAREN@3608..3609 ")"
+                            - WHITESPACE@3609..3612 "\n  "
+            - FIELD_DEFINITION@3612..3654
+                - NAME@3612..3616
+                    - IDENT@3612..3616 "name"
+                - COLON@3616..3617 ":"
+                - WHITESPACE@3617..3618 " "
+                - NAMED_TYPE@3618..3624
+                    - NAME@3618..3624
+                        - IDENT@3618..3624 "String"
+                - WHITESPACE@3624..3625 " "
+                - DIRECTIVES@3625..3654
+                    - DIRECTIVE@3625..3654
+                        - AT@3625..3626 "@"
+                        - NAME@3626..3637
+                            - IDENT@3626..3637 "join__field"
+                        - ARGUMENTS@3637..3654
+                            - L_PAREN@3637..3638 "("
+                            - ARGUMENT@3638..3650
+                                - NAME@3638..3643
+                                    - IDENT@3638..3643 "graph"
+                                - COLON@3643..3644 ":"
+                                - WHITESPACE@3644..3645 " "
+                                - ENUM_VALUE@3645..3650
+                                    - NAME@3645..3650
+                                        - IDENT@3645..3650 "BOOKS"
+                            - R_PAREN@3650..3651 ")"
+                            - WHITESPACE@3651..3654 "\n  "
+            - FIELD_DEFINITION@3654..3733
+                - NAME@3654..3665
+                    - IDENT@3654..3665 "userAccount"
+                - ARGUMENTS_DEFINITION@3665..3678
+                    - L_PAREN@3665..3666 "("
+                    - INPUT_VALUE_DEFINITION@3666..3677
+                        - NAME@3666..3668
+                            - IDENT@3666..3668 "id"
+                        - COLON@3668..3669 ":"
+                        - WHITESPACE@3669..3670 " "
+                        - NON_NULL_TYPE@3670..3674
+                            - NAMED_TYPE@3670..3672
+                                - NAME@3670..3672
+                                    - IDENT@3670..3672 "ID"
+                            - BANG@3672..3673 "!"
+                            - WHITESPACE@3673..3674 " "
+                        - DEFAULT_VALUE@3674..3677
+                            - EQ@3674..3675 "="
+                            - WHITESPACE@3675..3676 " "
+                            - INT_VALUE@3676..3677
+                                - INT@3676..3677 "1"
+                    - R_PAREN@3677..3678 ")"
+                - COLON@3678..3679 ":"
+                - WHITESPACE@3679..3680 " "
+                - NAMED_TYPE@3680..3684
+                    - NAME@3680..3684
+                        - IDENT@3680..3684 "User"
+                - WHITESPACE@3684..3685 " "
+                - DIRECTIVES@3685..3733
+                    - DIRECTIVE@3685..3733
+                        - AT@3685..3686 "@"
+                        - NAME@3686..3697
+                            - IDENT@3686..3697 "join__field"
+                        - ARGUMENTS@3697..3733
+                            - L_PAREN@3697..3698 "("
+                            - ARGUMENT@3698..3715
+                                - NAME@3698..3703
+                                    - IDENT@3698..3703 "graph"
+                                - COLON@3703..3704 ":"
+                                - WHITESPACE@3704..3705 " "
+                                - ENUM_VALUE@3705..3715
+                                    - NAME@3705..3715
+                                        - IDENT@3705..3713 "ACCOUNTS"
+                                        - COMMA@3713..3714 ","
+                                        - WHITESPACE@3714..3715 " "
+                            - ARGUMENT@3715..3731
+                                - NAME@3715..3723
+                                    - IDENT@3715..3723 "requires"
+                                - COLON@3723..3724 ":"
+                                - WHITESPACE@3724..3725 " "
+                                - STRING_VALUE@3725..3731
+                                    - STRING@3725..3731 "\"name\""
+                            - R_PAREN@3731..3732 ")"
+                            - WHITESPACE@3732..3733 "\n"
+            - R_CURLY@3733..3734 "}"
+            - WHITESPACE@3734..3736 "\n\n"
+    - UNION_TYPE_DEFINITION@3736..3778
+        - union_KW@3736..3741 "union"
+        - WHITESPACE@3741..3742 " "
+        - NAME@3742..3758
+            - IDENT@3742..3757 "MetadataOrError"
+            - WHITESPACE@3757..3758 " "
+        - UNION_MEMBER_TYPES@3758..3778
+            - EQ@3758..3759 "="
+            - WHITESPACE@3759..3760 " "
+            - NAMED_TYPE@3760..3769
+                - NAME@3760..3769
+                    - IDENT@3760..3768 "KeyValue"
+                    - WHITESPACE@3768..3769 " "
+            - PIPE@3769..3770 "|"
+            - WHITESPACE@3770..3771 " "
+            - NAMED_TYPE@3771..3778
+                - NAME@3771..3778
+                    - IDENT@3771..3776 "Error"
+                    - WHITESPACE@3776..3778 "\n\n"
+    - OBJECT_TYPE_DEFINITION@3778..4104
+        - type_KW@3778..3782 "type"
+        - WHITESPACE@3782..3783 " "
+        - NAME@3783..3792
+            - IDENT@3783..3791 "Mutation"
+            - WHITESPACE@3791..3792 " "
+        - FIELDS_DEFINITION@3792..4104
+            - L_CURLY@3792..3793 "{"
+            - WHITESPACE@3793..3796 "\n  "
+            - FIELD_DEFINITION@3796..3878
+                - NAME@3796..3801
+                    - IDENT@3796..3801 "login"
+                - ARGUMENTS_DEFINITION@3801..3839
+                    - L_PAREN@3801..3802 "("
+                    - INPUT_VALUE_DEFINITION@3802..3821
+                        - NAME@3802..3810
+                            - IDENT@3802..3810 "username"
+                        - COLON@3810..3811 ":"
+                        - WHITESPACE@3811..3812 " "
+                        - NON_NULL_TYPE@3812..3821
+                            - NAMED_TYPE@3812..3818
+                                - NAME@3812..3818
+                                    - IDENT@3812..3818 "String"
+                            - BANG@3818..3819 "!"
+                            - COMMA@3819..3820 ","
+                            - WHITESPACE@3820..3821 " "
+                    - INPUT_VALUE_DEFINITION@3821..3838
+                        - NAME@3821..3829
+                            - IDENT@3821..3829 "password"
+                        - COLON@3829..3830 ":"
+                        - WHITESPACE@3830..3831 " "
+                        - NON_NULL_TYPE@3831..3838
+                            - NAMED_TYPE@3831..3837
+                                - NAME@3831..3837
+                                    - IDENT@3831..3837 "String"
+                            - BANG@3837..3838 "!"
+                    - R_PAREN@3838..3839 ")"
+                - COLON@3839..3840 ":"
+                - WHITESPACE@3840..3841 " "
+                - NAMED_TYPE@3841..3845
+                    - NAME@3841..3845
+                        - IDENT@3841..3845 "User"
+                - WHITESPACE@3845..3846 " "
+                - DIRECTIVES@3846..3878
+                    - DIRECTIVE@3846..3878
+                        - AT@3846..3847 "@"
+                        - NAME@3847..3858
+                            - IDENT@3847..3858 "join__field"
+                        - ARGUMENTS@3858..3878
+                            - L_PAREN@3858..3859 "("
+                            - ARGUMENT@3859..3874
+                                - NAME@3859..3864
+                                    - IDENT@3859..3864 "graph"
+                                - COLON@3864..3865 ":"
+                                - WHITESPACE@3865..3866 " "
+                                - ENUM_VALUE@3866..3874
+                                    - NAME@3866..3874
+                                        - IDENT@3866..3874 "ACCOUNTS"
+                            - R_PAREN@3874..3875 ")"
+                            - WHITESPACE@3875..3878 "\n  "
+            - FIELD_DEFINITION@3878..3961
+                - NAME@3878..3891
+                    - IDENT@3878..3891 "reviewProduct"
+                - ARGUMENTS_DEFINITION@3891..3920
+                    - L_PAREN@3891..3892 "("
+                    - INPUT_VALUE_DEFINITION@3892..3906
+                        - NAME@3892..3895
+                            - IDENT@3892..3895 "upc"
+                        - COLON@3895..3896 ":"
+                        - WHITESPACE@3896..3897 " "
+                        - NON_NULL_TYPE@3897..3906
+                            - NAMED_TYPE@3897..3903
+                                - NAME@3897..3903
+                                    - IDENT@3897..3903 "String"
+                            - BANG@3903..3904 "!"
+                            - COMMA@3904..3905 ","
+                            - WHITESPACE@3905..3906 " "
+                    - INPUT_VALUE_DEFINITION@3906..3919
+                        - NAME@3906..3910
+                            - IDENT@3906..3910 "body"
+                        - COLON@3910..3911 ":"
+                        - WHITESPACE@3911..3912 " "
+                        - NON_NULL_TYPE@3912..3919
+                            - NAMED_TYPE@3912..3918
+                                - NAME@3912..3918
+                                    - IDENT@3912..3918 "String"
+                            - BANG@3918..3919 "!"
+                    - R_PAREN@3919..3920 ")"
+                - COLON@3920..3921 ":"
+                - WHITESPACE@3921..3922 " "
+                - NAMED_TYPE@3922..3929
+                    - NAME@3922..3929
+                        - IDENT@3922..3929 "Product"
+                - WHITESPACE@3929..3930 " "
+                - DIRECTIVES@3930..3961
+                    - DIRECTIVE@3930..3961
+                        - AT@3930..3931 "@"
+                        - NAME@3931..3942
+                            - IDENT@3931..3942 "join__field"
+                        - ARGUMENTS@3942..3961
+                            - L_PAREN@3942..3943 "("
+                            - ARGUMENT@3943..3957
+                                - NAME@3943..3948
+                                    - IDENT@3943..3948 "graph"
+                                - COLON@3948..3949 ":"
+                                - WHITESPACE@3949..3950 " "
+                                - ENUM_VALUE@3950..3957
+                                    - NAME@3950..3957
+                                        - IDENT@3950..3957 "REVIEWS"
+                            - R_PAREN@3957..3958 ")"
+                            - WHITESPACE@3958..3961 "\n  "
+            - FIELD_DEFINITION@3961..4041
+                - NAME@3961..3973
+                    - IDENT@3961..3973 "updateReview"
+                - ARGUMENTS_DEFINITION@3973..4001
+                    - L_PAREN@3973..3974 "("
+                    - INPUT_VALUE_DEFINITION@3974..4000
+                        - NAME@3974..3980
+                            - IDENT@3974..3980 "review"
+                        - COLON@3980..3981 ":"
+                        - WHITESPACE@3981..3982 " "
+                        - NON_NULL_TYPE@3982..4000
+                            - NAMED_TYPE@3982..3999
+                                - NAME@3982..3999
+                                    - IDENT@3982..3999 "UpdateReviewInput"
+                            - BANG@3999..4000 "!"
+                    - R_PAREN@4000..4001 ")"
+                - COLON@4001..4002 ":"
+                - WHITESPACE@4002..4003 " "
+                - NAMED_TYPE@4003..4009
+                    - NAME@4003..4009
+                        - IDENT@4003..4009 "Review"
+                - WHITESPACE@4009..4010 " "
+                - DIRECTIVES@4010..4041
+                    - DIRECTIVE@4010..4041
+                        - AT@4010..4011 "@"
+                        - NAME@4011..4022
+                            - IDENT@4011..4022 "join__field"
+                        - ARGUMENTS@4022..4041
+                            - L_PAREN@4022..4023 "("
+                            - ARGUMENT@4023..4037
+                                - NAME@4023..4028
+                                    - IDENT@4023..4028 "graph"
+                                - COLON@4028..4029 ":"
+                                - WHITESPACE@4029..4030 " "
+                                - ENUM_VALUE@4030..4037
+                                    - NAME@4030..4037
+                                        - IDENT@4030..4037 "REVIEWS"
+                            - R_PAREN@4037..4038 ")"
+                            - WHITESPACE@4038..4041 "\n  "
+            - FIELD_DEFINITION@4041..4101
+                - NAME@4041..4053
+                    - IDENT@4041..4053 "deleteReview"
+                - ARGUMENTS_DEFINITION@4053..4062
+                    - L_PAREN@4053..4054 "("
+                    - INPUT_VALUE_DEFINITION@4054..4061
+                        - NAME@4054..4056
+                            - IDENT@4054..4056 "id"
+                        - COLON@4056..4057 ":"
+                        - WHITESPACE@4057..4058 " "
+                        - NON_NULL_TYPE@4058..4061
+                            - NAMED_TYPE@4058..4060
+                                - NAME@4058..4060
+                                    - IDENT@4058..4060 "ID"
+                            - BANG@4060..4061 "!"
+                    - R_PAREN@4061..4062 ")"
+                - COLON@4062..4063 ":"
+                - WHITESPACE@4063..4064 " "
+                - NAMED_TYPE@4064..4071
+                    - NAME@4064..4071
+                        - IDENT@4064..4071 "Boolean"
+                - WHITESPACE@4071..4072 " "
+                - DIRECTIVES@4072..4101
+                    - DIRECTIVE@4072..4101
+                        - AT@4072..4073 "@"
+                        - NAME@4073..4084
+                            - IDENT@4073..4084 "join__field"
+                        - ARGUMENTS@4084..4101
+                            - L_PAREN@4084..4085 "("
+                            - ARGUMENT@4085..4099
+                                - NAME@4085..4090
+                                    - IDENT@4085..4090 "graph"
+                                - COLON@4090..4091 ":"
+                                - WHITESPACE@4091..4092 " "
+                                - ENUM_VALUE@4092..4099
+                                    - NAME@4092..4099
+                                        - IDENT@4092..4099 "REVIEWS"
+                            - R_PAREN@4099..4100 ")"
+                            - WHITESPACE@4100..4101 "\n"
+            - R_CURLY@4101..4102 "}"
+            - WHITESPACE@4102..4104 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4104..4150
+        - type_KW@4104..4108 "type"
+        - WHITESPACE@4108..4109 " "
+        - NAME@4109..4114
+            - IDENT@4109..4113 "Name"
+            - WHITESPACE@4113..4114 " "
+        - FIELDS_DEFINITION@4114..4150
+            - L_CURLY@4114..4115 "{"
+            - WHITESPACE@4115..4118 "\n  "
+            - FIELD_DEFINITION@4118..4134
+                - NAME@4118..4123
+                    - IDENT@4118..4123 "first"
+                - COLON@4123..4124 ":"
+                - WHITESPACE@4124..4125 " "
+                - NAMED_TYPE@4125..4131
+                    - NAME@4125..4131
+                        - IDENT@4125..4131 "String"
+                - WHITESPACE@4131..4134 "\n  "
+            - FIELD_DEFINITION@4134..4147
+                - NAME@4134..4138
+                    - IDENT@4134..4138 "last"
+                - COLON@4138..4139 ":"
+                - WHITESPACE@4139..4140 " "
+                - NAMED_TYPE@4140..4146
+                    - NAME@4140..4146
+                        - IDENT@4140..4146 "String"
+                - WHITESPACE@4146..4147 "\n"
+            - R_CURLY@4147..4148 "}"
+            - WHITESPACE@4148..4150 "\n\n"
+    - INTERFACE_TYPE_DEFINITION@4150..4193
+        - interface_KW@4150..4159 "interface"
+        - WHITESPACE@4159..4160 " "
+        - NAME@4160..4172
+            - IDENT@4160..4171 "NamedObject"
+            - WHITESPACE@4171..4172 " "
+        - FIELDS_DEFINITION@4172..4193
+            - L_CURLY@4172..4173 "{"
+            - WHITESPACE@4173..4176 "\n  "
+            - FIELD_DEFINITION@4176..4190
+                - NAME@4176..4180
+                    - IDENT@4176..4180 "name"
+                - COLON@4180..4181 ":"
+                - WHITESPACE@4181..4182 " "
+                - NON_NULL_TYPE@4182..4190
+                    - NAMED_TYPE@4182..4188
+                        - NAME@4182..4188
+                            - IDENT@4182..4188 "String"
+                    - BANG@4188..4189 "!"
+                    - WHITESPACE@4189..4190 "\n"
+            - R_CURLY@4190..4191 "}"
+            - WHITESPACE@4191..4193 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4193..4339
+        - type_KW@4193..4197 "type"
+        - WHITESPACE@4197..4198 " "
+        - NAME@4198..4214
+            - IDENT@4198..4213 "PasswordAccount"
+            - WHITESPACE@4213..4214 "\n"
+        - DIRECTIVES@4214..4287
+            - DIRECTIVE@4214..4244
+                - AT@4214..4215 "@"
+                - NAME@4215..4226
+                    - IDENT@4215..4226 "join__owner"
+                - ARGUMENTS@4226..4244
+                    - L_PAREN@4226..4227 "("
+                    - ARGUMENT@4227..4242
+                        - NAME@4227..4232
+                            - IDENT@4227..4232 "graph"
+                        - COLON@4232..4233 ":"
+                        - WHITESPACE@4233..4234 " "
+                        - ENUM_VALUE@4234..4242
+                            - NAME@4234..4242
+                                - IDENT@4234..4242 "ACCOUNTS"
+                    - R_PAREN@4242..4243 ")"
+                    - WHITESPACE@4243..4244 "\n"
+            - DIRECTIVE@4244..4287
+                - AT@4244..4245 "@"
+                - NAME@4245..4255
+                    - IDENT@4245..4255 "join__type"
+                - ARGUMENTS@4255..4287
+                    - L_PAREN@4255..4256 "("
+                    - ARGUMENT@4256..4273
+                        - NAME@4256..4261
+                            - IDENT@4256..4261 "graph"
+                        - COLON@4261..4262 ":"
+                        - WHITESPACE@4262..4263 " "
+                        - ENUM_VALUE@4263..4273
+                            - NAME@4263..4273
+                                - IDENT@4263..4271 "ACCOUNTS"
+                                - COMMA@4271..4272 ","
+                                - WHITESPACE@4272..4273 " "
+                    - ARGUMENT@4273..4285
+                        - NAME@4273..4276
+                            - IDENT@4273..4276 "key"
+                        - COLON@4276..4277 ":"
+                        - WHITESPACE@4277..4278 " "
+                        - STRING_VALUE@4278..4285
+                            - STRING@4278..4285 "\"email\""
+                    - R_PAREN@4285..4286 ")"
+                    - WHITESPACE@4286..4287 "\n"
+        - FIELDS_DEFINITION@4287..4339
+            - L_CURLY@4287..4288 "{"
+            - WHITESPACE@4288..4291 "\n  "
+            - FIELD_DEFINITION@4291..4336
+                - NAME@4291..4296
+                    - IDENT@4291..4296 "email"
+                - COLON@4296..4297 ":"
+                - WHITESPACE@4297..4298 " "
+                - NON_NULL_TYPE@4298..4306
+                    - NAMED_TYPE@4298..4304
+                        - NAME@4298..4304
+                            - IDENT@4298..4304 "String"
+                    - BANG@4304..4305 "!"
+                    - WHITESPACE@4305..4306 " "
+                - DIRECTIVES@4306..4336
+                    - DIRECTIVE@4306..4336
+                        - AT@4306..4307 "@"
+                        - NAME@4307..4318
+                            - IDENT@4307..4318 "join__field"
+                        - ARGUMENTS@4318..4336
+                            - L_PAREN@4318..4319 "("
+                            - ARGUMENT@4319..4334
+                                - NAME@4319..4324
+                                    - IDENT@4319..4324 "graph"
+                                - COLON@4324..4325 ":"
+                                - WHITESPACE@4325..4326 " "
+                                - ENUM_VALUE@4326..4334
+                                    - NAME@4326..4334
+                                        - IDENT@4326..4334 "ACCOUNTS"
+                            - R_PAREN@4334..4335 ")"
+                            - WHITESPACE@4335..4336 "\n"
+            - R_CURLY@4336..4337 "}"
+            - WHITESPACE@4337..4339 "\n\n"
+    - INTERFACE_TYPE_DEFINITION@4339..4488
+        - interface_KW@4339..4348 "interface"
+        - WHITESPACE@4348..4349 " "
+        - NAME@4349..4357
+            - IDENT@4349..4356 "Product"
+            - WHITESPACE@4356..4357 " "
+        - FIELDS_DEFINITION@4357..4488
+            - L_CURLY@4357..4358 "{"
+            - WHITESPACE@4358..4361 "\n  "
+            - FIELD_DEFINITION@4361..4376
+                - NAME@4361..4364
+                    - IDENT@4361..4364 "upc"
+                - COLON@4364..4365 ":"
+                - WHITESPACE@4365..4366 " "
+                - NON_NULL_TYPE@4366..4376
+                    - NAMED_TYPE@4366..4372
+                        - NAME@4366..4372
+                            - IDENT@4366..4372 "String"
+                    - BANG@4372..4373 "!"
+                    - WHITESPACE@4373..4376 "\n  "
+            - FIELD_DEFINITION@4376..4391
+                - NAME@4376..4379
+                    - IDENT@4376..4379 "sku"
+                - COLON@4379..4380 ":"
+                - WHITESPACE@4380..4381 " "
+                - NON_NULL_TYPE@4381..4391
+                    - NAMED_TYPE@4381..4387
+                        - NAME@4381..4387
+                            - IDENT@4381..4387 "String"
+                    - BANG@4387..4388 "!"
+                    - WHITESPACE@4388..4391 "\n  "
+            - FIELD_DEFINITION@4391..4406
+                - NAME@4391..4395
+                    - IDENT@4391..4395 "name"
+                - COLON@4395..4396 ":"
+                - WHITESPACE@4396..4397 " "
+                - NAMED_TYPE@4397..4403
+                    - NAME@4397..4403
+                        - IDENT@4397..4403 "String"
+                - WHITESPACE@4403..4406 "\n  "
+            - FIELD_DEFINITION@4406..4422
+                - NAME@4406..4411
+                    - IDENT@4406..4411 "price"
+                - COLON@4411..4412 ":"
+                - WHITESPACE@4412..4413 " "
+                - NAMED_TYPE@4413..4419
+                    - NAME@4413..4419
+                        - IDENT@4413..4419 "String"
+                - WHITESPACE@4419..4422 "\n  "
+            - FIELD_DEFINITION@4422..4448
+                - NAME@4422..4429
+                    - IDENT@4422..4429 "details"
+                - COLON@4429..4430 ":"
+                - WHITESPACE@4430..4431 " "
+                - NAMED_TYPE@4431..4445
+                    - NAME@4431..4445
+                        - IDENT@4431..4445 "ProductDetails"
+                - WHITESPACE@4445..4448 "\n  "
+            - FIELD_DEFINITION@4448..4467
+                - NAME@4448..4455
+                    - IDENT@4448..4455 "inStock"
+                - COLON@4455..4456 ":"
+                - WHITESPACE@4456..4457 " "
+                - NAMED_TYPE@4457..4464
+                    - NAME@4457..4464
+                        - IDENT@4457..4464 "Boolean"
+                - WHITESPACE@4464..4467 "\n  "
+            - FIELD_DEFINITION@4467..4485
+                - NAME@4467..4474
+                    - IDENT@4467..4474 "reviews"
+                - COLON@4474..4475 ":"
+                - WHITESPACE@4475..4476 " "
+                - LIST_TYPE@4476..4484
+                    - L_BRACK@4476..4477 "["
+                    - NAMED_TYPE@4477..4483
+                        - NAME@4477..4483
+                            - IDENT@4477..4483 "Review"
+                    - R_BRACK@4483..4484 "]"
+                - WHITESPACE@4484..4485 "\n"
+            - R_CURLY@4485..4486 "}"
+            - WHITESPACE@4486..4488 "\n\n"
+    - INTERFACE_TYPE_DEFINITION@4488..4536
+        - interface_KW@4488..4497 "interface"
+        - WHITESPACE@4497..4498 " "
+        - NAME@4498..4513
+            - IDENT@4498..4512 "ProductDetails"
+            - WHITESPACE@4512..4513 " "
+        - FIELDS_DEFINITION@4513..4536
+            - L_CURLY@4513..4514 "{"
+            - WHITESPACE@4514..4517 "\n  "
+            - FIELD_DEFINITION@4517..4533
+                - NAME@4517..4524
+                    - IDENT@4517..4524 "country"
+                - COLON@4524..4525 ":"
+                - WHITESPACE@4525..4526 " "
+                - NAMED_TYPE@4526..4532
+                    - NAME@4526..4532
+                        - IDENT@4526..4532 "String"
+                - WHITESPACE@4532..4533 "\n"
+            - R_CURLY@4533..4534 "}"
+            - WHITESPACE@4534..4536 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4536..4622
+        - type_KW@4536..4540 "type"
+        - WHITESPACE@4540..4541 " "
+        - NAME@4541..4560
+            - IDENT@4541..4559 "ProductDetailsBook"
+            - WHITESPACE@4559..4560 " "
+        - IMPLEMENTS_INTERFACES@4560..4586
+            - implements_KW@4560..4570 "implements"
+            - WHITESPACE@4570..4571 " "
+            - NAMED_TYPE@4571..4586
+                - NAME@4571..4586
+                    - IDENT@4571..4585 "ProductDetails"
+                    - WHITESPACE@4585..4586 " "
+        - FIELDS_DEFINITION@4586..4622
+            - L_CURLY@4586..4587 "{"
+            - WHITESPACE@4587..4590 "\n  "
+            - FIELD_DEFINITION@4590..4608
+                - NAME@4590..4597
+                    - IDENT@4590..4597 "country"
+                - COLON@4597..4598 ":"
+                - WHITESPACE@4598..4599 " "
+                - NAMED_TYPE@4599..4605
+                    - NAME@4599..4605
+                        - IDENT@4599..4605 "String"
+                - WHITESPACE@4605..4608 "\n  "
+            - FIELD_DEFINITION@4608..4619
+                - NAME@4608..4613
+                    - IDENT@4608..4613 "pages"
+                - COLON@4613..4614 ":"
+                - WHITESPACE@4614..4615 " "
+                - NAMED_TYPE@4615..4618
+                    - NAME@4615..4618
+                        - IDENT@4615..4618 "Int"
+                - WHITESPACE@4618..4619 "\n"
+            - R_CURLY@4619..4620 "}"
+            - WHITESPACE@4620..4622 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4622..4716
+        - type_KW@4622..4626 "type"
+        - WHITESPACE@4626..4627 " "
+        - NAME@4627..4651
+            - IDENT@4627..4650 "ProductDetailsFurniture"
+            - WHITESPACE@4650..4651 " "
+        - IMPLEMENTS_INTERFACES@4651..4677
+            - implements_KW@4651..4661 "implements"
+            - WHITESPACE@4661..4662 " "
+            - NAMED_TYPE@4662..4677
+                - NAME@4662..4677
+                    - IDENT@4662..4676 "ProductDetails"
+                    - WHITESPACE@4676..4677 " "
+        - FIELDS_DEFINITION@4677..4716
+            - L_CURLY@4677..4678 "{"
+            - WHITESPACE@4678..4681 "\n  "
+            - FIELD_DEFINITION@4681..4699
+                - NAME@4681..4688
+                    - IDENT@4681..4688 "country"
+                - COLON@4688..4689 ":"
+                - WHITESPACE@4689..4690 " "
+                - NAMED_TYPE@4690..4696
+                    - NAME@4690..4696
+                        - IDENT@4690..4696 "String"
+                - WHITESPACE@4696..4699 "\n  "
+            - FIELD_DEFINITION@4699..4713
+                - NAME@4699..4704
+                    - IDENT@4699..4704 "color"
+                - COLON@4704..4705 ":"
+                - WHITESPACE@4705..4706 " "
+                - NAMED_TYPE@4706..4712
+                    - NAME@4706..4712
+                        - IDENT@4706..4712 "String"
+                - WHITESPACE@4712..4713 "\n"
+            - R_CURLY@4713..4714 "}"
+            - WHITESPACE@4714..4716 "\n\n"
+    - OBJECT_TYPE_DEFINITION@4716..5346
+        - type_KW@4716..4720 "type"
+        - WHITESPACE@4720..4721 " "
+        - NAME@4721..4727
+            - IDENT@4721..4726 "Query"
+            - WHITESPACE@4726..4727 " "
+        - FIELDS_DEFINITION@4727..5346
+            - L_CURLY@4727..4728 "{"
+            - WHITESPACE@4728..4731 "\n  "
+            - FIELD_DEFINITION@4731..4783
+                - NAME@4731..4735
+                    - IDENT@4731..4735 "user"
+                - ARGUMENTS_DEFINITION@4735..4744
+                    - L_PAREN@4735..4736 "("
+                    - INPUT_VALUE_DEFINITION@4736..4743
+                        - NAME@4736..4738
+                            - IDENT@4736..4738 "id"
+                        - COLON@4738..4739 ":"
+                        - WHITESPACE@4739..4740 " "
+                        - NON_NULL_TYPE@4740..4743
+                            - NAMED_TYPE@4740..4742
+                                - NAME@4740..4742
+                                    - IDENT@4740..4742 "ID"
+                            - BANG@4742..4743 "!"
+                    - R_PAREN@4743..4744 ")"
+                - COLON@4744..4745 ":"
+                - WHITESPACE@4745..4746 " "
+                - NAMED_TYPE@4746..4750
+                    - NAME@4746..4750
+                        - IDENT@4746..4750 "User"
+                - WHITESPACE@4750..4751 " "
+                - DIRECTIVES@4751..4783
+                    - DIRECTIVE@4751..4783
+                        - AT@4751..4752 "@"
+                        - NAME@4752..4763
+                            - IDENT@4752..4763 "join__field"
+                        - ARGUMENTS@4763..4783
+                            - L_PAREN@4763..4764 "("
+                            - ARGUMENT@4764..4779
+                                - NAME@4764..4769
+                                    - IDENT@4764..4769 "graph"
+                                - COLON@4769..4770 ":"
+                                - WHITESPACE@4770..4771 " "
+                                - ENUM_VALUE@4771..4779
+                                    - NAME@4771..4779
+                                        - IDENT@4771..4779 "ACCOUNTS"
+                            - R_PAREN@4779..4780 ")"
+                            - WHITESPACE@4780..4783 "\n  "
+            - FIELD_DEFINITION@4783..4824
+                - NAME@4783..4785
+                    - IDENT@4783..4785 "me"
+                - COLON@4785..4786 ":"
+                - WHITESPACE@4786..4787 " "
+                - NAMED_TYPE@4787..4791
+                    - NAME@4787..4791
+                        - IDENT@4787..4791 "User"
+                - WHITESPACE@4791..4792 " "
+                - DIRECTIVES@4792..4824
+                    - DIRECTIVE@4792..4824
+                        - AT@4792..4793 "@"
+                        - NAME@4793..4804
+                            - IDENT@4793..4804 "join__field"
+                        - ARGUMENTS@4804..4824
+                            - L_PAREN@4804..4805 "("
+                            - ARGUMENT@4805..4820
+                                - NAME@4805..4810
+                                    - IDENT@4805..4810 "graph"
+                                - COLON@4810..4811 ":"
+                                - WHITESPACE@4811..4812 " "
+                                - ENUM_VALUE@4812..4820
+                                    - NAME@4812..4820
+                                        - IDENT@4812..4820 "ACCOUNTS"
+                            - R_PAREN@4820..4821 ")"
+                            - WHITESPACE@4821..4824 "\n  "
+            - FIELD_DEFINITION@4824..4879
+                - NAME@4824..4828
+                    - IDENT@4824..4828 "book"
+                - ARGUMENTS_DEFINITION@4828..4843
+                    - L_PAREN@4828..4829 "("
+                    - INPUT_VALUE_DEFINITION@4829..4842
+                        - NAME@4829..4833
+                            - IDENT@4829..4833 "isbn"
+                        - COLON@4833..4834 ":"
+                        - WHITESPACE@4834..4835 " "
+                        - NON_NULL_TYPE@4835..4842
+                            - NAMED_TYPE@4835..4841
+                                - NAME@4835..4841
+                                    - IDENT@4835..4841 "String"
+                            - BANG@4841..4842 "!"
+                    - R_PAREN@4842..4843 ")"
+                - COLON@4843..4844 ":"
+                - WHITESPACE@4844..4845 " "
+                - NAMED_TYPE@4845..4849
+                    - NAME@4845..4849
+                        - IDENT@4845..4849 "Book"
+                - WHITESPACE@4849..4850 " "
+                - DIRECTIVES@4850..4879
+                    - DIRECTIVE@4850..4879
+                        - AT@4850..4851 "@"
+                        - NAME@4851..4862
+                            - IDENT@4851..4862 "join__field"
+                        - ARGUMENTS@4862..4879
+                            - L_PAREN@4862..4863 "("
+                            - ARGUMENT@4863..4875
+                                - NAME@4863..4868
+                                    - IDENT@4863..4868 "graph"
+                                - COLON@4868..4869 ":"
+                                - WHITESPACE@4869..4870 " "
+                                - ENUM_VALUE@4870..4875
+                                    - NAME@4870..4875
+                                        - IDENT@4870..4875 "BOOKS"
+                            - R_PAREN@4875..4876 ")"
+                            - WHITESPACE@4876..4879 "\n  "
+            - FIELD_DEFINITION@4879..4922
+                - NAME@4879..4884
+                    - IDENT@4879..4884 "books"
+                - COLON@4884..4885 ":"
+                - WHITESPACE@4885..4886 " "
+                - LIST_TYPE@4886..4892
+                    - L_BRACK@4886..4887 "["
+                    - NAMED_TYPE@4887..4891
+                        - NAME@4887..4891
+                            - IDENT@4887..4891 "Book"
+                    - R_BRACK@4891..4892 "]"
+                - WHITESPACE@4892..4893 " "
+                - DIRECTIVES@4893..4922
+                    - DIRECTIVE@4893..4922
+                        - AT@4893..4894 "@"
+                        - NAME@4894..4905
+                            - IDENT@4894..4905 "join__field"
+                        - ARGUMENTS@4905..4922
+                            - L_PAREN@4905..4906 "("
+                            - ARGUMENT@4906..4918
+                                - NAME@4906..4911
+                                    - IDENT@4906..4911 "graph"
+                                - COLON@4911..4912 ":"
+                                - WHITESPACE@4912..4913 " "
+                                - ENUM_VALUE@4913..4918
+                                    - NAME@4913..4918
+                                        - IDENT@4913..4918 "BOOKS"
+                            - R_PAREN@4918..4919 ")"
+                            - WHITESPACE@4919..4922 "\n  "
+            - FIELD_DEFINITION@4922..4977
+                - NAME@4922..4929
+                    - IDENT@4922..4929 "library"
+                - ARGUMENTS_DEFINITION@4929..4938
+                    - L_PAREN@4929..4930 "("
+                    - INPUT_VALUE_DEFINITION@4930..4937
+                        - NAME@4930..4932
+                            - IDENT@4930..4932 "id"
+                        - COLON@4932..4933 ":"
+                        - WHITESPACE@4933..4934 " "
+                        - NON_NULL_TYPE@4934..4937
+                            - NAMED_TYPE@4934..4936
+                                - NAME@4934..4936
+                                    - IDENT@4934..4936 "ID"
+                            - BANG@4936..4937 "!"
+                    - R_PAREN@4937..4938 ")"
+                - COLON@4938..4939 ":"
+                - WHITESPACE@4939..4940 " "
+                - NAMED_TYPE@4940..4947
+                    - NAME@4940..4947
+                        - IDENT@4940..4947 "Library"
+                - WHITESPACE@4947..4948 " "
+                - DIRECTIVES@4948..4977
+                    - DIRECTIVE@4948..4977
+                        - AT@4948..4949 "@"
+                        - NAME@4949..4960
+                            - IDENT@4949..4960 "join__field"
+                        - ARGUMENTS@4960..4977
+                            - L_PAREN@4960..4961 "("
+                            - ARGUMENT@4961..4973
+                                - NAME@4961..4966
+                                    - IDENT@4961..4966 "graph"
+                                - COLON@4966..4967 ":"
+                                - WHITESPACE@4967..4968 " "
+                                - ENUM_VALUE@4968..4973
+                                    - NAME@4968..4973
+                                        - IDENT@4968..4973 "BOOKS"
+                            - R_PAREN@4973..4974 ")"
+                            - WHITESPACE@4974..4977 "\n  "
+            - FIELD_DEFINITION@4977..5022
+                - NAME@4977..4981
+                    - IDENT@4977..4981 "body"
+                - COLON@4981..4982 ":"
+                - WHITESPACE@4982..4983 " "
+                - NON_NULL_TYPE@4983..4989
+                    - NAMED_TYPE@4983..4987
+                        - NAME@4983..4987
+                            - IDENT@4983..4987 "Body"
+                    - BANG@4987..4988 "!"
+                    - WHITESPACE@4988..4989 " "
+                - DIRECTIVES@4989..5022
+                    - DIRECTIVE@4989..5022
+                        - AT@4989..4990 "@"
+                        - NAME@4990..5001
+                            - IDENT@4990..5001 "join__field"
+                        - ARGUMENTS@5001..5022
+                            - L_PAREN@5001..5002 "("
+                            - ARGUMENT@5002..5018
+                                - NAME@5002..5007
+                                    - IDENT@5002..5007 "graph"
+                                - COLON@5007..5008 ":"
+                                - WHITESPACE@5008..5009 " "
+                                - ENUM_VALUE@5009..5018
+                                    - NAME@5009..5018
+                                        - IDENT@5009..5018 "DOCUMENTS"
+                            - R_PAREN@5018..5019 ")"
+                            - WHITESPACE@5019..5022 "\n  "
+            - FIELD_DEFINITION@5022..5084
+                - NAME@5022..5029
+                    - IDENT@5022..5029 "product"
+                - ARGUMENTS_DEFINITION@5029..5043
+                    - L_PAREN@5029..5030 "("
+                    - INPUT_VALUE_DEFINITION@5030..5042
+                        - NAME@5030..5033
+                            - IDENT@5030..5033 "upc"
+                        - COLON@5033..5034 ":"
+                        - WHITESPACE@5034..5035 " "
+                        - NON_NULL_TYPE@5035..5042
+                            - NAMED_TYPE@5035..5041
+                                - NAME@5035..5041
+                                    - IDENT@5035..5041 "String"
+                            - BANG@5041..5042 "!"
+                    - R_PAREN@5042..5043 ")"
+                - COLON@5043..5044 ":"
+                - WHITESPACE@5044..5045 " "
+                - NAMED_TYPE@5045..5052
+                    - NAME@5045..5052
+                        - IDENT@5045..5052 "Product"
+                - WHITESPACE@5052..5053 " "
+                - DIRECTIVES@5053..5084
+                    - DIRECTIVE@5053..5084
+                        - AT@5053..5054 "@"
+                        - NAME@5054..5065
+                            - IDENT@5054..5065 "join__field"
+                        - ARGUMENTS@5065..5084
+                            - L_PAREN@5065..5066 "("
+                            - ARGUMENT@5066..5080
+                                - NAME@5066..5071
+                                    - IDENT@5066..5071 "graph"
+                                - COLON@5071..5072 ":"
+                                - WHITESPACE@5072..5073 " "
+                                - ENUM_VALUE@5073..5080
+                                    - NAME@5073..5080
+                                        - IDENT@5073..5080 "PRODUCT"
+                            - R_PAREN@5080..5081 ")"
+                            - WHITESPACE@5081..5084 "\n  "
+            - FIELD_DEFINITION@5084..5145
+                - NAME@5084..5091
+                    - IDENT@5084..5091 "vehicle"
+                - ARGUMENTS_DEFINITION@5091..5104
+                    - L_PAREN@5091..5092 "("
+                    - INPUT_VALUE_DEFINITION@5092..5103
+                        - NAME@5092..5094
+                            - IDENT@5092..5094 "id"
+                        - COLON@5094..5095 ":"
+                        - WHITESPACE@5095..5096 " "
+                        - NON_NULL_TYPE@5096..5103
+                            - NAMED_TYPE@5096..5102
+                                - NAME@5096..5102
+                                    - IDENT@5096..5102 "String"
+                            - BANG@5102..5103 "!"
+                    - R_PAREN@5103..5104 ")"
+                - COLON@5104..5105 ":"
+                - WHITESPACE@5105..5106 " "
+                - NAMED_TYPE@5106..5113
+                    - NAME@5106..5113
+                        - IDENT@5106..5113 "Vehicle"
+                - WHITESPACE@5113..5114 " "
+                - DIRECTIVES@5114..5145
+                    - DIRECTIVE@5114..5145
+                        - AT@5114..5115 "@"
+                        - NAME@5115..5126
+                            - IDENT@5115..5126 "join__field"
+                        - ARGUMENTS@5126..5145
+                            - L_PAREN@5126..5127 "("
+                            - ARGUMENT@5127..5141
+                                - NAME@5127..5132
+                                    - IDENT@5127..5132 "graph"
+                                - COLON@5132..5133 ":"
+                                - WHITESPACE@5133..5134 " "
+                                - ENUM_VALUE@5134..5141
+                                    - NAME@5134..5141
+                                        - IDENT@5134..5141 "PRODUCT"
+                            - R_PAREN@5141..5142 ")"
+                            - WHITESPACE@5142..5145 "\n  "
+            - FIELD_DEFINITION@5145..5215
+                - NAME@5145..5156
+                    - IDENT@5145..5156 "topProducts"
+                - ARGUMENTS_DEFINITION@5156..5172
+                    - L_PAREN@5156..5157 "("
+                    - INPUT_VALUE_DEFINITION@5157..5171
+                        - NAME@5157..5162
+                            - IDENT@5157..5162 "first"
+                        - COLON@5162..5163 ":"
+                        - WHITESPACE@5163..5164 " "
+                        - NAMED_TYPE@5164..5167
+                            - NAME@5164..5167
+                                - IDENT@5164..5167 "Int"
+                        - WHITESPACE@5167..5168 " "
+                        - DEFAULT_VALUE@5168..5171
+                            - EQ@5168..5169 "="
+                            - WHITESPACE@5169..5170 " "
+                            - INT_VALUE@5170..5171
+                                - INT@5170..5171 "5"
+                    - R_PAREN@5171..5172 ")"
+                - COLON@5172..5173 ":"
+                - WHITESPACE@5173..5174 " "
+                - LIST_TYPE@5174..5183
+                    - L_BRACK@5174..5175 "["
+                    - NAMED_TYPE@5175..5182
+                        - NAME@5175..5182
+                            - IDENT@5175..5182 "Product"
+                    - R_BRACK@5182..5183 "]"
+                - WHITESPACE@5183..5184 " "
+                - DIRECTIVES@5184..5215
+                    - DIRECTIVE@5184..5215
+                        - AT@5184..5185 "@"
+                        - NAME@5185..5196
+                            - IDENT@5185..5196 "join__field"
+                        - ARGUMENTS@5196..5215
+                            - L_PAREN@5196..5197 "("
+                            - ARGUMENT@5197..5211
+                                - NAME@5197..5202
+                                    - IDENT@5197..5202 "graph"
+                                - COLON@5202..5203 ":"
+                                - WHITESPACE@5203..5204 " "
+                                - ENUM_VALUE@5204..5211
+                                    - NAME@5204..5211
+                                        - IDENT@5204..5211 "PRODUCT"
+                            - R_PAREN@5211..5212 ")"
+                            - WHITESPACE@5212..5215 "\n  "
+            - FIELD_DEFINITION@5215..5277
+                - NAME@5215..5222
+                    - IDENT@5215..5222 "topCars"
+                - ARGUMENTS_DEFINITION@5222..5238
+                    - L_PAREN@5222..5223 "("
+                    - INPUT_VALUE_DEFINITION@5223..5237
+                        - NAME@5223..5228
+                            - IDENT@5223..5228 "first"
+                        - COLON@5228..5229 ":"
+                        - WHITESPACE@5229..5230 " "
+                        - NAMED_TYPE@5230..5233
+                            - NAME@5230..5233
+                                - IDENT@5230..5233 "Int"
+                        - WHITESPACE@5233..5234 " "
+                        - DEFAULT_VALUE@5234..5237
+                            - EQ@5234..5235 "="
+                            - WHITESPACE@5235..5236 " "
+                            - INT_VALUE@5236..5237
+                                - INT@5236..5237 "5"
+                    - R_PAREN@5237..5238 ")"
+                - COLON@5238..5239 ":"
+                - WHITESPACE@5239..5240 " "
+                - LIST_TYPE@5240..5245
+                    - L_BRACK@5240..5241 "["
+                    - NAMED_TYPE@5241..5244
+                        - NAME@5241..5244
+                            - IDENT@5241..5244 "Car"
+                    - R_BRACK@5244..5245 "]"
+                - WHITESPACE@5245..5246 " "
+                - DIRECTIVES@5246..5277
+                    - DIRECTIVE@5246..5277
+                        - AT@5246..5247 "@"
+                        - NAME@5247..5258
+                            - IDENT@5247..5258 "join__field"
+                        - ARGUMENTS@5258..5277
+                            - L_PAREN@5258..5259 "("
+                            - ARGUMENT@5259..5273
+                                - NAME@5259..5264
+                                    - IDENT@5259..5264 "graph"
+                                - COLON@5264..5265 ":"
+                                - WHITESPACE@5265..5266 " "
+                                - ENUM_VALUE@5266..5273
+                                    - NAME@5266..5273
+                                        - IDENT@5266..5273 "PRODUCT"
+                            - R_PAREN@5273..5274 ")"
+                            - WHITESPACE@5274..5277 "\n  "
+            - FIELD_DEFINITION@5277..5343
+                - NAME@5277..5287
+                    - IDENT@5277..5287 "topReviews"
+                - ARGUMENTS_DEFINITION@5287..5303
+                    - L_PAREN@5287..5288 "("
+                    - INPUT_VALUE_DEFINITION@5288..5302
+                        - NAME@5288..5293
+                            - IDENT@5288..5293 "first"
+                        - COLON@5293..5294 ":"
+                        - WHITESPACE@5294..5295 " "
+                        - NAMED_TYPE@5295..5298
+                            - NAME@5295..5298
+                                - IDENT@5295..5298 "Int"
+                        - WHITESPACE@5298..5299 " "
+                        - DEFAULT_VALUE@5299..5302
+                            - EQ@5299..5300 "="
+                            - WHITESPACE@5300..5301 " "
+                            - INT_VALUE@5301..5302
+                                - INT@5301..5302 "5"
+                    - R_PAREN@5302..5303 ")"
+                - COLON@5303..5304 ":"
+                - WHITESPACE@5304..5305 " "
+                - LIST_TYPE@5305..5313
+                    - L_BRACK@5305..5306 "["
+                    - NAMED_TYPE@5306..5312
+                        - NAME@5306..5312
+                            - IDENT@5306..5312 "Review"
+                    - R_BRACK@5312..5313 "]"
+                - WHITESPACE@5313..5314 " "
+                - DIRECTIVES@5314..5343
+                    - DIRECTIVE@5314..5343
+                        - AT@5314..5315 "@"
+                        - NAME@5315..5326
+                            - IDENT@5315..5326 "join__field"
+                        - ARGUMENTS@5326..5343
+                            - L_PAREN@5326..5327 "("
+                            - ARGUMENT@5327..5341
+                                - NAME@5327..5332
+                                    - IDENT@5327..5332 "graph"
+                                - COLON@5332..5333 ":"
+                                - WHITESPACE@5333..5334 " "
+                                - ENUM_VALUE@5334..5341
+                                    - NAME@5334..5341
+                                        - IDENT@5334..5341 "REVIEWS"
+                            - R_PAREN@5341..5342 ")"
+                            - WHITESPACE@5342..5343 "\n"
+            - R_CURLY@5343..5344 "}"
+            - WHITESPACE@5344..5346 "\n\n"
+    - OBJECT_TYPE_DEFINITION@5346..5712
+        - type_KW@5346..5350 "type"
+        - WHITESPACE@5350..5351 " "
+        - NAME@5351..5358
+            - IDENT@5351..5357 "Review"
+            - WHITESPACE@5357..5358 "\n"
+        - DIRECTIVES@5358..5426
+            - DIRECTIVE@5358..5387
+                - AT@5358..5359 "@"
+                - NAME@5359..5370
+                    - IDENT@5359..5370 "join__owner"
+                - ARGUMENTS@5370..5387
+                    - L_PAREN@5370..5371 "("
+                    - ARGUMENT@5371..5385
+                        - NAME@5371..5376
+                            - IDENT@5371..5376 "graph"
+                        - COLON@5376..5377 ":"
+                        - WHITESPACE@5377..5378 " "
+                        - ENUM_VALUE@5378..5385
+                            - NAME@5378..5385
+                                - IDENT@5378..5385 "REVIEWS"
+                    - R_PAREN@5385..5386 ")"
+                    - WHITESPACE@5386..5387 "\n"
+            - DIRECTIVE@5387..5426
+                - AT@5387..5388 "@"
+                - NAME@5388..5398
+                    - IDENT@5388..5398 "join__type"
+                - ARGUMENTS@5398..5426
+                    - L_PAREN@5398..5399 "("
+                    - ARGUMENT@5399..5415
+                        - NAME@5399..5404
+                            - IDENT@5399..5404 "graph"
+                        - COLON@5404..5405 ":"
+                        - WHITESPACE@5405..5406 " "
+                        - ENUM_VALUE@5406..5415
+                            - NAME@5406..5415
+                                - IDENT@5406..5413 "REVIEWS"
+                                - COMMA@5413..5414 ","
+                                - WHITESPACE@5414..5415 " "
+                    - ARGUMENT@5415..5424
+                        - NAME@5415..5418
+                            - IDENT@5415..5418 "key"
+                        - COLON@5418..5419 ":"
+                        - WHITESPACE@5419..5420 " "
+                        - STRING_VALUE@5420..5424
+                            - STRING@5420..5424 "\"id\""
+                    - R_PAREN@5424..5425 ")"
+                    - WHITESPACE@5425..5426 "\n"
+        - FIELDS_DEFINITION@5426..5712
+            - L_CURLY@5426..5427 "{"
+            - WHITESPACE@5427..5430 "\n  "
+            - FIELD_DEFINITION@5430..5469
+                - NAME@5430..5432
+                    - IDENT@5430..5432 "id"
+                - COLON@5432..5433 ":"
+                - WHITESPACE@5433..5434 " "
+                - NON_NULL_TYPE@5434..5438
+                    - NAMED_TYPE@5434..5436
+                        - NAME@5434..5436
+                            - IDENT@5434..5436 "ID"
+                    - BANG@5436..5437 "!"
+                    - WHITESPACE@5437..5438 " "
+                - DIRECTIVES@5438..5469
+                    - DIRECTIVE@5438..5469
+                        - AT@5438..5439 "@"
+                        - NAME@5439..5450
+                            - IDENT@5439..5450 "join__field"
+                        - ARGUMENTS@5450..5469
+                            - L_PAREN@5450..5451 "("
+                            - ARGUMENT@5451..5465
+                                - NAME@5451..5456
+                                    - IDENT@5451..5456 "graph"
+                                - COLON@5456..5457 ":"
+                                - WHITESPACE@5457..5458 " "
+                                - ENUM_VALUE@5458..5465
+                                    - NAME@5458..5465
+                                        - IDENT@5458..5465 "REVIEWS"
+                            - R_PAREN@5465..5466 ")"
+                            - WHITESPACE@5466..5469 "\n  "
+            - FIELD_DEFINITION@5469..5538
+                - NAME@5469..5473
+                    - IDENT@5469..5473 "body"
+                - ARGUMENTS_DEFINITION@5473..5498
+                    - L_PAREN@5473..5474 "("
+                    - INPUT_VALUE_DEFINITION@5474..5497
+                        - NAME@5474..5480
+                            - IDENT@5474..5480 "format"
+                        - COLON@5480..5481 ":"
+                        - WHITESPACE@5481..5482 " "
+                        - NAMED_TYPE@5482..5489
+                            - NAME@5482..5489
+                                - IDENT@5482..5489 "Boolean"
+                        - WHITESPACE@5489..5490 " "
+                        - DEFAULT_VALUE@5490..5497
+                            - EQ@5490..5491 "="
+                            - WHITESPACE@5491..5492 " "
+                            - BOOLEAN_VALUE@5492..5497
+                                - false_KW@5492..5497 "false"
+                    - R_PAREN@5497..5498 ")"
+                - COLON@5498..5499 ":"
+                - WHITESPACE@5499..5500 " "
+                - NAMED_TYPE@5500..5506
+                    - NAME@5500..5506
+                        - IDENT@5500..5506 "String"
+                - WHITESPACE@5506..5507 " "
+                - DIRECTIVES@5507..5538
+                    - DIRECTIVE@5507..5538
+                        - AT@5507..5508 "@"
+                        - NAME@5508..5519
+                            - IDENT@5508..5519 "join__field"
+                        - ARGUMENTS@5519..5538
+                            - L_PAREN@5519..5520 "("
+                            - ARGUMENT@5520..5534
+                                - NAME@5520..5525
+                                    - IDENT@5520..5525 "graph"
+                                - COLON@5525..5526 ":"
+                                - WHITESPACE@5526..5527 " "
+                                - ENUM_VALUE@5527..5534
+                                    - NAME@5527..5534
+                                        - IDENT@5527..5534 "REVIEWS"
+                            - R_PAREN@5534..5535 ")"
+                            - WHITESPACE@5535..5538 "\n  "
+            - FIELD_DEFINITION@5538..5604
+                - NAME@5538..5544
+                    - IDENT@5538..5544 "author"
+                - COLON@5544..5545 ":"
+                - WHITESPACE@5545..5546 " "
+                - NAMED_TYPE@5546..5550
+                    - NAME@5546..5550
+                        - IDENT@5546..5550 "User"
+                - WHITESPACE@5550..5551 " "
+                - DIRECTIVES@5551..5604
+                    - DIRECTIVE@5551..5604
+                        - AT@5551..5552 "@"
+                        - NAME@5552..5563
+                            - IDENT@5552..5563 "join__field"
+                        - ARGUMENTS@5563..5604
+                            - L_PAREN@5563..5564 "("
+                            - ARGUMENT@5564..5580
+                                - NAME@5564..5569
+                                    - IDENT@5564..5569 "graph"
+                                - COLON@5569..5570 ":"
+                                - WHITESPACE@5570..5571 " "
+                                - ENUM_VALUE@5571..5580
+                                    - NAME@5571..5580
+                                        - IDENT@5571..5578 "REVIEWS"
+                                        - COMMA@5578..5579 ","
+                                        - WHITESPACE@5579..5580 " "
+                            - ARGUMENT@5580..5600
+                                - NAME@5580..5588
+                                    - IDENT@5580..5588 "provides"
+                                - COLON@5588..5589 ":"
+                                - WHITESPACE@5589..5590 " "
+                                - STRING_VALUE@5590..5600
+                                    - STRING@5590..5600 "\"username\""
+                            - R_PAREN@5600..5601 ")"
+                            - WHITESPACE@5601..5604 "\n  "
+            - FIELD_DEFINITION@5604..5652
+                - NAME@5604..5611
+                    - IDENT@5604..5611 "product"
+                - COLON@5611..5612 ":"
+                - WHITESPACE@5612..5613 " "
+                - NAMED_TYPE@5613..5620
+                    - NAME@5613..5620
+                        - IDENT@5613..5620 "Product"
+                - WHITESPACE@5620..5621 " "
+                - DIRECTIVES@5621..5652
+                    - DIRECTIVE@5621..5652
+                        - AT@5621..5622 "@"
+                        - NAME@5622..5633
+                            - IDENT@5622..5633 "join__field"
+                        - ARGUMENTS@5633..5652
+                            - L_PAREN@5633..5634 "("
+                            - ARGUMENT@5634..5648
+                                - NAME@5634..5639
+                                    - IDENT@5634..5639 "graph"
+                                - COLON@5639..5640 ":"
+                                - WHITESPACE@5640..5641 " "
+                                - ENUM_VALUE@5641..5648
+                                    - NAME@5641..5648
+                                        - IDENT@5641..5648 "REVIEWS"
+                            - R_PAREN@5648..5649 ")"
+                            - WHITESPACE@5649..5652 "\n  "
+            - FIELD_DEFINITION@5652..5709
+                - NAME@5652..5660
+                    - IDENT@5652..5660 "metadata"
+                - COLON@5660..5661 ":"
+                - WHITESPACE@5661..5662 " "
+                - LIST_TYPE@5662..5679
+                    - L_BRACK@5662..5663 "["
+                    - NAMED_TYPE@5663..5678
+                        - NAME@5663..5678
+                            - IDENT@5663..5678 "MetadataOrError"
+                    - R_BRACK@5678..5679 "]"
+                - WHITESPACE@5679..5680 " "
+                - DIRECTIVES@5680..5709
+                    - DIRECTIVE@5680..5709
+                        - AT@5680..5681 "@"
+                        - NAME@5681..5692
+                            - IDENT@5681..5692 "join__field"
+                        - ARGUMENTS@5692..5709
+                            - L_PAREN@5692..5693 "("
+                            - ARGUMENT@5693..5707
+                                - NAME@5693..5698
+                                    - IDENT@5693..5698 "graph"
+                                - COLON@5698..5699 ":"
+                                - WHITESPACE@5699..5700 " "
+                                - ENUM_VALUE@5700..5707
+                                    - NAME@5700..5707
+                                        - IDENT@5700..5707 "REVIEWS"
+                            - R_PAREN@5707..5708 ")"
+                            - WHITESPACE@5708..5709 "\n"
+            - R_CURLY@5709..5710 "}"
+            - WHITESPACE@5710..5712 "\n\n"
+    - OBJECT_TYPE_DEFINITION@5712..5854
+        - type_KW@5712..5716 "type"
+        - WHITESPACE@5716..5717 " "
+        - NAME@5717..5728
+            - IDENT@5717..5727 "SMSAccount"
+            - WHITESPACE@5727..5728 "\n"
+        - DIRECTIVES@5728..5802
+            - DIRECTIVE@5728..5758
+                - AT@5728..5729 "@"
+                - NAME@5729..5740
+                    - IDENT@5729..5740 "join__owner"
+                - ARGUMENTS@5740..5758
+                    - L_PAREN@5740..5741 "("
+                    - ARGUMENT@5741..5756
+                        - NAME@5741..5746
+                            - IDENT@5741..5746 "graph"
+                        - COLON@5746..5747 ":"
+                        - WHITESPACE@5747..5748 " "
+                        - ENUM_VALUE@5748..5756
+                            - NAME@5748..5756
+                                - IDENT@5748..5756 "ACCOUNTS"
+                    - R_PAREN@5756..5757 ")"
+                    - WHITESPACE@5757..5758 "\n"
+            - DIRECTIVE@5758..5802
+                - AT@5758..5759 "@"
+                - NAME@5759..5769
+                    - IDENT@5759..5769 "join__type"
+                - ARGUMENTS@5769..5802
+                    - L_PAREN@5769..5770 "("
+                    - ARGUMENT@5770..5787
+                        - NAME@5770..5775
+                            - IDENT@5770..5775 "graph"
+                        - COLON@5775..5776 ":"
+                        - WHITESPACE@5776..5777 " "
+                        - ENUM_VALUE@5777..5787
+                            - NAME@5777..5787
+                                - IDENT@5777..5785 "ACCOUNTS"
+                                - COMMA@5785..5786 ","
+                                - WHITESPACE@5786..5787 " "
+                    - ARGUMENT@5787..5800
+                        - NAME@5787..5790
+                            - IDENT@5787..5790 "key"
+                        - COLON@5790..5791 ":"
+                        - WHITESPACE@5791..5792 " "
+                        - STRING_VALUE@5792..5800
+                            - STRING@5792..5800 "\"number\""
+                    - R_PAREN@5800..5801 ")"
+                    - WHITESPACE@5801..5802 "\n"
+        - FIELDS_DEFINITION@5802..5854
+            - L_CURLY@5802..5803 "{"
+            - WHITESPACE@5803..5806 "\n  "
+            - FIELD_DEFINITION@5806..5851
+                - NAME@5806..5812
+                    - IDENT@5806..5812 "number"
+                - COLON@5812..5813 ":"
+                - WHITESPACE@5813..5814 " "
+                - NAMED_TYPE@5814..5820
+                    - NAME@5814..5820
+                        - IDENT@5814..5820 "String"
+                - WHITESPACE@5820..5821 " "
+                - DIRECTIVES@5821..5851
+                    - DIRECTIVE@5821..5851
+                        - AT@5821..5822 "@"
+                        - NAME@5822..5833
+                            - IDENT@5822..5833 "join__field"
+                        - ARGUMENTS@5833..5851
+                            - L_PAREN@5833..5834 "("
+                            - ARGUMENT@5834..5849
+                                - NAME@5834..5839
+                                    - IDENT@5834..5839 "graph"
+                                - COLON@5839..5840 ":"
+                                - WHITESPACE@5840..5841 " "
+                                - ENUM_VALUE@5841..5849
+                                    - NAME@5841..5849
+                                        - IDENT@5841..5849 "ACCOUNTS"
+                            - R_PAREN@5849..5850 ")"
+                            - WHITESPACE@5850..5851 "\n"
+            - R_CURLY@5851..5852 "}"
+            - WHITESPACE@5852..5854 "\n\n"
+    - OBJECT_TYPE_DEFINITION@5854..5938
+        - type_KW@5854..5858 "type"
+        - WHITESPACE@5858..5859 " "
+        - NAME@5859..5864
+            - IDENT@5859..5863 "Text"
+            - WHITESPACE@5863..5864 " "
+        - IMPLEMENTS_INTERFACES@5864..5887
+            - implements_KW@5864..5874 "implements"
+            - WHITESPACE@5874..5875 " "
+            - NAMED_TYPE@5875..5887
+                - NAME@5875..5887
+                    - IDENT@5875..5886 "NamedObject"
+                    - WHITESPACE@5886..5887 " "
+        - FIELDS_DEFINITION@5887..5938
+            - L_CURLY@5887..5888 "{"
+            - WHITESPACE@5888..5891 "\n  "
+            - FIELD_DEFINITION@5891..5907
+                - NAME@5891..5895
+                    - IDENT@5891..5895 "name"
+                - COLON@5895..5896 ":"
+                - WHITESPACE@5896..5897 " "
+                - NON_NULL_TYPE@5897..5907
+                    - NAMED_TYPE@5897..5903
+                        - NAME@5897..5903
+                            - IDENT@5897..5903 "String"
+                    - BANG@5903..5904 "!"
+                    - WHITESPACE@5904..5907 "\n  "
+            - FIELD_DEFINITION@5907..5935
+                - NAME@5907..5917
+                    - IDENT@5907..5917 "attributes"
+                - COLON@5917..5918 ":"
+                - WHITESPACE@5918..5919 " "
+                - NON_NULL_TYPE@5919..5935
+                    - NAMED_TYPE@5919..5933
+                        - NAME@5919..5933
+                            - IDENT@5919..5933 "TextAttributes"
+                    - BANG@5933..5934 "!"
+                    - WHITESPACE@5934..5935 "\n"
+            - R_CURLY@5935..5936 "}"
+            - WHITESPACE@5936..5938 "\n\n"
+    - OBJECT_TYPE_DEFINITION@5938..5994
+        - type_KW@5938..5942 "type"
+        - WHITESPACE@5942..5943 " "
+        - NAME@5943..5958
+            - IDENT@5943..5957 "TextAttributes"
+            - WHITESPACE@5957..5958 " "
+        - FIELDS_DEFINITION@5958..5994
+            - L_CURLY@5958..5959 "{"
+            - WHITESPACE@5959..5962 "\n  "
+            - FIELD_DEFINITION@5962..5978
+                - NAME@5962..5966
+                    - IDENT@5962..5966 "bold"
+                - COLON@5966..5967 ":"
+                - WHITESPACE@5967..5968 " "
+                - NAMED_TYPE@5968..5975
+                    - NAME@5968..5975
+                        - IDENT@5968..5975 "Boolean"
+                - WHITESPACE@5975..5978 "\n  "
+            - FIELD_DEFINITION@5978..5991
+                - NAME@5978..5982
+                    - IDENT@5978..5982 "text"
+                - COLON@5982..5983 ":"
+                - WHITESPACE@5983..5984 " "
+                - NAMED_TYPE@5984..5990
+                    - NAME@5984..5990
+                        - IDENT@5984..5990 "String"
+                - WHITESPACE@5990..5991 "\n"
+            - R_CURLY@5991..5992 "}"
+            - WHITESPACE@5992..5994 "\n\n"
+    - UNION_TYPE_DEFINITION@5994..6020
+        - union_KW@5994..5999 "union"
+        - WHITESPACE@5999..6000 " "
+        - NAME@6000..6006
+            - IDENT@6000..6005 "Thing"
+            - WHITESPACE@6005..6006 " "
+        - UNION_MEMBER_TYPES@6006..6020
+            - EQ@6006..6007 "="
+            - WHITESPACE@6007..6008 " "
+            - NAMED_TYPE@6008..6012
+                - NAME@6008..6012
+                    - IDENT@6008..6011 "Car"
+                    - WHITESPACE@6011..6012 " "
+            - PIPE@6012..6013 "|"
+            - WHITESPACE@6013..6014 " "
+            - NAMED_TYPE@6014..6020
+                - NAME@6014..6020
+                    - IDENT@6014..6018 "Ikea"
+                    - WHITESPACE@6018..6020 "\n\n"
+    - INPUT_OBJECT_TYPE_DEFINITION@6020..6074
+        - input_KW@6020..6025 "input"
+        - WHITESPACE@6025..6026 " "
+        - NAME@6026..6044
+            - IDENT@6026..6043 "UpdateReviewInput"
+            - WHITESPACE@6043..6044 " "
+        - INPUT_FIELDS_DEFINITION@6044..6074
+            - L_CURLY@6044..6045 "{"
+            - WHITESPACE@6045..6048 "\n  "
+            - INPUT_VALUE_DEFINITION@6048..6058
+                - NAME@6048..6050
+                    - IDENT@6048..6050 "id"
+                - COLON@6050..6051 ":"
+                - WHITESPACE@6051..6052 " "
+                - NON_NULL_TYPE@6052..6058
+                    - NAMED_TYPE@6052..6054
+                        - NAME@6052..6054
+                            - IDENT@6052..6054 "ID"
+                    - BANG@6054..6055 "!"
+                    - WHITESPACE@6055..6058 "\n  "
+            - INPUT_VALUE_DEFINITION@6058..6071
+                - NAME@6058..6062
+                    - IDENT@6058..6062 "body"
+                - COLON@6062..6063 ":"
+                - WHITESPACE@6063..6064 " "
+                - NAMED_TYPE@6064..6070
+                    - NAME@6064..6070
+                        - IDENT@6064..6070 "String"
+                - WHITESPACE@6070..6071 "\n"
+            - R_CURLY@6071..6072 "}"
+            - WHITESPACE@6072..6074 "\n\n"
+    - OBJECT_TYPE_DEFINITION@6074..7019
+        - type_KW@6074..6078 "type"
+        - WHITESPACE@6078..6079 " "
+        - NAME@6079..6084
+            - IDENT@6079..6083 "User"
+            - WHITESPACE@6083..6084 "\n"
+        - DIRECTIVES@6084..6336
+            - DIRECTIVE@6084..6114
+                - AT@6084..6085 "@"
+                - NAME@6085..6096
+                    - IDENT@6085..6096 "join__owner"
+                - ARGUMENTS@6096..6114
+                    - L_PAREN@6096..6097 "("
+                    - ARGUMENT@6097..6112
+                        - NAME@6097..6102
+                            - IDENT@6097..6102 "graph"
+                        - COLON@6102..6103 ":"
+                        - WHITESPACE@6103..6104 " "
+                        - ENUM_VALUE@6104..6112
+                            - NAME@6104..6112
+                                - IDENT@6104..6112 "ACCOUNTS"
+                    - R_PAREN@6112..6113 ")"
+                    - WHITESPACE@6113..6114 "\n"
+            - DIRECTIVE@6114..6154
+                - AT@6114..6115 "@"
+                - NAME@6115..6125
+                    - IDENT@6115..6125 "join__type"
+                - ARGUMENTS@6125..6154
+                    - L_PAREN@6125..6126 "("
+                    - ARGUMENT@6126..6143
+                        - NAME@6126..6131
+                            - IDENT@6126..6131 "graph"
+                        - COLON@6131..6132 ":"
+                        - WHITESPACE@6132..6133 " "
+                        - ENUM_VALUE@6133..6143
+                            - NAME@6133..6143
+                                - IDENT@6133..6141 "ACCOUNTS"
+                                - COMMA@6141..6142 ","
+                                - WHITESPACE@6142..6143 " "
+                    - ARGUMENT@6143..6152
+                        - NAME@6143..6146
+                            - IDENT@6143..6146 "key"
+                        - COLON@6146..6147 ":"
+                        - WHITESPACE@6147..6148 " "
+                        - STRING_VALUE@6148..6152
+                            - STRING@6148..6152 "\"id\""
+                    - R_PAREN@6152..6153 ")"
+                    - WHITESPACE@6153..6154 "\n"
+            - DIRECTIVE@6154..6217
+                - AT@6154..6155 "@"
+                - NAME@6155..6165
+                    - IDENT@6155..6165 "join__type"
+                - ARGUMENTS@6165..6217
+                    - L_PAREN@6165..6166 "("
+                    - ARGUMENT@6166..6183
+                        - NAME@6166..6171
+                            - IDENT@6166..6171 "graph"
+                        - COLON@6171..6172 ":"
+                        - WHITESPACE@6172..6173 " "
+                        - ENUM_VALUE@6173..6183
+                            - NAME@6173..6183
+                                - IDENT@6173..6181 "ACCOUNTS"
+                                - COMMA@6181..6182 ","
+                                - WHITESPACE@6182..6183 " "
+                    - ARGUMENT@6183..6215
+                        - NAME@6183..6186
+                            - IDENT@6183..6186 "key"
+                        - COLON@6186..6187 ":"
+                        - WHITESPACE@6187..6188 " "
+                        - STRING_VALUE@6188..6215
+                            - STRING@6188..6215 "\"username name{first last}\""
+                    - R_PAREN@6215..6216 ")"
+                    - WHITESPACE@6216..6217 "\n"
+            - DIRECTIVE@6217..6258
+                - AT@6217..6218 "@"
+                - NAME@6218..6228
+                    - IDENT@6218..6228 "join__type"
+                - ARGUMENTS@6228..6258
+                    - L_PAREN@6228..6229 "("
+                    - ARGUMENT@6229..6247
+                        - NAME@6229..6234
+                            - IDENT@6229..6234 "graph"
+                        - COLON@6234..6235 ":"
+                        - WHITESPACE@6235..6236 " "
+                        - ENUM_VALUE@6236..6247
+                            - NAME@6236..6247
+                                - IDENT@6236..6245 "INVENTORY"
+                                - COMMA@6245..6246 ","
+                                - WHITESPACE@6246..6247 " "
+                    - ARGUMENT@6247..6256
+                        - NAME@6247..6250
+                            - IDENT@6247..6250 "key"
+                        - COLON@6250..6251 ":"
+                        - WHITESPACE@6251..6252 " "
+                        - STRING_VALUE@6252..6256
+                            - STRING@6252..6256 "\"id\""
+                    - R_PAREN@6256..6257 ")"
+                    - WHITESPACE@6257..6258 "\n"
+            - DIRECTIVE@6258..6297
+                - AT@6258..6259 "@"
+                - NAME@6259..6269
+                    - IDENT@6259..6269 "join__type"
+                - ARGUMENTS@6269..6297
+                    - L_PAREN@6269..6270 "("
+                    - ARGUMENT@6270..6286
+                        - NAME@6270..6275
+                            - IDENT@6270..6275 "graph"
+                        - COLON@6275..6276 ":"
+                        - WHITESPACE@6276..6277 " "
+                        - ENUM_VALUE@6277..6286
+                            - NAME@6277..6286
+                                - IDENT@6277..6284 "PRODUCT"
+                                - COMMA@6284..6285 ","
+                                - WHITESPACE@6285..6286 " "
+                    - ARGUMENT@6286..6295
+                        - NAME@6286..6289
+                            - IDENT@6286..6289 "key"
+                        - COLON@6289..6290 ":"
+                        - WHITESPACE@6290..6291 " "
+                        - STRING_VALUE@6291..6295
+                            - STRING@6291..6295 "\"id\""
+                    - R_PAREN@6295..6296 ")"
+                    - WHITESPACE@6296..6297 "\n"
+            - DIRECTIVE@6297..6336
+                - AT@6297..6298 "@"
+                - NAME@6298..6308
+                    - IDENT@6298..6308 "join__type"
+                - ARGUMENTS@6308..6336
+                    - L_PAREN@6308..6309 "("
+                    - ARGUMENT@6309..6325
+                        - NAME@6309..6314
+                            - IDENT@6309..6314 "graph"
+                        - COLON@6314..6315 ":"
+                        - WHITESPACE@6315..6316 " "
+                        - ENUM_VALUE@6316..6325
+                            - NAME@6316..6325
+                                - IDENT@6316..6323 "REVIEWS"
+                                - COMMA@6323..6324 ","
+                                - WHITESPACE@6324..6325 " "
+                    - ARGUMENT@6325..6334
+                        - NAME@6325..6328
+                            - IDENT@6325..6328 "key"
+                        - COLON@6328..6329 ":"
+                        - WHITESPACE@6329..6330 " "
+                        - STRING_VALUE@6330..6334
+                            - STRING@6330..6334 "\"id\""
+                    - R_PAREN@6334..6335 ")"
+                    - WHITESPACE@6335..6336 "\n"
+        - FIELDS_DEFINITION@6336..7019
+            - L_CURLY@6336..6337 "{"
+            - WHITESPACE@6337..6340 "\n  "
+            - FIELD_DEFINITION@6340..6380
+                - NAME@6340..6342
+                    - IDENT@6340..6342 "id"
+                - COLON@6342..6343 ":"
+                - WHITESPACE@6343..6344 " "
+                - NON_NULL_TYPE@6344..6348
+                    - NAMED_TYPE@6344..6346
+                        - NAME@6344..6346
+                            - IDENT@6344..6346 "ID"
+                    - BANG@6346..6347 "!"
+                    - WHITESPACE@6347..6348 " "
+                - DIRECTIVES@6348..6380
+                    - DIRECTIVE@6348..6380
+                        - AT@6348..6349 "@"
+                        - NAME@6349..6360
+                            - IDENT@6349..6360 "join__field"
+                        - ARGUMENTS@6360..6380
+                            - L_PAREN@6360..6361 "("
+                            - ARGUMENT@6361..6376
+                                - NAME@6361..6366
+                                    - IDENT@6361..6366 "graph"
+                                - COLON@6366..6367 ":"
+                                - WHITESPACE@6367..6368 " "
+                                - ENUM_VALUE@6368..6376
+                                    - NAME@6368..6376
+                                        - IDENT@6368..6376 "ACCOUNTS"
+                            - R_PAREN@6376..6377 ")"
+                            - WHITESPACE@6377..6380 "\n  "
+            - FIELD_DEFINITION@6380..6423
+                - NAME@6380..6384
+                    - IDENT@6380..6384 "name"
+                - COLON@6384..6385 ":"
+                - WHITESPACE@6385..6386 " "
+                - NAMED_TYPE@6386..6390
+                    - NAME@6386..6390
+                        - IDENT@6386..6390 "Name"
+                - WHITESPACE@6390..6391 " "
+                - DIRECTIVES@6391..6423
+                    - DIRECTIVE@6391..6423
+                        - AT@6391..6392 "@"
+                        - NAME@6392..6403
+                            - IDENT@6392..6403 "join__field"
+                        - ARGUMENTS@6403..6423
+                            - L_PAREN@6403..6404 "("
+                            - ARGUMENT@6404..6419
+                                - NAME@6404..6409
+                                    - IDENT@6404..6409 "graph"
+                                - COLON@6409..6410 ":"
+                                - WHITESPACE@6410..6411 " "
+                                - ENUM_VALUE@6411..6419
+                                    - NAME@6411..6419
+                                        - IDENT@6411..6419 "ACCOUNTS"
+                            - R_PAREN@6419..6420 ")"
+                            - WHITESPACE@6420..6423 "\n  "
+            - FIELD_DEFINITION@6423..6472
+                - NAME@6423..6431
+                    - IDENT@6423..6431 "username"
+                - COLON@6431..6432 ":"
+                - WHITESPACE@6432..6433 " "
+                - NAMED_TYPE@6433..6439
+                    - NAME@6433..6439
+                        - IDENT@6433..6439 "String"
+                - WHITESPACE@6439..6440 " "
+                - DIRECTIVES@6440..6472
+                    - DIRECTIVE@6440..6472
+                        - AT@6440..6441 "@"
+                        - NAME@6441..6452
+                            - IDENT@6441..6452 "join__field"
+                        - ARGUMENTS@6452..6472
+                            - L_PAREN@6452..6453 "("
+                            - ARGUMENT@6453..6468
+                                - NAME@6453..6458
+                                    - IDENT@6453..6458 "graph"
+                                - COLON@6458..6459 ":"
+                                - WHITESPACE@6459..6460 " "
+                                - ENUM_VALUE@6460..6468
+                                    - NAME@6460..6468
+                                        - IDENT@6460..6468 "ACCOUNTS"
+                            - R_PAREN@6468..6469 ")"
+                            - WHITESPACE@6469..6472 "\n  "
+            - FIELD_DEFINITION@6472..6538
+                - NAME@6472..6481
+                    - IDENT@6472..6481 "birthDate"
+                - ARGUMENTS_DEFINITION@6481..6497
+                    - L_PAREN@6481..6482 "("
+                    - INPUT_VALUE_DEFINITION@6482..6496
+                        - NAME@6482..6488
+                            - IDENT@6482..6488 "locale"
+                        - COLON@6488..6489 ":"
+                        - WHITESPACE@6489..6490 " "
+                        - NAMED_TYPE@6490..6496
+                            - NAME@6490..6496
+                                - IDENT@6490..6496 "String"
+                    - R_PAREN@6496..6497 ")"
+                - COLON@6497..6498 ":"
+                - WHITESPACE@6498..6499 " "
+                - NAMED_TYPE@6499..6505
+                    - NAME@6499..6505
+                        - IDENT@6499..6505 "String"
+                - WHITESPACE@6505..6506 " "
+                - DIRECTIVES@6506..6538
+                    - DIRECTIVE@6506..6538
+                        - AT@6506..6507 "@"
+                        - NAME@6507..6518
+                            - IDENT@6507..6518 "join__field"
+                        - ARGUMENTS@6518..6538
+                            - L_PAREN@6518..6519 "("
+                            - ARGUMENT@6519..6534
+                                - NAME@6519..6524
+                                    - IDENT@6519..6524 "graph"
+                                - COLON@6524..6525 ":"
+                                - WHITESPACE@6525..6526 " "
+                                - ENUM_VALUE@6526..6534
+                                    - NAME@6526..6534
+                                        - IDENT@6526..6534 "ACCOUNTS"
+                            - R_PAREN@6534..6535 ")"
+                            - WHITESPACE@6535..6538 "\n  "
+            - FIELD_DEFINITION@6538..6591
+                - NAME@6538..6545
+                    - IDENT@6538..6545 "account"
+                - COLON@6545..6546 ":"
+                - WHITESPACE@6546..6547 " "
+                - NAMED_TYPE@6547..6558
+                    - NAME@6547..6558
+                        - IDENT@6547..6558 "AccountType"
+                - WHITESPACE@6558..6559 " "
+                - DIRECTIVES@6559..6591
+                    - DIRECTIVE@6559..6591
+                        - AT@6559..6560 "@"
+                        - NAME@6560..6571
+                            - IDENT@6560..6571 "join__field"
+                        - ARGUMENTS@6571..6591
+                            - L_PAREN@6571..6572 "("
+                            - ARGUMENT@6572..6587
+                                - NAME@6572..6577
+                                    - IDENT@6572..6577 "graph"
+                                - COLON@6577..6578 ":"
+                                - WHITESPACE@6578..6579 " "
+                                - ENUM_VALUE@6579..6587
+                                    - NAME@6579..6587
+                                        - IDENT@6579..6587 "ACCOUNTS"
+                            - R_PAREN@6587..6588 ")"
+                            - WHITESPACE@6588..6591 "\n  "
+            - FIELD_DEFINITION@6591..6648
+                - NAME@6591..6599
+                    - IDENT@6591..6599 "metadata"
+                - COLON@6599..6600 ":"
+                - WHITESPACE@6600..6601 " "
+                - LIST_TYPE@6601..6615
+                    - L_BRACK@6601..6602 "["
+                    - NAMED_TYPE@6602..6614
+                        - NAME@6602..6614
+                            - IDENT@6602..6614 "UserMetadata"
+                    - R_BRACK@6614..6615 "]"
+                - WHITESPACE@6615..6616 " "
+                - DIRECTIVES@6616..6648
+                    - DIRECTIVE@6616..6648
+                        - AT@6616..6617 "@"
+                        - NAME@6617..6628
+                            - IDENT@6617..6628 "join__field"
+                        - ARGUMENTS@6628..6648
+                            - L_PAREN@6628..6629 "("
+                            - ARGUMENT@6629..6644
+                                - NAME@6629..6634
+                                    - IDENT@6629..6634 "graph"
+                                - COLON@6634..6635 ":"
+                                - WHITESPACE@6635..6636 " "
+                                - ENUM_VALUE@6636..6644
+                                    - NAME@6636..6644
+                                        - IDENT@6636..6644 "ACCOUNTS"
+                            - R_PAREN@6644..6645 ")"
+                            - WHITESPACE@6645..6648 "\n  "
+            - FIELD_DEFINITION@6648..6741
+                - NAME@6648..6663
+                    - IDENT@6648..6663 "goodDescription"
+                - COLON@6663..6664 ":"
+                - WHITESPACE@6664..6665 " "
+                - NAMED_TYPE@6665..6672
+                    - NAME@6665..6672
+                        - IDENT@6665..6672 "Boolean"
+                - WHITESPACE@6672..6673 " "
+                - DIRECTIVES@6673..6741
+                    - DIRECTIVE@6673..6741
+                        - AT@6673..6674 "@"
+                        - NAME@6674..6685
+                            - IDENT@6674..6685 "join__field"
+                        - ARGUMENTS@6685..6741
+                            - L_PAREN@6685..6686 "("
+                            - ARGUMENT@6686..6704
+                                - NAME@6686..6691
+                                    - IDENT@6686..6691 "graph"
+                                - COLON@6691..6692 ":"
+                                - WHITESPACE@6692..6693 " "
+                                - ENUM_VALUE@6693..6704
+                                    - NAME@6693..6704
+                                        - IDENT@6693..6702 "INVENTORY"
+                                        - COMMA@6702..6703 ","
+                                        - WHITESPACE@6703..6704 " "
+                            - ARGUMENT@6704..6737
+                                - NAME@6704..6712
+                                    - IDENT@6704..6712 "requires"
+                                - COLON@6712..6713 ":"
+                                - WHITESPACE@6713..6714 " "
+                                - STRING_VALUE@6714..6737
+                                    - STRING@6714..6737 "\"metadata{description}\""
+                            - R_PAREN@6737..6738 ")"
+                            - WHITESPACE@6738..6741 "\n  "
+            - FIELD_DEFINITION@6741..6789
+                - NAME@6741..6748
+                    - IDENT@6741..6748 "vehicle"
+                - COLON@6748..6749 ":"
+                - WHITESPACE@6749..6750 " "
+                - NAMED_TYPE@6750..6757
+                    - NAME@6750..6757
+                        - IDENT@6750..6757 "Vehicle"
+                - WHITESPACE@6757..6758 " "
+                - DIRECTIVES@6758..6789
+                    - DIRECTIVE@6758..6789
+                        - AT@6758..6759 "@"
+                        - NAME@6759..6770
+                            - IDENT@6759..6770 "join__field"
+                        - ARGUMENTS@6770..6789
+                            - L_PAREN@6770..6771 "("
+                            - ARGUMENT@6771..6785
+                                - NAME@6771..6776
+                                    - IDENT@6771..6776 "graph"
+                                - COLON@6776..6777 ":"
+                                - WHITESPACE@6777..6778 " "
+                                - ENUM_VALUE@6778..6785
+                                    - NAME@6778..6785
+                                        - IDENT@6778..6785 "PRODUCT"
+                            - R_PAREN@6785..6786 ")"
+                            - WHITESPACE@6786..6789 "\n  "
+            - FIELD_DEFINITION@6789..6833
+                - NAME@6789..6794
+                    - IDENT@6789..6794 "thing"
+                - COLON@6794..6795 ":"
+                - WHITESPACE@6795..6796 " "
+                - NAMED_TYPE@6796..6801
+                    - NAME@6796..6801
+                        - IDENT@6796..6801 "Thing"
+                - WHITESPACE@6801..6802 " "
+                - DIRECTIVES@6802..6833
+                    - DIRECTIVE@6802..6833
+                        - AT@6802..6803 "@"
+                        - NAME@6803..6814
+                            - IDENT@6803..6814 "join__field"
+                        - ARGUMENTS@6814..6833
+                            - L_PAREN@6814..6815 "("
+                            - ARGUMENT@6815..6829
+                                - NAME@6815..6820
+                                    - IDENT@6815..6820 "graph"
+                                - COLON@6820..6821 ":"
+                                - WHITESPACE@6821..6822 " "
+                                - ENUM_VALUE@6822..6829
+                                    - NAME@6822..6829
+                                        - IDENT@6822..6829 "PRODUCT"
+                            - R_PAREN@6829..6830 ")"
+                            - WHITESPACE@6830..6833 "\n  "
+            - FIELD_DEFINITION@6833..6882
+                - NAME@6833..6840
+                    - IDENT@6833..6840 "reviews"
+                - COLON@6840..6841 ":"
+                - WHITESPACE@6841..6842 " "
+                - LIST_TYPE@6842..6850
+                    - L_BRACK@6842..6843 "["
+                    - NAMED_TYPE@6843..6849
+                        - NAME@6843..6849
+                            - IDENT@6843..6849 "Review"
+                    - R_BRACK@6849..6850 "]"
+                - WHITESPACE@6850..6851 " "
+                - DIRECTIVES@6851..6882
+                    - DIRECTIVE@6851..6882
+                        - AT@6851..6852 "@"
+                        - NAME@6852..6863
+                            - IDENT@6852..6863 "join__field"
+                        - ARGUMENTS@6863..6882
+                            - L_PAREN@6863..6864 "("
+                            - ARGUMENT@6864..6878
+                                - NAME@6864..6869
+                                    - IDENT@6864..6869 "graph"
+                                - COLON@6869..6870 ":"
+                                - WHITESPACE@6870..6871 " "
+                                - ENUM_VALUE@6871..6878
+                                    - NAME@6871..6878
+                                        - IDENT@6871..6878 "REVIEWS"
+                            - R_PAREN@6878..6879 ")"
+                            - WHITESPACE@6879..6882 "\n  "
+            - FIELD_DEFINITION@6882..6935
+                - NAME@6882..6897
+                    - IDENT@6882..6897 "numberOfReviews"
+                - COLON@6897..6898 ":"
+                - WHITESPACE@6898..6899 " "
+                - NON_NULL_TYPE@6899..6904
+                    - NAMED_TYPE@6899..6902
+                        - NAME@6899..6902
+                            - IDENT@6899..6902 "Int"
+                    - BANG@6902..6903 "!"
+                    - WHITESPACE@6903..6904 " "
+                - DIRECTIVES@6904..6935
+                    - DIRECTIVE@6904..6935
+                        - AT@6904..6905 "@"
+                        - NAME@6905..6916
+                            - IDENT@6905..6916 "join__field"
+                        - ARGUMENTS@6916..6935
+                            - L_PAREN@6916..6917 "("
+                            - ARGUMENT@6917..6931
+                                - NAME@6917..6922
+                                    - IDENT@6917..6922 "graph"
+                                - COLON@6922..6923 ":"
+                                - WHITESPACE@6923..6924 " "
+                                - ENUM_VALUE@6924..6931
+                                    - NAME@6924..6931
+                                        - IDENT@6924..6931 "REVIEWS"
+                            - R_PAREN@6931..6932 ")"
+                            - WHITESPACE@6932..6935 "\n  "
+            - FIELD_DEFINITION@6935..7016
+                - NAME@6935..6946
+                    - IDENT@6935..6946 "goodAddress"
+                - COLON@6946..6947 ":"
+                - WHITESPACE@6947..6948 " "
+                - NAMED_TYPE@6948..6955
+                    - NAME@6948..6955
+                        - IDENT@6948..6955 "Boolean"
+                - WHITESPACE@6955..6956 " "
+                - DIRECTIVES@6956..7016
+                    - DIRECTIVE@6956..7016
+                        - AT@6956..6957 "@"
+                        - NAME@6957..6968
+                            - IDENT@6957..6968 "join__field"
+                        - ARGUMENTS@6968..7016
+                            - L_PAREN@6968..6969 "("
+                            - ARGUMENT@6969..6985
+                                - NAME@6969..6974
+                                    - IDENT@6969..6974 "graph"
+                                - COLON@6974..6975 ":"
+                                - WHITESPACE@6975..6976 " "
+                                - ENUM_VALUE@6976..6985
+                                    - NAME@6976..6985
+                                        - IDENT@6976..6983 "REVIEWS"
+                                        - COMMA@6983..6984 ","
+                                        - WHITESPACE@6984..6985 " "
+                            - ARGUMENT@6985..7014
+                                - NAME@6985..6993
+                                    - IDENT@6985..6993 "requires"
+                                - COLON@6993..6994 ":"
+                                - WHITESPACE@6994..6995 " "
+                                - STRING_VALUE@6995..7014
+                                    - STRING@6995..7014 "\"metadata{address}\""
+                            - R_PAREN@7014..7015 ")"
+                            - WHITESPACE@7015..7016 "\n"
+            - R_CURLY@7016..7017 "}"
+            - WHITESPACE@7017..7019 "\n\n"
+    - OBJECT_TYPE_DEFINITION@7019..7097
+        - type_KW@7019..7023 "type"
+        - WHITESPACE@7023..7024 " "
+        - NAME@7024..7037
+            - IDENT@7024..7036 "UserMetadata"
+            - WHITESPACE@7036..7037 " "
+        - FIELDS_DEFINITION@7037..7097
+            - L_CURLY@7037..7038 "{"
+            - WHITESPACE@7038..7041 "\n  "
+            - FIELD_DEFINITION@7041..7056
+                - NAME@7041..7045
+                    - IDENT@7041..7045 "name"
+                - COLON@7045..7046 ":"
+                - WHITESPACE@7046..7047 " "
+                - NAMED_TYPE@7047..7053
+                    - NAME@7047..7053
+                        - IDENT@7047..7053 "String"
+                - WHITESPACE@7053..7056 "\n  "
+            - FIELD_DEFINITION@7056..7074
+                - NAME@7056..7063
+                    - IDENT@7056..7063 "address"
+                - COLON@7063..7064 ":"
+                - WHITESPACE@7064..7065 " "
+                - NAMED_TYPE@7065..7071
+                    - NAME@7065..7071
+                        - IDENT@7065..7071 "String"
+                - WHITESPACE@7071..7074 "\n  "
+            - FIELD_DEFINITION@7074..7094
+                - NAME@7074..7085
+                    - IDENT@7074..7085 "description"
+                - COLON@7085..7086 ":"
+                - WHITESPACE@7086..7087 " "
+                - NAMED_TYPE@7087..7093
+                    - NAME@7087..7093
+                        - IDENT@7087..7093 "String"
+                - WHITESPACE@7093..7094 "\n"
+            - R_CURLY@7094..7095 "}"
+            - WHITESPACE@7095..7097 "\n\n"
+    - OBJECT_TYPE_DEFINITION@7097..7446
+        - type_KW@7097..7101 "type"
+        - WHITESPACE@7101..7102 " "
+        - NAME@7102..7106
+            - IDENT@7102..7105 "Van"
+            - WHITESPACE@7105..7106 " "
+        - IMPLEMENTS_INTERFACES@7106..7125
+            - implements_KW@7106..7116 "implements"
+            - WHITESPACE@7116..7117 " "
+            - NAMED_TYPE@7117..7125
+                - NAME@7117..7125
+                    - IDENT@7117..7124 "Vehicle"
+                    - WHITESPACE@7124..7125 "\n"
+        - DIRECTIVES@7125..7232
+            - DIRECTIVE@7125..7154
+                - AT@7125..7126 "@"
+                - NAME@7126..7137
+                    - IDENT@7126..7137 "join__owner"
+                - ARGUMENTS@7137..7154
+                    - L_PAREN@7137..7138 "("
+                    - ARGUMENT@7138..7152
+                        - NAME@7138..7143
+                            - IDENT@7138..7143 "graph"
+                        - COLON@7143..7144 ":"
+                        - WHITESPACE@7144..7145 " "
+                        - ENUM_VALUE@7145..7152
+                            - NAME@7145..7152
+                                - IDENT@7145..7152 "PRODUCT"
+                    - R_PAREN@7152..7153 ")"
+                    - WHITESPACE@7153..7154 "\n"
+            - DIRECTIVE@7154..7193
+                - AT@7154..7155 "@"
+                - NAME@7155..7165
+                    - IDENT@7155..7165 "join__type"
+                - ARGUMENTS@7165..7193
+                    - L_PAREN@7165..7166 "("
+                    - ARGUMENT@7166..7182
+                        - NAME@7166..7171
+                            - IDENT@7166..7171 "graph"
+                        - COLON@7171..7172 ":"
+                        - WHITESPACE@7172..7173 " "
+                        - ENUM_VALUE@7173..7182
+                            - NAME@7173..7182
+                                - IDENT@7173..7180 "PRODUCT"
+                                - COMMA@7180..7181 ","
+                                - WHITESPACE@7181..7182 " "
+                    - ARGUMENT@7182..7191
+                        - NAME@7182..7185
+                            - IDENT@7182..7185 "key"
+                        - COLON@7185..7186 ":"
+                        - WHITESPACE@7186..7187 " "
+                        - STRING_VALUE@7187..7191
+                            - STRING@7187..7191 "\"id\""
+                    - R_PAREN@7191..7192 ")"
+                    - WHITESPACE@7192..7193 "\n"
+            - DIRECTIVE@7193..7232
+                - AT@7193..7194 "@"
+                - NAME@7194..7204
+                    - IDENT@7194..7204 "join__type"
+                - ARGUMENTS@7204..7232
+                    - L_PAREN@7204..7205 "("
+                    - ARGUMENT@7205..7221
+                        - NAME@7205..7210
+                            - IDENT@7205..7210 "graph"
+                        - COLON@7210..7211 ":"
+                        - WHITESPACE@7211..7212 " "
+                        - ENUM_VALUE@7212..7221
+                            - NAME@7212..7221
+                                - IDENT@7212..7219 "REVIEWS"
+                                - COMMA@7219..7220 ","
+                                - WHITESPACE@7220..7221 " "
+                    - ARGUMENT@7221..7230
+                        - NAME@7221..7224
+                            - IDENT@7221..7224 "key"
+                        - COLON@7224..7225 ":"
+                        - WHITESPACE@7225..7226 " "
+                        - STRING_VALUE@7226..7230
+                            - STRING@7226..7230 "\"id\""
+                    - R_PAREN@7230..7231 ")"
+                    - WHITESPACE@7231..7232 "\n"
+        - FIELDS_DEFINITION@7232..7446
+            - L_CURLY@7232..7233 "{"
+            - WHITESPACE@7233..7236 "\n  "
+            - FIELD_DEFINITION@7236..7279
+                - NAME@7236..7238
+                    - IDENT@7236..7238 "id"
+                - COLON@7238..7239 ":"
+                - WHITESPACE@7239..7240 " "
+                - NON_NULL_TYPE@7240..7248
+                    - NAMED_TYPE@7240..7246
+                        - NAME@7240..7246
+                            - IDENT@7240..7246 "String"
+                    - BANG@7246..7247 "!"
+                    - WHITESPACE@7247..7248 " "
+                - DIRECTIVES@7248..7279
+                    - DIRECTIVE@7248..7279
+                        - AT@7248..7249 "@"
+                        - NAME@7249..7260
+                            - IDENT@7249..7260 "join__field"
+                        - ARGUMENTS@7260..7279
+                            - L_PAREN@7260..7261 "("
+                            - ARGUMENT@7261..7275
+                                - NAME@7261..7266
+                                    - IDENT@7261..7266 "graph"
+                                - COLON@7266..7267 ":"
+                                - WHITESPACE@7267..7268 " "
+                                - ENUM_VALUE@7268..7275
+                                    - NAME@7268..7275
+                                        - IDENT@7268..7275 "PRODUCT"
+                            - R_PAREN@7275..7276 ")"
+                            - WHITESPACE@7276..7279 "\n  "
+            - FIELD_DEFINITION@7279..7330
+                - NAME@7279..7290
+                    - IDENT@7279..7290 "description"
+                - COLON@7290..7291 ":"
+                - WHITESPACE@7291..7292 " "
+                - NAMED_TYPE@7292..7298
+                    - NAME@7292..7298
+                        - IDENT@7292..7298 "String"
+                - WHITESPACE@7298..7299 " "
+                - DIRECTIVES@7299..7330
+                    - DIRECTIVE@7299..7330
+                        - AT@7299..7300 "@"
+                        - NAME@7300..7311
+                            - IDENT@7300..7311 "join__field"
+                        - ARGUMENTS@7311..7330
+                            - L_PAREN@7311..7312 "("
+                            - ARGUMENT@7312..7326
+                                - NAME@7312..7317
+                                    - IDENT@7312..7317 "graph"
+                                - COLON@7317..7318 ":"
+                                - WHITESPACE@7318..7319 " "
+                                - ENUM_VALUE@7319..7326
+                                    - NAME@7319..7326
+                                        - IDENT@7319..7326 "PRODUCT"
+                            - R_PAREN@7326..7327 ")"
+                            - WHITESPACE@7327..7330 "\n  "
+            - FIELD_DEFINITION@7330..7375
+                - NAME@7330..7335
+                    - IDENT@7330..7335 "price"
+                - COLON@7335..7336 ":"
+                - WHITESPACE@7336..7337 " "
+                - NAMED_TYPE@7337..7343
+                    - NAME@7337..7343
+                        - IDENT@7337..7343 "String"
+                - WHITESPACE@7343..7344 " "
+                - DIRECTIVES@7344..7375
+                    - DIRECTIVE@7344..7375
+                        - AT@7344..7345 "@"
+                        - NAME@7345..7356
+                            - IDENT@7345..7356 "join__field"
+                        - ARGUMENTS@7356..7375
+                            - L_PAREN@7356..7357 "("
+                            - ARGUMENT@7357..7371
+                                - NAME@7357..7362
+                                    - IDENT@7357..7362 "graph"
+                                - COLON@7362..7363 ":"
+                                - WHITESPACE@7363..7364 " "
+                                - ENUM_VALUE@7364..7371
+                                    - NAME@7364..7371
+                                        - IDENT@7364..7371 "PRODUCT"
+                            - R_PAREN@7371..7372 ")"
+                            - WHITESPACE@7372..7375 "\n  "
+            - FIELD_DEFINITION@7375..7443
+                - NAME@7375..7386
+                    - IDENT@7375..7386 "retailPrice"
+                - COLON@7386..7387 ":"
+                - WHITESPACE@7387..7388 " "
+                - NAMED_TYPE@7388..7394
+                    - NAME@7388..7394
+                        - IDENT@7388..7394 "String"
+                - WHITESPACE@7394..7395 " "
+                - DIRECTIVES@7395..7443
+                    - DIRECTIVE@7395..7443
+                        - AT@7395..7396 "@"
+                        - NAME@7396..7407
+                            - IDENT@7396..7407 "join__field"
+                        - ARGUMENTS@7407..7443
+                            - L_PAREN@7407..7408 "("
+                            - ARGUMENT@7408..7424
+                                - NAME@7408..7413
+                                    - IDENT@7408..7413 "graph"
+                                - COLON@7413..7414 ":"
+                                - WHITESPACE@7414..7415 " "
+                                - ENUM_VALUE@7415..7424
+                                    - NAME@7415..7424
+                                        - IDENT@7415..7422 "REVIEWS"
+                                        - COMMA@7422..7423 ","
+                                        - WHITESPACE@7423..7424 " "
+                            - ARGUMENT@7424..7441
+                                - NAME@7424..7432
+                                    - IDENT@7424..7432 "requires"
+                                - COLON@7432..7433 ":"
+                                - WHITESPACE@7433..7434 " "
+                                - STRING_VALUE@7434..7441
+                                    - STRING@7434..7441 "\"price\""
+                            - R_PAREN@7441..7442 ")"
+                            - WHITESPACE@7442..7443 "\n"
+            - R_CURLY@7443..7444 "}"
+            - WHITESPACE@7444..7446 "\n\n"
+    - INTERFACE_TYPE_DEFINITION@7446..7541
+        - interface_KW@7446..7455 "interface"
+        - WHITESPACE@7455..7456 " "
+        - NAME@7456..7464
+            - IDENT@7456..7463 "Vehicle"
+            - WHITESPACE@7463..7464 " "
+        - FIELDS_DEFINITION@7464..7541
+            - L_CURLY@7464..7465 "{"
+            - WHITESPACE@7465..7468 "\n  "
+            - FIELD_DEFINITION@7468..7482
+                - NAME@7468..7470
+                    - IDENT@7468..7470 "id"
+                - COLON@7470..7471 ":"
+                - WHITESPACE@7471..7472 " "
+                - NON_NULL_TYPE@7472..7482
+                    - NAMED_TYPE@7472..7478
+                        - NAME@7472..7478
+                            - IDENT@7472..7478 "String"
+                    - BANG@7478..7479 "!"
+                    - WHITESPACE@7479..7482 "\n  "
+            - FIELD_DEFINITION@7482..7504
+                - NAME@7482..7493
+                    - IDENT@7482..7493 "description"
+                - COLON@7493..7494 ":"
+                - WHITESPACE@7494..7495 " "
+                - NAMED_TYPE@7495..7501
+                    - NAME@7495..7501
+                        - IDENT@7495..7501 "String"
+                - WHITESPACE@7501..7504 "\n  "
+            - FIELD_DEFINITION@7504..7520
+                - NAME@7504..7509
+                    - IDENT@7504..7509 "price"
+                - COLON@7509..7510 ":"
+                - WHITESPACE@7510..7511 " "
+                - NAMED_TYPE@7511..7517
+                    - NAME@7511..7517
+                        - IDENT@7511..7517 "String"
+                - WHITESPACE@7517..7520 "\n  "
+            - FIELD_DEFINITION@7520..7540
+                - NAME@7520..7531
+                    - IDENT@7520..7531 "retailPrice"
+                - COLON@7531..7532 ":"
+                - WHITESPACE@7532..7533 " "
+                - NAMED_TYPE@7533..7539
+                    - NAME@7533..7539
+                        - IDENT@7533..7539 "String"
+                - WHITESPACE@7539..7540 "\n"
+            - R_CURLY@7540..7541 "}"
+recursion limit: 4096, high: 0


### PR DESCRIPTION
partial of #246

This looks over each directive usage and checks whether it's in a correct location as specified by its original DirectiveDefinition. In case of incorrect usage `UnsupportedLocation` error is returned. Since we are already looking for the original DirectiveDefinition, this PR also adds a `UndefinedDefinition` error for undefined directives in case that DirectiveDefinition is not found.

While working on this validation rule, I realised we need to tidy up our ValidationDatabase before we implement any follow up rules. Primarily we are using two different paths for validating: `check_*` and `validate_*`, which should be unified in some way. 
We are also creating a lot of `let diagnostics = Vec::new()` for pretty much each validation step, and it would be good to not keep allocating new vecs for each node as we add diagnostics.



