### PR TITLE
feat(smith): derive Clone for most types

### DIFF
--- a/crates/apollo-smith/src/document.rs
+++ b/crates/apollo-smith/src/document.rs
@@ -20,7 +20,7 @@ use crate::{
 ///     DirectiveDefinition*
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Document).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Document {
     pub(crate) operation_definitions: Vec<OperationDef>,
     pub(crate) fragment_definitions: Vec<FragmentDef>,

--- a/crates/apollo-smith/src/field.rs
+++ b/crates/apollo-smith/src/field.rs
@@ -77,7 +77,7 @@ impl TryFrom<apollo_parser::ast::FieldDefinition> for FieldDef {
 ///     Alias? Name Arguments? Directives? SelectionSet?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Language.Fields).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Field {
     pub(crate) alias: Option<Name>,
     pub(crate) name: Name,

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -16,7 +16,7 @@ use crate::{
 ///     fragment FragmentName TypeCondition Directives? SelectionSet
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#FragmentDefinition).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FragmentDef {
     pub(crate) name: Name,
     pub(crate) type_condition: TypeCondition,
@@ -64,7 +64,7 @@ impl TryFrom<apollo_parser::ast::FragmentDefinition> for FragmentDef {
 ///     ... FragmentName Directives?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#FragmentSpread).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FragmentSpread {
     pub(crate) name: Name,
     pub(crate) directives: HashMap<Name, Directive>,
@@ -109,7 +109,7 @@ impl TryFrom<apollo_parser::ast::FragmentSpread> for FragmentSpread {
 ///     ... TypeCondition? Directives? SelectionSet
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Inline-Fragments).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InlineFragment {
     pub(crate) type_condition: Option<TypeCondition>,
     pub(crate) directives: HashMap<Name, Directive>,
@@ -152,7 +152,7 @@ impl TryFrom<apollo_parser::ast::InlineFragment> for InlineFragment {
 ///     on NamedType
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#TypeCondition).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TypeCondition {
     name: Name,
 }

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -16,7 +16,7 @@ use crate::{
 ///     OperationType Name? VariableDefinitions? Directives? SelectionSet
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Language.Operations).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OperationDef {
     pub(crate) operation_type: OperationType,
     pub(crate) name: Option<Name>,

--- a/crates/apollo-smith/src/scalar.rs
+++ b/crates/apollo-smith/src/scalar.rs
@@ -16,7 +16,7 @@ use crate::{
 ///     Description? **scalar** Name Directives?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Scalar).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ScalarTypeDef {
     pub(crate) name: Name,
     pub(crate) description: Option<Description>,

--- a/crates/apollo-smith/src/selection_set.rs
+++ b/crates/apollo-smith/src/selection_set.rs
@@ -13,7 +13,7 @@ use crate::{
 ///     Selection*
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Selection-Sets).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SelectionSet {
     selections: Vec<Selection>,
 }
@@ -49,7 +49,7 @@ impl TryFrom<apollo_parser::ast::SelectionSet> for SelectionSet {
 ///     Field | FragmentSpread | InlineFragment
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#Selection).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Selection {
     /// Represents a field
     Field(Field),

--- a/crates/apollo-smith/src/union.rs
+++ b/crates/apollo-smith/src/union.rs
@@ -17,7 +17,7 @@ use crate::{
 ///     Description? **union** Name Directives? UnionDefMemberTypes?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-UnionDef).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UnionTypeDef {
     pub(crate) name: Name,
     pub(crate) description: Option<Description>,

--- a/crates/apollo-smith/src/variable.rs
+++ b/crates/apollo-smith/src/variable.rs
@@ -16,7 +16,7 @@ use crate::{
 ///     VariableName : Type DefaultValue? Directives?
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Language.Variables).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VariableDef {
     name: Name,
     ty: Ty,


### PR DESCRIPTION
Cloning `Document` enables calling `DocumentBuilder::with_document` multiple times without reparsing.