### PR TITLE
chore(compiler): use Display impls for OperationType, DirectiveLocation

### DIFF
--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     sync::Arc,
 };
 
@@ -307,24 +308,12 @@ impl OperationType {
     }
 }
 
-impl std::fmt::Display for OperationType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for OperationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             OperationType::Query => write!(f, "Query"),
             OperationType::Mutation => write!(f, "Mutation"),
             OperationType::Subscription => write!(f, "Subscription"),
-        }
-    }
-}
-
-impl From<OperationType> for String {
-    fn from(op_type: OperationType) -> Self {
-        if op_type.is_subscription() {
-            "Subscription".to_string()
-        } else if op_type.is_mutation() {
-            "Mutation".to_string()
-        } else {
-            "Query".to_string()
         }
     }
 }
@@ -572,7 +561,7 @@ impl DirectiveDefinition {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum DirectiveLocation {
     Query,
     Mutation,
@@ -593,6 +582,39 @@ pub enum DirectiveLocation {
     EnumValue,
     InputObject,
     InputFieldDefinition,
+}
+
+impl DirectiveLocation {
+    /// Get the name of this directive location as it would appear in GraphQL source code.
+    pub fn name(self) -> &'static str {
+        match self {
+            DirectiveLocation::Query => "QUERY",
+            DirectiveLocation::Mutation => "MUTATION",
+            DirectiveLocation::Subscription => "SUBSCRIPTION",
+            DirectiveLocation::Field => "FIELD",
+            DirectiveLocation::FragmentDefinition => "FRAGMENT_DEFINITION",
+            DirectiveLocation::FragmentSpread => "FRAGMENT_SPREAD",
+            DirectiveLocation::InlineFragment => "INLINE_FRAGMENT",
+            DirectiveLocation::VariableDefinition => "VARIABLE_DEFINITION",
+            DirectiveLocation::Schema => "SCHEMA",
+            DirectiveLocation::Scalar => "SCALAR",
+            DirectiveLocation::Object => "OBJECT",
+            DirectiveLocation::FieldDefinition => "FIELD_DEFINITION",
+            DirectiveLocation::ArgumentDefinition => "ARGUMENT_DEFINITION",
+            DirectiveLocation::Interface => "INTERFACE",
+            DirectiveLocation::Union => "UNION",
+            DirectiveLocation::Enum => "ENUM",
+            DirectiveLocation::EnumValue => "ENUM_VALUE",
+            DirectiveLocation::InputObject => "INPUT_OBJECT",
+            DirectiveLocation::InputFieldDefinition => "INPUT_FIELD_DEFINITION",
+        }
+    }
+}
+
+impl fmt::Display for DirectiveLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
 }
 
 impl From<ast::DirectiveLocation> for DirectiveLocation {
@@ -635,32 +657,6 @@ impl From<ast::DirectiveLocation> for DirectiveLocation {
             DirectiveLocation::InputObject
         } else {
             DirectiveLocation::InputFieldDefinition
-        }
-    }
-}
-
-impl From<DirectiveLocation> for String {
-    fn from(dir_loc: DirectiveLocation) -> Self {
-        match dir_loc {
-            DirectiveLocation::Query => "QUERY".to_string(),
-            DirectiveLocation::Mutation => "MUTATION".to_string(),
-            DirectiveLocation::Subscription => "SUBSCRIPTION".to_string(),
-            DirectiveLocation::Field => "FIELD".to_string(),
-            DirectiveLocation::FragmentDefinition => "FRAGMENT_DEFINITION".to_string(),
-            DirectiveLocation::FragmentSpread => "FRAGMENT_SPREAD".to_string(),
-            DirectiveLocation::InlineFragment => "INLINE_FRAGMENT".to_string(),
-            DirectiveLocation::VariableDefinition => "VARIABLE_DEFINITION".to_string(),
-            DirectiveLocation::Schema => "SCHEMA".to_string(),
-            DirectiveLocation::Scalar => "SCALAR".to_string(),
-            DirectiveLocation::Object => "OBJECT".to_string(),
-            DirectiveLocation::FieldDefinition => "FIELD_DEFINITION".to_string(),
-            DirectiveLocation::ArgumentDefinition => "ARGUMENT_DEFINITION".to_string(),
-            DirectiveLocation::Interface => "INTERFACE".to_string(),
-            DirectiveLocation::Union => "UNION".to_string(),
-            DirectiveLocation::Enum => "ENUM".to_string(),
-            DirectiveLocation::EnumValue => "ENUM_VALUE".to_string(),
-            DirectiveLocation::InputObject => "INPUT_OBJECT".to_string(),
-            DirectiveLocation::InputFieldDefinition => "INPUT_FIELD_DEFINITION".to_string(),
         }
     }
 }

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -1,5 +1,6 @@
 use std::{fmt, sync::Arc};
 
+use crate::database::hir::DirectiveLocation;
 use miette::{Diagnostic, Report, SourceSpan};
 use thiserror::Error;
 
@@ -410,12 +411,12 @@ pub struct UnsupportedLocation {
     pub ty: String,
 
     // current location where the directive is used
-    pub dir_loc: String,
+    pub dir_loc: DirectiveLocation,
 
     #[source_code]
     pub src: Arc<str>,
 
-    #[label("{} is not a valid location", self.dir_loc)]
+    #[label("{} is not a valid location for this directive", self.dir_loc)]
     pub directive: SourceSpan,
 
     #[label("consider adding {} directive location here", self.dir_loc)]

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -840,7 +840,7 @@ type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
         let locations: Vec<_> = directives["delegateField"]
             .directive_locations()
             .iter()
-            .map(|loc| loc.clone().name())
+            .map(|loc| loc.name())
             .collect();
 
         assert_eq!(locations, ["OBJECT", "INTERFACE"]);

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -837,10 +837,10 @@ type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
         assert!(diagnostics.is_empty());
 
         let directives = compiler.db.directive_definitions();
-        let locations: Vec<String> = directives["delegateField"]
+        let locations: Vec<_> = directives["delegateField"]
             .directive_locations()
             .iter()
-            .map(|loc| loc.clone().into())
+            .map(|loc| loc.clone().name())
             .collect();
 
         assert_eq!(locations, ["OBJECT", "INTERFACE"]);

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -435,7 +435,7 @@ pub fn check_directive(
         if !allowed_loc.contains(&dir_loc) {
             diagnostics.push(ApolloDiagnostic::UnsupportedLocation(UnsupportedLocation {
                 ty: name.into(),
-                dir_loc: dir_loc.into(),
+                dir_loc,
                 src: db.source_code(loc.file_id()),
                 directive: (offset, len).into(),
                 directive_def: directive_def_loc,

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -278,7 +278,7 @@ pub fn check_input_values(
     let mut seen: HashMap<&str, &hir::InputValueDefinition> = HashMap::new();
 
     for input_value in input_values.iter() {
-        diagnostics.extend(db.check_directives(input_value.directives().to_vec(), dir_loc.clone()));
+        diagnostics.extend(db.check_directives(input_value.directives().to_vec(), dir_loc));
         let name = input_value.name();
         if let Some(prev_arg) = seen.get(name) {
             let prev_offset = prev_arg.loc().unwrap().offset();
@@ -407,7 +407,7 @@ pub fn check_directives(
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
     for dir in dirs {
-        diagnostics.extend(db.check_directive(dir.clone(), dir_loc.clone()));
+        diagnostics.extend(db.check_directive(dir.clone(), dir_loc));
     }
     diagnostics
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
@@ -2,7 +2,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "skip",
-            dir_loc: "QUERY",
+            dir_loc: Query,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -21,7 +21,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "skip",
-            dir_loc: "VARIABLE_DEFINITION",
+            dir_loc: VariableDefinition,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -40,7 +40,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "deprecated",
-            dir_loc: "FIELD",
+            dir_loc: Field,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -59,7 +59,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveB",
-            dir_loc: "FRAGMENT_SPREAD",
+            dir_loc: FragmentSpread,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -87,7 +87,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveA",
-            dir_loc: "SUBSCRIPTION",
+            dir_loc: Subscription,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -115,7 +115,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "skip",
-            dir_loc: "MUTATION",
+            dir_loc: Mutation,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -134,7 +134,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveB",
-            dir_loc: "FRAGMENT_DEFINITION",
+            dir_loc: FragmentDefinition,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -162,7 +162,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveA",
-            dir_loc: "INLINE_FRAGMENT",
+            dir_loc: InlineFragment,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -190,7 +190,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveB",
-            dir_loc: "SCALAR",
+            dir_loc: Scalar,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -218,7 +218,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveB",
-            dir_loc: "FIELD_DEFINITION",
+            dir_loc: FieldDefinition,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -246,7 +246,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "deprecated",
-            dir_loc: "OBJECT",
+            dir_loc: Object,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -265,7 +265,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "specifiedBy",
-            dir_loc: "ARGUMENT_DEFINITION",
+            dir_loc: ArgumentDefinition,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -284,7 +284,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "skip",
-            dir_loc: "INTERFACE",
+            dir_loc: Interface,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -303,7 +303,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveB",
-            dir_loc: "UNION",
+            dir_loc: Union,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -331,7 +331,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveA",
-            dir_loc: "ENUM",
+            dir_loc: Enum,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -359,7 +359,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "directiveA",
-            dir_loc: "ENUM_VALUE",
+            dir_loc: EnumValue,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -387,7 +387,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "include",
-            dir_loc: "INPUT_OBJECT",
+            dir_loc: InputObject,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -406,7 +406,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "include",
-            dir_loc: "INPUT_FIELD_DEFINITION",
+            dir_loc: InputFieldDefinition,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(
@@ -425,7 +425,7 @@
     UnsupportedLocation(
         UnsupportedLocation {
             ty: "include",
-            dir_loc: "SCHEMA",
+            dir_loc: Schema,
             src: "query queryA($status: String @skip) @skip(if: $foo){\n  field\n  response(status: $status) @deprecated\n  human {\n    ... pet @directiveB\n  }\n}\n\nfragment pet on Cat @directiveB{\n  meowVolume\n  ... on Pet @directiveA {\n    name\n  }\n}\n\nsubscription subscriptionA @directiveA {\n  newMessage {\n    body\n    sender\n  }\n}\n\nmutation @skip(if: true) {\n  setMessage (message: \"Hello, World! Yours, GraphQL.\")\n}\n\ninterface Pet @skip {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String @directiveB\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\ninput Example @include {\n  self: Example @include\n  value: String\n}\n\nunion CatOrDog @directiveB = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\nenum Status @directiveA {\n  GREEN @directiveA,\n  RED,\n  YELLOW\n}\n\ntype Query @deprecated {\n  human: Human\n  field: String,\n  response(status: String @specifiedBy(url: \"https://tools.ietf.org/html/rfc4122\")): Status\n}\n\ntype Subscription {\n  newMessage: Result\n}\n\ntype Mutation {\n  setMessage(message: String): String\n}\n\nschema @include {\n  query: Query\n  subscription: Subscription\n  mutation: Mutation\n}\n\ntype Result {\n  body: String,\n  sender: String\n}\n\nscalar spec @directiveB @specifiedBy(url: \"https://spec.graphql.org/\")\n\ndirective @directiveA on UNION\ndirective @directiveB on ENUM",
             directive: SourceSpan {
                 offset: SourceOffset(


### PR DESCRIPTION
Noticed a small improvement opportunity while merging `main` into #414…

`OperationType` already has a `Display` impl, so we don't actually need a separate `Into<String>`: users can do `ty.to_string()` and it will use `Display`.

`DirectiveLocation` also has a `Into<String>` impl. If we use a `Display` impl instead, we can print `DirectiveLocation`s directly in format strings. Then we can also just stick the `DirectiveLocation` value into our diagnostics, instead of stringifying them first, which makes the diagnostic more programmatically useful.