### PR TITLE
Reset FileId between directory tests

### DIFF
--- a/crates/apollo-compiler/src/database/sources.rs
+++ b/crates/apollo-compiler/src/database/sources.rs
@@ -67,13 +67,22 @@ pub struct FileId {
     id: u64,
 }
 
+/// The next file ID to use. This is global so file IDs do not conflict between different compiler
+/// instances.
+static NEXT: atomic::AtomicU64 = atomic::AtomicU64::new(0);
+
 impl FileId {
     // Returning a different value every time does not sound like good `impl Default`
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        static NEXT: atomic::AtomicU64 = atomic::AtomicU64::new(0);
         Self {
             id: NEXT.fetch_add(1, atomic::Ordering::Relaxed),
         }
+    }
+
+    /// Reset file ID back to 0, used to get consistent results in tests.
+    #[allow(unused)]
+    pub(crate) fn reset() {
+        NEXT.store(0, atomic::Ordering::SeqCst);
     }
 }

--- a/crates/apollo-compiler/src/tests.rs
+++ b/crates/apollo-compiler/src/tests.rs
@@ -84,7 +84,7 @@ where
 
 /// Collects all `.graphql` files from `dir` subdirectories defined by `paths`.
 fn collect_graphql_files(root_dir: &Path, paths: &[&str]) -> Vec<(PathBuf, String)> {
-    paths
+    let mut files = paths
         .iter()
         .flat_map(|path| {
             let path = root_dir.to_owned().join(path);
@@ -95,7 +95,10 @@ fn collect_graphql_files(root_dir: &Path, paths: &[&str]) -> Vec<(PathBuf, Strin
                 .unwrap_or_else(|_| panic!("File at {:?} should be valid", path));
             (path, text)
         })
-        .collect()
+        .collect::<Vec<_>>();
+    // Sort alphabetically to ensure consistent File IDs
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files
 }
 
 /// Collects paths to all `.graphql` files from `dir` in a sorted `Vec<PathBuf>`.

--- a/crates/apollo-compiler/src/tests.rs
+++ b/crates/apollo-compiler/src/tests.rs
@@ -12,7 +12,7 @@ use std::{
 
 use expect_test::expect_file;
 
-use crate::{ApolloCompiler, ApolloDiagnostic, AstDatabase};
+use crate::{ApolloCompiler, ApolloDiagnostic, AstDatabase, FileId};
 
 // To run these tests and update files:
 // ```bash
@@ -74,6 +74,8 @@ fn dir_tests<F>(test_data_dir: &Path, paths: &[&str], outfile_extension: &str, f
 where
     F: Fn(&str, &Path) -> String,
 {
+    FileId::reset();
+
     for (path, input_code) in collect_graphql_files(test_data_dir, paths) {
         let mut actual = f(&input_code, &path);
         actual.push('\n');


### PR DESCRIPTION
This feels a little janky, but should make the issue with File IDs that we are running into in #414 much less urgent. By resetting file IDs before scanning a directory for file-based tests we get a consistent order each time, and adding tests to 1 directory doesnt increment every file ID in another directory.

The `FileId::reset()` api is not public here, we can see if the router ends up needing it for some tests too or if at that point we should consider other approaches. for now this is the simplest change I can think of to make the `expect` based tests work well enoguh.