### PR TITLE
fix(parser): Fix token order in parse tree around types

### DIFF
--- a/crates/apollo-compiler/src/tests.rs
+++ b/crates/apollo-compiler/src/tests.rs
@@ -39,6 +39,9 @@ fn compiler_tests() {
         compiler.add_document(text, path.file_name().unwrap());
 
         let diagnostics = compiler.validate();
+        for diagnostic in &diagnostics {
+            println!("{diagnostic}");
+        }
         assert_diagnostics_are_present(&diagnostics, path);
         format!("{diagnostics:#?}")
     });

--- a/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
@@ -104,13 +104,13 @@
                             - IDENT@255..259 "name"
                         - COLON@259..260 ":"
                         - WHITESPACE@260..261 " "
-                        - NON_NULL_TYPE@261..270
+                        - NON_NULL_TYPE@261..268
                             - NAMED_TYPE@261..267
                                 - NAME@261..267
                                     - IDENT@261..267 "String"
                             - BANG@267..268 "!"
-                            - COMMA@268..269 ","
-                            - WHITESPACE@269..270 " "
+                        - COMMA@268..269 ","
+                        - WHITESPACE@269..270 " "
                     - INPUT_VALUE_DEFINITION@270..286
                         - NAME@270..277
                             - IDENT@270..277 "petType"
@@ -122,12 +122,12 @@
                     - R_PAREN@286..287 ")"
                 - COLON@287..288 ":"
                 - WHITESPACE@288..289 " "
-                - NON_NULL_TYPE@289..297
+                - NON_NULL_TYPE@289..296
                     - NAMED_TYPE@289..295
                         - NAME@289..295
                             - IDENT@289..295 "Result"
                     - BANG@295..296 "!"
-                    - WHITESPACE@296..297 "\n"
+                - WHITESPACE@296..297 "\n"
             - R_CURLY@297..298 "}"
             - WHITESPACE@298..300 "\n\n"
     - OBJECT_TYPE_DEFINITION@300..328

--- a/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
@@ -20,12 +20,12 @@
                     - IDENT@33..35 "id"
                 - COLON@35..36 ":"
                 - WHITESPACE@36..37 " "
-                - NON_NULL_TYPE@37..41
+                - NON_NULL_TYPE@37..40
                     - NAMED_TYPE@37..39
                         - NAME@37..39
                             - IDENT@37..39 "ID"
                     - BANG@39..40 "!"
-                    - WHITESPACE@40..41 "\n"
+                - WHITESPACE@40..41 "\n"
             - R_CURLY@41..42 "}"
             - WHITESPACE@42..44 "\n\n"
     - INTERFACE_TYPE_DEFINITION@44..74
@@ -42,12 +42,12 @@
                     - IDENT@63..65 "id"
                 - COLON@65..66 ":"
                 - WHITESPACE@66..67 " "
-                - NON_NULL_TYPE@67..71
+                - NON_NULL_TYPE@67..70
                     - NAMED_TYPE@67..69
                         - NAME@67..69
                             - IDENT@67..69 "ID"
                     - BANG@69..70 "!"
-                    - WHITESPACE@70..71 "\n"
+                - WHITESPACE@70..71 "\n"
             - R_CURLY@71..72 "}"
             - WHITESPACE@72..74 "\n\n"
     - INTERFACE_TYPE_DEFINITION@74..151
@@ -71,12 +71,12 @@
                     - IDENT@113..115 "id"
                 - COLON@115..116 ":"
                 - WHITESPACE@116..117 " "
-                - NON_NULL_TYPE@117..123
+                - NON_NULL_TYPE@117..120
                     - NAMED_TYPE@117..119
                         - NAME@117..119
                             - IDENT@117..119 "ID"
                     - BANG@119..120 "!"
-                    - WHITESPACE@120..123 "\n  "
+                - WHITESPACE@120..123 "\n  "
             - FIELD_DEFINITION@123..136
                 - NAME@123..128
                     - IDENT@123..128 "width"
@@ -124,12 +124,12 @@
                     - IDENT@198..200 "id"
                 - COLON@200..201 ":"
                 - WHITESPACE@201..202 " "
-                - NON_NULL_TYPE@202..208
+                - NON_NULL_TYPE@202..205
                     - NAMED_TYPE@202..204
                         - NAME@202..204
                             - IDENT@202..204 "ID"
                     - BANG@204..205 "!"
-                    - WHITESPACE@205..208 "\n  "
+                - WHITESPACE@205..208 "\n  "
             - FIELD_DEFINITION@208..221
                 - NAME@208..213
                     - IDENT@208..213 "width"

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
@@ -97,11 +97,11 @@
                     - IDENT@190..192 "id"
                 - COLON@192..193 ":"
                 - WHITESPACE@193..194 " "
-                - NON_NULL_TYPE@194..198
+                - NON_NULL_TYPE@194..197
                     - NAMED_TYPE@194..196
                         - NAME@194..196
                             - IDENT@194..196 "ID"
                     - BANG@196..197 "!"
-                    - WHITESPACE@197..198 "\n"
+                - WHITESPACE@197..198 "\n"
             - R_CURLY@198..199 "}"
 recursion limit: 4096, high: 0

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -154,12 +154,12 @@
                     - IDENT@285..288 "upc"
                 - COLON@288..289 ":"
                 - WHITESPACE@289..290 " "
-                - NON_NULL_TYPE@290..300
+                - NON_NULL_TYPE@290..297
                     - NAMED_TYPE@290..296
                         - NAME@290..296
                             - IDENT@290..296 "String"
                     - BANG@296..297 "!"
-                    - WHITESPACE@297..300 "\n  "
+                - WHITESPACE@297..300 "\n  "
             - FIELD_DEFINITION@300..312
                 - NAME@300..306
                     - IDENT@300..306 "weight"

--- a/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
+++ b/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
@@ -521,7 +521,7 @@
                     - IDENT@1344..1349 "types"
                 - COLON@1349..1350 ":"
                 - WHITESPACE@1350..1351 " "
-                - NON_NULL_TYPE@1351..1364
+                - NON_NULL_TYPE@1351..1361
                     - LIST_TYPE@1351..1360
                         - L_BRACK@1351..1352 "["
                         - NON_NULL_TYPE@1352..1359
@@ -531,18 +531,18 @@
                             - BANG@1358..1359 "!"
                         - R_BRACK@1359..1360 "]"
                     - BANG@1360..1361 "!"
-                    - WHITESPACE@1361..1364 "\n  "
+                - WHITESPACE@1361..1364 "\n  "
             - FIELD_DEFINITION@1364..1385
                 - NAME@1364..1373
                     - IDENT@1364..1373 "queryType"
                 - COLON@1373..1374 ":"
                 - WHITESPACE@1374..1375 " "
-                - NON_NULL_TYPE@1375..1385
+                - NON_NULL_TYPE@1375..1382
                     - NAMED_TYPE@1375..1381
                         - NAME@1375..1381
                             - IDENT@1375..1381 "__Type"
                     - BANG@1381..1382 "!"
-                    - WHITESPACE@1382..1385 "\n  "
+                - WHITESPACE@1382..1385 "\n  "
             - FIELD_DEFINITION@1385..1408
                 - NAME@1385..1397
                     - IDENT@1385..1397 "mutationType"
@@ -566,7 +566,7 @@
                     - IDENT@1435..1445 "directives"
                 - COLON@1445..1446 ":"
                 - WHITESPACE@1446..1447 " "
-                - NON_NULL_TYPE@1447..1463
+                - NON_NULL_TYPE@1447..1462
                     - LIST_TYPE@1447..1461
                         - L_BRACK@1447..1448 "["
                         - NON_NULL_TYPE@1448..1460
@@ -576,7 +576,7 @@
                             - BANG@1459..1460 "!"
                         - R_BRACK@1460..1461 "]"
                     - BANG@1461..1462 "!"
-                    - WHITESPACE@1462..1463 "\n"
+                - WHITESPACE@1462..1463 "\n"
             - R_CURLY@1463..1464 "}"
             - WHITESPACE@1464..1466 "\n\n"
     - OBJECT_TYPE_DEFINITION@1466..2191
@@ -593,12 +593,12 @@
                     - IDENT@1482..1486 "kind"
                 - COLON@1486..1487 ":"
                 - WHITESPACE@1487..1488 " "
-                - NON_NULL_TYPE@1488..1502
+                - NON_NULL_TYPE@1488..1499
                     - NAMED_TYPE@1488..1498
                         - NAME@1488..1498
                             - IDENT@1488..1498 "__TypeKind"
                     - BANG@1498..1499 "!"
-                    - WHITESPACE@1499..1502 "\n  "
+                - WHITESPACE@1499..1502 "\n  "
             - FIELD_DEFINITION@1502..1517
                 - NAME@1502..1506
                     - IDENT@1502..1506 "name"
@@ -613,11 +613,11 @@
                     - IDENT@1517..1528 "description"
                 - COLON@1528..1529 ":"
                 - WHITESPACE@1529..1530 " "
-                - NAMED_TYPE@1530..1599
-                    - COMMENT@1530..1590 "# must be non-null for OBJECT and INTERFACE, otherwise null."
-                    - WHITESPACE@1590..1593 "\n  "
-                    - NAME@1593..1599
-                        - IDENT@1593..1599 "String"
+                - NAMED_TYPE@1530..1536
+                    - NAME@1530..1536
+                        - IDENT@1530..1536 "String"
+                - WHITESPACE@1536..1539 "\n  "
+                - COMMENT@1539..1599 "# must be non-null for OBJECT and INTERFACE, otherwise null."
                 - WHITESPACE@1599..1602 "\n  "
             - FIELD_DEFINITION@1602..1722
                 - NAME@1602..1608
@@ -641,48 +641,48 @@
                     - R_PAREN@1643..1644 ")"
                 - COLON@1644..1645 ":"
                 - WHITESPACE@1645..1646 " "
-                - LIST_TYPE@1646..1719
-                    - COMMENT@1646..1706 "# must be non-null for OBJECT and INTERFACE, otherwise null."
-                    - WHITESPACE@1706..1709 "\n  "
-                    - L_BRACK@1709..1710 "["
-                    - NON_NULL_TYPE@1710..1718
-                        - NAMED_TYPE@1710..1717
-                            - NAME@1710..1717
-                                - IDENT@1710..1717 "__Field"
-                        - BANG@1717..1718 "!"
-                    - R_BRACK@1718..1719 "]"
+                - LIST_TYPE@1646..1656
+                    - L_BRACK@1646..1647 "["
+                    - NON_NULL_TYPE@1647..1655
+                        - NAMED_TYPE@1647..1654
+                            - NAME@1647..1654
+                                - IDENT@1647..1654 "__Field"
+                        - BANG@1654..1655 "!"
+                    - R_BRACK@1655..1656 "]"
+                - WHITESPACE@1656..1659 "\n  "
+                - COMMENT@1659..1719 "# must be non-null for OBJECT and INTERFACE, otherwise null."
                 - WHITESPACE@1719..1722 "\n  "
             - FIELD_DEFINITION@1722..1808
                 - NAME@1722..1732
                     - IDENT@1722..1732 "interfaces"
                 - COLON@1732..1733 ":"
                 - WHITESPACE@1733..1734 " "
-                - LIST_TYPE@1734..1805
-                    - COMMENT@1734..1793 "# must be non-null for INTERFACE and UNION, otherwise null."
-                    - WHITESPACE@1793..1796 "\n  "
-                    - L_BRACK@1796..1797 "["
-                    - NON_NULL_TYPE@1797..1804
-                        - NAMED_TYPE@1797..1803
-                            - NAME@1797..1803
-                                - IDENT@1797..1803 "__Type"
-                        - BANG@1803..1804 "!"
-                    - R_BRACK@1804..1805 "]"
+                - LIST_TYPE@1734..1743
+                    - L_BRACK@1734..1735 "["
+                    - NON_NULL_TYPE@1735..1742
+                        - NAMED_TYPE@1735..1741
+                            - NAME@1735..1741
+                                - IDENT@1735..1741 "__Type"
+                        - BANG@1741..1742 "!"
+                    - R_BRACK@1742..1743 "]"
+                - WHITESPACE@1743..1746 "\n  "
+                - COMMENT@1746..1805 "# must be non-null for INTERFACE and UNION, otherwise null."
                 - WHITESPACE@1805..1808 "\n  "
             - FIELD_DEFINITION@1808..1882
                 - NAME@1808..1821
                     - IDENT@1808..1821 "possibleTypes"
                 - COLON@1821..1822 ":"
                 - WHITESPACE@1822..1823 " "
-                - LIST_TYPE@1823..1879
-                    - COMMENT@1823..1867 "# must be non-null for ENUM, otherwise null."
-                    - WHITESPACE@1867..1870 "\n  "
-                    - L_BRACK@1870..1871 "["
-                    - NON_NULL_TYPE@1871..1878
-                        - NAMED_TYPE@1871..1877
-                            - NAME@1871..1877
-                                - IDENT@1871..1877 "__Type"
-                        - BANG@1877..1878 "!"
-                    - R_BRACK@1878..1879 "]"
+                - LIST_TYPE@1823..1832
+                    - L_BRACK@1823..1824 "["
+                    - NON_NULL_TYPE@1824..1831
+                        - NAMED_TYPE@1824..1830
+                            - NAME@1824..1830
+                                - IDENT@1824..1830 "__Type"
+                        - BANG@1830..1831 "!"
+                    - R_BRACK@1831..1832 "]"
+                - WHITESPACE@1832..1835 "\n  "
+                - COMMENT@1835..1879 "# must be non-null for ENUM, otherwise null."
                 - WHITESPACE@1879..1882 "\n  "
             - FIELD_DEFINITION@1882..2002
                 - NAME@1882..1892
@@ -706,43 +706,43 @@
                     - R_PAREN@1927..1928 ")"
                 - COLON@1928..1929 ":"
                 - WHITESPACE@1929..1930 " "
-                - LIST_TYPE@1930..1999
-                    - COMMENT@1930..1982 "# must be non-null for INPUT_OBJECT, otherwise null."
-                    - WHITESPACE@1982..1985 "\n  "
-                    - L_BRACK@1985..1986 "["
-                    - NON_NULL_TYPE@1986..1998
-                        - NAMED_TYPE@1986..1997
-                            - NAME@1986..1997
-                                - IDENT@1986..1997 "__EnumValue"
-                        - BANG@1997..1998 "!"
-                    - R_BRACK@1998..1999 "]"
+                - LIST_TYPE@1930..1944
+                    - L_BRACK@1930..1931 "["
+                    - NON_NULL_TYPE@1931..1943
+                        - NAMED_TYPE@1931..1942
+                            - NAME@1931..1942
+                                - IDENT@1931..1942 "__EnumValue"
+                        - BANG@1942..1943 "!"
+                    - R_BRACK@1943..1944 "]"
+                - WHITESPACE@1944..1947 "\n  "
+                - COMMENT@1947..1999 "# must be non-null for INPUT_OBJECT, otherwise null."
                 - WHITESPACE@1999..2002 "\n  "
             - FIELD_DEFINITION@2002..2093
                 - NAME@2002..2013
                     - IDENT@2002..2013 "inputFields"
                 - COLON@2013..2014 ":"
                 - WHITESPACE@2014..2015 " "
-                - LIST_TYPE@2015..2090
-                    - COMMENT@2015..2072 "# must be non-null for NON_NULL and LIST, otherwise null."
-                    - WHITESPACE@2072..2075 "\n  "
-                    - L_BRACK@2075..2076 "["
-                    - NON_NULL_TYPE@2076..2089
-                        - NAMED_TYPE@2076..2088
-                            - NAME@2076..2088
-                                - IDENT@2076..2088 "__InputValue"
-                        - BANG@2088..2089 "!"
-                    - R_BRACK@2089..2090 "]"
+                - LIST_TYPE@2015..2030
+                    - L_BRACK@2015..2016 "["
+                    - NON_NULL_TYPE@2016..2029
+                        - NAMED_TYPE@2016..2028
+                            - NAME@2016..2028
+                                - IDENT@2016..2028 "__InputValue"
+                        - BANG@2028..2029 "!"
+                    - R_BRACK@2029..2030 "]"
+                - WHITESPACE@2030..2033 "\n  "
+                - COMMENT@2033..2090 "# must be non-null for NON_NULL and LIST, otherwise null."
                 - WHITESPACE@2090..2093 "\n  "
             - FIELD_DEFINITION@2093..2165
                 - NAME@2093..2099
                     - IDENT@2093..2099 "ofType"
                 - COLON@2099..2100 ":"
                 - WHITESPACE@2100..2101 " "
-                - NAMED_TYPE@2101..2162
-                    - COMMENT@2101..2153 "# may be non-null for custom SCALAR, otherwise null."
-                    - WHITESPACE@2153..2156 "\n  "
-                    - NAME@2156..2162
-                        - IDENT@2156..2162 "__Type"
+                - NAMED_TYPE@2101..2107
+                    - NAME@2101..2107
+                        - IDENT@2101..2107 "__Type"
+                - WHITESPACE@2107..2110 "\n  "
+                - COMMENT@2110..2162 "# may be non-null for custom SCALAR, otherwise null."
                 - WHITESPACE@2162..2165 "\n  "
             - FIELD_DEFINITION@2165..2188
                 - NAME@2165..2179
@@ -820,12 +820,12 @@
                     - IDENT@2307..2311 "name"
                 - COLON@2311..2312 ":"
                 - WHITESPACE@2312..2313 " "
-                - NON_NULL_TYPE@2313..2323
+                - NON_NULL_TYPE@2313..2320
                     - NAMED_TYPE@2313..2319
                         - NAME@2313..2319
                             - IDENT@2313..2319 "String"
                     - BANG@2319..2320 "!"
-                    - WHITESPACE@2320..2323 "\n  "
+                - WHITESPACE@2320..2323 "\n  "
             - FIELD_DEFINITION@2323..2345
                 - NAME@2323..2334
                     - IDENT@2323..2334 "description"
@@ -840,7 +840,7 @@
                     - IDENT@2345..2349 "args"
                 - COLON@2349..2350 ":"
                 - WHITESPACE@2350..2351 " "
-                - NON_NULL_TYPE@2351..2370
+                - NON_NULL_TYPE@2351..2367
                     - LIST_TYPE@2351..2366
                         - L_BRACK@2351..2352 "["
                         - NON_NULL_TYPE@2352..2365
@@ -850,29 +850,29 @@
                             - BANG@2364..2365 "!"
                         - R_BRACK@2365..2366 "]"
                     - BANG@2366..2367 "!"
-                    - WHITESPACE@2367..2370 "\n  "
+                - WHITESPACE@2367..2370 "\n  "
             - FIELD_DEFINITION@2370..2386
                 - NAME@2370..2374
                     - IDENT@2370..2374 "type"
                 - COLON@2374..2375 ":"
                 - WHITESPACE@2375..2376 " "
-                - NON_NULL_TYPE@2376..2386
+                - NON_NULL_TYPE@2376..2383
                     - NAMED_TYPE@2376..2382
                         - NAME@2376..2382
                             - IDENT@2376..2382 "__Type"
                     - BANG@2382..2383 "!"
-                    - WHITESPACE@2383..2386 "\n  "
+                - WHITESPACE@2383..2386 "\n  "
             - FIELD_DEFINITION@2386..2411
                 - NAME@2386..2398
                     - IDENT@2386..2398 "isDeprecated"
                 - COLON@2398..2399 ":"
                 - WHITESPACE@2399..2400 " "
-                - NON_NULL_TYPE@2400..2411
+                - NON_NULL_TYPE@2400..2408
                     - NAMED_TYPE@2400..2407
                         - NAME@2400..2407
                             - IDENT@2400..2407 "Boolean"
                     - BANG@2407..2408 "!"
-                    - WHITESPACE@2408..2411 "\n  "
+                - WHITESPACE@2408..2411 "\n  "
             - FIELD_DEFINITION@2411..2437
                 - NAME@2411..2428
                     - IDENT@2411..2428 "deprecationReason"
@@ -898,12 +898,12 @@
                     - IDENT@2462..2466 "name"
                 - COLON@2466..2467 ":"
                 - WHITESPACE@2467..2468 " "
-                - NON_NULL_TYPE@2468..2478
+                - NON_NULL_TYPE@2468..2475
                     - NAMED_TYPE@2468..2474
                         - NAME@2468..2474
                             - IDENT@2468..2474 "String"
                     - BANG@2474..2475 "!"
-                    - WHITESPACE@2475..2478 "\n  "
+                - WHITESPACE@2475..2478 "\n  "
             - FIELD_DEFINITION@2478..2500
                 - NAME@2478..2489
                     - IDENT@2478..2489 "description"
@@ -918,12 +918,12 @@
                     - IDENT@2500..2504 "type"
                 - COLON@2504..2505 ":"
                 - WHITESPACE@2505..2506 " "
-                - NON_NULL_TYPE@2506..2516
+                - NON_NULL_TYPE@2506..2513
                     - NAMED_TYPE@2506..2512
                         - NAME@2506..2512
                             - IDENT@2506..2512 "__Type"
                     - BANG@2512..2513 "!"
-                    - WHITESPACE@2513..2516 "\n  "
+                - WHITESPACE@2513..2516 "\n  "
             - FIELD_DEFINITION@2516..2537
                 - NAME@2516..2528
                     - IDENT@2516..2528 "defaultValue"
@@ -949,12 +949,12 @@
                     - IDENT@2561..2565 "name"
                 - COLON@2565..2566 ":"
                 - WHITESPACE@2566..2567 " "
-                - NON_NULL_TYPE@2567..2577
+                - NON_NULL_TYPE@2567..2574
                     - NAMED_TYPE@2567..2573
                         - NAME@2567..2573
                             - IDENT@2567..2573 "String"
                     - BANG@2573..2574 "!"
-                    - WHITESPACE@2574..2577 "\n  "
+                - WHITESPACE@2574..2577 "\n  "
             - FIELD_DEFINITION@2577..2599
                 - NAME@2577..2588
                     - IDENT@2577..2588 "description"
@@ -969,12 +969,12 @@
                     - IDENT@2599..2611 "isDeprecated"
                 - COLON@2611..2612 ":"
                 - WHITESPACE@2612..2613 " "
-                - NON_NULL_TYPE@2613..2624
+                - NON_NULL_TYPE@2613..2621
                     - NAMED_TYPE@2613..2620
                         - NAME@2613..2620
                             - IDENT@2613..2620 "Boolean"
                     - BANG@2620..2621 "!"
-                    - WHITESPACE@2621..2624 "\n  "
+                - WHITESPACE@2621..2624 "\n  "
             - FIELD_DEFINITION@2624..2650
                 - NAME@2624..2641
                     - IDENT@2624..2641 "deprecationReason"
@@ -1000,12 +1000,12 @@
                     - IDENT@2674..2678 "name"
                 - COLON@2678..2679 ":"
                 - WHITESPACE@2679..2680 " "
-                - NON_NULL_TYPE@2680..2690
+                - NON_NULL_TYPE@2680..2687
                     - NAMED_TYPE@2680..2686
                         - NAME@2680..2686
                             - IDENT@2680..2686 "String"
                     - BANG@2686..2687 "!"
-                    - WHITESPACE@2687..2690 "\n  "
+                - WHITESPACE@2687..2690 "\n  "
             - FIELD_DEFINITION@2690..2712
                 - NAME@2690..2701
                     - IDENT@2690..2701 "description"
@@ -1020,7 +1020,7 @@
                     - IDENT@2712..2721 "locations"
                 - COLON@2721..2722 ":"
                 - WHITESPACE@2722..2723 " "
-                - NON_NULL_TYPE@2723..2749
+                - NON_NULL_TYPE@2723..2746
                     - LIST_TYPE@2723..2745
                         - L_BRACK@2723..2724 "["
                         - NON_NULL_TYPE@2724..2744
@@ -1030,13 +1030,13 @@
                             - BANG@2743..2744 "!"
                         - R_BRACK@2744..2745 "]"
                     - BANG@2745..2746 "!"
-                    - WHITESPACE@2746..2749 "\n  "
+                - WHITESPACE@2746..2749 "\n  "
             - FIELD_DEFINITION@2749..2774
                 - NAME@2749..2753
                     - IDENT@2749..2753 "args"
                 - COLON@2753..2754 ":"
                 - WHITESPACE@2754..2755 " "
-                - NON_NULL_TYPE@2755..2774
+                - NON_NULL_TYPE@2755..2771
                     - LIST_TYPE@2755..2770
                         - L_BRACK@2755..2756 "["
                         - NON_NULL_TYPE@2756..2769
@@ -1046,18 +1046,18 @@
                             - BANG@2768..2769 "!"
                         - R_BRACK@2769..2770 "]"
                     - BANG@2770..2771 "!"
-                    - WHITESPACE@2771..2774 "\n  "
+                - WHITESPACE@2771..2774 "\n  "
             - FIELD_DEFINITION@2774..2797
                 - NAME@2774..2786
                     - IDENT@2774..2786 "isRepeatable"
                 - COLON@2786..2787 ":"
                 - WHITESPACE@2787..2788 " "
-                - NON_NULL_TYPE@2788..2797
+                - NON_NULL_TYPE@2788..2796
                     - NAMED_TYPE@2788..2795
                         - NAME@2788..2795
                             - IDENT@2788..2795 "Boolean"
                     - BANG@2795..2796 "!"
-                    - WHITESPACE@2796..2797 "\n"
+                - WHITESPACE@2796..2797 "\n"
             - R_CURLY@2797..2798 "}"
             - WHITESPACE@2798..2800 "\n\n"
     - ENUM_TYPE_DEFINITION@2800..3098

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
@@ -141,13 +141,13 @@
                     - IDENT@347..352 "graph"
                 - COLON@352..353 ":"
                 - WHITESPACE@353..354 " "
-                - NON_NULL_TYPE@354..368
+                - NON_NULL_TYPE@354..366
                     - NAMED_TYPE@354..365
                         - NAME@354..365
                             - IDENT@354..365 "join__Graph"
                     - BANG@365..366 "!"
-                    - COMMA@366..367 ","
-                    - WHITESPACE@367..368 " "
+                - COMMA@366..367 ","
+                - WHITESPACE@367..368 " "
             - INPUT_VALUE_DEFINITION@368..387
                 - NAME@368..371
                     - IDENT@368..371 "key"
@@ -215,13 +215,13 @@
                     - IDENT@511..515 "name"
                 - COLON@515..516 ":"
                 - WHITESPACE@516..517 " "
-                - NON_NULL_TYPE@517..526
+                - NON_NULL_TYPE@517..524
                     - NAMED_TYPE@517..523
                         - NAME@517..523
                             - IDENT@517..523 "String"
                     - BANG@523..524 "!"
-                    - COMMA@524..525 ","
-                    - WHITESPACE@525..526 " "
+                - COMMA@524..525 ","
+                - WHITESPACE@525..526 " "
             - INPUT_VALUE_DEFINITION@526..538
                 - NAME@526..529
                     - IDENT@526..529 "url"
@@ -475,12 +475,12 @@
                     - IDENT@964..968 "isbn"
                 - COLON@968..969 ":"
                 - WHITESPACE@969..970 " "
-                - NON_NULL_TYPE@970..978
+                - NON_NULL_TYPE@970..977
                     - NAMED_TYPE@970..976
                         - NAME@970..976
                             - IDENT@970..976 "String"
                     - BANG@976..977 "!"
-                    - WHITESPACE@977..978 " "
+                - WHITESPACE@977..978 " "
                 - DIRECTIVES@978..1007
                     - DIRECTIVE@978..1007
                         - AT@978..979 "@"
@@ -555,7 +555,7 @@
                     - IDENT@1089..1101 "similarBooks"
                 - COLON@1101..1102 ":"
                 - WHITESPACE@1102..1103 " "
-                - NON_NULL_TYPE@1103..1111
+                - NON_NULL_TYPE@1103..1110
                     - LIST_TYPE@1103..1109
                         - L_BRACK@1103..1104 "["
                         - NAMED_TYPE@1104..1108
@@ -563,7 +563,7 @@
                                 - IDENT@1104..1108 "Book"
                         - R_BRACK@1108..1109 "]"
                     - BANG@1109..1110 "!"
-                    - WHITESPACE@1110..1111 " "
+                - WHITESPACE@1110..1111 " "
                 - DIRECTIVES@1111..1140
                     - DIRECTIVE@1111..1140
                         - AT@1111..1112 "@"
@@ -667,12 +667,12 @@
                     - IDENT@1302..1305 "upc"
                 - COLON@1305..1306 ":"
                 - WHITESPACE@1306..1307 " "
-                - NON_NULL_TYPE@1307..1315
+                - NON_NULL_TYPE@1307..1314
                     - NAMED_TYPE@1307..1313
                         - NAME@1307..1313
                             - IDENT@1307..1313 "String"
                     - BANG@1313..1314 "!"
-                    - WHITESPACE@1314..1315 " "
+                - WHITESPACE@1314..1315 " "
                 - DIRECTIVES@1315..1346
                     - DIRECTIVE@1315..1346
                         - AT@1315..1316 "@"
@@ -695,12 +695,12 @@
                     - IDENT@1346..1349 "sku"
                 - COLON@1349..1350 ":"
                 - WHITESPACE@1350..1351 " "
-                - NON_NULL_TYPE@1351..1359
+                - NON_NULL_TYPE@1351..1358
                     - NAMED_TYPE@1351..1357
                         - NAME@1351..1357
                             - IDENT@1351..1357 "String"
                     - BANG@1357..1358 "!"
-                    - WHITESPACE@1358..1359 " "
+                - WHITESPACE@1358..1359 " "
                 - DIRECTIVES@1359..1390
                     - DIRECTIVE@1359..1390
                         - AT@1359..1360 "@"
@@ -856,7 +856,7 @@
                     - IDENT@1636..1650 "relatedReviews"
                 - COLON@1650..1651 ":"
                 - WHITESPACE@1651..1652 " "
-                - NON_NULL_TYPE@1652..1663
+                - NON_NULL_TYPE@1652..1662
                     - LIST_TYPE@1652..1661
                         - L_BRACK@1652..1653 "["
                         - NON_NULL_TYPE@1653..1660
@@ -866,7 +866,7 @@
                             - BANG@1659..1660 "!"
                         - R_BRACK@1660..1661 "]"
                     - BANG@1661..1662 "!"
-                    - WHITESPACE@1662..1663 " "
+                - WHITESPACE@1662..1663 " "
                 - DIRECTIVES@1663..1724
                     - DIRECTIVE@1663..1724
                         - AT@1663..1664 "@"
@@ -1002,12 +1002,12 @@
                     - IDENT@1895..1897 "id"
                 - COLON@1897..1898 ":"
                 - WHITESPACE@1898..1899 " "
-                - NON_NULL_TYPE@1899..1907
+                - NON_NULL_TYPE@1899..1906
                     - NAMED_TYPE@1899..1905
                         - NAME@1899..1905
                             - IDENT@1899..1905 "String"
                     - BANG@1905..1906 "!"
-                    - WHITESPACE@1906..1907 " "
+                - WHITESPACE@1906..1907 " "
                 - DIRECTIVES@1907..1938
                     - DIRECTIVE@1907..1938
                         - AT@1907..1908 "@"
@@ -1281,12 +1281,12 @@
                     - IDENT@2380..2383 "upc"
                 - COLON@2383..2384 ":"
                 - WHITESPACE@2384..2385 " "
-                - NON_NULL_TYPE@2385..2393
+                - NON_NULL_TYPE@2385..2392
                     - NAMED_TYPE@2385..2391
                         - NAME@2385..2391
                             - IDENT@2385..2391 "String"
                     - BANG@2391..2392 "!"
-                    - WHITESPACE@2392..2393 " "
+                - WHITESPACE@2392..2393 " "
                 - DIRECTIVES@2393..2424
                     - DIRECTIVE@2393..2424
                         - AT@2393..2394 "@"
@@ -1309,12 +1309,12 @@
                     - IDENT@2424..2427 "sku"
                 - COLON@2427..2428 ":"
                 - WHITESPACE@2428..2429 " "
-                - NON_NULL_TYPE@2429..2437
+                - NON_NULL_TYPE@2429..2436
                     - NAMED_TYPE@2429..2435
                         - NAME@2429..2435
                             - IDENT@2429..2435 "String"
                     - BANG@2435..2436 "!"
-                    - WHITESPACE@2436..2437 " "
+                - WHITESPACE@2436..2437 " "
                 - DIRECTIVES@2437..2468
                     - DIRECTIVE@2437..2468
                         - AT@2437..2438 "@"
@@ -1589,23 +1589,23 @@
                     - IDENT@2940..2944 "name"
                 - COLON@2944..2945 ":"
                 - WHITESPACE@2945..2946 " "
-                - NON_NULL_TYPE@2946..2956
+                - NON_NULL_TYPE@2946..2953
                     - NAMED_TYPE@2946..2952
                         - NAME@2946..2952
                             - IDENT@2946..2952 "String"
                     - BANG@2952..2953 "!"
-                    - WHITESPACE@2953..2956 "\n  "
+                - WHITESPACE@2953..2956 "\n  "
             - FIELD_DEFINITION@2956..2985
                 - NAME@2956..2966
                     - IDENT@2956..2966 "attributes"
                 - COLON@2966..2967 ":"
                 - WHITESPACE@2967..2968 " "
-                - NON_NULL_TYPE@2968..2985
+                - NON_NULL_TYPE@2968..2984
                     - NAMED_TYPE@2968..2983
                         - NAME@2968..2983
                             - IDENT@2968..2983 "ImageAttributes"
                     - BANG@2983..2984 "!"
-                    - WHITESPACE@2984..2985 "\n"
+                - WHITESPACE@2984..2985 "\n"
             - R_CURLY@2985..2986 "}"
             - WHITESPACE@2986..2988 "\n\n"
     - OBJECT_TYPE_DEFINITION@2988..3029
@@ -1622,12 +1622,12 @@
                     - IDENT@3013..3016 "url"
                 - COLON@3016..3017 ":"
                 - WHITESPACE@3017..3018 " "
-                - NON_NULL_TYPE@3018..3026
+                - NON_NULL_TYPE@3018..3025
                     - NAMED_TYPE@3018..3024
                         - NAME@3018..3024
                             - IDENT@3018..3024 "String"
                     - BANG@3024..3025 "!"
-                    - WHITESPACE@3025..3026 "\n"
+                - WHITESPACE@3025..3026 "\n"
             - R_CURLY@3026..3027 "}"
             - WHITESPACE@3027..3029 "\n\n"
     - SCALAR_TYPE_DEFINITION@3029..3099
@@ -1851,23 +1851,23 @@
                     - IDENT@3421..3424 "key"
                 - COLON@3424..3425 ":"
                 - WHITESPACE@3425..3426 " "
-                - NON_NULL_TYPE@3426..3436
+                - NON_NULL_TYPE@3426..3433
                     - NAMED_TYPE@3426..3432
                         - NAME@3426..3432
                             - IDENT@3426..3432 "String"
                     - BANG@3432..3433 "!"
-                    - WHITESPACE@3433..3436 "\n  "
+                - WHITESPACE@3433..3436 "\n  "
             - FIELD_DEFINITION@3436..3451
                 - NAME@3436..3441
                     - IDENT@3436..3441 "value"
                 - COLON@3441..3442 ":"
                 - WHITESPACE@3442..3443 " "
-                - NON_NULL_TYPE@3443..3451
+                - NON_NULL_TYPE@3443..3450
                     - NAMED_TYPE@3443..3449
                         - NAME@3443..3449
                             - IDENT@3443..3449 "String"
                     - BANG@3449..3450 "!"
-                    - WHITESPACE@3450..3451 "\n"
+                - WHITESPACE@3450..3451 "\n"
             - R_CURLY@3451..3452 "}"
             - WHITESPACE@3452..3454 "\n\n"
     - OBJECT_TYPE_DEFINITION@3454..3736
@@ -1951,12 +1951,12 @@
                     - IDENT@3575..3577 "id"
                 - COLON@3577..3578 ":"
                 - WHITESPACE@3578..3579 " "
-                - NON_NULL_TYPE@3579..3583
+                - NON_NULL_TYPE@3579..3582
                     - NAMED_TYPE@3579..3581
                         - NAME@3579..3581
                             - IDENT@3579..3581 "ID"
                     - BANG@3581..3582 "!"
-                    - WHITESPACE@3582..3583 " "
+                - WHITESPACE@3582..3583 " "
                 - DIRECTIVES@3583..3612
                     - DIRECTIVE@3583..3612
                         - AT@3583..3584 "@"
@@ -2010,12 +2010,12 @@
                             - IDENT@3666..3668 "id"
                         - COLON@3668..3669 ":"
                         - WHITESPACE@3669..3670 " "
-                        - NON_NULL_TYPE@3670..3674
+                        - NON_NULL_TYPE@3670..3673
                             - NAMED_TYPE@3670..3672
                                 - NAME@3670..3672
                                     - IDENT@3670..3672 "ID"
                             - BANG@3672..3673 "!"
-                            - WHITESPACE@3673..3674 " "
+                        - WHITESPACE@3673..3674 " "
                         - DEFAULT_VALUE@3674..3677
                             - EQ@3674..3675 "="
                             - WHITESPACE@3675..3676 " "
@@ -2094,13 +2094,13 @@
                             - IDENT@3802..3810 "username"
                         - COLON@3810..3811 ":"
                         - WHITESPACE@3811..3812 " "
-                        - NON_NULL_TYPE@3812..3821
+                        - NON_NULL_TYPE@3812..3819
                             - NAMED_TYPE@3812..3818
                                 - NAME@3812..3818
                                     - IDENT@3812..3818 "String"
                             - BANG@3818..3819 "!"
-                            - COMMA@3819..3820 ","
-                            - WHITESPACE@3820..3821 " "
+                        - COMMA@3819..3820 ","
+                        - WHITESPACE@3820..3821 " "
                     - INPUT_VALUE_DEFINITION@3821..3838
                         - NAME@3821..3829
                             - IDENT@3821..3829 "password"
@@ -2145,13 +2145,13 @@
                             - IDENT@3892..3895 "upc"
                         - COLON@3895..3896 ":"
                         - WHITESPACE@3896..3897 " "
-                        - NON_NULL_TYPE@3897..3906
+                        - NON_NULL_TYPE@3897..3904
                             - NAMED_TYPE@3897..3903
                                 - NAME@3897..3903
                                     - IDENT@3897..3903 "String"
                             - BANG@3903..3904 "!"
-                            - COMMA@3904..3905 ","
-                            - WHITESPACE@3905..3906 " "
+                        - COMMA@3904..3905 ","
+                        - WHITESPACE@3905..3906 " "
                     - INPUT_VALUE_DEFINITION@3906..3919
                         - NAME@3906..3910
                             - IDENT@3906..3910 "body"
@@ -2309,12 +2309,12 @@
                     - IDENT@4176..4180 "name"
                 - COLON@4180..4181 ":"
                 - WHITESPACE@4181..4182 " "
-                - NON_NULL_TYPE@4182..4190
+                - NON_NULL_TYPE@4182..4189
                     - NAMED_TYPE@4182..4188
                         - NAME@4182..4188
                             - IDENT@4182..4188 "String"
                     - BANG@4188..4189 "!"
-                    - WHITESPACE@4189..4190 "\n"
+                - WHITESPACE@4189..4190 "\n"
             - R_CURLY@4190..4191 "}"
             - WHITESPACE@4191..4193 "\n\n"
     - OBJECT_TYPE_DEFINITION@4193..4339
@@ -2373,12 +2373,12 @@
                     - IDENT@4291..4296 "email"
                 - COLON@4296..4297 ":"
                 - WHITESPACE@4297..4298 " "
-                - NON_NULL_TYPE@4298..4306
+                - NON_NULL_TYPE@4298..4305
                     - NAMED_TYPE@4298..4304
                         - NAME@4298..4304
                             - IDENT@4298..4304 "String"
                     - BANG@4304..4305 "!"
-                    - WHITESPACE@4305..4306 " "
+                - WHITESPACE@4305..4306 " "
                 - DIRECTIVES@4306..4336
                     - DIRECTIVE@4306..4336
                         - AT@4306..4307 "@"
@@ -2412,23 +2412,23 @@
                     - IDENT@4361..4364 "upc"
                 - COLON@4364..4365 ":"
                 - WHITESPACE@4365..4366 " "
-                - NON_NULL_TYPE@4366..4376
+                - NON_NULL_TYPE@4366..4373
                     - NAMED_TYPE@4366..4372
                         - NAME@4366..4372
                             - IDENT@4366..4372 "String"
                     - BANG@4372..4373 "!"
-                    - WHITESPACE@4373..4376 "\n  "
+                - WHITESPACE@4373..4376 "\n  "
             - FIELD_DEFINITION@4376..4391
                 - NAME@4376..4379
                     - IDENT@4376..4379 "sku"
                 - COLON@4379..4380 ":"
                 - WHITESPACE@4380..4381 " "
-                - NON_NULL_TYPE@4381..4391
+                - NON_NULL_TYPE@4381..4388
                     - NAMED_TYPE@4381..4387
                         - NAME@4381..4387
                             - IDENT@4381..4387 "String"
                     - BANG@4387..4388 "!"
-                    - WHITESPACE@4388..4391 "\n  "
+                - WHITESPACE@4388..4391 "\n  "
             - FIELD_DEFINITION@4391..4406
                 - NAME@4391..4395
                     - IDENT@4391..4395 "name"
@@ -2757,12 +2757,12 @@
                     - IDENT@4977..4981 "body"
                 - COLON@4981..4982 ":"
                 - WHITESPACE@4982..4983 " "
-                - NON_NULL_TYPE@4983..4989
+                - NON_NULL_TYPE@4983..4988
                     - NAMED_TYPE@4983..4987
                         - NAME@4983..4987
                             - IDENT@4983..4987 "Body"
                     - BANG@4987..4988 "!"
-                    - WHITESPACE@4988..4989 " "
+                - WHITESPACE@4988..4989 " "
                 - DIRECTIVES@4989..5022
                     - DIRECTIVE@4989..5022
                         - AT@4989..4990 "@"
@@ -3054,12 +3054,12 @@
                     - IDENT@5430..5432 "id"
                 - COLON@5432..5433 ":"
                 - WHITESPACE@5433..5434 " "
-                - NON_NULL_TYPE@5434..5438
+                - NON_NULL_TYPE@5434..5437
                     - NAMED_TYPE@5434..5436
                         - NAME@5434..5436
                             - IDENT@5434..5436 "ID"
                     - BANG@5436..5437 "!"
-                    - WHITESPACE@5437..5438 " "
+                - WHITESPACE@5437..5438 " "
                 - DIRECTIVES@5438..5469
                     - DIRECTIVE@5438..5469
                         - AT@5438..5439 "@"
@@ -3312,23 +3312,23 @@
                     - IDENT@5891..5895 "name"
                 - COLON@5895..5896 ":"
                 - WHITESPACE@5896..5897 " "
-                - NON_NULL_TYPE@5897..5907
+                - NON_NULL_TYPE@5897..5904
                     - NAMED_TYPE@5897..5903
                         - NAME@5897..5903
                             - IDENT@5897..5903 "String"
                     - BANG@5903..5904 "!"
-                    - WHITESPACE@5904..5907 "\n  "
+                - WHITESPACE@5904..5907 "\n  "
             - FIELD_DEFINITION@5907..5935
                 - NAME@5907..5917
                     - IDENT@5907..5917 "attributes"
                 - COLON@5917..5918 ":"
                 - WHITESPACE@5918..5919 " "
-                - NON_NULL_TYPE@5919..5935
+                - NON_NULL_TYPE@5919..5934
                     - NAMED_TYPE@5919..5933
                         - NAME@5919..5933
                             - IDENT@5919..5933 "TextAttributes"
                     - BANG@5933..5934 "!"
-                    - WHITESPACE@5934..5935 "\n"
+                - WHITESPACE@5934..5935 "\n"
             - R_CURLY@5935..5936 "}"
             - WHITESPACE@5936..5938 "\n\n"
     - OBJECT_TYPE_DEFINITION@5938..5994
@@ -3393,12 +3393,12 @@
                     - IDENT@6048..6050 "id"
                 - COLON@6050..6051 ":"
                 - WHITESPACE@6051..6052 " "
-                - NON_NULL_TYPE@6052..6058
+                - NON_NULL_TYPE@6052..6055
                     - NAMED_TYPE@6052..6054
                         - NAME@6052..6054
                             - IDENT@6052..6054 "ID"
                     - BANG@6054..6055 "!"
-                    - WHITESPACE@6055..6058 "\n  "
+                - WHITESPACE@6055..6058 "\n  "
             - INPUT_VALUE_DEFINITION@6058..6071
                 - NAME@6058..6062
                     - IDENT@6058..6062 "body"
@@ -3566,12 +3566,12 @@
                     - IDENT@6340..6342 "id"
                 - COLON@6342..6343 ":"
                 - WHITESPACE@6343..6344 " "
-                - NON_NULL_TYPE@6344..6348
+                - NON_NULL_TYPE@6344..6347
                     - NAMED_TYPE@6344..6346
                         - NAME@6344..6346
                             - IDENT@6344..6346 "ID"
                     - BANG@6346..6347 "!"
-                    - WHITESPACE@6347..6348 " "
+                - WHITESPACE@6347..6348 " "
                 - DIRECTIVES@6348..6380
                     - DIRECTIVE@6348..6380
                         - AT@6348..6349 "@"
@@ -3854,12 +3854,12 @@
                     - IDENT@6882..6897 "numberOfReviews"
                 - COLON@6897..6898 ":"
                 - WHITESPACE@6898..6899 " "
-                - NON_NULL_TYPE@6899..6904
+                - NON_NULL_TYPE@6899..6903
                     - NAMED_TYPE@6899..6902
                         - NAME@6899..6902
                             - IDENT@6899..6902 "Int"
                     - BANG@6902..6903 "!"
-                    - WHITESPACE@6903..6904 " "
+                - WHITESPACE@6903..6904 " "
                 - DIRECTIVES@6904..6935
                     - DIRECTIVE@6904..6935
                         - AT@6904..6905 "@"
@@ -4040,12 +4040,12 @@
                     - IDENT@7236..7238 "id"
                 - COLON@7238..7239 ":"
                 - WHITESPACE@7239..7240 " "
-                - NON_NULL_TYPE@7240..7248
+                - NON_NULL_TYPE@7240..7247
                     - NAMED_TYPE@7240..7246
                         - NAME@7240..7246
                             - IDENT@7240..7246 "String"
                     - BANG@7246..7247 "!"
-                    - WHITESPACE@7247..7248 " "
+                - WHITESPACE@7247..7248 " "
                 - DIRECTIVES@7248..7279
                     - DIRECTIVE@7248..7279
                         - AT@7248..7249 "@"
@@ -4166,12 +4166,12 @@
                     - IDENT@7468..7470 "id"
                 - COLON@7470..7471 ":"
                 - WHITESPACE@7471..7472 " "
-                - NON_NULL_TYPE@7472..7482
+                - NON_NULL_TYPE@7472..7479
                     - NAMED_TYPE@7472..7478
                         - NAME@7472..7478
                             - IDENT@7472..7478 "String"
                     - BANG@7478..7479 "!"
-                    - WHITESPACE@7479..7482 "\n  "
+                - WHITESPACE@7479..7482 "\n  "
             - FIELD_DEFINITION@7482..7504
                 - NAME@7482..7493
                     - IDENT@7482..7493 "description"

--- a/crates/apollo-parser/src/parser/grammar/name.rs
+++ b/crates/apollo-parser/src/parser/grammar/name.rs
@@ -8,14 +8,14 @@ pub(crate) fn name(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::NAME);
     match p.peek() {
         Some(TokenKind::Name) => {
-            validate_name(p.peek_data().unwrap(), p);
+            validate_name(&p.peek_data().unwrap(), p);
             p.bump(SyntaxKind::IDENT);
         }
         _ => p.err("expected a Name"),
     }
 }
 
-pub(crate) fn validate_name(name: String, p: &mut Parser) {
+pub(crate) fn validate_name(name: &str, p: &mut Parser) {
     if !name.starts_with(is_start_char) {
         p.err_and_pop("expected Name to start with a letter or an _");
     }

--- a/crates/apollo-parser/src/parser/grammar/ty.rs
+++ b/crates/apollo-parser/src/parser/grammar/ty.rs
@@ -20,27 +20,9 @@ use crate::{parser::grammar::name, Parser, SyntaxKind, Token, TokenKind, S, T};
 // created in the processing stage of this parsing rule.
 pub(crate) fn ty(p: &mut Parser) {
     match parse(p) {
-        Ok(ty) => process(ty, p),
+        Ok(_) => (),
         Err(token) => p.err_at_token(&token, "expected a type"),
     }
-}
-
-#[derive(Debug)]
-enum TokenTy {
-    List {
-        nullable: Option<Token>,
-        open_token: Token,
-        close_token: Option<Token>,
-        inner: Option<Box<TokenTy>>,
-        comma: Option<Token>,
-        trailing_ws: Option<Token>,
-    },
-    Named {
-        nullable: Option<Token>,
-        token: Token,
-        comma: Option<Token>,
-        trailing_ws: Option<Token>,
-    },
 }
 
 /// Returns the type on success, or the TokenKind that caused an error.
@@ -48,143 +30,49 @@ enum TokenTy {
 /// When errors occur deeper inside nested types like lists, this function
 /// pushes errors *inside* the list to the parser, and returns an Ok() with
 /// an incomplete type.
-fn parse(p: &mut Parser) -> Result<TokenTy, Token> {
-    let token = p.pop();
-    let mut types = match token.kind() {
-        T!['['] => {
-            let inner = match parse(p) {
-                Ok(ty) => Some(Box::new(ty)),
-                Err(token) => {
-                    // TODO(@goto-bus-stop) ideally the span here would point to the entire list
-                    // type, so both opening and closing brackets `[]`.
-                    p.err_at_token(&token, "expected item type");
-                    None
-                }
-            };
-            let close_token = if let Some(T![']']) = p.peek() {
-                Some(p.pop())
-            } else {
-                None
-            };
-
-            TokenTy::List {
-                inner,
-                open_token: token,
-                close_token,
-                nullable: None,
-                comma: None,
-                trailing_ws: None,
+fn parse(p: &mut Parser) -> Result<(), Token> {
+    let checkpoint = p.checkpoint_node();
+    match p.peek() {
+        Some(T!['[']) => {
+            let _guard = p.start_node(SyntaxKind::LIST_TYPE);
+            p.eat(S!['[']);
+            if let Err(token) = parse(p) {
+                // TODO(@goto-bus-stop) ideally the span here would point to the entire list
+                // type, so both opening and closing brackets `[]`.
+                p.err_at_token(&token, "expected item type");
+            }
+            if let Some(T![']']) = p.peek() {
+                p.eat(S![']']);
             }
         }
-        TokenKind::Name => TokenTy::Named {
-            token,
-            nullable: None,
-            comma: None,
-            trailing_ws: None,
-        },
-        _ => return Err(token),
+        Some(TokenKind::Name) => {
+            let _guard = p.start_node(SyntaxKind::NAMED_TYPE);
+            let _name_node_guard = p.start_node(SyntaxKind::NAME);
+
+            let token = p.pop();
+            name::validate_name(token.data(), p);
+            p.push_ast(SyntaxKind::IDENT, token);
+        }
+        _ => return Err(p.pop()),
     };
 
     // Deal with nullable types
     if let Some(T![!]) = p.peek() {
-        match &mut types {
-            TokenTy::List { nullable, .. } => nullable.replace(p.pop()),
-            TokenTy::Named { nullable, .. } => nullable.replace(p.pop()),
-        };
+        let _guard = checkpoint.wrap_node(SyntaxKind::NON_NULL_TYPE);
+
+        p.eat(S![!]);
     }
 
     // deal with ignored tokens
     if let Some(T![,]) = p.peek() {
-        match &mut types {
-            TokenTy::List { comma, .. } => comma.replace(p.pop()),
-            TokenTy::Named { comma, .. } => comma.replace(p.pop()),
-        };
+        p.eat(S![,]);
     }
 
     if let Some(TokenKind::Whitespace) = p.peek() {
-        match &mut types {
-            TokenTy::List { trailing_ws, .. } => trailing_ws.replace(p.pop()),
-            TokenTy::Named { trailing_ws, .. } => trailing_ws.replace(p.pop()),
-        };
+        p.eat(SyntaxKind::WHITESPACE);
     }
 
-    Ok(types)
-}
-
-fn process(ty: TokenTy, p: &mut Parser) {
-    match ty {
-        TokenTy::List {
-            nullable,
-            open_token,
-            close_token,
-            inner,
-            comma,
-            trailing_ws,
-        } => match nullable {
-            Some(nullable_token) => {
-                let _non_null_g = p.start_node(SyntaxKind::NON_NULL_TYPE);
-                process_list(p, open_token, inner, close_token);
-                p.push_ast(S![!], nullable_token);
-                process_ignored_tokens(comma, p, trailing_ws);
-            }
-            None => {
-                process_list(p, open_token, inner, close_token);
-                process_ignored_tokens(comma, p, trailing_ws);
-            }
-        },
-        TokenTy::Named {
-            nullable,
-            token,
-            comma,
-            trailing_ws,
-        } => match nullable {
-            Some(nullable_token) => {
-                let _non_null_g = p.start_node(SyntaxKind::NON_NULL_TYPE);
-                process_named(p, token);
-
-                p.push_ast(S![!], nullable_token);
-                process_ignored_tokens(comma, p, trailing_ws);
-            }
-            None => {
-                process_named(p, token);
-                process_ignored_tokens(comma, p, trailing_ws);
-            }
-        },
-    }
-}
-
-fn process_ignored_tokens(comma: Option<Token>, p: &mut Parser, whitespace: Option<Token>) {
-    if let Some(comma_token) = comma {
-        p.push_ast(SyntaxKind::COMMA, comma_token);
-    }
-    if let Some(ws_token) = whitespace {
-        p.push_ast(SyntaxKind::WHITESPACE, ws_token);
-    }
-}
-
-fn process_list(
-    p: &mut Parser,
-    open_token: Token,
-    inner: Option<Box<TokenTy>>,
-    close_token: Option<Token>,
-) {
-    let _list_g = p.start_node(SyntaxKind::LIST_TYPE);
-    p.push_ast(S!['['], open_token);
-    if let Some(inner) = inner {
-        process(*inner, p);
-    }
-    if let Some(close_token) = close_token {
-        p.push_ast(S![']'], close_token);
-    }
-}
-
-fn process_named(p: &mut Parser, token: Token) {
-    let named_g = p.start_node(SyntaxKind::NAMED_TYPE);
-    let name_g = p.start_node(SyntaxKind::NAME);
-    name::validate_name(token.data().to_string(), p);
-    p.push_ast(SyntaxKind::IDENT, token);
-    name_g.finish_node();
-    named_g.finish_node();
+    Ok(())
 }
 
 /// See: https://spec.graphql.org/October2021/#NamedType

--- a/crates/apollo-parser/src/parser/grammar/ty.rs
+++ b/crates/apollo-parser/src/parser/grammar/ty.rs
@@ -35,7 +35,7 @@ fn parse(p: &mut Parser) -> Result<(), Token> {
     match p.peek() {
         Some(T!['[']) => {
             let _guard = p.start_node(SyntaxKind::LIST_TYPE);
-            p.eat(S!['[']);
+            p.bump(S!['[']);
             if let Err(token) = parse(p) {
                 // TODO(@goto-bus-stop) ideally the span here would point to the entire list
                 // type, so both opening and closing brackets `[]`.
@@ -56,6 +56,9 @@ fn parse(p: &mut Parser) -> Result<(), Token> {
         _ => return Err(p.pop()),
     };
 
+    // There may be whitespace inside a list node or between the type and the non-null `!`.
+    p.bump_ignored();
+
     // Deal with nullable types
     if let Some(T![!]) = p.peek() {
         let _guard = checkpoint.wrap_node(SyntaxKind::NON_NULL_TYPE);
@@ -64,6 +67,8 @@ fn parse(p: &mut Parser) -> Result<(), Token> {
     }
 
     // Handle post-node commas, whitespace, comments
+    // TODO(@goto-bus-stop) This should maybe be done further up the parse tree? the type node is
+    // parsed completely at this point.
     p.bump_ignored();
 
     Ok(())

--- a/crates/apollo-parser/src/parser/grammar/ty.rs
+++ b/crates/apollo-parser/src/parser/grammar/ty.rs
@@ -63,14 +63,8 @@ fn parse(p: &mut Parser) -> Result<(), Token> {
         p.eat(S![!]);
     }
 
-    // deal with ignored tokens
-    if let Some(T![,]) = p.peek() {
-        p.eat(S![,]);
-    }
-
-    if let Some(TokenKind::Whitespace) = p.peek() {
-        p.eat(SyntaxKind::WHITESPACE);
-    }
+    // Handle post-node commas, whitespace, comments
+    p.bump_ignored();
 
     Ok(())
 }

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -327,6 +327,8 @@ impl<'a> Parser<'a> {
         guard
     }
 
+    /// Set a checkpoint for *maybe* wrapping the following parse tree in some
+    /// other node.
     pub(crate) fn checkpoint_node(&self) -> Checkpoint {
         let checkpoint = self.builder.borrow().checkpoint();
         Checkpoint::new(self.builder.clone(), checkpoint)
@@ -399,6 +401,7 @@ impl Drop for NodeGuard {
     }
 }
 
+/// A rowan Checkpoint that can self-close the new wrapper node if required.
 pub(crate) struct Checkpoint {
     builder: Rc<RefCell<SyntaxTreeBuilder>>,
     checkpoint: rowan::Checkpoint,
@@ -412,6 +415,9 @@ impl Checkpoint {
         }
     }
 
+    /// Wrap the nodes that were parsed since setting this checkpoint in a new parent node of kind
+    /// `kind`. Returns a NodeGuard that when dropped, finishes this new parent node. More children
+    /// can be added to this new node in the mean time.
     pub(crate) fn wrap_node(self, kind: SyntaxKind) -> NodeGuard {
         self.builder.borrow_mut().wrap_node(self.checkpoint, kind);
         NodeGuard::new(self.builder)

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -328,7 +328,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn checkpoint_node(&self) -> Checkpoint {
-        let checkpoint = self.builder.borrow_mut().checkpoint();
+        let checkpoint = self.builder.borrow().checkpoint();
         Checkpoint::new(self.builder.clone(), checkpoint)
     }
 

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -529,11 +529,11 @@ mod tests {
                       R_PAREN@70..71 ")"
                     COLON@71..72 ":"
                     WHITESPACE@72..73 " "
-                    NAMED_TYPE@73..96
-                      COMMENT@73..93 "# limit reached here"
-                      NAME@93..96
-                        IDENT@93..96 "Int"
-                    WHITESPACE@96..113 "\n                "
+                    NAMED_TYPE@73..76
+                      NAME@73..76
+                        IDENT@73..76 "Int"
+                    WHITESPACE@76..93 "\n                "
+                    COMMENT@93..113 "# limit reached here"
         "##]];
         tree.assert_eq(&format!("{:#?}", ast.document().syntax));
     }

--- a/crates/apollo-parser/src/parser/syntax_tree.rs
+++ b/crates/apollo-parser/src/parser/syntax_tree.rs
@@ -132,6 +132,10 @@ impl SyntaxTreeBuilder {
         }
     }
 
+    pub(crate) fn checkpoint(&self) -> rowan::Checkpoint {
+        self.builder.checkpoint()
+    }
+
     /// Start new node and make it current.
     pub(crate) fn start_node(&mut self, kind: SyntaxKind) {
         self.builder.start_node(rowan::SyntaxKind(kind as u16));
@@ -140,6 +144,11 @@ impl SyntaxTreeBuilder {
     /// Finish current branch and restore previous branch as current.
     pub(crate) fn finish_node(&mut self) {
         self.builder.finish_node();
+    }
+
+    pub(crate) fn wrap_node(&mut self, checkpoint: rowan::Checkpoint, kind: SyntaxKind) {
+        self.builder
+            .start_node_at(checkpoint, rowan::SyntaxKind(kind as u16));
     }
 
     /// Adds new token to the current branch.

--- a/crates/apollo-parser/test_data/parser/err/0010_input_definition_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0010_input_definition_with_missing_name.txt
@@ -19,12 +19,12 @@
                     - IDENT@26..27 "b"
                 - COLON@27..28 ":"
                 - WHITESPACE@28..29 " "
-                - NON_NULL_TYPE@29..34
+                - NON_NULL_TYPE@29..33
                     - NAMED_TYPE@29..32
                         - NAME@29..32
                             - IDENT@29..32 "Int"
                     - BANG@32..33 "!"
-                    - WHITESPACE@33..34 "\n"
+                - WHITESPACE@33..34 "\n"
             - R_CURLY@34..35 "}"
 - ERROR@6:7 "expected a Name" {
 recursion limit: 4096, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0033_directive_with_erronous_string_value.txt
+++ b/crates/apollo-parser/test_data/parser/err/0033_directive_with_erronous_string_value.txt
@@ -59,12 +59,12 @@
                     - IDENT@110..112 "id"
                 - COLON@112..113 ":"
                 - WHITESPACE@113..114 " "
-                - NON_NULL_TYPE@114..118
+                - NON_NULL_TYPE@114..117
                     - NAMED_TYPE@114..116
                         - NAME@114..116
                             - IDENT@114..116 "ID"
                     - BANG@116..117 "!"
-                    - WHITESPACE@117..118 "\n"
+                - WHITESPACE@117..118 "\n"
             - R_CURLY@118..119 "}"
 - ERROR@105:128 "unexpected escaped character" "\ errronous string \""
 - ERROR@128:129 "expected a valid Value" )

--- a/crates/apollo-parser/test_data/parser/err/0043_type_with_trailing_garbage.txt
+++ b/crates/apollo-parser/test_data/parser/err/0043_type_with_trailing_garbage.txt
@@ -13,12 +13,12 @@
                     - IDENT@16..18 "id"
                 - COLON@18..19 ":"
                 - WHITESPACE@19..20 " "
-                - NON_NULL_TYPE@20..26
+                - NON_NULL_TYPE@20..23
                     - NAMED_TYPE@20..22
                         - NAME@20..22
                             - IDENT@20..22 "ID"
                     - BANG@22..23 "!"
-                    - WHITESPACE@23..26 "\n  "
+                - WHITESPACE@23..26 "\n  "
             - FIELD_DEFINITION@26..44
                 - NAME@26..36
                     - IDENT@26..36 "appearedIn"

--- a/crates/apollo-parser/test_data/parser/ok/0014_input_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0014_input_definition.txt
@@ -22,11 +22,11 @@
                     - IDENT@45..46 "b"
                 - COLON@46..47 ":"
                 - WHITESPACE@47..48 " "
-                - NON_NULL_TYPE@48..53
+                - NON_NULL_TYPE@48..52
                     - NAMED_TYPE@48..51
                         - NAME@48..51
                             - IDENT@48..51 "Int"
                     - BANG@51..52 "!"
-                    - WHITESPACE@52..53 "\n"
+                - WHITESPACE@52..53 "\n"
             - R_CURLY@53..54 "}"
 recursion limit: 4096, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0032_supergraph.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0032_supergraph.txt
@@ -141,13 +141,13 @@
                     - IDENT@347..352 "graph"
                 - COLON@352..353 ":"
                 - WHITESPACE@353..354 " "
-                - NON_NULL_TYPE@354..368
+                - NON_NULL_TYPE@354..366
                     - NAMED_TYPE@354..365
                         - NAME@354..365
                             - IDENT@354..365 "join__Graph"
                     - BANG@365..366 "!"
-                    - COMMA@366..367 ","
-                    - WHITESPACE@367..368 " "
+                - COMMA@366..367 ","
+                - WHITESPACE@367..368 " "
             - INPUT_VALUE_DEFINITION@368..387
                 - NAME@368..371
                     - IDENT@368..371 "key"
@@ -215,13 +215,13 @@
                     - IDENT@511..515 "name"
                 - COLON@515..516 ":"
                 - WHITESPACE@516..517 " "
-                - NON_NULL_TYPE@517..526
+                - NON_NULL_TYPE@517..524
                     - NAMED_TYPE@517..523
                         - NAME@517..523
                             - IDENT@517..523 "String"
                     - BANG@523..524 "!"
-                    - COMMA@524..525 ","
-                    - WHITESPACE@525..526 " "
+                - COMMA@524..525 ","
+                - WHITESPACE@525..526 " "
             - INPUT_VALUE_DEFINITION@526..538
                 - NAME@526..529
                     - IDENT@526..529 "url"
@@ -475,12 +475,12 @@
                     - IDENT@964..968 "isbn"
                 - COLON@968..969 ":"
                 - WHITESPACE@969..970 " "
-                - NON_NULL_TYPE@970..978
+                - NON_NULL_TYPE@970..977
                     - NAMED_TYPE@970..976
                         - NAME@970..976
                             - IDENT@970..976 "String"
                     - BANG@976..977 "!"
-                    - WHITESPACE@977..978 " "
+                - WHITESPACE@977..978 " "
                 - DIRECTIVES@978..1007
                     - DIRECTIVE@978..1007
                         - AT@978..979 "@"
@@ -555,7 +555,7 @@
                     - IDENT@1089..1101 "similarBooks"
                 - COLON@1101..1102 ":"
                 - WHITESPACE@1102..1103 " "
-                - NON_NULL_TYPE@1103..1111
+                - NON_NULL_TYPE@1103..1110
                     - LIST_TYPE@1103..1109
                         - L_BRACK@1103..1104 "["
                         - NAMED_TYPE@1104..1108
@@ -563,7 +563,7 @@
                                 - IDENT@1104..1108 "Book"
                         - R_BRACK@1108..1109 "]"
                     - BANG@1109..1110 "!"
-                    - WHITESPACE@1110..1111 " "
+                - WHITESPACE@1110..1111 " "
                 - DIRECTIVES@1111..1140
                     - DIRECTIVE@1111..1140
                         - AT@1111..1112 "@"
@@ -667,12 +667,12 @@
                     - IDENT@1302..1305 "upc"
                 - COLON@1305..1306 ":"
                 - WHITESPACE@1306..1307 " "
-                - NON_NULL_TYPE@1307..1315
+                - NON_NULL_TYPE@1307..1314
                     - NAMED_TYPE@1307..1313
                         - NAME@1307..1313
                             - IDENT@1307..1313 "String"
                     - BANG@1313..1314 "!"
-                    - WHITESPACE@1314..1315 " "
+                - WHITESPACE@1314..1315 " "
                 - DIRECTIVES@1315..1346
                     - DIRECTIVE@1315..1346
                         - AT@1315..1316 "@"
@@ -695,12 +695,12 @@
                     - IDENT@1346..1349 "sku"
                 - COLON@1349..1350 ":"
                 - WHITESPACE@1350..1351 " "
-                - NON_NULL_TYPE@1351..1359
+                - NON_NULL_TYPE@1351..1358
                     - NAMED_TYPE@1351..1357
                         - NAME@1351..1357
                             - IDENT@1351..1357 "String"
                     - BANG@1357..1358 "!"
-                    - WHITESPACE@1358..1359 " "
+                - WHITESPACE@1358..1359 " "
                 - DIRECTIVES@1359..1390
                     - DIRECTIVE@1359..1390
                         - AT@1359..1360 "@"
@@ -856,7 +856,7 @@
                     - IDENT@1636..1650 "relatedReviews"
                 - COLON@1650..1651 ":"
                 - WHITESPACE@1651..1652 " "
-                - NON_NULL_TYPE@1652..1663
+                - NON_NULL_TYPE@1652..1662
                     - LIST_TYPE@1652..1661
                         - L_BRACK@1652..1653 "["
                         - NON_NULL_TYPE@1653..1660
@@ -866,7 +866,7 @@
                             - BANG@1659..1660 "!"
                         - R_BRACK@1660..1661 "]"
                     - BANG@1661..1662 "!"
-                    - WHITESPACE@1662..1663 " "
+                - WHITESPACE@1662..1663 " "
                 - DIRECTIVES@1663..1724
                     - DIRECTIVE@1663..1724
                         - AT@1663..1664 "@"
@@ -1002,12 +1002,12 @@
                     - IDENT@1895..1897 "id"
                 - COLON@1897..1898 ":"
                 - WHITESPACE@1898..1899 " "
-                - NON_NULL_TYPE@1899..1907
+                - NON_NULL_TYPE@1899..1906
                     - NAMED_TYPE@1899..1905
                         - NAME@1899..1905
                             - IDENT@1899..1905 "String"
                     - BANG@1905..1906 "!"
-                    - WHITESPACE@1906..1907 " "
+                - WHITESPACE@1906..1907 " "
                 - DIRECTIVES@1907..1938
                     - DIRECTIVE@1907..1938
                         - AT@1907..1908 "@"
@@ -1281,12 +1281,12 @@
                     - IDENT@2380..2383 "upc"
                 - COLON@2383..2384 ":"
                 - WHITESPACE@2384..2385 " "
-                - NON_NULL_TYPE@2385..2393
+                - NON_NULL_TYPE@2385..2392
                     - NAMED_TYPE@2385..2391
                         - NAME@2385..2391
                             - IDENT@2385..2391 "String"
                     - BANG@2391..2392 "!"
-                    - WHITESPACE@2392..2393 " "
+                - WHITESPACE@2392..2393 " "
                 - DIRECTIVES@2393..2424
                     - DIRECTIVE@2393..2424
                         - AT@2393..2394 "@"
@@ -1309,12 +1309,12 @@
                     - IDENT@2424..2427 "sku"
                 - COLON@2427..2428 ":"
                 - WHITESPACE@2428..2429 " "
-                - NON_NULL_TYPE@2429..2437
+                - NON_NULL_TYPE@2429..2436
                     - NAMED_TYPE@2429..2435
                         - NAME@2429..2435
                             - IDENT@2429..2435 "String"
                     - BANG@2435..2436 "!"
-                    - WHITESPACE@2436..2437 " "
+                - WHITESPACE@2436..2437 " "
                 - DIRECTIVES@2437..2468
                     - DIRECTIVE@2437..2468
                         - AT@2437..2438 "@"
@@ -1589,23 +1589,23 @@
                     - IDENT@2940..2944 "name"
                 - COLON@2944..2945 ":"
                 - WHITESPACE@2945..2946 " "
-                - NON_NULL_TYPE@2946..2956
+                - NON_NULL_TYPE@2946..2953
                     - NAMED_TYPE@2946..2952
                         - NAME@2946..2952
                             - IDENT@2946..2952 "String"
                     - BANG@2952..2953 "!"
-                    - WHITESPACE@2953..2956 "\n  "
+                - WHITESPACE@2953..2956 "\n  "
             - FIELD_DEFINITION@2956..2985
                 - NAME@2956..2966
                     - IDENT@2956..2966 "attributes"
                 - COLON@2966..2967 ":"
                 - WHITESPACE@2967..2968 " "
-                - NON_NULL_TYPE@2968..2985
+                - NON_NULL_TYPE@2968..2984
                     - NAMED_TYPE@2968..2983
                         - NAME@2968..2983
                             - IDENT@2968..2983 "ImageAttributes"
                     - BANG@2983..2984 "!"
-                    - WHITESPACE@2984..2985 "\n"
+                - WHITESPACE@2984..2985 "\n"
             - R_CURLY@2985..2986 "}"
             - WHITESPACE@2986..2988 "\n\n"
     - OBJECT_TYPE_DEFINITION@2988..3029
@@ -1622,12 +1622,12 @@
                     - IDENT@3013..3016 "url"
                 - COLON@3016..3017 ":"
                 - WHITESPACE@3017..3018 " "
-                - NON_NULL_TYPE@3018..3026
+                - NON_NULL_TYPE@3018..3025
                     - NAMED_TYPE@3018..3024
                         - NAME@3018..3024
                             - IDENT@3018..3024 "String"
                     - BANG@3024..3025 "!"
-                    - WHITESPACE@3025..3026 "\n"
+                - WHITESPACE@3025..3026 "\n"
             - R_CURLY@3026..3027 "}"
             - WHITESPACE@3027..3029 "\n\n"
     - SCALAR_TYPE_DEFINITION@3029..3052
@@ -1835,23 +1835,23 @@
                     - IDENT@3374..3377 "key"
                 - COLON@3377..3378 ":"
                 - WHITESPACE@3378..3379 " "
-                - NON_NULL_TYPE@3379..3389
+                - NON_NULL_TYPE@3379..3386
                     - NAMED_TYPE@3379..3385
                         - NAME@3379..3385
                             - IDENT@3379..3385 "String"
                     - BANG@3385..3386 "!"
-                    - WHITESPACE@3386..3389 "\n  "
+                - WHITESPACE@3386..3389 "\n  "
             - FIELD_DEFINITION@3389..3404
                 - NAME@3389..3394
                     - IDENT@3389..3394 "value"
                 - COLON@3394..3395 ":"
                 - WHITESPACE@3395..3396 " "
-                - NON_NULL_TYPE@3396..3404
+                - NON_NULL_TYPE@3396..3403
                     - NAMED_TYPE@3396..3402
                         - NAME@3396..3402
                             - IDENT@3396..3402 "String"
                     - BANG@3402..3403 "!"
-                    - WHITESPACE@3403..3404 "\n"
+                - WHITESPACE@3403..3404 "\n"
             - R_CURLY@3404..3405 "}"
             - WHITESPACE@3405..3407 "\n\n"
     - OBJECT_TYPE_DEFINITION@3407..3689
@@ -1935,12 +1935,12 @@
                     - IDENT@3528..3530 "id"
                 - COLON@3530..3531 ":"
                 - WHITESPACE@3531..3532 " "
-                - NON_NULL_TYPE@3532..3536
+                - NON_NULL_TYPE@3532..3535
                     - NAMED_TYPE@3532..3534
                         - NAME@3532..3534
                             - IDENT@3532..3534 "ID"
                     - BANG@3534..3535 "!"
-                    - WHITESPACE@3535..3536 " "
+                - WHITESPACE@3535..3536 " "
                 - DIRECTIVES@3536..3565
                     - DIRECTIVE@3536..3565
                         - AT@3536..3537 "@"
@@ -1994,12 +1994,12 @@
                             - IDENT@3619..3621 "id"
                         - COLON@3621..3622 ":"
                         - WHITESPACE@3622..3623 " "
-                        - NON_NULL_TYPE@3623..3627
+                        - NON_NULL_TYPE@3623..3626
                             - NAMED_TYPE@3623..3625
                                 - NAME@3623..3625
                                     - IDENT@3623..3625 "ID"
                             - BANG@3625..3626 "!"
-                            - WHITESPACE@3626..3627 " "
+                        - WHITESPACE@3626..3627 " "
                         - DEFAULT_VALUE@3627..3630
                             - EQ@3627..3628 "="
                             - WHITESPACE@3628..3629 " "
@@ -2078,13 +2078,13 @@
                             - IDENT@3755..3763 "username"
                         - COLON@3763..3764 ":"
                         - WHITESPACE@3764..3765 " "
-                        - NON_NULL_TYPE@3765..3774
+                        - NON_NULL_TYPE@3765..3772
                             - NAMED_TYPE@3765..3771
                                 - NAME@3765..3771
                                     - IDENT@3765..3771 "String"
                             - BANG@3771..3772 "!"
-                            - COMMA@3772..3773 ","
-                            - WHITESPACE@3773..3774 " "
+                        - COMMA@3772..3773 ","
+                        - WHITESPACE@3773..3774 " "
                     - INPUT_VALUE_DEFINITION@3774..3791
                         - NAME@3774..3782
                             - IDENT@3774..3782 "password"
@@ -2129,13 +2129,13 @@
                             - IDENT@3845..3848 "upc"
                         - COLON@3848..3849 ":"
                         - WHITESPACE@3849..3850 " "
-                        - NON_NULL_TYPE@3850..3859
+                        - NON_NULL_TYPE@3850..3857
                             - NAMED_TYPE@3850..3856
                                 - NAME@3850..3856
                                     - IDENT@3850..3856 "String"
                             - BANG@3856..3857 "!"
-                            - COMMA@3857..3858 ","
-                            - WHITESPACE@3858..3859 " "
+                        - COMMA@3857..3858 ","
+                        - WHITESPACE@3858..3859 " "
                     - INPUT_VALUE_DEFINITION@3859..3872
                         - NAME@3859..3863
                             - IDENT@3859..3863 "body"
@@ -2293,12 +2293,12 @@
                     - IDENT@4129..4133 "name"
                 - COLON@4133..4134 ":"
                 - WHITESPACE@4134..4135 " "
-                - NON_NULL_TYPE@4135..4143
+                - NON_NULL_TYPE@4135..4142
                     - NAMED_TYPE@4135..4141
                         - NAME@4135..4141
                             - IDENT@4135..4141 "String"
                     - BANG@4141..4142 "!"
-                    - WHITESPACE@4142..4143 "\n"
+                - WHITESPACE@4142..4143 "\n"
             - R_CURLY@4143..4144 "}"
             - WHITESPACE@4144..4146 "\n\n"
     - OBJECT_TYPE_DEFINITION@4146..4292
@@ -2357,12 +2357,12 @@
                     - IDENT@4244..4249 "email"
                 - COLON@4249..4250 ":"
                 - WHITESPACE@4250..4251 " "
-                - NON_NULL_TYPE@4251..4259
+                - NON_NULL_TYPE@4251..4258
                     - NAMED_TYPE@4251..4257
                         - NAME@4251..4257
                             - IDENT@4251..4257 "String"
                     - BANG@4257..4258 "!"
-                    - WHITESPACE@4258..4259 " "
+                - WHITESPACE@4258..4259 " "
                 - DIRECTIVES@4259..4289
                     - DIRECTIVE@4259..4289
                         - AT@4259..4260 "@"
@@ -2396,23 +2396,23 @@
                     - IDENT@4314..4317 "upc"
                 - COLON@4317..4318 ":"
                 - WHITESPACE@4318..4319 " "
-                - NON_NULL_TYPE@4319..4329
+                - NON_NULL_TYPE@4319..4326
                     - NAMED_TYPE@4319..4325
                         - NAME@4319..4325
                             - IDENT@4319..4325 "String"
                     - BANG@4325..4326 "!"
-                    - WHITESPACE@4326..4329 "\n  "
+                - WHITESPACE@4326..4329 "\n  "
             - FIELD_DEFINITION@4329..4344
                 - NAME@4329..4332
                     - IDENT@4329..4332 "sku"
                 - COLON@4332..4333 ":"
                 - WHITESPACE@4333..4334 " "
-                - NON_NULL_TYPE@4334..4344
+                - NON_NULL_TYPE@4334..4341
                     - NAMED_TYPE@4334..4340
                         - NAME@4334..4340
                             - IDENT@4334..4340 "String"
                     - BANG@4340..4341 "!"
-                    - WHITESPACE@4341..4344 "\n  "
+                - WHITESPACE@4341..4344 "\n  "
             - FIELD_DEFINITION@4344..4359
                 - NAME@4344..4348
                     - IDENT@4344..4348 "name"
@@ -2741,12 +2741,12 @@
                     - IDENT@4930..4934 "body"
                 - COLON@4934..4935 ":"
                 - WHITESPACE@4935..4936 " "
-                - NON_NULL_TYPE@4936..4942
+                - NON_NULL_TYPE@4936..4941
                     - NAMED_TYPE@4936..4940
                         - NAME@4936..4940
                             - IDENT@4936..4940 "Body"
                     - BANG@4940..4941 "!"
-                    - WHITESPACE@4941..4942 " "
+                - WHITESPACE@4941..4942 " "
                 - DIRECTIVES@4942..4975
                     - DIRECTIVE@4942..4975
                         - AT@4942..4943 "@"
@@ -3038,12 +3038,12 @@
                     - IDENT@5383..5385 "id"
                 - COLON@5385..5386 ":"
                 - WHITESPACE@5386..5387 " "
-                - NON_NULL_TYPE@5387..5391
+                - NON_NULL_TYPE@5387..5390
                     - NAMED_TYPE@5387..5389
                         - NAME@5387..5389
                             - IDENT@5387..5389 "ID"
                     - BANG@5389..5390 "!"
-                    - WHITESPACE@5390..5391 " "
+                - WHITESPACE@5390..5391 " "
                 - DIRECTIVES@5391..5422
                     - DIRECTIVE@5391..5422
                         - AT@5391..5392 "@"
@@ -3296,23 +3296,23 @@
                     - IDENT@5844..5848 "name"
                 - COLON@5848..5849 ":"
                 - WHITESPACE@5849..5850 " "
-                - NON_NULL_TYPE@5850..5860
+                - NON_NULL_TYPE@5850..5857
                     - NAMED_TYPE@5850..5856
                         - NAME@5850..5856
                             - IDENT@5850..5856 "String"
                     - BANG@5856..5857 "!"
-                    - WHITESPACE@5857..5860 "\n  "
+                - WHITESPACE@5857..5860 "\n  "
             - FIELD_DEFINITION@5860..5888
                 - NAME@5860..5870
                     - IDENT@5860..5870 "attributes"
                 - COLON@5870..5871 ":"
                 - WHITESPACE@5871..5872 " "
-                - NON_NULL_TYPE@5872..5888
+                - NON_NULL_TYPE@5872..5887
                     - NAMED_TYPE@5872..5886
                         - NAME@5872..5886
                             - IDENT@5872..5886 "TextAttributes"
                     - BANG@5886..5887 "!"
-                    - WHITESPACE@5887..5888 "\n"
+                - WHITESPACE@5887..5888 "\n"
             - R_CURLY@5888..5889 "}"
             - WHITESPACE@5889..5891 "\n\n"
     - OBJECT_TYPE_DEFINITION@5891..5947
@@ -3377,12 +3377,12 @@
                     - IDENT@6001..6003 "id"
                 - COLON@6003..6004 ":"
                 - WHITESPACE@6004..6005 " "
-                - NON_NULL_TYPE@6005..6011
+                - NON_NULL_TYPE@6005..6008
                     - NAMED_TYPE@6005..6007
                         - NAME@6005..6007
                             - IDENT@6005..6007 "ID"
                     - BANG@6007..6008 "!"
-                    - WHITESPACE@6008..6011 "\n  "
+                - WHITESPACE@6008..6011 "\n  "
             - INPUT_VALUE_DEFINITION@6011..6024
                 - NAME@6011..6015
                     - IDENT@6011..6015 "body"
@@ -3550,12 +3550,12 @@
                     - IDENT@6293..6295 "id"
                 - COLON@6295..6296 ":"
                 - WHITESPACE@6296..6297 " "
-                - NON_NULL_TYPE@6297..6301
+                - NON_NULL_TYPE@6297..6300
                     - NAMED_TYPE@6297..6299
                         - NAME@6297..6299
                             - IDENT@6297..6299 "ID"
                     - BANG@6299..6300 "!"
-                    - WHITESPACE@6300..6301 " "
+                - WHITESPACE@6300..6301 " "
                 - DIRECTIVES@6301..6333
                     - DIRECTIVE@6301..6333
                         - AT@6301..6302 "@"
@@ -3838,12 +3838,12 @@
                     - IDENT@6835..6850 "numberOfReviews"
                 - COLON@6850..6851 ":"
                 - WHITESPACE@6851..6852 " "
-                - NON_NULL_TYPE@6852..6857
+                - NON_NULL_TYPE@6852..6856
                     - NAMED_TYPE@6852..6855
                         - NAME@6852..6855
                             - IDENT@6852..6855 "Int"
                     - BANG@6855..6856 "!"
-                    - WHITESPACE@6856..6857 " "
+                - WHITESPACE@6856..6857 " "
                 - DIRECTIVES@6857..6888
                     - DIRECTIVE@6857..6888
                         - AT@6857..6858 "@"
@@ -4024,12 +4024,12 @@
                     - IDENT@7189..7191 "id"
                 - COLON@7191..7192 ":"
                 - WHITESPACE@7192..7193 " "
-                - NON_NULL_TYPE@7193..7201
+                - NON_NULL_TYPE@7193..7200
                     - NAMED_TYPE@7193..7199
                         - NAME@7193..7199
                             - IDENT@7193..7199 "String"
                     - BANG@7199..7200 "!"
-                    - WHITESPACE@7200..7201 " "
+                - WHITESPACE@7200..7201 " "
                 - DIRECTIVES@7201..7232
                     - DIRECTIVE@7201..7232
                         - AT@7201..7202 "@"
@@ -4150,12 +4150,12 @@
                     - IDENT@7421..7423 "id"
                 - COLON@7423..7424 ":"
                 - WHITESPACE@7424..7425 " "
-                - NON_NULL_TYPE@7425..7435
+                - NON_NULL_TYPE@7425..7432
                     - NAMED_TYPE@7425..7431
                         - NAME@7425..7431
                             - IDENT@7425..7431 "String"
                     - BANG@7431..7432 "!"
-                    - WHITESPACE@7432..7435 "\n  "
+                - WHITESPACE@7432..7435 "\n  "
             - FIELD_DEFINITION@7435..7457
                 - NAME@7435..7446
                     - IDENT@7435..7446 "description"

--- a/crates/apollo-parser/test_data/parser/ok/0037_operation_type_definition_with_inline_fragment.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0037_operation_type_definition_with_inline_fragment.txt
@@ -15,12 +15,12 @@
                         - IDENT@20..26 "param1"
                 - COLON@26..27 ":"
                 - WHITESPACE@27..28 " "
-                - NON_NULL_TYPE@28..38
+                - NON_NULL_TYPE@28..35
                     - NAMED_TYPE@28..34
                         - NAME@28..34
                             - IDENT@28..34 "String"
                     - BANG@34..35 "!"
-                    - WHITESPACE@35..38 "\n  "
+                - WHITESPACE@35..38 "\n  "
             - VARIABLE_DEFINITION@38..55
                 - VARIABLE@38..45
                     - DOLLAR@38..39 "$"
@@ -28,12 +28,12 @@
                         - IDENT@39..45 "param2"
                 - COLON@45..46 ":"
                 - WHITESPACE@46..47 " "
-                - NON_NULL_TYPE@47..55
+                - NON_NULL_TYPE@47..54
                     - NAMED_TYPE@47..53
                         - NAME@47..53
                             - IDENT@47..53 "String"
                     - BANG@53..54 "!"
-                    - WHITESPACE@54..55 "\n"
+                - WHITESPACE@54..55 "\n"
             - R_PAREN@55..56 ")"
             - WHITESPACE@56..57 " "
         - SELECTION_SET@57..193

--- a/crates/apollo-parser/test_data/parser/ok/0038_wrapped_named_types.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0038_wrapped_named_types.txt
@@ -22,18 +22,18 @@
                     - IDENT@35..36 "b"
                 - COLON@36..37 ":"
                 - WHITESPACE@37..38 " "
-                - NON_NULL_TYPE@38..47
+                - NON_NULL_TYPE@38..42
                     - NAMED_TYPE@38..41
                         - NAME@38..41
                             - IDENT@38..41 "Int"
                     - BANG@41..42 "!"
-                    - WHITESPACE@42..47 "\n    "
+                - WHITESPACE@42..47 "\n    "
             - FIELD_DEFINITION@47..62
                 - NAME@47..48
                     - IDENT@47..48 "c"
                 - COLON@48..49 ":"
                 - WHITESPACE@49..50 " "
-                - NON_NULL_TYPE@50..62
+                - NON_NULL_TYPE@50..57
                     - LIST_TYPE@50..56
                         - L_BRACK@50..51 "["
                         - NON_NULL_TYPE@51..55
@@ -43,7 +43,7 @@
                             - BANG@54..55 "!"
                         - R_BRACK@55..56 "]"
                     - BANG@56..57 "!"
-                    - WHITESPACE@57..62 "\n    "
+                - WHITESPACE@57..62 "\n    "
             - FIELD_DEFINITION@62..83
                 - NAME@62..63
                     - IDENT@62..63 "d"
@@ -73,7 +73,7 @@
                     - IDENT@83..84 "d"
                 - COLON@84..85 ":"
                 - WHITESPACE@85..86 " "
-                - NON_NULL_TYPE@86..106
+                - NON_NULL_TYPE@86..105
                     - LIST_TYPE@86..104
                         - L_BRACK@86..87 "["
                         - NON_NULL_TYPE@87..103
@@ -103,7 +103,7 @@
                             - BANG@102..103 "!"
                         - R_BRACK@103..104 "]"
                     - BANG@104..105 "!"
-                    - WHITESPACE@105..106 "\n"
+                - WHITESPACE@105..106 "\n"
             - R_CURLY@106..107 "}"
             - WHITESPACE@107..109 "\n\n"
     - OBJECT_TYPE_DEFINITION@109..224
@@ -130,19 +130,19 @@
                     - IDENT@148..149 "b"
                 - COLON@149..150 ":"
                 - WHITESPACE@150..151 " "
-                - NON_NULL_TYPE@151..161
+                - NON_NULL_TYPE@151..155
                     - NAMED_TYPE@151..154
                         - NAME@151..154
                             - IDENT@151..154 "Int"
                     - BANG@154..155 "!"
-                    - COMMA@155..156 ","
-                    - WHITESPACE@156..161 "\n    "
+                - COMMA@155..156 ","
+                - WHITESPACE@156..161 "\n    "
             - FIELD_DEFINITION@161..177
                 - NAME@161..162
                     - IDENT@161..162 "c"
                 - COLON@162..163 ":"
                 - WHITESPACE@163..164 " "
-                - NON_NULL_TYPE@164..177
+                - NON_NULL_TYPE@164..171
                     - LIST_TYPE@164..170
                         - L_BRACK@164..165 "["
                         - NON_NULL_TYPE@165..169
@@ -152,8 +152,8 @@
                             - BANG@168..169 "!"
                         - R_BRACK@169..170 "]"
                     - BANG@170..171 "!"
-                    - COMMA@171..172 ","
-                    - WHITESPACE@172..177 "\n    "
+                - COMMA@171..172 ","
+                - WHITESPACE@172..177 "\n    "
             - FIELD_DEFINITION@177..199
                 - NAME@177..178
                     - IDENT@177..178 "d"
@@ -184,7 +184,7 @@
                     - IDENT@199..200 "d"
                 - COLON@200..201 ":"
                 - WHITESPACE@201..202 " "
-                - NON_NULL_TYPE@202..223
+                - NON_NULL_TYPE@202..221
                     - LIST_TYPE@202..220
                         - L_BRACK@202..203 "["
                         - NON_NULL_TYPE@203..219
@@ -214,7 +214,7 @@
                             - BANG@218..219 "!"
                         - R_BRACK@219..220 "]"
                     - BANG@220..221 "!"
-                    - COMMA@221..222 ","
-                    - WHITESPACE@222..223 "\n"
+                - COMMA@221..222 ","
+                - WHITESPACE@222..223 "\n"
             - R_CURLY@223..224 "}"
 recursion limit: 4096, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0040_type_token_order.graphql
+++ b/crates/apollo-parser/test_data/parser/ok/0040_type_token_order.graphql
@@ -1,0 +1,8 @@
+type Object {
+  #(apparently you can stick a comma in there?? please dont do it!)
+  field : [Int ,!] # comment
+  _other:
+String,,,   ,
+#garbage
+  realField: ID!
+}

--- a/crates/apollo-parser/test_data/parser/ok/0040_type_token_order.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0040_type_token_order.txt
@@ -1,0 +1,61 @@
+- DOCUMENT@0..163
+    - OBJECT_TYPE_DEFINITION@0..163
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..5 " "
+        - NAME@5..12
+            - IDENT@5..11 "Object"
+            - WHITESPACE@11..12 " "
+        - FIELDS_DEFINITION@12..163
+            - L_CURLY@12..13 "{"
+            - WHITESPACE@13..16 "\n  "
+            - COMMENT@16..81 "#(apparently you can stick a comma in there?? please dont do it!)"
+            - WHITESPACE@81..84 "\n  "
+            - FIELD_DEFINITION@84..113
+                - NAME@84..90
+                    - IDENT@84..89 "field"
+                    - WHITESPACE@89..90 " "
+                - COLON@90..91 ":"
+                - WHITESPACE@91..92 " "
+                - LIST_TYPE@92..100
+                    - L_BRACK@92..93 "["
+                    - NON_NULL_TYPE@93..99
+                        - NAMED_TYPE@93..96
+                            - NAME@93..96
+                                - IDENT@93..96 "Int"
+                        - WHITESPACE@96..97 " "
+                        - COMMA@97..98 ","
+                        - BANG@98..99 "!"
+                    - R_BRACK@99..100 "]"
+                - WHITESPACE@100..101 " "
+                - COMMENT@101..110 "# comment"
+                - WHITESPACE@110..113 "\n  "
+            - FIELD_DEFINITION@113..146
+                - NAME@113..119
+                    - IDENT@113..119 "_other"
+                - COLON@119..120 ":"
+                - WHITESPACE@120..121 "\n"
+                - NAMED_TYPE@121..127
+                    - NAME@121..127
+                        - IDENT@121..127 "String"
+                - COMMA@127..128 ","
+                - COMMA@128..129 ","
+                - COMMA@129..130 ","
+                - WHITESPACE@130..133 "   "
+                - COMMA@133..134 ","
+                - WHITESPACE@134..135 "\n"
+                - COMMENT@135..143 "#garbage"
+                - WHITESPACE@143..146 "\n  "
+            - FIELD_DEFINITION@146..161
+                - NAME@146..155
+                    - IDENT@146..155 "realField"
+                - COLON@155..156 ":"
+                - WHITESPACE@156..157 " "
+                - NON_NULL_TYPE@157..160
+                    - NAMED_TYPE@157..159
+                        - NAME@157..159
+                            - IDENT@157..159 "ID"
+                    - BANG@159..160 "!"
+                - WHITESPACE@160..161 "\n"
+            - R_CURLY@161..162 "}"
+            - WHITESPACE@162..163 "\n"
+recursion limit: 4096, high: 0


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-rs/issues/362

This uses rowan's checkpoint feature. We can set a checkpoint before parsing a type node, parse the type normally, and then if we see a `!` at the end, we retroactively wrap the node in a NonNullType node. Then we add the `!` token to this NonNullType node.

Compared to the previous two-step parsing strategy that we used for this, we can no longer run into issues with tokens being added to the parse tree out of order.

Ignored tokens like commas, whitespace, and comments are not considered part of the type node, but part of the parent node. eg in this:
```graphql
type Object {
  field: Ty # comment
}
```
`# comment` is part of the FieldDefinition instead of part of the ObjectTypeDefinition. I think *ideally* we could hoist it up even further, so the FieldDefinition doesnt include trailing whitespace and comments either. that would improve our error display too.

We now also support whitespace inside type nodes better, eg `[ [Type !] ] !` while previously there could be no whitespace before the `!`. Because I just used `.bump_ignored()`, you can also do some weird things like `[ Type , , , ! ]` which looks wrong, however graphql-js also allows this, so maybe it's intentional 🤷🏻‍♀️  .