### PR TITLE
make FromError public

### DIFF
--- a/crates/apollo-encoder/src/from_parser.rs
+++ b/crates/apollo-encoder/src/from_parser.rs
@@ -10,10 +10,13 @@ use thiserror::Error;
 // occurred
 #[derive(Debug, Clone, Error)]
 pub enum FromError {
+    /// the parse tree is missing a node
     #[error("parse tree is missing a node")]
     MissingNode,
+    /// expected to parse a `i32`
     #[error("invalid i32")]
     ParseIntError(#[from] std::num::ParseIntError),
+    /// expected to parse a `f64`
     #[error("invalid f64")]
     ParseFloatError(#[from] std::num::ParseFloatError),
 }

--- a/crates/apollo-encoder/src/lib.rs
+++ b/crates/apollo-encoder/src/lib.rs
@@ -37,6 +37,7 @@ pub use enum_def::EnumDefinition;
 pub use enum_value::EnumValue;
 pub use field::{Field, FieldDefinition};
 pub use fragment::{FragmentDefinition, FragmentSpread, InlineFragment, TypeCondition};
+pub use from_parser::FromError;
 pub use input_field::InputField;
 pub use input_object_def::InputObjectDefinition;
 pub use input_value::InputValueDefinition;


### PR DESCRIPTION
otherwise we cannot build upon the TryFrom implementation with apollo-parser types