### PR TITLE
feat(compiler): find queries accept &str

### DIFF
--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -33,9 +33,9 @@ pub(crate) fn types_definitions_by_name(
 
 pub(crate) fn find_type_definition_by_name(
     db: &dyn HirDatabase,
-    name: String,
+    name: &str,
 ) -> Option<TypeDefinition> {
-    db.types_definitions_by_name().get(&name).cloned()
+    db.types_definitions_by_name().get(name).cloned()
 }
 
 pub(crate) fn find_operation_by_name(
@@ -62,44 +62,44 @@ pub(crate) fn find_anonymous_operation(
 pub(crate) fn find_fragment_by_name(
     db: &dyn HirDatabase,
     file_id: FileId,
-    name: String,
+    name: &str,
 ) -> Option<Arc<FragmentDefinition>> {
-    db.fragments(file_id).get(&name).cloned()
+    db.fragments(file_id).get(name).cloned()
 }
 
 pub(crate) fn find_object_type_by_name(
     db: &dyn HirDatabase,
-    name: String,
+    name: &str,
 ) -> Option<Arc<ObjectTypeDefinition>> {
-    db.object_types().get(&name).cloned()
+    db.object_types().get(name).cloned()
 }
 
 pub(crate) fn find_union_by_name(
     db: &dyn HirDatabase,
-    name: String,
+    name: &str,
 ) -> Option<Arc<UnionTypeDefinition>> {
-    db.unions().get(&name).cloned()
+    db.unions().get(name).cloned()
 }
 
 pub(crate) fn find_enum_by_name(
     db: &dyn HirDatabase,
-    name: String,
+    name: &str,
 ) -> Option<Arc<EnumTypeDefinition>> {
-    db.enums().get(&name).cloned()
+    db.enums().get(name).cloned()
 }
 
 pub(crate) fn find_interface_by_name(
     db: &dyn HirDatabase,
-    name: String,
+    name: &str,
 ) -> Option<Arc<InterfaceTypeDefinition>> {
-    db.interfaces().get(&name).cloned()
+    db.interfaces().get(name).cloned()
 }
 
 pub(crate) fn find_directive_definition_by_name(
     db: &dyn HirDatabase,
-    name: String,
+    name: &str,
 ) -> Option<Arc<DirectiveDefinition>> {
-    db.directive_definitions().get(&name).cloned()
+    db.directive_definitions().get(name).cloned()
 }
 
 /// Find any definitions that use the specified directive.
@@ -118,9 +118,9 @@ pub(crate) fn find_types_with_directive(
 
 pub(crate) fn find_input_object_by_name(
     db: &dyn HirDatabase,
-    name: String,
+    name: &str,
 ) -> Option<Arc<InputObjectTypeDefinition>> {
-    db.input_objects().get(&name).cloned()
+    db.input_objects().get(name).cloned()
 }
 
 pub(crate) fn query_operations(

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -198,7 +198,7 @@ impl FragmentDefinition {
     }
 
     pub fn type_def(&self, db: &dyn HirDatabase) -> Option<TypeDefinition> {
-        db.find_type_definition_by_name(self.name().to_string())
+        db.find_type_definition_by_name(self.name())
     }
 
     /// Get the AST location information for this HIR node.
@@ -477,7 +477,7 @@ impl Type {
 
     /// Get current Type's Type Definition.
     pub fn type_def(&self, db: &dyn HirDatabase) -> Option<TypeDefinition> {
-        db.find_type_definition_by_name(self.name())
+        db.find_type_definition_by_name(&self.name())
     }
 
     /// Get current Type's name.
@@ -519,7 +519,7 @@ impl Directive {
 
     // Get directive definition of the currently used directive
     pub fn directive(&self, db: &dyn HirDatabase) -> Option<Arc<DirectiveDefinition>> {
-        db.find_directive_definition_by_name(self.name().to_string())
+        db.find_directive_definition_by_name(self.name())
     }
 
     /// Get the AST location information for this HIR node.
@@ -973,7 +973,7 @@ impl Field {
     /// Get a reference to field's type.
     pub fn ty(&self, db: &dyn HirDatabase) -> Option<Type> {
         let def = db
-            .find_type_definition_by_name(self.parent_obj.as_ref()?.to_string())?
+            .find_type_definition_by_name(self.parent_obj.as_ref()?)?
             .field(self.name())?
             .ty()
             .to_owned();
@@ -982,7 +982,7 @@ impl Field {
 
     /// Get field's original field definition.
     pub fn field_definition(&self, db: &dyn HirDatabase) -> Option<FieldDefinition> {
-        db.find_object_type_by_name(self.parent_obj.as_ref()?.to_string())?
+        db.find_object_type_by_name(self.parent_obj.as_ref()?)?
             .fields_definition()
             .iter()
             .find(|field| field.name() == self.name())
@@ -1096,7 +1096,7 @@ impl FragmentSpread {
 
     /// Get the fragment definition this fragment spread is referencing.
     pub fn fragment(&self, db: &dyn HirDatabase) -> Option<Arc<FragmentDefinition>> {
-        db.find_fragment_by_name(self.loc.file_id(), self.name().to_string())
+        db.find_fragment_by_name(self.loc.file_id(), self.name())
     }
 
     /// Get fragment spread's defined variables.
@@ -1260,7 +1260,7 @@ impl RootOperationTypeDefinition {
 
     /// Get the object type this root operation is referencing.
     pub fn object_type(&self, db: &dyn HirDatabase) -> Option<Arc<ObjectTypeDefinition>> {
-        db.find_object_type_by_name(self.named_type().name())
+        db.find_object_type_by_name(&self.named_type().name())
     }
 
     /// Get the AST location information for this HIR node.
@@ -1352,7 +1352,7 @@ impl ImplementsInterface {
         &self,
         db: &dyn HirDatabase,
     ) -> Option<Arc<InterfaceTypeDefinition>> {
-        db.find_interface_by_name(self.interface().to_string())
+        db.find_interface_by_name(self.interface())
     }
 
     /// Get implements interfaces' interface name.
@@ -1656,7 +1656,7 @@ impl UnionMember {
 
     /// Get the object definition this union member is referencing.
     pub fn object(&self, db: &dyn HirDatabase) -> Option<Arc<ObjectTypeDefinition>> {
-        db.find_object_type_by_name(self.name().to_string())
+        db.find_object_type_by_name(self.name())
     }
 
     /// Get the AST location information for this HIR node.

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -2112,7 +2112,7 @@ mod tests {
 
         let default_values: Vec<_> = compiler
             .db
-            .find_input_object_by_name("HugeFloats".into())
+            .find_input_object_by_name("HugeFloats")
             .unwrap()
             .input_fields_definition
             .iter()
@@ -2143,10 +2143,7 @@ mod tests {
             }",
             "person.graphql",
         );
-        let person = compiler
-            .db
-            .find_object_type_by_name("Person".into())
-            .unwrap();
+        let person = compiler.db.find_object_type_by_name("Person").unwrap();
         let hir_field_names: Vec<_> = person
             .fields_definition
             .iter()

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -78,36 +78,33 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
     /// Return an fragment definition corresponding to the name and file id.
     /// Result of this query is not cached internally.
     #[salsa::transparent]
-    fn find_fragment_by_name(
-        &self,
-        file_id: FileId,
-        name: String,
-    ) -> Option<Arc<FragmentDefinition>>;
+    fn find_fragment_by_name(&self, file_id: FileId, name: &str)
+        -> Option<Arc<FragmentDefinition>>;
 
     /// Return an object type definition corresponding to the name.
     /// Result of this query is not cached internally.
     #[salsa::transparent]
-    fn find_object_type_by_name(&self, name: String) -> Option<Arc<ObjectTypeDefinition>>;
+    fn find_object_type_by_name(&self, name: &str) -> Option<Arc<ObjectTypeDefinition>>;
 
     /// Return an union type definition corresponding to the name.
     /// Result of this query is not cached internally.
     #[salsa::transparent]
-    fn find_union_by_name(&self, name: String) -> Option<Arc<UnionTypeDefinition>>;
+    fn find_union_by_name(&self, name: &str) -> Option<Arc<UnionTypeDefinition>>;
 
     /// Return an enum type definition corresponding to the name.
     /// Result of this query is not cached internally.
     #[salsa::transparent]
-    fn find_enum_by_name(&self, name: String) -> Option<Arc<EnumTypeDefinition>>;
+    fn find_enum_by_name(&self, name: &str) -> Option<Arc<EnumTypeDefinition>>;
 
     /// Return an interface type definition corresponding to the name.
     /// Result of this query is not cached internally.
     #[salsa::transparent]
-    fn find_interface_by_name(&self, name: String) -> Option<Arc<InterfaceTypeDefinition>>;
+    fn find_interface_by_name(&self, name: &str) -> Option<Arc<InterfaceTypeDefinition>>;
 
     /// Return an directive definition corresponding to the name.
     /// Result of this query is not cached internally.
     #[salsa::transparent]
-    fn find_directive_definition_by_name(&self, name: String) -> Option<Arc<DirectiveDefinition>>;
+    fn find_directive_definition_by_name(&self, name: &str) -> Option<Arc<DirectiveDefinition>>;
 
     /// Return any type definitions that contain the corresponding directive
     fn find_types_with_directive(&self, directive: String) -> Arc<Vec<TypeDefinition>>;
@@ -115,14 +112,14 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
     /// Return an input object type definition corresponding to the name.
     /// Result of this query is not cached internally.
     #[salsa::transparent]
-    fn find_input_object_by_name(&self, name: String) -> Option<Arc<InputObjectTypeDefinition>>;
+    fn find_input_object_by_name(&self, name: &str) -> Option<Arc<InputObjectTypeDefinition>>;
 
     fn types_definitions_by_name(&self) -> Arc<IndexMap<String, TypeDefinition>>;
 
     /// Return a type definition corresponding to the name.
     /// Result of this query is not cached internally.
     #[salsa::transparent]
-    fn find_type_definition_by_name(&self, name: String) -> Option<TypeDefinition>;
+    fn find_type_definition_by_name(&self, name: &str) -> Option<TypeDefinition>;
 
     /// Return all query operations in a corresponding file.
     fn query_operations(&self, file_id: FileId) -> Arc<Vec<Arc<OperationDefinition>>>;
@@ -1315,7 +1312,7 @@ fn field(
 
 fn parent_ty(db: &dyn HirDatabase, field_name: &str, parent_obj: Option<String>) -> Option<String> {
     Some(
-        db.find_type_definition_by_name(parent_obj?)?
+        db.find_type_definition_by_name(&parent_obj?)?
             .field(field_name)?
             .ty()
             .name(),

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -1163,7 +1163,7 @@ scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
         let snapshot = compiler.snapshot();
         let snapshot2 = compiler.snapshot();
 
-        let thread1 = std::thread::spawn(move || snapshot.find_object_type_by_name("Query".into()));
+        let thread1 = std::thread::spawn(move || snapshot.find_object_type_by_name("Query"));
         let thread2 = std::thread::spawn(move || snapshot2.scalars());
 
         thread1.join().expect("object_type_by_name panicked");
@@ -1182,10 +1182,7 @@ type Query {
         let mut compiler = ApolloCompiler::new();
         let input_id = compiler.add_document(input, "document.graphql");
 
-        let object_type = compiler
-            .db
-            .find_object_type_by_name("Query".into())
-            .unwrap();
+        let object_type = compiler.db.find_object_type_by_name("Query").unwrap();
         assert!(object_type.directives().is_empty());
 
         let input = r#"
@@ -1196,10 +1193,7 @@ type Query @withDirective {
 "#;
         compiler.update_document(input_id, input);
 
-        let object_type = compiler
-            .db
-            .find_object_type_by_name("Query".into())
-            .unwrap();
+        let object_type = compiler.db.find_object_type_by_name("Query").unwrap();
         assert_eq!(object_type.directives().len(), 1);
     }
 

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -902,10 +902,7 @@ directive @directiveB(name: String) on OBJECT | INTERFACE
         }
         assert!(diagnostics.is_empty());
 
-        let book_obj = compiler
-            .db
-            .find_object_type_by_name("Book".to_string())
-            .unwrap();
+        let book_obj = compiler.db.find_object_type_by_name("Book").unwrap();
 
         let directive_names: Vec<&str> = book_obj.directives().iter().map(|d| d.name()).collect();
         assert_eq!(directive_names, ["directiveA", "directiveB"]);
@@ -936,7 +933,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
         }
         assert!(diagnostics.is_empty());
 
-        let person_obj = compiler.db.find_object_type_by_name("Person".to_string());
+        let person_obj = compiler.db.find_object_type_by_name("Person");
 
         if let Some(person) = person_obj {
             let field_ty_directive: Vec<String> = person
@@ -1018,7 +1015,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
         }
         assert!(diagnostics.is_empty());
 
-        let person_obj = compiler.db.find_input_object_by_name("Person".to_string());
+        let person_obj = compiler.db.find_input_object_by_name("Person");
 
         if let Some(person) = person_obj {
             let field_ty_directive: Vec<String> = person

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -97,7 +97,7 @@ pub fn validate_directives(
         let name = dir.name();
         let loc = dir.loc();
 
-        if let Some(directive_definition) = db.find_directive_definition_by_name(name.into()) {
+        if let Some(directive_definition) = db.find_directive_definition_by_name(name) {
             let allowed_loc: HashSet<hir::DirectiveLocation> =
                 HashSet::from_iter(directive_definition.directive_locations().iter().cloned());
             if !allowed_loc.contains(&dir_loc) {

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -98,7 +98,7 @@ pub fn validate_field(
         .help(help);
 
         let parent_type_loc = db
-            .find_type_definition_by_name(field.parent_obj.clone().unwrap())
+            .find_type_definition_by_name(&field.parent_obj.clone().unwrap())
             .and_then(|type_def| type_def.loc());
 
         let diagnostic = if let Some(parent_type_loc) = parent_type_loc {

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -11,7 +11,7 @@ pub fn validate_fragment_definitions(
             DirectiveLocation::FragmentDefinition,
         ));
 
-        let fragment_type_def = db.find_type_definition_by_name(def.type_condition().to_string());
+        let fragment_type_def = db.find_type_definition_by_name(def.type_condition());
         // Make sure the fragment type exists in the schema
         if fragment_type_def.is_some() {
             // TODO handle cases where the type does not support fragments (Enum, Scalar...)

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -62,7 +62,7 @@ pub fn validate_union_definition(
             seen.insert(name, union_member);
         }
 
-        match db.upcast().find_type_definition_by_name(name.to_string()) {
+        match db.upcast().find_type_definition_by_name(name) {
             None => {
                 // Union member must be defined.
                 diagnostics.push(


### PR DESCRIPTION
This should make it a bit easier querying for definitions. Because all find_queries are transparent, and not cacheable, we can use &str instead of String.