### PR TITLE
fix(parser): correct recursion counting in selection sets

### DIFF
--- a/crates/apollo-compiler/src/database/ast.rs
+++ b/crates/apollo-compiler/src/database/ast.rs
@@ -86,7 +86,7 @@ mod tests {
 
         assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 2);
+        assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }
 
     #[test]
@@ -103,7 +103,7 @@ mod tests {
 
         let ast = compiler.db.ast(doc_id);
 
-        assert_eq!(ast.recursion_limit().high, 4);
+        assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 0);
         assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }

--- a/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
@@ -61,4 +61,4 @@
                         - IDENT@79..85 "String"
             - WHITESPACE@85..86 "\n"
             - R_CURLY@86..87 "}"
-recursion limit: 4096, high: 4
+recursion limit: 4096, high: 2

--- a/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
@@ -128,4 +128,4 @@
             - WHITESPACE@214..215 "\n"
             - R_CURLY@215..216 "}"
     - WHITESPACE@216..217 "\n"
-recursion limit: 4096, high: 6
+recursion limit: 4096, high: 3

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -214,4 +214,4 @@
         - DIRECTIVE_LOCATIONS@413..429
             - DIRECTIVE_LOCATION@413..429
                 - FIELD_DEFINITION_KW@413..429 "FIELD_DEFINITION"
-recursion limit: 4096, high: 6
+recursion limit: 4096, high: 2

--- a/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
@@ -142,4 +142,4 @@
                         - IDENT@202..204 "ID"
             - WHITESPACE@204..205 "\n"
             - R_CURLY@205..206 "}"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 2

--- a/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
+++ b/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
@@ -1165,4 +1165,4 @@
                         - IDENT@3074..3096 "INPUT_FIELD_DEFINITION"
             - WHITESPACE@3096..3097 "\n"
             - R_CURLY@3097..3098 "}"
-recursion limit: 4096, high: 31
+recursion limit: 4096, high: 8

--- a/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
@@ -163,4 +163,4 @@
                         - IDENT@316..319 "Int"
             - WHITESPACE@319..320 "\n"
             - R_CURLY@320..321 "}"
-recursion limit: 4096, high: 5
+recursion limit: 4096, high: 2

--- a/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
+++ b/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
@@ -186,4 +186,4 @@
                     - BANG@369..370 "!"
             - WHITESPACE@370..371 "\n"
             - R_CURLY@371..372 "}"
-recursion limit: 4096, high: 4
+recursion limit: 4096, high: 2

--- a/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
@@ -300,4 +300,4 @@
                         - IDENT@591..598 "Boolean"
             - WHITESPACE@598..599 "\n"
             - R_CURLY@599..600 "}"
-recursion limit: 4096, high: 4
+recursion limit: 4096, high: 2

--- a/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
+++ b/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
@@ -110,4 +110,4 @@
             - WHITESPACE@201..202 "\n"
             - R_CURLY@202..203 "}"
     - WHITESPACE@203..204 "\n"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 2

--- a/crates/apollo-parser/src/parser/grammar/field.rs
+++ b/crates/apollo-parser/src/parser/grammar/field.rs
@@ -13,7 +13,6 @@ pub(crate) fn field(p: &mut Parser) {
     // We need to enforce recursion limits to prevent
     // excessive resource consumption or (more seriously)
     // stack overflows.
-    p.recursion_limit.consume();
     if p.recursion_limit.limited() {
         p.limit_err(format!("parser limit({}) reached", p.recursion_limit.limit));
         return;

--- a/crates/apollo-parser/src/parser/grammar/fragment.rs
+++ b/crates/apollo-parser/src/parser/grammar/fragment.rs
@@ -77,7 +77,7 @@ pub(crate) fn inline_fragment(p: &mut Parser) {
     }
 
     match p.peek() {
-        Some(T!['{']) => selection::top_selection_set(p),
+        Some(T!['{']) => selection::selection_set(p),
         _ => p.err("expected Selection Set"),
     }
 }

--- a/crates/apollo-parser/src/parser/grammar/selection.rs
+++ b/crates/apollo-parser/src/parser/grammar/selection.rs
@@ -321,7 +321,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 2);
+        assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }
 
     #[test]
@@ -337,7 +337,7 @@ query SomeQuery(
 
         let ast = parser.parse();
 
-        assert_eq!(ast.recursion_limit().high, 4);
+        assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 0);
         assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }
@@ -352,11 +352,11 @@ query SomeQuery(
           }
         }
         "#;
-        let parser = Parser::new(schema).recursion_limit(2);
+        let parser = Parser::new(schema).recursion_limit(1);
 
         let ast = parser.parse();
 
-        assert_eq!(ast.recursion_limit().high, 3);
+        assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
         assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }
@@ -370,11 +370,11 @@ query SomeQuery(
           }
         }
         "#;
-        let parser = Parser::new(schema).recursion_limit(2);
+        let parser = Parser::new(schema).recursion_limit(1);
 
         let ast = parser.parse();
 
-        assert_eq!(ast.recursion_limit().high, 3);
+        assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
         assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }
@@ -402,7 +402,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 4);
+        assert_eq!(ast.document().definitions().into_iter().count(), 2);
     }
 
     #[test]
@@ -418,7 +418,7 @@ query SomeQuery(
 
         let ast = parser.parse();
 
-        assert_eq!(ast.recursion_limit().high, 4);
+        assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 0);
         assert_eq!(ast.document().definitions().into_iter().count(), 1);
     }

--- a/crates/apollo-parser/src/parser/mod.rs
+++ b/crates/apollo-parser/src/parser/mod.rs
@@ -495,7 +495,7 @@ mod tests {
         let parser = Parser::new(source).recursion_limit(3).token_limit(200);
         let ast = parser.parse();
         let errors = ast.errors().collect::<Vec<_>>();
-        assert_eq!(errors, &[&Error::limit("parser limit(3) reached", 61),]);
+        assert_eq!(errors, &[&Error::limit("parser limit(3) reached", 121),]);
     }
 
     #[test]

--- a/crates/apollo-parser/test_data/parser/err/0007_fragment_definition_with_invalid_fragment_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0007_fragment_definition_with_invalid_fragment_name.txt
@@ -25,4 +25,4 @@
             - WHITESPACE@34..35 "\n"
             - R_CURLY@35..36 "}"
 - ERROR@9:11 "Fragment Name cannot be 'on'" on
-recursion limit: 4096, high: 2
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0008_fragment_definition_with_invalid_type_condition.txt
+++ b/crates/apollo-parser/test_data/parser/err/0008_fragment_definition_with_invalid_type_condition.txt
@@ -26,4 +26,4 @@
             - WHITESPACE@44..45 "\n"
             - R_CURLY@45..46 "}"
 - ERROR@22:26 "exptected 'on'" User
-recursion limit: 4096, high: 2
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0025_document_with_incorrect_definition_and_selection_set.txt
+++ b/crates/apollo-parser/test_data/parser/err/0025_document_with_incorrect_definition_and_selection_set.txt
@@ -15,4 +15,4 @@
             - WHITESPACE@39..40 "\n"
             - R_CURLY@40..41 "}"
 - ERROR@0:14 "expected definition" uasdf21230jkdw
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0026_invalid_definition_squished_between_two_valid_definitions.txt
+++ b/crates/apollo-parser/test_data/parser/err/0026_invalid_definition_squished_between_two_valid_definitions.txt
@@ -56,4 +56,4 @@
             - WHITESPACE@138..139 "\n"
             - R_CURLY@139..140 "}"
 - ERROR@99:113 "expected definition" uasdf21230jkdw
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0031_argument_with_erronous_string_value.txt
+++ b/crates/apollo-parser/test_data/parser/err/0031_argument_with_erronous_string_value.txt
@@ -18,4 +18,4 @@
             - R_CURLY@15..16 "}"
 - ERROR@13:25 "unexpected escaped character" "\string ID"
 - ERROR@25:26 "expected a valid Value" )
-recursion limit: 4096, high: 2
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0035_unterminated_string_value_in_object_value.txt
+++ b/crates/apollo-parser/test_data/parser/err/0035_unterminated_string_value_in_object_value.txt
@@ -56,4 +56,4 @@
 - ERROR@116:116 "expected }" EOF
 - ERROR@116:116 "expected R_PAREN, got EOF" EOF
 - ERROR@116:116 "expected R_CURLY, got EOF" EOF
-recursion limit: 4096, high: 2
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
+++ b/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
@@ -42,4 +42,4 @@
             - R_CURLY@82..83 "}"
 - ERROR@0:1 "expected a StringValue, Name or OperationDefinition" @
 - ERROR@49:50 "expected a StringValue, Name or OperationDefinition" }
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0002_selection_simple.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0002_selection_simple.txt
@@ -12,4 +12,4 @@
                     - IDENT@14..23 "faveSnack"
             - WHITESPACE@23..24 "\n"
             - R_CURLY@24..25 "}"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0003_selection_with_fields.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0003_selection_with_fields.txt
@@ -56,4 +56,4 @@
                     - IDENT@168..177 "faveSnack"
             - WHITESPACE@177..178 "\n"
             - R_CURLY@178..179 "}"
-recursion limit: 4096, high: 13
+recursion limit: 4096, high: 4

--- a/crates/apollo-parser/test_data/parser/ok/0004_selection_with_fields_aliases_arguments.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0004_selection_with_fields_aliases_arguments.txt
@@ -71,4 +71,4 @@
                     - R_PAREN@199..200 ")"
             - WHITESPACE@200..201 "\n"
             - R_CURLY@201..202 "}"
-recursion limit: 4096, high: 13
+recursion limit: 4096, high: 4

--- a/crates/apollo-parser/test_data/parser/ok/0005_selection_with_inline_fragments.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0005_selection_with_inline_fragments.txt
@@ -40,4 +40,4 @@
                     - R_CURLY@88..89 "}"
             - WHITESPACE@89..90 "\n"
             - R_CURLY@90..91 "}"
-recursion limit: 4096, high: 4
+recursion limit: 4096, high: 3

--- a/crates/apollo-parser/test_data/parser/ok/0006_selection_with_fragment_spread.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0006_selection_with_fragment_spread.txt
@@ -113,4 +113,4 @@
             - WHITESPACE@207..208 "\n"
             - R_CURLY@208..209 "}"
     - WHITESPACE@209..210 "\n"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 4

--- a/crates/apollo-parser/test_data/parser/ok/0012_fragment_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0012_fragment_definition.txt
@@ -45,4 +45,4 @@
                     - R_PAREN@80..81 ")"
             - WHITESPACE@81..82 "\n"
             - R_CURLY@82..83 "}"
-recursion limit: 4096, high: 4
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0013_fragment_definition_with_fragment_spread.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0013_fragment_definition_with_fragment_spread.txt
@@ -31,4 +31,4 @@
                         - IDENT@55..73 "standardProfilePic"
             - WHITESPACE@73..74 "\n"
             - R_CURLY@74..75 "}"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0020_operation_type_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0020_operation_type_definition.txt
@@ -51,4 +51,4 @@
                     - IDENT@113..117 "lion"
             - WHITESPACE@117..118 "\n"
             - R_CURLY@118..119 "}"
-recursion limit: 4096, high: 8
+recursion limit: 4096, high: 3

--- a/crates/apollo-parser/test_data/parser/ok/0021_operation_type_definition_with_arguments.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0021_operation_type_definition_with_arguments.txt
@@ -41,4 +41,4 @@
                     - IDENT@65..70 "treat"
             - WHITESPACE@70..71 "\n"
             - R_CURLY@71..72 "}"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0022_operation_type_definition_with_arguments_and_directives.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0022_operation_type_definition_with_arguments_and_directives.txt
@@ -53,4 +53,4 @@
                     - IDENT@86..91 "treat"
             - WHITESPACE@91..92 "\n"
             - R_CURLY@92..93 "}"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0030_values.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0030_values.txt
@@ -83,4 +83,4 @@
                     - R_PAREN@111..112 ")"
             - WHITESPACE@112..113 "\n"
             - R_CURLY@113..114 "}"
-recursion limit: 4096, high: 2
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0031_variables_with_default.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0031_variables_with_default.txt
@@ -50,4 +50,4 @@
                     - IDENT@66..72 "animal"
             - WHITESPACE@72..73 "\n"
             - R_CURLY@73..74 "}"
-recursion limit: 4096, high: 2
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0034_query_shorthand_followed_by_fragment_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0034_query_shorthand_followed_by_fragment_definition.txt
@@ -37,4 +37,4 @@
                     - IDENT@62..66 "name"
             - WHITESPACE@66..67 "\n"
             - R_CURLY@67..68 "}"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0035_query_with_variables.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0035_query_with_variables.txt
@@ -27,4 +27,4 @@
                     - IDENT@27..31 "name"
             - WHITESPACE@31..32 "\n"
             - R_CURLY@32..33 "}"
-recursion limit: 4096, high: 2
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0036_parses_variable_definition_with_list_type.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0036_parses_variable_definition_with_list_type.txt
@@ -44,4 +44,4 @@
                     - R_PAREN@57..58 ")"
             - WHITESPACE@58..59 "\n"
             - R_CURLY@59..60 "}"
-recursion limit: 4096, high: 3
+recursion limit: 4096, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0039_variable_with_directives.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0039_variable_with_directives.txt
@@ -66,4 +66,4 @@
                     - IDENT@103..109 "animal"
             - WHITESPACE@109..110 "\n"
             - R_CURLY@110..111 "}"
-recursion limit: 4096, high: 2
+recursion limit: 4096, high: 1


### PR DESCRIPTION
We've been not quite double maybe more like 1.5 counting nested selection sets in operations with our recursion limit. This PR should provide a fix.

An operation like this should have a recursion high of 4.
```graphql
query {
    a {
        a {
            a {
                a
            }
        }
    }
}
```

An operation like this should have a recursion high of 3.
```graphql
query {
    a {
        a {
            a
        }
    }
}
```