### PR TITLE
validate leaf selection of scalar & enum

### DIFF
--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -265,6 +265,13 @@ pub enum DiagnosticData {
         /// Name of the field
         field: String,
     },
+    #[error("`{name}` field of type '{ty}' must not have a sub selection")]
+    NoSubselectionAllowed {
+        // field name
+        name: String,
+        // field type
+        ty: String,
+    },
 }
 
 impl DiagnosticData {

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::diagnostics::{DiagnosticData, Label};
 use crate::{hir, validation::ValidationDatabase, ApolloDiagnostic};
 
 pub fn validate_selection(
@@ -11,7 +12,7 @@ pub fn validate_selection(
     for sel in selection.iter() {
         match sel {
             hir::Selection::Field(field) => {
-                diagnostics.extend(db.validate_field(field.clone()));
+                validate_selection_field(db, field.clone(), &mut diagnostics);
             }
 
             // TODO handle fragment spreads on invalid parent types
@@ -29,15 +30,100 @@ pub fn validate_selection(
     diagnostics
 }
 
+fn validate_selection_field(
+    db: &dyn ValidationDatabase,
+    field: Arc<hir::Field>,
+    diagnostics: &mut Vec<ApolloDiagnostic>,
+) {
+    let leaf = !field.selection_set.selection.is_empty();
+    let mut leaf_validation_error = false;
+    if leaf {
+        let field_type = field.ty(db.upcast());
+        if let Some(field_type) = field_type {
+            let type_name = field_type.name();
+            let type_def = db.find_type_definition_by_name(type_name.clone());
+            if let Some(type_def) = type_def {
+                if type_def.is_enum_type_definition() || type_def.is_scalar_type_definition() {
+                    leaf_validation_error = true;
+                    let name = field.name.src.clone();
+                    let label_text = if type_def.is_enum_type_definition() {
+                        "This field is an enum and cannot select any fields"
+                    } else {
+                        "This field is a scalar and cannot select any fields"
+                    };
+                    let diagnostic = ApolloDiagnostic::new(
+                        db,
+                        field.loc.into(),
+                        DiagnosticData::NoSubselectionAllowed {
+                            name,
+                            ty: type_name.clone(),
+                        },
+                    )
+                    .label(Label::new(field.loc, label_text));
+                    let diagnostic = if let Some(type_def_loc) = type_def.loc() {
+                        diagnostic.label(Label::new(
+                            type_def_loc,
+                            format!("`{}` declared here", &type_name),
+                        ))
+                    } else {
+                        diagnostic
+                    };
+                    diagnostics.push(diagnostic);
+                }
+            }
+        }
+    }
+
+    if !leaf_validation_error {
+        diagnostics.extend(db.validate_field(field));
+    }
+}
+
 pub fn validate_selection_set(
     db: &dyn ValidationDatabase,
     selection_set: hir::SelectionSet,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
-    // TODO handle Enums, Scalar (no selection set content allowed), Unions
+    // TODO handle Unions
 
     diagnostics.extend(db.validate_selection(selection_set.selection));
 
     diagnostics
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ApolloCompiler;
+
+    #[test]
+    fn it_validates_subselections_of_enums() {
+        let input = r#"
+query SelectionOfEnum {
+  pet {
+    name
+  }
+}
+
+type Query {
+  pet: Pet,
+}
+
+enum Pet {
+    CAT
+    DOG
+    FOX
+}
+"#;
+
+        let mut compiler = ApolloCompiler::new();
+        compiler.add_document(input, "schema.graphql");
+
+        let diagnostics = compiler.validate();
+        for diagnostic in &diagnostics {
+            println!("{diagnostic}");
+        }
+
+        assert_eq!(diagnostics.len(), 1)
+    }
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0065_subselection_of_enum.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0065_subselection_of_enum.graphql
@@ -1,0 +1,15 @@
+query SelectionOfEnum {
+  pet {
+    name
+  }
+}
+
+type Query {
+  pet: Pet,
+}
+
+enum Pet {
+    CAT
+    DOG
+    FOX
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0065_subselection_of_enum.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0065_subselection_of_enum.txt
@@ -1,0 +1,41 @@
+[
+    ApolloDiagnostic {
+        cache: {
+            65: "0065_subselection_of_enum.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 65,
+            },
+            offset: 26,
+            length: 18,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 65,
+                    },
+                    offset: 26,
+                    length: 18,
+                },
+                text: "This field is an enum and cannot select any fields",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 65,
+                    },
+                    offset: 76,
+                    length: 36,
+                },
+                text: "`Pet` declared here",
+            },
+        ],
+        help: None,
+        data: NoSubselectionAllowed {
+            name: "pet",
+            ty: "Pet",
+        },
+    },
+]

--- a/crates/apollo-compiler/test_data/diagnostics/0066_subselection_of_scalar.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0066_subselection_of_scalar.graphql
@@ -1,0 +1,11 @@
+query SelectionOfScalar {
+  url {
+    name
+  }
+}
+
+type Query {
+  url: URL,
+}
+
+scalar URL @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")

--- a/crates/apollo-compiler/test_data/diagnostics/0066_subselection_of_scalar.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0066_subselection_of_scalar.txt
@@ -1,0 +1,41 @@
+[
+    ApolloDiagnostic {
+        cache: {
+            66: "0066_subselection_of_scalar.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 66,
+            },
+            offset: 28,
+            length: 18,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 66,
+                    },
+                    offset: 28,
+                    length: 18,
+                },
+                text: "This field is a scalar and cannot select any fields",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 66,
+                    },
+                    offset: 78,
+                    length: 67,
+                },
+                text: "`URL` declared here",
+            },
+        ],
+        help: None,
+        data: NoSubselectionAllowed {
+            name: "url",
+            ty: "URL",
+        },
+    },
+]


### PR DESCRIPTION
Partial implementation of https://github.com/apollographql/apollo-rs/issues/307

From https://spec.graphql.org/October2021/#sec-Leaf-Field-Selections
```
If selectionType is a scalar or enum:

    The subselection set of that selection must be empty
```