### PR TITLE
fix clippy warnings related to unnecessary into_iter

### DIFF
--- a/crates/apollo-compiler/src/database/ast.rs
+++ b/crates/apollo-compiler/src/database/ast.rs
@@ -46,7 +46,6 @@ fn syntax_errors(db: &dyn AstDatabase) -> Vec<ApolloDiagnostic> {
         .flat_map(|file_id| {
             db.ast(file_id)
                 .errors()
-                .into_iter()
                 .map(|err| {
                     ApolloDiagnostic::new(
                         db,

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -677,7 +677,6 @@ fn enum_values_definition(
         Some(enum_values) => {
             let enum_values = enum_values
                 .enum_value_definitions()
-                .into_iter()
                 .filter_map(|e| enum_value_definition(e, file_id))
                 .collect();
             Arc::new(enum_values)
@@ -747,7 +746,6 @@ fn union_members(
         Some(members) => {
             let mems = members
                 .named_types()
-                .into_iter()
                 .filter_map(|u| union_member(u, file_id))
                 .collect();
             Arc::new(mems)
@@ -1096,7 +1094,6 @@ fn variable_definitions(
         Some(vars) => {
             let variable_definitions = vars
                 .variable_definitions()
-                .into_iter()
                 .filter_map(|v| variable_definition(v, file_id))
                 .collect();
             Arc::new(variable_definitions)
@@ -1171,7 +1168,6 @@ fn directive_locations(
         Some(directive_loc) => {
             let locations: Vec<DirectiveLocation> = directive_loc
                 .directive_locations()
-                .into_iter()
                 .map(|loc| loc.into())
                 .collect();
             Arc::new(locations)
@@ -1185,7 +1181,6 @@ fn directives(directives: Option<ast::Directives>, file_id: FileId) -> Arc<Vec<D
         Some(directives) => {
             let directives = directives
                 .directives()
-                .into_iter()
                 .filter_map(|d| directive(d, file_id))
                 .collect();
             Arc::new(directives)
@@ -1211,7 +1206,6 @@ fn arguments(arguments: Option<ast::Arguments>, file_id: FileId) -> Arc<Vec<Argu
         Some(arguments) => {
             let arguments = arguments
                 .arguments()
-                .into_iter()
                 .filter_map(|a| argument(a, file_id))
                 .collect();
             Arc::new(arguments)
@@ -1269,7 +1263,6 @@ fn selection_set(
     let selection_set = match selections {
         Some(sel) => sel
             .selections()
-            .into_iter()
             .filter_map(|sel| selection(db, sel, parent_obj_ty.as_ref().cloned(), file_id))
             .collect(),
         None => Vec::new(),


### PR DESCRIPTION
Noticed some minor clippy warnings when opening my previous PR. 

```
warning: useless conversion to the same type: `std::slice::Iter<'_, apollo_parser::Error>`
  --> crates/apollo-compiler/src/database/ast.rs:47:13
   |
47 | /             db.ast(file_id)
48 | |                 .errors()
49 | |                 .into_iter()
   | |____________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
   = note: `#[warn(clippy::useless_conversion)]` on by default
help: consider removing `.into_iter()`
   |
47 ~             db.ast(file_id)
48 +                 .errors()
   |

warning: useless conversion to the same type: `apollo_parser::ast::AstChildren<apollo_parser::ast::EnumValueDefinition>`
   --> crates/apollo-compiler/src/database/hir_db.rs:678:31
    |
678 |               let enum_values = enum_values
    |  _______________________________^
679 | |                 .enum_value_definitions()
680 | |                 .into_iter()
    | |____________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into_iter()`
    |
678 ~             let enum_values = enum_values
679 +                 .enum_value_definitions()
    |

warning: useless conversion to the same type: `apollo_parser::ast::AstChildren<apollo_parser::ast::NamedType>`
   --> crates/apollo-compiler/src/database/hir_db.rs:748:24
    |
748 |               let mems = members
    |  ________________________^
749 | |                 .named_types()
750 | |                 .into_iter()
    | |____________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into_iter()`
    |
748 ~             let mems = members
749 +                 .named_types()
    |

warning: useless conversion to the same type: `apollo_parser::ast::AstChildren<apollo_parser::ast::VariableDefinition>`
    --> crates/apollo-compiler/src/database/hir_db.rs:1097:40
     |
1097 |               let variable_definitions = vars
     |  ________________________________________^
1098 | |                 .variable_definitions()
1099 | |                 .into_iter()
     | |____________________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into_iter()`
     |
1097 ~             let variable_definitions = vars
1098 +                 .variable_definitions()
     |

warning: useless conversion to the same type: `apollo_parser::ast::AstChildren<apollo_parser::ast::DirectiveLocation>`
    --> crates/apollo-compiler/src/database/hir_db.rs:1172:53
     |
1172 |               let locations: Vec<DirectiveLocation> = directive_loc
     |  _____________________________________________________^
1173 | |                 .directive_locations()
1174 | |                 .into_iter()
     | |____________________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into_iter()`
     |
1172 ~             let locations: Vec<DirectiveLocation> = directive_loc
1173 +                 .directive_locations()
     |

warning: useless conversion to the same type: `apollo_parser::ast::AstChildren<apollo_parser::ast::Directive>`
    --> crates/apollo-compiler/src/database/hir_db.rs:1186:30
     |
1186 |               let directives = directives
     |  ______________________________^
1187 | |                 .directives()
1188 | |                 .into_iter()
     | |____________________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into_iter()`
     |
1186 ~             let directives = directives
1187 +                 .directives()
     |

warning: useless conversion to the same type: `apollo_parser::ast::AstChildren<apollo_parser::ast::Argument>`
    --> crates/apollo-compiler/src/database/hir_db.rs:1212:29
     |
1212 |               let arguments = arguments
     |  _____________________________^
1213 | |                 .arguments()
1214 | |                 .into_iter()
     | |____________________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into_iter()`
     |
1212 ~             let arguments = arguments
1213 +                 .arguments()
     |

warning: useless conversion to the same type: `apollo_parser::ast::AstChildren<apollo_parser::ast::Selection>`
    --> crates/apollo-compiler/src/database/hir_db.rs:1270:22
     |
1270 |           Some(sel) => sel
     |  ______________________^
1271 | |             .selections()
1272 | |             .into_iter()
     | |________________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `.into_iter()`
     |
1270 ~         Some(sel) => sel
1271 +             .selections()
     |

warning: `apollo-compiler` (lib) generated 8 warnings
```