### PR TITLE
chore: remove unnecessary into_iter() calls

### DIFF
--- a/crates/apollo-compiler/src/database/ast.rs
+++ b/crates/apollo-compiler/src/database/ast.rs
@@ -85,7 +85,7 @@ mod tests {
 
         assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 2);
+        assert_eq!(ast.document().definitions().count(), 2);
     }
 
     #[test]
@@ -104,6 +104,6 @@ mod tests {
 
         assert_eq!(ast.recursion_limit().high, 4);
         assert_eq!(ast.errors().len(), 0);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 }

--- a/crates/apollo-parser/src/parser/grammar/argument.rs
+++ b/crates/apollo-parser/src/parser/grammar/argument.rs
@@ -77,7 +77,6 @@ type Query {
                             .arguments_definition()
                             .unwrap()
                             .input_value_definitions()
-                            .into_iter()
                             .next()
                             .unwrap();
                         assert_eq!(argument.name().unwrap().text(), "category");

--- a/crates/apollo-parser/src/parser/grammar/document.rs
+++ b/crates/apollo-parser/src/parser/grammar/document.rs
@@ -126,7 +126,7 @@ uasdf21230jkdw
         let ast = parser.parse();
 
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 
     #[test]
@@ -138,7 +138,7 @@ uasdf21230jkdw
         assert_eq!(ast.errors().len(), 1);
 
         let doc = ast.document();
-        assert!(doc.definitions().into_iter().next().is_none());
+        assert!(doc.definitions().next().is_none());
     }
 
     #[test]

--- a/crates/apollo-parser/src/parser/grammar/extensions.rs
+++ b/crates/apollo-parser/src/parser/grammar/extensions.rs
@@ -136,7 +136,7 @@ extend Cat
         let ast = parser.parse();
 
         assert!(ast.errors().len() == 2);
-        assert_eq!(ast.document().definitions().into_iter().count(), 0);
+        assert_eq!(ast.document().definitions().count(), 0);
     }
 
     #[test]
@@ -153,6 +153,6 @@ extend interface NamedEntity {
         let ast = parser.parse();
 
         assert!(ast.errors().len() == 2);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 }

--- a/crates/apollo-parser/src/parser/grammar/operation.rs
+++ b/crates/apollo-parser/src/parser/grammar/operation.rs
@@ -103,6 +103,6 @@ mod test {
         let ast = parser.parse();
 
         assert_eq!(ast.errors().len(), 2);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 }

--- a/crates/apollo-parser/src/parser/grammar/selection.rs
+++ b/crates/apollo-parser/src/parser/grammar/selection.rs
@@ -304,7 +304,7 @@ query SomeQuery(
         let ast = parser.parse();
 
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 
     #[test]
@@ -322,7 +322,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 2);
+        assert_eq!(ast.document().definitions().count(), 2);
     }
 
     #[test]
@@ -340,7 +340,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 4);
         assert_eq!(ast.errors().len(), 0);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 
     #[test]
@@ -359,7 +359,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 3);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 
     #[test]
@@ -377,7 +377,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 3);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 
     #[test]
@@ -403,7 +403,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().into_iter().count(), 4);
+        assert_eq!(ast.document().definitions().count(), 4);
     }
 
     #[test]
@@ -421,6 +421,6 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 4);
         assert_eq!(ast.errors().len(), 0);
-        assert_eq!(ast.document().definitions().into_iter().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 1);
     }
 }

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -368,7 +368,6 @@ mod tests {
     #[test]
     fn test_input_value_for_type() {
         let data: Vec<u8> = (0..=5000usize)
-            .into_iter()
             .map(|n| (n % 255) as u8)
             .collect();
         let mut u = Unstructured::new(&data);


### PR DESCRIPTION
these make clippy angery in rust 1.68