### PR TITLE
feat(compiler): implicit extensions in HIR uniquely-named-item APIs

### DIFF
--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -275,7 +275,7 @@ pub(crate) fn subtype_map(db: &dyn HirDatabase) -> Arc<HashMap<String, HashSet<S
             .insert(value.to_owned())
     };
     for (name, definition) in &*db.object_types() {
-        for implements in definition.implements_interfaces() {
+        for implements in definition.self_implements_interfaces() {
             add(implements.interface(), name);
         }
         for extension in definition.extensions() {
@@ -285,7 +285,7 @@ pub(crate) fn subtype_map(db: &dyn HirDatabase) -> Arc<HashMap<String, HashSet<S
         }
     }
     for (name, definition) in &*db.interfaces() {
-        for implements in definition.implements_interfaces() {
+        for implements in definition.self_implements_interfaces() {
             add(implements.interface(), name);
         }
         for extension in definition.extensions() {
@@ -295,7 +295,7 @@ pub(crate) fn subtype_map(db: &dyn HirDatabase) -> Arc<HashMap<String, HashSet<S
         }
     }
     for (name, definition) in &*db.unions() {
-        for member in definition.union_members() {
+        for member in definition.self_members() {
             add(name, member.name());
         }
         for extension in definition.extensions() {

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -748,7 +748,7 @@ enum Pet {
 
         let enums = compiler.db.enums();
         let enum_values: Vec<&str> = enums["Pet"]
-            .enum_values_definition()
+            .self_values()
             .iter()
             .map(|enum_val| enum_val.enum_value())
             .collect();
@@ -790,14 +790,14 @@ type SearchQuery {
 
         let unions = compiler.db.unions();
         let union_members: Vec<&str> = unions["SearchResult"]
-            .union_members()
+            .self_members()
             .iter()
             .map(|member| member.name())
             .collect();
         assert_eq!(union_members, ["Photo", "Person"]);
 
         let photo_object = unions["SearchResult"]
-            .union_members()
+            .self_members()
             .iter()
             .find(|mem| mem.name() == "Person")
             .unwrap()
@@ -805,7 +805,7 @@ type SearchQuery {
 
         if let Some(photo) = photo_object {
             let fields: Vec<&str> = photo
-                .fields_definition()
+                .self_fields()
                 .iter()
                 .map(|field| field.name())
                 .collect();
@@ -873,7 +873,7 @@ input Point2D {
 
         let input_objects = compiler.db.input_objects();
         let fields: Vec<&str> = input_objects["Point2D"]
-            .input_fields_definition()
+            .self_fields()
             .iter()
             .map(|val| val.name())
             .collect();
@@ -944,7 +944,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 
         if let Some(person) = person_obj {
             let field_ty_directive: Vec<String> = person
-                .fields_definition()
+                .self_fields()
                 .iter()
                 .filter_map(|f| {
                     // get access to the actual definition the field is using
@@ -969,7 +969,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
             assert_eq!(field_ty_directive, ["specifiedBy"]);
 
             let field_arg_ty_vals: Vec<String> = person
-                .fields_definition()
+                .self_fields()
                 .iter()
                 .flat_map(|f| {
                     let enum_vals: Vec<String> = f
@@ -982,7 +982,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
                                     // get that definition's directives, for example
                                     TypeDefinition::EnumTypeDefinition(enum_) => {
                                         let dir_names: Vec<String> = enum_
-                                            .enum_values_definition()
+                                            .self_values()
                                             .iter()
                                             .map(|enum_val| enum_val.enum_value().to_owned())
                                             .collect();
@@ -1026,7 +1026,7 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 
         if let Some(person) = person_obj {
             let field_ty_directive: Vec<String> = person
-                .input_fields_definition()
+                .self_fields()
                 .iter()
                 .filter_map(|f| {
                     if let Some(field_ty) = f.ty().type_def(&compiler.db) {

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -27,7 +27,7 @@ pub fn validate_enum_definition(
     );
 
     let mut seen: HashMap<&str, &EnumValueDefinition> = HashMap::new();
-    for enum_val in enum_def.enum_values_definition() {
+    for enum_val in enum_def.self_values() {
         diagnostics.extend(db.validate_enum_value(enum_val.clone()));
 
         // An Enum type must define one or more unique enum values.

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -30,10 +30,11 @@ pub fn validate_object_type_definition(
     ));
 
     // Object Type field validations.
-    diagnostics.extend(db.validate_field_definitions(object.fields_definition().to_vec()));
+    diagnostics.extend(db.validate_field_definitions(object.self_fields().to_vec()));
 
     // Implements Interfaces validation.
-    diagnostics.extend(db.validate_implements_interfaces(object.implements_interfaces().to_vec()));
+    diagnostics
+        .extend(db.validate_implements_interfaces(object.self_implements_interfaces().to_vec()));
 
     // When defining an interface that implements another interface, the
     // implementing interface must define each field that is specified by
@@ -41,17 +42,17 @@ pub fn validate_object_type_definition(
     //
     // Returns a Missing Field error.
     let fields: HashSet<ValidationSet> = object
-        .fields_definition()
+        .self_fields()
         .iter()
         .map(|field| ValidationSet {
             name: field.name().into(),
             loc: field.loc(),
         })
         .collect();
-    for implements_interface in object.implements_interfaces().iter() {
+    for implements_interface in object.self_implements_interfaces().iter() {
         if let Some(interface) = implements_interface.interface_definition(db.upcast()) {
             let implements_interface_fields: HashSet<ValidationSet> = interface
-                .fields_definition()
+                .self_fields()
                 .iter()
                 .map(|field| ValidationSet {
                     name: field.name().into(),

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -27,7 +27,7 @@ pub fn validate_union_definition(
     );
 
     let mut seen: HashMap<&str, &UnionMember> = HashMap::new();
-    for union_member in union_def.union_members().iter() {
+    for union_member in union_def.self_members().iter() {
         let name = union_member.name();
         let redefined_definition = union_member.loc();
         // A Union type must include one or more unique member types.


### PR DESCRIPTION
Part of https://github.com/apollographql/apollo-rs/issues/468, for components that have a unique name such as fields of object types.

Internally, `IndexMap` is used to map names to `Vec` indices.

Renamed:

* `ObjectTypeDefinition::fields_definition` → `self_fields`
* `ObjectTypeDefinition::implements_interfaces` → `self_implements_interfaces`
* `InterfaceTypeDefinition::fields_definition` → `self_fields`
* `InterfaceTypeDefinition::implements_interfaces` → `self_implements_interfaces`
* `InputObjectTypeDefinition::input_fields_definition` → `self_fields`
* `UnionTypeDefinition::union_members` → `self_members`
* `EnumTypeDefinition::enum_values_definition` → `self_values`

Names freed by the above, redefined with new behavior (to consider extensions) and signature:

* `ObjectTypeDefinition::implements_interfaces() -> impl Iterator`
* `InterfaceTypeDefinition::implements_interfaces() -> impl Iterator`

Behavior changed to consider extensions (no signature change):

* `TypeDefinition::field(name) -> Option`
* `ObjectTypeDefinition::field(name) -> Option`
* `InterfaceTypeDefinition::field(name) -> Option`

New APIs (that all consider extensions):

* `ObjectTypeDefinition::fields() -> impl Iterator`
* `ObjectTypeDefinition::implements_interface(name) -> bool`
* `InterfaceTypeDefinition::fields() -> impl Iterator`
* `InterfaceTypeDefinition::implements_interface(name) -> bool`
* `InputObjectTypeDefinition::self_fields() -> &[_]`
* `InputObjectTypeDefinition::fields() -> impl Iterator`
* `InputObjectTypeDefinition::field(name) -> Option`
* `UnionTypeDefinition::members() -> impl Iterator`
* `UnionTypeDefinition::has_member(name) -> bool`
* `EnumTypeDefinition::values() -> impl Iterator`
* `EnumTypeDefinition::value(name) -> Option`