### PR TITLE
feat(compiler): implicit extensions in HIR root operation APIs

### DIFF
--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -437,11 +437,13 @@ impl OperationDefinition {
 
     /// Get operation's definition object type.
     pub fn object_type(&self, db: &dyn HirDatabase) -> Option<Arc<ObjectTypeDefinition>> {
-        match self.operation_ty {
-            OperationType::Query => db.schema().query(db),
-            OperationType::Mutation => db.schema().mutation(db),
-            OperationType::Subscription => db.schema().subscription(db),
-        }
+        let schema = db.schema();
+        let name = match self.operation_ty {
+            OperationType::Query => schema.query()?,
+            OperationType::Mutation => schema.mutation()?,
+            OperationType::Subscription => schema.subscription()?,
+        };
+        db.object_types().get(name).cloned()
     }
 
     /// Get a reference to the operation definition's variables.
@@ -545,13 +547,19 @@ impl OperationType {
     }
 }
 
+impl From<OperationType> for &'static str {
+    fn from(ty: OperationType) -> &'static str {
+        match ty {
+            OperationType::Query => "Query",
+            OperationType::Mutation => "Mutation",
+            OperationType::Subscription => "Subscription",
+        }
+    }
+}
+
 impl fmt::Display for OperationType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            OperationType::Query => write!(f, "Query"),
-            OperationType::Mutation => write!(f, "Mutation"),
-            OperationType::Subscription => write!(f, "Subscription"),
-        }
+        f.write_str((*self).into())
     }
 }
 
@@ -1463,13 +1471,21 @@ impl Float {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Default, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct SchemaDefinition {
     pub(crate) description: Option<String>,
     pub(crate) directives: Arc<Vec<Directive>>,
     pub(crate) root_operation_type_definition: Arc<Vec<RootOperationTypeDefinition>>,
     pub(crate) loc: Option<HirNodeLocation>,
     pub(crate) extensions: Vec<Arc<SchemaExtension>>,
+    pub(crate) root_operation_names: RootOperationNames,
+}
+
+#[derive(Default, Clone, Debug, Hash, PartialEq, Eq)]
+pub(crate) struct RootOperationNames {
+    pub(crate) query: Option<String>,
+    pub(crate) mutation: Option<String>,
+    pub(crate) subscription: Option<String>,
 }
 
 impl SchemaDefinition {
@@ -1509,16 +1525,19 @@ impl SchemaDefinition {
             .filter(move |directive| directive.name() == name)
     }
 
-    /// Get a reference to the schema definition's root operation type definition.
-    pub fn root_operation_type_definition(&self) -> &[RootOperationTypeDefinition] {
+    /// Returns the root operations from this schema definition,
+    /// excluding those from schema extensions.
+    pub fn self_root_operations(&self) -> &[RootOperationTypeDefinition] {
         self.root_operation_type_definition.as_ref()
     }
 
-    /// Set the schema definition's root operation type definition.
-    pub(crate) fn set_root_operation_type_definition(&mut self, op: RootOperationTypeDefinition) {
-        Arc::get_mut(&mut self.root_operation_type_definition)
-            .unwrap()
-            .push(op)
+    /// Returns an iterator of root operations, from either on this schema defintion or its extensions.
+    pub fn root_operations(&self) -> impl Iterator<Item = &RootOperationTypeDefinition> {
+        self.self_root_operations().iter().chain(
+            self.extensions()
+                .iter()
+                .flat_map(|ext| ext.root_operations()),
+        )
     }
 
     /// Get the AST location information for this HIR node.
@@ -1531,40 +1550,31 @@ impl SchemaDefinition {
         &self.extensions
     }
 
-    // NOTE(@lrlna): potentially have the following fns on the database itself
-    // so they are memoised as well
-
-    /// Get Schema's query object type definition.
-    pub fn query(&self, db: &dyn HirDatabase) -> Option<Arc<ObjectTypeDefinition>> {
-        self.root_operation_type_definition().iter().find_map(|op| {
-            if op.operation_ty.is_query() {
-                op.object_type(db)
-            } else {
-                None
-            }
-        })
+    /// Returns the name of the object type for the `query` root operation,
+    /// defined either on this schema defintion or its extensions.
+    ///
+    /// The corresponding object type definition can be found
+    /// at [`compiler.db.object_types().get(name)`][HirDatabase::object_types].
+    pub fn query(&self) -> Option<&str> {
+        self.root_operation_names.query.as_deref()
     }
 
-    /// Get Schema's mutation object type definition.
-    pub fn mutation(&self, db: &dyn HirDatabase) -> Option<Arc<ObjectTypeDefinition>> {
-        self.root_operation_type_definition().iter().find_map(|op| {
-            if op.operation_ty.is_mutation() {
-                op.object_type(db)
-            } else {
-                None
-            }
-        })
+    /// Returns the name of the object type for the `mutation` root operation,
+    /// defined either on this schema defintion or its extensions.
+    ///
+    /// The corresponding object type definition can be found
+    /// at [`compiler.db.object_types().get(name)`][HirDatabase::object_types].
+    pub fn mutation(&self) -> Option<&str> {
+        self.root_operation_names.mutation.as_deref()
     }
 
-    /// Get Schema's subscription object type definition.
-    pub fn subscription(&self, db: &dyn HirDatabase) -> Option<Arc<ObjectTypeDefinition>> {
-        self.root_operation_type_definition().iter().find_map(|op| {
-            if op.operation_ty.is_subscription() {
-                op.object_type(db)
-            } else {
-                None
-            }
-        })
+    /// Returns the name of the object type for the `subscription` root operation,
+    /// defined either on this schema defintion or its extensions.
+    ///
+    /// The corresponding object type definition can be found
+    /// at [`compiler.db.object_types().get(name)`][HirDatabase::object_types].
+    pub fn subscription(&self) -> Option<&str> {
+        self.root_operation_names.subscription.as_deref()
     }
 }
 
@@ -2407,7 +2417,7 @@ impl SchemaExtension {
     }
 
     /// Get a reference to the schema definition's root operation type definition.
-    pub fn root_operation_type_definition(&self) -> &[RootOperationTypeDefinition] {
+    pub fn root_operations(&self) -> &[RootOperationTypeDefinition] {
         self.root_operation_type_definition.as_ref()
     }
 
@@ -2833,6 +2843,50 @@ mod tests {
         // but this is approximation is still in the range of finite f64 values.
         assert_eq!(default_values[2], "98765432109876540000");
         assert_eq!(default_values[3], "98765432109876540000");
+    }
+
+    #[test]
+    fn root_operations() {
+        let mut compiler = ApolloCompiler::new();
+        let first = r#"
+            schema @core(feature: "https://specs.apollo.dev/core/v0.1")
+            type Query {
+                field: Int
+            }
+            type Subscription {
+                newsletter: [String]
+            }
+        "#;
+        let second = r#"
+            extend schema @core(feature: "https://specs.apollo.dev/join/v0.1") {
+                query: MyQuery
+            }
+            type MyQuery {
+                different_field: String
+            }
+        "#;
+        compiler.add_type_system(first, "first.graphql");
+        compiler.add_type_system(second, "second.graphql");
+
+        let schema = compiler.db.schema();
+        assert_eq!(
+            schema
+                .self_root_operations()
+                .iter()
+                .map(|op| op.named_type().name())
+                .collect::<Vec<_>>(),
+            ["Subscription"]
+        );
+        assert_eq!(
+            schema
+                .root_operations()
+                .map(|op| op.named_type().name())
+                .collect::<Vec<_>>(),
+            ["Subscription", "MyQuery"]
+        );
+        assert!(schema.mutation().is_none());
+        assert_eq!(schema.query().unwrap(), "MyQuery");
+        assert_eq!(schema.subscription().unwrap(), "Subscription");
     }
 
     #[test]

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -133,7 +133,7 @@ pub fn validate_subscription_operations(
     // defined schema root operation types.
     //
     //   * subscription operation - subscription root operation
-    if !subscriptions.is_empty() && db.schema().subscription(db.upcast()).is_none() {
+    if !subscriptions.is_empty() && db.schema().subscription().is_none() {
         let unsupported_ops: Vec<ApolloDiagnostic> = subscriptions
             .iter()
             .map(|op| {
@@ -162,7 +162,7 @@ pub fn validate_query_operations(
     // defined schema root operation types.
     //
     //   * query operation - query root operation
-    if !queries.is_empty() && db.schema().query(db.upcast()).is_none() {
+    if !queries.is_empty() && db.schema().query().is_none() {
         let unsupported_ops: Vec<ApolloDiagnostic> = queries
             .iter()
             .map(|op| {
@@ -202,7 +202,7 @@ pub fn validate_mutation_operations(
     // defined schema root operation types.
     //
     //   * mutation operation - mutation root operation
-    if !mutations.is_empty() && db.schema().mutation(db.upcast()).is_none() {
+    if !mutations.is_empty() && db.schema().mutation().is_none() {
         let unsupported_ops: Vec<ApolloDiagnostic> = mutations
             .iter()
             .map(|op| {

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -12,7 +12,7 @@ pub fn validate_schema_definition(
     let mut diagnostics = Vec::new();
 
     // A GraphQL schema must have a Query root operation.
-    if schema_def.query(db.upcast()).is_none() {
+    if schema_def.query().is_none() {
         if let Some(loc) = db.schema().loc() {
             diagnostics.push(
                 ApolloDiagnostic::new(db, loc.into(), DiagnosticData::QueryRootOperationType)
@@ -23,11 +23,8 @@ pub fn validate_schema_definition(
             );
         }
     }
-    diagnostics.extend(
-        db.validate_root_operation_definitions(
-            schema_def.root_operation_type_definition().to_vec(),
-        ),
-    );
+    diagnostics
+        .extend(db.validate_root_operation_definitions(schema_def.self_root_operations().to_vec()));
 
     diagnostics.extend(db.validate_directives(
         schema_def.self_directives().to_vec(),

--- a/crates/apollo-compiler/test_data/diagnostics/0059_root_operation_object_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0059_root_operation_object_type.txt
@@ -7,32 +7,6 @@
             file_id: FileId {
                 id: 58,
             },
-            offset: 0,
-            length: 36,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 58,
-                    },
-                    offset: 0,
-                    length: 36,
-                },
-                text: "`query` root operation type must be defined here",
-            },
-        ],
-        help: None,
-        data: QueryRootOperationType,
-    },
-    ApolloDiagnostic {
-        cache: {
-            58: "0059_root_operation_object_type.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 58,
-            },
             offset: 13,
             length: 20,
         },

--- a/crates/apollo-compiler/test_data/diagnostics/0060_root_operation_definition_undefined_operation_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0060_root_operation_definition_undefined_operation_type.txt
@@ -7,32 +7,6 @@
             file_id: FileId {
                 id: 59,
             },
-            offset: 0,
-            length: 31,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 59,
-                    },
-                    offset: 0,
-                    length: 31,
-                },
-                text: "`query` root operation type must be defined here",
-            },
-        ],
-        help: None,
-        data: QueryRootOperationType,
-    },
-    ApolloDiagnostic {
-        cache: {
-            59: "0060_root_operation_definition_undefined_operation_type.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 59,
-            },
             offset: 13,
             length: 16,
         },

--- a/crates/apollo-compiler/test_data/diagnostics/0061_root_operation_with_default_undefined_query.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0061_root_operation_with_default_undefined_query.txt
@@ -7,32 +7,6 @@
             file_id: FileId {
                 id: 60,
             },
-            offset: 0,
-            length: 27,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 60,
-                    },
-                    offset: 0,
-                    length: 27,
-                },
-                text: "`query` root operation type must be defined here",
-            },
-        ],
-        help: None,
-        data: QueryRootOperationType,
-    },
-    ApolloDiagnostic {
-        cache: {
-            60: "0061_root_operation_with_default_undefined_query.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 60,
-            },
             offset: 13,
             length: 12,
         },


### PR DESCRIPTION
A collection of loosely related changes, part of https://github.com/apollographql/apollo-rs/issues/468.

HIR no longer creates an implicit root operation if an explicit one exists in a schema extension, even if an object type named `Query`/`Mutation`/`Subscription` exists and the base schema definition doesn’t define an explicit root operation of that type.

`SchemaDefinition::root_operation_type_definition()` was renamed to `self_root_operations`.

`SchemaDefinition::root_operations() -> impl Iterator` was added. It includes root operations from extensions.

`SchemaDefinition::query()`, `mutation()`, and `subscription()` now account for schema extensions, and return `Option<&str>` with the name instead of the definition of the corresponding object type. That definition can be found at `compiler.db.objects().get(name)`. starting % with '%' will be ignored, and an empty message aborts the commit.

As a side effect of that last change these methods can return `Some(name)` for invalid documents where that name doesn’t have a type definition, or it’s not an object type. Previously they would return `None` since there is no object type definition to return. As a result, validation stopped emitting "`query` root operation type must be defined here" diagnostics for such documents. I believe this is correct, since a "not found in this scope" or "root operation type must be of an Object Type" diagnostic was and still is emitted separately.