### PR TITLE
chore(compiler): use salsa invoke for ease of navigating

### DIFF
--- a/crates/apollo-compiler/src/database/ast.rs
+++ b/crates/apollo-compiler/src/database/ast.rs
@@ -10,14 +10,17 @@ pub trait AstDatabase: InputDatabase {
     /// Get an AST for a particular file. Returns a `rowan` SyntaxTree.  The
     /// SyntaxTree can be safely shared between threads as it's `Send` and
     /// `Sync`.
+    #[salsa::invoke(ast)]
     fn ast(&self, file_id: FileId) -> SyntaxTree;
 
     /// Get a file's GraphQL Document. Returns a `rowan` Green Node. This is the
     /// top level document node that can be used when going between an
     /// SyntaxNodePtr to an actual SyntaxNode.
+    #[salsa::invoke(document)]
     fn document(&self, file_id: FileId) -> GreenNode;
 
     /// Get syntax errors found in the compiler's manifest.
+    #[salsa::invoke(syntax_errors)]
     fn syntax_errors(&self) -> Vec<ApolloDiagnostic>;
 }
 

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -20,51 +20,66 @@ use crate::InputDatabase;
 #[salsa::query_group(HirStorage)]
 pub trait HirDatabase: InputDatabase + AstDatabase {
     /// Return all type system definitions defined in the compiler.
+    #[salsa::invoke(type_system_definitions)]
     fn type_system_definitions(&self) -> Arc<TypeSystemDefinitions>;
 
     /// Return a [`TypeSystem`] containing definitions and more.
     ///
     /// This can be used with [`set_type_system_hir`][crate::ApolloCompiler::set_type_system_hir]
     /// on another compiler.
+    #[salsa::invoke(type_system)]
     fn type_system(&self) -> Arc<TypeSystem>;
 
     /// Return all the extensions defined in the type system.
+    #[salsa::invoke(extensions)]
     fn extensions(&self) -> Arc<Vec<TypeExtension>>;
 
     /// Return all the operations defined in a file.
+    #[salsa::invoke(operations)]
     fn operations(&self, file_id: FileId) -> Arc<Vec<Arc<OperationDefinition>>>;
 
     /// Return all the fragments defined in a file.
+    #[salsa::invoke(fragments)]
     fn fragments(&self, file_id: FileId) -> ByName<FragmentDefinition>;
 
     /// Return all the operations defined in any file.
+    #[salsa::invoke(all_operations)]
     fn all_operations(&self) -> Arc<Vec<Arc<OperationDefinition>>>;
 
     /// Return all the fragments defined in any file.
+    #[salsa::invoke(all_fragments)]
     fn all_fragments(&self) -> ByName<FragmentDefinition>;
 
     /// Return schema definition defined in the compiler.
+    #[salsa::invoke(schema)]
     fn schema(&self) -> Arc<SchemaDefinition>;
 
     /// Return all object type definitions defined in the compiler.
+    #[salsa::invoke(object_types)]
     fn object_types(&self) -> ByName<ObjectTypeDefinition>;
 
     /// Return all scalar type definitions defined in the compiler.
+    #[salsa::invoke(scalars)]
     fn scalars(&self) -> ByName<ScalarTypeDefinition>;
 
     /// Return all enum type definitions defined in the compiler.
+    #[salsa::invoke(enums)]
     fn enums(&self) -> ByName<EnumTypeDefinition>;
 
     /// Return all union type definitions defined in the compiler.
+    #[salsa::invoke(unions)]
     fn unions(&self) -> ByName<UnionTypeDefinition>;
 
     /// Return all interface type definitions defined in the compiler.
+    #[salsa::invoke(interfaces)]
     fn interfaces(&self) -> ByName<InterfaceTypeDefinition>;
 
     /// Return all directive definitions defined in the compiler.
+    #[salsa::invoke(directive_definitions)]
     fn directive_definitions(&self) -> ByName<DirectiveDefinition>;
 
     /// Return all input object type definitions defined in the compiler.
+    #[salsa::invoke(input_objects)]
     fn input_objects(&self) -> ByName<InputObjectTypeDefinition>;
 
     // Derived from above queries:

--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -64,9 +64,11 @@ pub trait InputDatabase {
     fn input(&self, file_id: FileId) -> Source;
 
     /// Get the GraphQL source text for a file.
+    #[salsa::invoke(source_code)]
     fn source_code(&self, file_id: FileId) -> Arc<str>;
 
     /// Get the source type (document/schema/executable) for a file.
+    #[salsa::invoke(source_type)]
     fn source_type(&self, file_id: FileId) -> SourceType;
 
     /// Get all file ids currently in the compiler.
@@ -75,15 +77,20 @@ pub trait InputDatabase {
 
     /// Get the GraphQL source text for a file, split up into lines for
     /// printing diagnostics.
+    #[salsa::invoke(source_with_lines)]
     fn source_with_lines(&self, file_id: FileId) -> Arc<AriadneSource>;
+
     /// Get all GraphQL sources known to the compiler, split up into lines
     /// for printing diagnostics.
+    #[salsa::invoke(source_cache)]
     fn source_cache(&self) -> Arc<SourceCache>;
 
     /// Get all type system definition (GraphQL schema) files.
+    #[salsa::invoke(type_definition_files)]
     fn type_definition_files(&self) -> Vec<FileId>;
 
     /// Get all executable definition (GraphQL query) files.
+    #[salsa::invoke(executable_definition_files)]
     fn executable_definition_files(&self) -> Vec<FileId>;
 }
 


### PR DESCRIPTION
Using `salsa::invoke` to indicate where the function comes from in our `hir_db`. Makes it _soooo_ much easier to click through to the function definition and just to read where the function is.