### PR TITLE
Include built-in enum types in db.type_system()

### DIFF
--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -3971,7 +3971,7 @@ type Query {
             .enums_with_built_ins()
             .contains_key("__TypeKind"));
     }
-    
+
     #[test]
     fn field_definition() {
         let input = r#"

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -3926,4 +3926,21 @@ type Query {
             .find_directive_definition_by_name("deprecated".to_string())
             .is_some());
     }
+
+    #[test]
+    fn built_in_types_in_type_system_hir() {
+        let mut compiler_1 = ApolloCompiler::new();
+        compiler_1.add_type_system("type Query { unused: Int }", "unused.graphql");
+
+        let mut compiler_2 = ApolloCompiler::new();
+        compiler_2.set_type_system_hir(compiler_1.db.type_system());
+        assert!(compiler_2
+            .db
+            .object_types_with_built_ins()
+            .contains_key("__Schema"));
+        assert!(compiler_2
+            .db
+            .enums_with_built_ins()
+            .contains_key("__TypeKind"));
+    }
 }

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -288,7 +288,7 @@ fn type_system_definitions(db: &dyn HirDatabase) -> Arc<TypeSystemDefinitions> {
         objects: db.object_types_with_built_ins(),
         interfaces: db.interfaces(),
         unions: db.unions(),
-        enums: db.enums(),
+        enums: db.enums_with_built_ins(),
         input_objects: db.input_objects(),
         directives: db.directive_definitions(),
     })


### PR DESCRIPTION
Like built-in object types are included. This is consistent with the implicit input for built-in types being skipped when using set_type_system_hir()