### PR TITLE
breaking(compiler): add parser's token limiting to compiler's API

### DIFF
--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -60,6 +60,10 @@ pub trait InputDatabase {
     #[salsa::input]
     fn recursion_limit(&self) -> Option<usize>;
 
+    /// Get the currently set token limit.
+    #[salsa::input]
+    fn token_limit(&self) -> Option<usize>;
+
     /// Get input source of the corresponding file.
     #[salsa::input]
     fn type_system_hir_input(&self) -> Option<Arc<TypeSystem>>;

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -75,6 +75,7 @@ impl ApolloCompiler {
     }
 
     /// Configure the recursion limit to use during parsing.
+    /// Recursion limit must be set prior to adding sources to the compiler.
     pub fn recursion_limit(mut self, limit: usize) -> Self {
         if !self.db.source_files().is_empty() {
             panic!(
@@ -87,6 +88,7 @@ impl ApolloCompiler {
     }
 
     /// Configure the token limit to use during parsing.
+    /// Token limit must be set prior to adding sources to the compiler.
     pub fn token_limit(mut self, limit: usize) -> Self {
         if !self.db.source_files().is_empty() {
             panic!(

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -74,12 +74,28 @@ impl ApolloCompiler {
         Default::default()
     }
 
-    /// Create a new instance of Apollo Compiler,
-    /// and configure the parser with the given recursion limit.
-    pub fn with_recursion_limit(limit: usize) -> Self {
-        let mut compiler = Self::new();
-        compiler.db.set_recursion_limit(Some(limit));
-        compiler
+    /// Configure the recursion limit to use during parsing.
+    pub fn recursion_limit(mut self, limit: usize) -> Self {
+        if !self.db.source_files().is_empty() {
+            panic!(
+                "There are already parsed files in the compiler. \
+                 Setting recursion limit after files are parsed is not supported."
+            );
+        }
+        self.db.set_recursion_limit(Some(limit));
+        self
+    }
+
+    /// Configure the token limit to use during parsing.
+    pub fn token_limit(mut self, limit: usize) -> Self {
+        if !self.db.source_files().is_empty() {
+            panic!(
+                "There are already parsed files in the compiler. \
+                 Setting token limit after files are parsed is not supported."
+            );
+        }
+        self.db.set_token_limit(Some(limit));
+        self
     }
 
     /// Add or update a pre-computed input for type system definitions
@@ -232,6 +248,7 @@ impl Default for ApolloCompiler {
         let mut db = RootDatabase::default();
         // TODO(@goto-bus-stop) can we make salsa fill in these defaults for us…?
         db.set_recursion_limit(None);
+        db.set_token_limit(None);
         db.set_type_system_hir_input(None);
         db.set_source_files(vec![]);
 
@@ -1271,39 +1288,39 @@ type Query {
         schema {
             query: Query
           }
-          
+
           type Query {
             peopleCount: Int!
             person: Person!
           }
-          
+
           interface Pet {
             name: String!
           }
-          
+
           type Dog implements Pet {
             name: String!
             dogBreed: DogBreed!
           }
-          
+
           type Cat implements Pet {
             name: String!
             catBreed: CatBreed!
           }
-          
+
           type Person {
             firstName: String!
             lastName: String!
             age: Int
             pets: [Pet!]!
           }
-          
+
           enum DogBreed {
             CHIHUAHUA
             RETRIEVER
             LAB
           }
-          
+
           enum CatBreed {
             TABBY
             MIX


### PR DESCRIPTION
Adding the token API that already works nicely in the parser to the compiler. This *breaks* the current recursion_limit API we have in the compiler, but hopefully makes it a lot more ergonomic in terms of usage.

Here is how you'd set both limits:
```rust
let schema = r#"
    query {
        a {
            a {
                a {
                    a
                }
            }
        }
    }
"#;
let mut compiler = ApolloCompiler::new().token_limit(22).recursion_limit(10);
compiler.add_document(schema, "schema.graphql");
```

closes #509 