### PR TITLE
chore(encoder): add missing clone impl to encoder types

### DIFF
--- a/crates/apollo-encoder/src/directive_def.rs
+++ b/crates/apollo-encoder/src/directive_def.rs
@@ -30,7 +30,7 @@ use crate::{ArgumentsDefinition, InputValueDefinition, StringValue};
 /// "#
 /// );
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DirectiveDefinition {
     // Name must return a String.
     name: String,

--- a/crates/apollo-encoder/src/document.rs
+++ b/crates/apollo-encoder/src/document.rs
@@ -73,7 +73,7 @@ use crate::{
 ///     "#}
 /// );
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Document {
     operation_definitions: Vec<OperationDefinition>,
     fragment_definitions: Vec<FragmentDefinition>,

--- a/crates/apollo-encoder/src/fragment.rs
+++ b/crates/apollo-encoder/src/fragment.rs
@@ -34,7 +34,7 @@ use crate::{Directive, SelectionSet};
 ///     "#}
 /// );
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FragmentDefinition {
     name: String,
     type_condition: TypeCondition,

--- a/crates/apollo-encoder/src/object_def.rs
+++ b/crates/apollo-encoder/src/object_def.rs
@@ -51,7 +51,7 @@ use crate::{Directive, FieldDefinition, StringValue};
 ///     "#}
 /// );
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ObjectDefinition {
     // Name must return a String.
     name: String,

--- a/crates/apollo-encoder/src/operation.rs
+++ b/crates/apollo-encoder/src/operation.rs
@@ -51,7 +51,7 @@ use crate::{Directive, SelectionSet, VariableDefinition};
 ///     "#}
 /// );
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OperationDefinition {
     operation_type: OperationType,
     name: Option<String>,
@@ -139,7 +139,7 @@ impl fmt::Display for OperationDefinition {
 ///     query | mutation | subscription
 ///
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#OperationType).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum OperationType {
     /// Represents a query operation
     Query,

--- a/crates/apollo-encoder/src/variable.rs
+++ b/crates/apollo-encoder/src/variable.rs
@@ -29,7 +29,7 @@ use crate::{Directive, Type_, Value};
 ///     String::from(r#"$my_var: MyType = { first: 25, second: "test" }"#)
 /// );
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VariableDefinition {
     variable: String,
     ty: Type_,


### PR DESCRIPTION
Noticed that `Clone` was derived on some but not all encoder types when I tried to `.clone()` an `encoder::ObjectDefinition` instance. 

Not sure if there's a good reason, but ahead and opened this PR if it just happened to be an omission.