### PR TITLE
fix(compiler): Fix duplicate directive validation location information

### DIFF
--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -171,19 +171,19 @@ pub fn validate_directives(
 
             if !is_repeatable {
                 // original loc must be Some
-                let loc = original.loc.expect("undefined original directive location");
+                let original_loc = original.loc.expect("undefined original directive location");
                 diagnostics.push(
                     ApolloDiagnostic::new(
                         db,
                         loc.into(),
                         DiagnosticData::UniqueDirective {
                             name: name.to_string(),
-                            original_call: loc.into(),
+                            original_call: original_loc.into(),
                             conflicting_call: loc.into(),
                         },
                     )
                     .label(Label::new(
-                        loc,
+                        original_loc,
                         format!("directive {name} first called here"),
                     ))
                     .label(Label::new(

--- a/crates/apollo-compiler/test_data/diagnostics/0079_directive_is_unique.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0079_directive_is_unique.txt
@@ -8,7 +8,7 @@
             file_id: FileId {
                 id: 76,
             },
-            offset: 164,
+            offset: 172,
             length: 7,
         },
         labels: [
@@ -27,7 +27,7 @@
                     file_id: FileId {
                         id: 76,
                     },
-                    offset: 164,
+                    offset: 172,
                     length: 7,
                 },
                 text: "directive unique called again here",
@@ -47,7 +47,7 @@
                 file_id: FileId {
                     id: 76,
                 },
-                offset: 164,
+                offset: 172,
                 length: 7,
             },
         },

--- a/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
@@ -64,7 +64,7 @@
             file_id: FileId {
                 id: 77,
             },
-            offset: 178,
+            offset: 214,
             length: 14,
         },
         labels: [
@@ -83,7 +83,7 @@
                     file_id: FileId {
                         id: 77,
                     },
-                    offset: 178,
+                    offset: 214,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -103,7 +103,7 @@
                 file_id: FileId {
                     id: 77,
                 },
-                offset: 178,
+                offset: 214,
                 length: 14,
             },
         },
@@ -117,7 +117,7 @@
             file_id: FileId {
                 id: 77,
             },
-            offset: 110,
+            offset: 79,
             length: 14,
         },
         labels: [
@@ -136,7 +136,7 @@
                     file_id: FileId {
                         id: 77,
                     },
-                    offset: 110,
+                    offset: 79,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -156,7 +156,7 @@
                 file_id: FileId {
                     id: 77,
                 },
-                offset: 110,
+                offset: 79,
                 length: 14,
             },
         },
@@ -170,7 +170,7 @@
             file_id: FileId {
                 id: 77,
             },
-            offset: 110,
+            offset: 148,
             length: 14,
         },
         labels: [
@@ -189,7 +189,7 @@
                     file_id: FileId {
                         id: 77,
                     },
-                    offset: 110,
+                    offset: 148,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -209,7 +209,7 @@
                 file_id: FileId {
                     id: 77,
                 },
-                offset: 110,
+                offset: 148,
                 length: 14,
             },
         },

--- a/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
@@ -8,7 +8,7 @@
             file_id: FileId {
                 id: 78,
             },
-            offset: 97,
+            offset: 112,
             length: 14,
         },
         labels: [
@@ -27,7 +27,7 @@
                     file_id: FileId {
                         id: 78,
                     },
-                    offset: 97,
+                    offset: 112,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -47,7 +47,7 @@
                 file_id: FileId {
                     id: 78,
                 },
-                offset: 97,
+                offset: 112,
                 length: 14,
             },
         },
@@ -61,7 +61,7 @@
             file_id: FileId {
                 id: 78,
             },
-            offset: 162,
+            offset: 177,
             length: 14,
         },
         labels: [
@@ -80,7 +80,7 @@
                     file_id: FileId {
                         id: 78,
                     },
-                    offset: 162,
+                    offset: 177,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -100,7 +100,7 @@
                 file_id: FileId {
                     id: 78,
                 },
-                offset: 162,
+                offset: 177,
                 length: 14,
             },
         },
@@ -114,7 +114,7 @@
             file_id: FileId {
                 id: 78,
             },
-            offset: 336,
+            offset: 351,
             length: 14,
         },
         labels: [
@@ -133,7 +133,7 @@
                     file_id: FileId {
                         id: 78,
                     },
-                    offset: 336,
+                    offset: 351,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -153,7 +153,7 @@
                 file_id: FileId {
                     id: 78,
                 },
-                offset: 336,
+                offset: 351,
                 length: 14,
             },
         },
@@ -167,7 +167,7 @@
             file_id: FileId {
                 id: 78,
             },
-            offset: 290,
+            offset: 305,
             length: 14,
         },
         labels: [
@@ -186,7 +186,7 @@
                     file_id: FileId {
                         id: 78,
                     },
-                    offset: 290,
+                    offset: 305,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -206,7 +206,7 @@
                 file_id: FileId {
                     id: 78,
                 },
-                offset: 290,
+                offset: 305,
                 length: 14,
             },
         },
@@ -220,7 +220,7 @@
             file_id: FileId {
                 id: 78,
             },
-            offset: 382,
+            offset: 397,
             length: 14,
         },
         labels: [
@@ -239,7 +239,7 @@
                     file_id: FileId {
                         id: 78,
                     },
-                    offset: 382,
+                    offset: 397,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -259,7 +259,7 @@
                 file_id: FileId {
                     id: 78,
                 },
-                offset: 382,
+                offset: 397,
                 length: 14,
             },
         },
@@ -273,7 +273,7 @@
             file_id: FileId {
                 id: 78,
             },
-            offset: 236,
+            offset: 251,
             length: 14,
         },
         labels: [
@@ -292,7 +292,7 @@
                     file_id: FileId {
                         id: 78,
                     },
-                    offset: 236,
+                    offset: 251,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -312,7 +312,7 @@
                 file_id: FileId {
                     id: 78,
                 },
-                offset: 236,
+                offset: 251,
                 length: 14,
             },
         },


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1006268/230019707-9018d8a0-636f-4b43-ab14-b0296870e825.png)

After:
![image](https://user-images.githubusercontent.com/1006268/230019754-47818b8b-5099-409f-929f-b8b6c08b6707.png)
