### PR TITLE
feat: add a validation executable

### DIFF
--- a/crates/apollo-compiler/examples/validate.rs
+++ b/crates/apollo-compiler/examples/validate.rs
@@ -1,6 +1,11 @@
 use apollo_compiler::ApolloCompiler;
 use std::io::Read;
 
+/// A simple program to run the validations implemented by apollo-compiler
+/// and report any errors.
+///
+/// To use, do:
+/// cargo run --example validate path/to/input.graphql
 fn main() {
     let (source, filename) = match std::env::args().nth(1).as_deref() {
         Some("-") | None => {
@@ -19,7 +24,9 @@ fn main() {
 
     let diagnostics = compiler.validate();
 
-    for diagnostic in diagnostics {
+    for diagnostic in &diagnostics {
         println!("{diagnostic}");
     }
+
+    std::process::exit(if diagnostics.is_empty() { 0 } else { 1 });
 }

--- a/crates/apollo-compiler/examples/validate.rs
+++ b/crates/apollo-compiler/examples/validate.rs
@@ -1,0 +1,25 @@
+use apollo_compiler::ApolloCompiler;
+use std::io::Read;
+
+fn main() {
+    let (source, filename) = match std::env::args().nth(1).as_deref() {
+        Some("-") | None => {
+            let mut source = String::new();
+            std::io::stdin().read_to_string(&mut source).unwrap();
+            (source, "input.graphql".to_string())
+        }
+        Some(filename) => (
+            std::fs::read_to_string(filename).unwrap(),
+            filename.to_string(),
+        ),
+    };
+
+    let mut compiler = ApolloCompiler::new();
+    compiler.add_document(&source, &filename);
+
+    let diagnostics = compiler.validate();
+
+    for diagnostic in diagnostics {
+        println!("{diagnostic}");
+    }
+}


### PR DESCRIPTION
Just a way to run all the validations on a single file.

I found this quite useful just to check the output of a single test_data file or to try things out separate of our tests. You can do:
```
cargo run --example validate path/to/document.graphql
```