### PR TITLE
fix(compiler): add limit exceeded diagnostic

### DIFF
--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -141,6 +141,8 @@ impl fmt::Display for ApolloDiagnostic {
 pub enum DiagnosticData {
     #[error("syntax error: {message}")]
     SyntaxError { message: String },
+    #[error("limit exceeded: {message}")]
+    LimitExceeded { message: String },
     #[error("expected identifier")]
     MissingIdent,
     #[error("the {ty} `{name}` is defined multiple times in the document")]

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -288,7 +288,6 @@ query ExampleQuery {
         let mut compiler = ApolloCompiler::new();
         compiler.add_document(schema, "schema.graphql");
         compiler.add_executable(query, "query.graphql");
-        dbg!(compiler.db.source_files());
     }
 
     #[test]


### PR DESCRIPTION
Noticed the diagnostics for exceeded limits were noting them as "syntax errors", when they are in fact "limit exceeded" errors. 