### PR TITLE
feat(compiler): validate object type extensions

### DIFF
--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -221,6 +221,8 @@ pub enum DiagnosticData {
     },
     #[error("the required argument `{name}` is not provided")]
     RequiredArgument { name: String },
+    #[error("`implements` declarations must be unique")]
+    DuplicateImplementsInterface { name: String },
     #[error(
         "Transitively implemented interfaces must also be defined on an implementing interface or object"
     )]

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -221,8 +221,8 @@ pub enum DiagnosticData {
     },
     #[error("the required argument `{name}` is not provided")]
     RequiredArgument { name: String },
-    #[error("`implements` declarations must be unique")]
-    DuplicateImplementsInterface { name: String },
+    #[error("type `{ty}` can only implement interface `{interface}` once")]
+    DuplicateImplementsInterface { ty: String, interface: String },
     #[error(
         "Transitively implemented interfaces must also be defined on an implementing interface or object"
     )]

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -73,9 +73,10 @@ pub fn validate_interface_definition(
     diagnostics.extend(db.validate_field_definitions(interface_def.self_fields().to_vec()));
 
     // Implements Interfaceds validation.
-    diagnostics.extend(
-        db.validate_implements_interfaces(interface_def.self_implements_interfaces().to_vec()),
-    );
+    diagnostics.extend(db.validate_implements_interfaces(
+        interface_def.name().to_string(),
+        interface_def.self_implements_interfaces().to_vec(),
+    ));
 
     // When defining an interface that implements another interface, the
     // implementing interface must define each field that is specified by
@@ -134,6 +135,7 @@ pub fn validate_interface_definition(
 
 pub fn validate_implements_interfaces(
     db: &dyn ValidationDatabase,
+    implementor_name: String,
     impl_interfaces: Vec<ImplementsInterface>,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
@@ -228,7 +230,8 @@ pub fn validate_implements_interfaces(
                     db,
                     impl_interface.loc().into(),
                     DiagnosticData::DuplicateImplementsInterface {
-                        name: name.to_string(),
+                        ty: implementor_name.clone(),
+                        interface: name.to_string(),
                     },
                 )
                 .label(Label::new(

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -64,7 +64,9 @@ pub fn validate_object_type_definition(
         object.extensions(),
         hir::ObjectTypeExtension::implements_interfaces,
     );
-    diagnostics.extend(db.validate_implements_interfaces(implements_interfaces));
+    diagnostics.extend(
+        db.validate_implements_interfaces(object.name().to_string(), implements_interfaces),
+    );
 
     // When defining an interface that implements another interface, the
     // implementing interface must define each field that is specified by

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -71,11 +71,10 @@ pub fn validate_object_type_definition(
     // the implemented interface.
     //
     // Returns a Missing Field error.
-    for implements_interface in object.self_implements_interfaces().iter() {
+    for implements_interface in object.implements_interfaces() {
         if let Some(interface) = implements_interface.interface_definition(db.upcast()) {
             let implements_interface_fields: HashSet<ValidationSet> = interface
-                .self_fields()
-                .iter()
+                .fields()
                 .map(|field| ValidationSet {
                     name: field.name().into(),
                     loc: field.loc(),

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -41,31 +41,36 @@ pub fn validate_object_type_definition(
         hir::DirectiveLocation::Object,
     ));
 
-    // Object Type field validations.
-    let fields = collect_nodes(
+    // Collect all fields, including duplicates
+    let field_definitions = collect_nodes(
         object.self_fields(),
         object.extensions(),
         hir::ObjectTypeExtension::fields_definition,
     );
-    diagnostics.extend(db.validate_field_definitions(fields));
-
-    // Implements Interfaces validation.
-    diagnostics
-        .extend(db.validate_implements_interfaces(object.self_implements_interfaces().to_vec()));
-
-    // When defining an interface that implements another interface, the
-    // implementing interface must define each field that is specified by
-    // the implemented interface.
-    //
-    // Returns a Missing Field error.
-    let fields: HashSet<ValidationSet> = object
-        .self_fields()
+    let fields: HashSet<ValidationSet> = field_definitions
         .iter()
         .map(|field| ValidationSet {
             name: field.name().into(),
             loc: field.loc(),
         })
         .collect();
+
+    // Object Type field validations.
+    diagnostics.extend(db.validate_field_definitions(field_definitions));
+
+    // Implements Interfaces validation.
+    let implements_interfaces = collect_nodes(
+        object.self_implements_interfaces(),
+        object.extensions(),
+        hir::ObjectTypeExtension::implements_interfaces,
+    );
+    diagnostics.extend(db.validate_implements_interfaces(implements_interfaces));
+
+    // When defining an interface that implements another interface, the
+    // implementing interface must define each field that is specified by
+    // the implemented interface.
+    //
+    // Returns a Missing Field error.
     for implements_interface in object.self_implements_interfaces().iter() {
         if let Some(interface) = implements_interface.interface_definition(db.upcast()) {
             let implements_interface_fields: HashSet<ValidationSet> = interface

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -79,6 +79,7 @@ pub trait ValidationDatabase:
     #[salsa::invoke(interface::validate_implements_interfaces)]
     fn validate_implements_interfaces(
         &self,
+        implementor_name: String,
         impl_interfaces: Vec<ImplementsInterface>,
     ) -> Vec<ApolloDiagnostic>;
 

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.graphql
@@ -29,6 +29,15 @@ type UniqueInterfaces implements Base {
   nickname: String
 }
 extend type UniqueInterfaces implements Base {
-  name: String
   age: Int
+}
+
+interface ExtendedInterface {
+  name: String
+}
+type ImplementsBaseButNotExtension implements ExtendedInterface {
+  name: String
+}
+extend interface ExtendedInterface {
+  fail: Boolean
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.graphql
@@ -1,0 +1,34 @@
+type UniqueNames {
+  name: String
+}
+extend type UniqueNames {
+  age: Int
+  age: Int
+}
+
+type ConflictingNames {
+  name: String
+}
+extend type ConflictingNames {
+  name: String
+}
+
+directive @nonRepeatable on OBJECT
+type UniqueDirective @nonRepeatable {
+  a: Int!
+}
+extend type UniqueDirective @nonRepeatable {
+  b: Int
+}
+
+interface Base {
+  name: String
+}
+type UniqueInterfaces implements Base {
+  name: String
+  nickname: String
+}
+extend type UniqueInterfaces implements Base {
+  name: String
+  age: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
@@ -171,6 +171,45 @@
             file_id: FileId {
                 id: 91,
             },
+            offset: 469,
+            length: 4,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 386,
+                    length: 4,
+                },
+                text: "`Base` interface implementation previously declared here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 469,
+                    length: 4,
+                },
+                text: "`Base` interface implementation declared again here",
+            },
+        ],
+        help: None,
+        data: DuplicateImplementsInterface {
+            name: "Base",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            91: "0094_object_type_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 91,
+            },
             offset: 537,
             length: 82,
         },

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
@@ -198,7 +198,8 @@
         ],
         help: None,
         data: DuplicateImplementsInterface {
-            name: "Base",
+            ty: "UniqueInterfaces",
+            interface: "Base",
         },
     },
     ApolloDiagnostic {

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
@@ -171,8 +171,8 @@
             file_id: FileId {
                 id: 91,
             },
-            offset: 395,
-            length: 12,
+            offset: 537,
+            length: 82,
         },
         labels: [
             Label {
@@ -180,41 +180,27 @@
                     file_id: FileId {
                         id: 91,
                     },
-                    offset: 395,
-                    length: 12,
+                    offset: 537,
+                    length: 82,
                 },
-                text: "previous definition of `name` here",
+                text: "add `fail` field to this object",
             },
             Label {
                 location: DiagnosticLocation {
                     file_id: FileId {
                         id: 91,
                     },
-                    offset: 478,
-                    length: 12,
+                    offset: 659,
+                    length: 13,
                 },
-                text: "`name` redefined here",
+                text: "`fail` was originally defined here",
             },
         ],
         help: Some(
-            "`name` field must only be defined once in this input object definition.",
+            "An object must provide all fields required by the interfaces it implements",
         ),
-        data: UniqueField {
-            field: "name",
-            original_definition: DiagnosticLocation {
-                file_id: FileId {
-                    id: 91,
-                },
-                offset: 395,
-                length: 12,
-            },
-            redefined_definition: DiagnosticLocation {
-                file_id: FileId {
-                    id: 91,
-                },
-                offset: 478,
-                length: 12,
-            },
+        data: MissingField {
+            field: "fail",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
@@ -1,0 +1,220 @@
+[
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            91: "0094_object_type_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 91,
+            },
+            offset: 64,
+            length: 8,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 64,
+                    length: 8,
+                },
+                text: "previous definition of `age` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 75,
+                    length: 8,
+                },
+                text: "`age` redefined here",
+            },
+        ],
+        help: Some(
+            "`age` field must only be defined once in this input object definition.",
+        ),
+        data: UniqueField {
+            field: "age",
+            original_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 91,
+                },
+                offset: 64,
+                length: 8,
+            },
+            redefined_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 91,
+                },
+                offset: 75,
+                length: 8,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            91: "0094_object_type_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 91,
+            },
+            offset: 113,
+            length: 12,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 113,
+                    length: 12,
+                },
+                text: "previous definition of `name` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 161,
+                    length: 12,
+                },
+                text: "`name` redefined here",
+            },
+        ],
+        help: Some(
+            "`name` field must only be defined once in this input object definition.",
+        ),
+        data: UniqueField {
+            field: "name",
+            original_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 91,
+                },
+                offset: 113,
+                length: 12,
+            },
+            redefined_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 91,
+                },
+                offset: 161,
+                length: 12,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            91: "0094_object_type_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 91,
+            },
+            offset: 290,
+            length: 14,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 233,
+                    length: 14,
+                },
+                text: "directive nonRepeatable first called here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 290,
+                    length: 14,
+                },
+                text: "directive nonRepeatable called again here",
+            },
+        ],
+        help: None,
+        data: UniqueDirective {
+            name: "nonRepeatable",
+            original_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 91,
+                },
+                offset: 233,
+                length: 14,
+            },
+            conflicting_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 91,
+                },
+                offset: 290,
+                length: 14,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            91: "0094_object_type_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 91,
+            },
+            offset: 395,
+            length: 12,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 395,
+                    length: 12,
+                },
+                text: "previous definition of `name` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 91,
+                    },
+                    offset: 478,
+                    length: 12,
+                },
+                text: "`name` redefined here",
+            },
+        ],
+        help: Some(
+            "`name` field must only be defined once in this input object definition.",
+        ),
+        data: UniqueField {
+            field: "name",
+            original_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 91,
+                },
+                offset: 395,
+                length: 12,
+            },
+            redefined_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 91,
+                },
+                offset: 478,
+                length: 12,
+            },
+        },
+    },
+]

--- a/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.graphql
@@ -10,3 +10,13 @@ type Extended implements Intf {
   field: String
 }
 extend type Extended implements Intf
+
+interface SubIntf implements Intf & Intf {
+  field: String
+}
+
+# TODO(@goto-bus-stop): support interface extensions in validation
+# interface ExtendedIntf implements Intf {
+#   field: String
+# }
+# extend interface ExtendedIntf implements Intf

--- a/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.graphql
@@ -1,0 +1,12 @@
+interface Intf {
+  field: String
+}
+
+type Object implements Intf & Intf {
+  field: String
+}
+
+type Extended implements Intf {
+  field: String
+}
+extend type Extended implements Intf

--- a/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.txt
@@ -8,6 +8,46 @@
             file_id: FileId {
                 id: 92,
             },
+            offset: 216,
+            length: 4,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 92,
+                    },
+                    offset: 209,
+                    length: 4,
+                },
+                text: "`Intf` interface implementation previously declared here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 92,
+                    },
+                    offset: 216,
+                    length: 4,
+                },
+                text: "`Intf` interface implementation declared again here",
+            },
+        ],
+        help: None,
+        data: DuplicateImplementsInterface {
+            ty: "SubIntf",
+            interface: "Intf",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            92: "0095_interface_implementation_declared_once.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 92,
+            },
             offset: 66,
             length: 4,
         },
@@ -35,7 +75,8 @@
         ],
         help: None,
         data: DuplicateImplementsInterface {
-            name: "Intf",
+            ty: "Object",
+            interface: "Intf",
         },
     },
     ApolloDiagnostic {
@@ -74,7 +115,8 @@
         ],
         help: None,
         data: DuplicateImplementsInterface {
-            name: "Intf",
+            ty: "Extended",
+            interface: "Intf",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.txt
@@ -1,0 +1,80 @@
+[
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            92: "0095_interface_implementation_declared_once.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 92,
+            },
+            offset: 66,
+            length: 4,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 92,
+                    },
+                    offset: 59,
+                    length: 4,
+                },
+                text: "`Intf` interface implementation previously declared here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 92,
+                    },
+                    offset: 66,
+                    length: 4,
+                },
+                text: "`Intf` interface implementation declared again here",
+            },
+        ],
+        help: None,
+        data: DuplicateImplementsInterface {
+            name: "Intf",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            92: "0095_interface_implementation_declared_once.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 92,
+            },
+            offset: 174,
+            length: 4,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 92,
+                    },
+                    offset: 117,
+                    length: 4,
+                },
+                text: "`Intf` interface implementation previously declared here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 92,
+                    },
+                    offset: 174,
+                    length: 4,
+                },
+                text: "`Intf` interface implementation declared again here",
+            },
+        ],
+        help: None,
+        data: DuplicateImplementsInterface {
+            name: "Intf",
+        },
+    },
+]


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-rs/issues/476

Progress:
* [x] The named type must already be defined
* [x] the already defined type must be an Object type.
* [x] The fields of an Object type extension must have unique names; no two fields may share the same name.
* [x] Any fields of an Object type extension must not be already defined on the original Object type.
* [x] Any non-repeatable directives provided must not already apply to the original Object type.
* [x] Any interfaces provided must not be already implemented by the original Object type.
* [x] The resulting extended object type must be a super-set of all interfaces it implements.

[spec](https://spec.graphql.org/October2021/#sec-Object-Extensions.Type-Validation)