### PR TITLE
feat(compiler): validate enum extensions, fixes #479

### DIFF
--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -57,7 +57,7 @@ pub fn validate_enum_definition(
                     db,
                     redefined_definition.into(),
                     DiagnosticData::UniqueDefinition {
-                        ty: "enum",
+                        ty: "enum value",
                         name: value.into(),
                         original_definition: original_definition.into(),
                         redefined_definition: redefined_definition.into(),

--- a/crates/apollo-compiler/test_data/diagnostics/0019_enum_definition_with_duplicate_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0019_enum_definition_with_duplicate_values.txt
@@ -37,7 +37,7 @@
             "CAT must only be defined once in this enum.",
         ),
         data: UniqueDefinition {
-            ty: "enum",
+            ty: "enum value",
             name: "CAT",
             original_definition: DiagnosticLocation {
                 file_id: FileId {
@@ -93,7 +93,7 @@
             "THRIVE_PET_FOODS must only be defined once in this enum.",
         ),
         data: UniqueDefinition {
-            ty: "enum",
+            ty: "enum value",
             name: "THRIVE_PET_FOODS",
             original_definition: DiagnosticLocation {
                 file_id: FileId {

--- a/crates/apollo-compiler/test_data/diagnostics/0070_self_referential_directive_definition.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0070_self_referential_directive_definition.graphql
@@ -18,6 +18,6 @@ enum Enum { NON_RECURSIVE }
 extend enum Enum { RECURSIVE @wrong }
 input Name { value: String!, type: Enum }
 input InputObject { name: Name }
-directive @wrong(input: InputObject) on INPUT_FIELD_DEFINITION
+directive @wrong(input: InputObject) on INPUT_FIELD_DEFINITION | ENUM_VALUE
 
 directive @thisOneShouldNotError(arg: Boolean @loopC) on FIELD

--- a/crates/apollo-compiler/test_data/diagnostics/0070_self_referential_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0070_self_referential_directive_definition.txt
@@ -204,7 +204,7 @@
                 id: 70,
             },
             offset: 705,
-            length: 62,
+            length: 75,
         },
         labels: [
             Label {

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.graphql
@@ -1,14 +1,16 @@
+directive @nonRepeatable on ENUM
+
 enum E {
   MEMBER_1
   MEMBER_2
 }
 
-extend enum E {
+extend enum E @nonRepeatable {
   MEMBER_3
   MEMBER_4
 }
 
-extend enum E {
+extend enum E @nonRepeatable {
   MEMBER_2
   MEMBER_4
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.graphql
@@ -1,0 +1,14 @@
+enum E {
+  MEMBER_1
+  MEMBER_2
+}
+
+extend enum E {
+  MEMBER_3
+  MEMBER_4
+}
+
+extend enum E {
+  MEMBER_2
+  MEMBER_4
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
@@ -1,0 +1,114 @@
+[
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            94: "0097_enum_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 94,
+            },
+            offset: 93,
+            length: 8,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 94,
+                    },
+                    offset: 22,
+                    length: 8,
+                },
+                text: "previous definition of `MEMBER_2` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 94,
+                    },
+                    offset: 93,
+                    length: 8,
+                },
+                text: "`MEMBER_2` redefined here",
+            },
+        ],
+        help: Some(
+            "MEMBER_2 must only be defined once in this enum.",
+        ),
+        data: UniqueDefinition {
+            ty: "enum",
+            name: "MEMBER_2",
+            original_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 94,
+                },
+                offset: 22,
+                length: 8,
+            },
+            redefined_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 94,
+                },
+                offset: 93,
+                length: 8,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            94: "0097_enum_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 94,
+            },
+            offset: 104,
+            length: 8,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 94,
+                    },
+                    offset: 63,
+                    length: 8,
+                },
+                text: "previous definition of `MEMBER_4` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 94,
+                    },
+                    offset: 104,
+                    length: 8,
+                },
+                text: "`MEMBER_4` redefined here",
+            },
+        ],
+        help: Some(
+            "MEMBER_4 must only be defined once in this enum.",
+        ),
+        data: UniqueDefinition {
+            ty: "enum",
+            name: "MEMBER_4",
+            original_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 94,
+                },
+                offset: 63,
+                length: 8,
+            },
+            redefined_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 94,
+                },
+                offset: 104,
+                length: 8,
+            },
+        },
+    },
+]

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
@@ -90,7 +90,7 @@
             "MEMBER_2 must only be defined once in this enum.",
         ),
         data: UniqueDefinition {
-            ty: "enum",
+            ty: "enum value",
             name: "MEMBER_2",
             original_definition: DiagnosticLocation {
                 file_id: FileId {
@@ -146,7 +146,7 @@
             "MEMBER_4 must only be defined once in this enum.",
         ),
         data: UniqueDefinition {
-            ty: "enum",
+            ty: "enum value",
             name: "MEMBER_4",
             original_definition: DiagnosticLocation {
                 file_id: FileId {

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
@@ -8,7 +8,60 @@
             file_id: FileId {
                 id: 94,
             },
-            offset: 93,
+            offset: 138,
+            length: 14,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 94,
+                    },
+                    offset: 82,
+                    length: 14,
+                },
+                text: "directive nonRepeatable first called here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 94,
+                    },
+                    offset: 138,
+                    length: 14,
+                },
+                text: "directive nonRepeatable called again here",
+            },
+        ],
+        help: None,
+        data: UniqueDirective {
+            name: "nonRepeatable",
+            original_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 94,
+                },
+                offset: 82,
+                length: 14,
+            },
+            conflicting_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 94,
+                },
+                offset: 138,
+                length: 14,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            94: "0097_enum_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 94,
+            },
+            offset: 157,
             length: 8,
         },
         labels: [
@@ -17,7 +70,7 @@
                     file_id: FileId {
                         id: 94,
                     },
-                    offset: 22,
+                    offset: 56,
                     length: 8,
                 },
                 text: "previous definition of `MEMBER_2` here",
@@ -27,7 +80,7 @@
                     file_id: FileId {
                         id: 94,
                     },
-                    offset: 93,
+                    offset: 157,
                     length: 8,
                 },
                 text: "`MEMBER_2` redefined here",
@@ -43,14 +96,14 @@
                 file_id: FileId {
                     id: 94,
                 },
-                offset: 22,
+                offset: 56,
                 length: 8,
             },
             redefined_definition: DiagnosticLocation {
                 file_id: FileId {
                     id: 94,
                 },
-                offset: 93,
+                offset: 157,
                 length: 8,
             },
         },
@@ -64,7 +117,7 @@
             file_id: FileId {
                 id: 94,
             },
-            offset: 104,
+            offset: 168,
             length: 8,
         },
         labels: [
@@ -73,7 +126,7 @@
                     file_id: FileId {
                         id: 94,
                     },
-                    offset: 63,
+                    offset: 112,
                     length: 8,
                 },
                 text: "previous definition of `MEMBER_4` here",
@@ -83,7 +136,7 @@
                     file_id: FileId {
                         id: 94,
                     },
-                    offset: 104,
+                    offset: 168,
                     length: 8,
                 },
                 text: "`MEMBER_4` redefined here",
@@ -99,14 +152,14 @@
                 file_id: FileId {
                     id: 94,
                 },
-                offset: 63,
+                offset: 112,
                 length: 8,
             },
             redefined_definition: DiagnosticLocation {
                 file_id: FileId {
                     id: 94,
                 },
-                offset: 104,
+                offset: 168,
                 length: 8,
             },
         },


### PR DESCRIPTION
New errors for:

- duplicate members
  ```graphql
  enum E { MEMBER_A }
  extend enum E { MEMBER_A } # ERROR: the enum value `MEMBER_2` is defined multiple times in the document
  ```
  (the diagnostic message is not ideal there as it's not related to the document, could be improved by adding a DiagnosticData type specifically for enum values)

- duplicate directive applications
  ```graphql
  enum E @nonRepeatable {}
  extend enum E @nonRepeatable # ERROR: non-repeatable directive nonRepeatable can only be used once per location
  ```
