### PR TITLE
feat(compiler): validate input object extensions, closes #480

### DIFF
--- a/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.graphql
@@ -1,0 +1,12 @@
+input UniqueNames {
+  field: String
+}
+extend input UniqueNames {
+  field: String
+}
+
+directive @nonRepeatable on INPUT_OBJECT
+input UniqueDirective @nonRepeatable {
+  field: String
+}
+extend input UniqueDirective @nonRepeatable

--- a/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.txt
@@ -1,0 +1,110 @@
+[
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            96: "0099_input_object_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 96,
+            },
+            offset: 22,
+            length: 13,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 96,
+                    },
+                    offset: 22,
+                    length: 13,
+                },
+                text: "previous definition of `field` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 96,
+                    },
+                    offset: 67,
+                    length: 13,
+                },
+                text: "`field` redefined here",
+            },
+        ],
+        help: Some(
+            "`field` field must only be defined once in this input object definition.",
+        ),
+        data: UniqueInputValue {
+            name: "field",
+            original_value: DiagnosticLocation {
+                file_id: FileId {
+                    id: 96,
+                },
+                offset: 22,
+                length: 13,
+            },
+            redefined_value: DiagnosticLocation {
+                file_id: FileId {
+                    id: 96,
+                },
+                offset: 67,
+                length: 13,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            96: "0099_input_object_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 96,
+            },
+            offset: 211,
+            length: 14,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 96,
+                    },
+                    offset: 147,
+                    length: 14,
+                },
+                text: "directive nonRepeatable first called here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 96,
+                    },
+                    offset: 211,
+                    length: 14,
+                },
+                text: "directive nonRepeatable called again here",
+            },
+        ],
+        help: None,
+        data: UniqueDirective {
+            name: "nonRepeatable",
+            original_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 96,
+                },
+                offset: 147,
+                length: 14,
+            },
+            conflicting_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 96,
+                },
+                offset: 211,
+                length: 14,
+            },
+        },
+    },
+]


### PR DESCRIPTION
Currently duplicating `collect_nodes` in every file, will consolidate after the fact.