### PR TITLE
feat(compiler): validate executable documents do not contain type definitions, fixes #409

### DIFF
--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -162,7 +162,7 @@ fn executable_definition_files(db: &dyn InputDatabase) -> Vec<FileId> {
         .filter(|source| {
             matches!(
                 db.source_type(*source),
-                SourceType::Query | SourceType::Document
+                SourceType::Executable | SourceType::Document
             )
         })
         .collect()

--- a/crates/apollo-compiler/src/database/sources.rs
+++ b/crates/apollo-compiler/src/database/sources.rs
@@ -6,7 +6,7 @@ use std::{
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SourceType {
     Schema,
-    Query,
+    Executable,
     Document,
     BuiltIn,
 }
@@ -28,12 +28,12 @@ impl SourceType {
         matches!(self, Self::Document)
     }
 
-    /// Returns `true` if the source type is [`Query`].
+    /// Returns `true` if the source type is [`Executable`].
     ///
-    /// [`Query`]: SourceType::Query
+    /// [`Executable`]: SourceType::Executable
     #[must_use]
-    pub fn is_query(&self) -> bool {
-        matches!(self, Self::Query)
+    pub fn is_executable(&self) -> bool {
+        matches!(self, Self::Executable)
     }
 
     /// Returns `true` if the source type is [`Schema`].
@@ -66,7 +66,7 @@ impl Source {
     /// Create a GraphQL executable source file.
     pub fn executable(filename: PathBuf, text: impl Into<Arc<str>>) -> Self {
         Self {
-            ty: SourceType::Query,
+            ty: SourceType::Executable,
             filename,
             text: text.into(),
         }

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -145,6 +145,8 @@ pub enum DiagnosticData {
     LimitExceeded { message: String },
     #[error("expected identifier")]
     MissingIdent,
+    #[error("executable documents must not contain {kind}")]
+    ExecutableDefinition { kind: &'static str },
     #[error("the {ty} `{name}` is defined multiple times in the document")]
     UniqueDefinition {
         ty: &'static str,

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -103,6 +103,35 @@ impl ast::Definition {
         }
     }
 
+    pub fn kind(&self) -> &'static str {
+        match self {
+            ast::Definition::OperationDefinition(_) => "OperationDefinition",
+            ast::Definition::FragmentDefinition(_) => "FragmentDefinition",
+            ast::Definition::DirectiveDefinition(_) => "DirectiveDefinition",
+            ast::Definition::ScalarTypeDefinition(_) => "ScalarTypeDefinition",
+            ast::Definition::ObjectTypeDefinition(_) => "ObjectTypeDefinition",
+            ast::Definition::InterfaceTypeDefinition(_) => "InterfaceTypeDefinition",
+            ast::Definition::UnionTypeDefinition(_) => "UnionTypeDefinition",
+            ast::Definition::EnumTypeDefinition(_) => "EnumTypeDefinition",
+            ast::Definition::InputObjectTypeDefinition(_) => "InputObjectTypeDefinition",
+            ast::Definition::SchemaDefinition(_) => "SchemaDefinition",
+            ast::Definition::SchemaExtension(_) => "SchemaExtension",
+            ast::Definition::ScalarTypeExtension(_) => "ScalarTypeExtension",
+            ast::Definition::ObjectTypeExtension(_) => "ObjectTypeExtension",
+            ast::Definition::InterfaceTypeExtension(_) => "InterfaceTypeExtension",
+            ast::Definition::UnionTypeExtension(_) => "UnionTypeExtension",
+            ast::Definition::EnumTypeExtension(_) => "EnumTypeExtension",
+            ast::Definition::InputObjectTypeExtension(_) => "InputObjectTypeExtension",
+        }
+    }
+
+    pub fn is_executable_definition(&self) -> bool {
+        matches!(
+            self,
+            Self::OperationDefinition(_) | Self::FragmentDefinition(_)
+        )
+    }
+
     pub fn is_extension_definition(&self) -> bool {
         matches!(
             self,


### PR DESCRIPTION
This doesn't check the opposite, so you can put executable definitions in a schema document ... the spec doesn't appear to prohibit that as far as I can tell.

we have to check the `source_type` is `SourceType::Executable` before running this check, as `SourceType::Document` sources are also run through this `validate_executable` function.