### PR TITLE
breaking(compiler): align extension getters to their type def counterparts

### DIFF
--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -341,7 +341,7 @@ pub(crate) fn subtype_map(db: &dyn HirDatabase) -> Arc<HashMap<String, HashSet<S
             add(name, member.name());
         }
         for extension in definition.extensions() {
-            for member in extension.union_members() {
+            for member in extension.members() {
                 add(name, member.name());
             }
         }

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -2123,7 +2123,7 @@ impl ObjectTypeDefinition {
         self.fields_by_name.iter(
             self.self_fields(),
             self.extensions(),
-            ObjectTypeExtension::fields_definition,
+            ObjectTypeExtension::fields,
         )
     }
 
@@ -2134,7 +2134,7 @@ impl ObjectTypeDefinition {
                 name,
                 self.self_fields(),
                 self.extensions(),
-                ObjectTypeExtension::fields_definition,
+                ObjectTypeExtension::fields,
             )
             .or_else(|| self.implicit_fields(db).iter().find(|f| f.name() == name))
     }
@@ -2182,11 +2182,8 @@ impl ObjectTypeDefinition {
 
     pub(crate) fn push_extension(&mut self, ext: Arc<ObjectTypeExtension>) {
         let next_index = self.extensions.len();
-        self.fields_by_name.add_extension(
-            next_index,
-            ext.fields_definition(),
-            FieldDefinition::name,
-        );
+        self.fields_by_name
+            .add_extension(next_index, ext.fields(), FieldDefinition::name);
         self.implements_interfaces_by_name.add_extension(
             next_index,
             ext.implements_interfaces(),
@@ -2556,7 +2553,7 @@ impl EnumTypeDefinition {
         self.values_by_name.iter(
             self.self_values(),
             self.extensions(),
-            EnumTypeExtension::enum_values_definition,
+            EnumTypeExtension::values,
         )
     }
 
@@ -2566,7 +2563,7 @@ impl EnumTypeDefinition {
             name,
             self.self_values(),
             self.extensions(),
-            EnumTypeExtension::enum_values_definition,
+            EnumTypeExtension::values,
         )
     }
 
@@ -2584,7 +2581,7 @@ impl EnumTypeDefinition {
         let next_index = self.extensions.len();
         self.values_by_name.add_extension(
             next_index,
-            ext.enum_values_definition(),
+            ext.values(),
             EnumValueDefinition::enum_value,
         );
         self.extensions.push(ext);
@@ -2725,7 +2722,7 @@ impl UnionTypeDefinition {
         self.members_by_name.iter(
             self.self_members(),
             self.extensions(),
-            UnionTypeExtension::union_members,
+            UnionTypeExtension::members,
         )
     }
 
@@ -2737,7 +2734,7 @@ impl UnionTypeDefinition {
                 name,
                 self.self_members(),
                 self.extensions(),
-                UnionTypeExtension::union_members,
+                UnionTypeExtension::members,
             )
             .is_some()
     }
@@ -2755,7 +2752,7 @@ impl UnionTypeDefinition {
     pub(crate) fn push_extension(&mut self, ext: Arc<UnionTypeExtension>) {
         let next_index = self.extensions.len();
         self.members_by_name
-            .add_extension(next_index, ext.union_members(), UnionMember::name);
+            .add_extension(next_index, ext.members(), UnionMember::name);
         self.extensions.push(ext);
     }
 
@@ -2898,7 +2895,7 @@ impl InterfaceTypeDefinition {
         self.fields_by_name.iter(
             self.self_fields(),
             self.extensions(),
-            InterfaceTypeExtension::fields_definition,
+            InterfaceTypeExtension::fields,
         )
     }
 
@@ -2909,7 +2906,7 @@ impl InterfaceTypeDefinition {
                 name,
                 self.self_fields(),
                 self.extensions(),
-                InterfaceTypeExtension::fields_definition,
+                InterfaceTypeExtension::fields,
             )
             .or_else(|| self.implicit_fields().iter().find(|f| f.name() == name))
     }
@@ -2926,11 +2923,8 @@ impl InterfaceTypeDefinition {
 
     pub(crate) fn push_extension(&mut self, ext: Arc<InterfaceTypeExtension>) {
         let next_index = self.extensions.len();
-        self.fields_by_name.add_extension(
-            next_index,
-            ext.fields_definition(),
-            FieldDefinition::name,
-        );
+        self.fields_by_name
+            .add_extension(next_index, ext.fields(), FieldDefinition::name);
         self.implements_interfaces_by_name.add_extension(
             next_index,
             ext.implements_interfaces(),
@@ -3021,7 +3015,7 @@ impl InputObjectTypeDefinition {
         self.input_fields_by_name.iter(
             self.self_fields(),
             self.extensions(),
-            InputObjectTypeExtension::input_fields_definition,
+            InputObjectTypeExtension::fields,
         )
     }
 
@@ -3031,7 +3025,7 @@ impl InputObjectTypeDefinition {
             name,
             self.self_fields(),
             self.extensions(),
-            InputObjectTypeExtension::input_fields_definition,
+            InputObjectTypeExtension::fields,
         )
     }
 
@@ -3049,7 +3043,7 @@ impl InputObjectTypeDefinition {
         let next_index = self.extensions.len();
         self.input_fields_by_name.add_extension(
             next_index,
-            ext.input_fields_definition(),
+            ext.fields(),
             InputValueDefinition::name,
         );
         self.extensions.push(ext);
@@ -3224,13 +3218,13 @@ impl ObjectTypeExtension {
     }
 
     /// Get a reference to the object type definition's field definitions.
-    pub fn fields_definition(&self) -> &[FieldDefinition] {
+    pub fn fields(&self) -> &[FieldDefinition] {
         self.fields_definition.as_ref()
     }
 
     /// Find a field in object type definition.
     pub fn field(&self, name: &str) -> Option<&FieldDefinition> {
-        self.fields_definition().iter().find(|f| f.name() == name)
+        self.fields().iter().find(|f| f.name() == name)
     }
 
     /// Get a reference to object type definition's implements interfaces vector.
@@ -3294,13 +3288,13 @@ impl InterfaceTypeExtension {
     }
 
     /// Get a reference to interface definition's fields.
-    pub fn fields_definition(&self) -> &[FieldDefinition] {
+    pub fn fields(&self) -> &[FieldDefinition] {
         self.fields_definition.as_ref()
     }
 
     /// Find a field in interface face definition.
     pub fn field(&self, name: &str) -> Option<&FieldDefinition> {
-        self.fields_definition().iter().find(|f| f.name() == name)
+        self.fields().iter().find(|f| f.name() == name)
     }
 
     /// Get the AST location information for this HIR node.
@@ -3354,7 +3348,7 @@ impl UnionTypeExtension {
     }
 
     /// Get a reference to union definition's union members.
-    pub fn union_members(&self) -> &[UnionMember] {
+    pub fn members(&self) -> &[UnionMember] {
         self.union_members.as_ref()
     }
 
@@ -3408,7 +3402,7 @@ impl EnumTypeExtension {
     }
 
     /// Get a reference to enum definition's enum values definition vector.
-    pub fn enum_values_definition(&self) -> &[EnumValueDefinition] {
+    pub fn values(&self) -> &[EnumValueDefinition] {
         self.enum_values_definition.as_ref()
     }
 
@@ -3461,7 +3455,7 @@ impl InputObjectTypeExtension {
             .filter(move |directive| directive.name() == name)
     }
 
-    pub fn input_fields_definition(&self) -> &[InputValueDefinition] {
+    pub fn fields(&self) -> &[InputValueDefinition] {
         self.input_fields_definition.as_ref()
     }
 

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -38,7 +38,7 @@ pub fn validate_enum_definition(
     let enum_values = iter_with_extensions(
         enum_def.self_values(),
         enum_def.extensions(),
-        hir::EnumTypeExtension::enum_values_definition,
+        hir::EnumTypeExtension::values,
     );
 
     let mut seen: HashMap<&str, &EnumValueDefinition> = HashMap::new();

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -124,7 +124,7 @@ pub fn validate_input_object_definition(
     let fields = collect_nodes(
         input_obj.input_fields_definition.as_ref(),
         input_obj.extensions(),
-        hir::InputObjectTypeExtension::input_fields_definition,
+        hir::InputObjectTypeExtension::fields,
     );
     diagnostics.extend(db.validate_input_values(
         Arc::new(fields),

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -85,7 +85,7 @@ pub fn validate_interface_definition(
     let field_definitions = collect_nodes(
         interface_def.self_fields(),
         interface_def.extensions(),
-        hir::InterfaceTypeExtension::fields_definition,
+        hir::InterfaceTypeExtension::fields,
     );
     diagnostics.extend(db.validate_field_definitions(field_definitions));
 

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -45,7 +45,7 @@ pub fn validate_object_type_definition(
     let field_definitions = collect_nodes(
         object.self_fields(),
         object.extensions(),
-        hir::ObjectTypeExtension::fields_definition,
+        hir::ObjectTypeExtension::fields,
     );
     let fields: HashSet<ValidationSet> = field_definitions
         .iter()

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -38,7 +38,7 @@ pub fn validate_union_definition(
     let union_members = iter_with_extensions(
         union_def.self_members(),
         union_def.extensions(),
-        hir::UnionTypeExtension::union_members,
+        hir::UnionTypeExtension::members,
     );
     let mut seen: HashMap<&str, &UnionMember> = HashMap::new();
     for union_member in union_members {

--- a/crates/apollo-encoder/src/from_hir.rs
+++ b/crates/apollo-encoder/src/from_hir.rs
@@ -47,7 +47,7 @@ impl TryFrom<&hir::ObjectTypeExtension> for ObjectDefinition {
             def.interface(interface.interface().to_owned());
         }
 
-        for field in value.fields_definition() {
+        for field in value.fields() {
             def.field(field.try_into()?);
         }
 
@@ -98,7 +98,7 @@ impl TryFrom<&hir::InterfaceTypeExtension> for InterfaceDefinition {
             def.interface(interface.interface().to_owned());
         }
 
-        for field in value.fields_definition() {
+        for field in value.fields() {
             def.field(field.try_into()?);
         }
 
@@ -176,7 +176,7 @@ impl TryFrom<&hir::UnionTypeExtension> for UnionDefinition {
         let mut def = UnionDefinition::new(name);
         def.extend();
 
-        for member in value.union_members() {
+        for member in value.members() {
             def.member(member.name().to_owned());
         }
 
@@ -215,7 +215,7 @@ impl TryFrom<&hir::EnumTypeExtension> for EnumDefinition {
         let mut def = EnumDefinition::new(name);
         def.extend();
 
-        for value in value.enum_values_definition() {
+        for value in value.values() {
             def.value(value.try_into()?);
         }
 
@@ -281,7 +281,7 @@ impl TryFrom<&hir::InputObjectTypeExtension> for InputObjectDefinition {
             def.directive(directive.try_into()?);
         }
 
-        for input_field in value.input_fields_definition() {
+        for input_field in value.fields() {
             def.field(input_field.try_into()?);
         }
 


### PR DESCRIPTION
While merging #428, I noticed some of our extension APIs weren't matching their type definition APIs. For example, `UnionTypeDefinition` has `.members()` API. `UnionTypeExtension`'s version of this API is `.union_members`. 

This PR fixes those inconsistencies.

Changed methods:
- `InputObjectTypeExtension.fields_definition()` -> `InputObjectTypeDefinition.fields()`
- `ObjectTypeExtension.fields_definition()` -> `ObjectTypeExtension.fields()`
- `InterfaceTypeExtension.fields_definition()` -> `InterfaceTypeExtension.fields()`
- `EnumTypeExtension.enum_values_definition()` -> `EnumTypeExtension.values()`
- `UnionTypeExtension.union_members()` -> `UnionTypeExtension.members()`

@SimonSapin tagging you to double check here - i know you did the initial API improvements for `.fields` and `.directives`.