### PR TITLE
Prevents recursion for operations referencing fragments with cycles

### DIFF
--- a/crates/apollo-compiler/src/database/document.rs
+++ b/crates/apollo-compiler/src/database/document.rs
@@ -199,6 +199,21 @@ pub(crate) fn operation_inline_fragment_fields(
     Arc::new(fields)
 }
 
+pub(crate) fn operation_fragment_references(
+    db: &dyn HirDatabase,
+    selection_set: SelectionSet,
+) -> Arc<Vec<Arc<FragmentDefinition>>> {
+    let fields = selection_set
+        .selection()
+        .iter()
+        .filter_map(|sel| match sel {
+            Selection::FragmentSpread(fragment_spread) => Some(fragment_spread.fragment(db)?),
+            _ => None,
+        })
+        .collect();
+    Arc::new(fields)
+}
+
 pub(crate) fn operation_fragment_spread_fields(
     db: &dyn HirDatabase,
     selection_set: SelectionSet,

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -529,6 +529,11 @@ impl OperationDefinition {
         db.operation_fragment_spread_fields(self.selection_set.clone())
     }
 
+    /// Get all fragment definitions referenced by the operation.
+    pub fn fragment_references(&self, db: &dyn HirDatabase) -> Arc<Vec<Arc<FragmentDefinition>>> {
+        db.operation_fragment_references(self.selection_set.clone())
+    }
+
     /// Get the AST location information for this HIR node.
     pub fn loc(&self) -> HirNodeLocation {
         self.loc

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -206,6 +206,13 @@ pub trait HirDatabase: InputDatabase + AstDatabase {
     #[salsa::invoke(document::operation_fragment_spread_fields)]
     fn operation_fragment_spread_fields(&self, selection_set: SelectionSet) -> Arc<Vec<Field>>;
 
+    /// Return all fragment definitions referenced in the operation.
+    #[salsa::invoke(document::operation_fragment_references)]
+    fn operation_fragment_references(
+        &self,
+        selection_set: SelectionSet,
+    ) -> Arc<Vec<Arc<FragmentDefinition>>>;
+
     /// Return the fields that `selection_set` selects including visiting fragments and inline fragments.
     #[salsa::invoke(document::flattened_operation_fields)]
     fn flattened_operation_fields(&self, selection_set: SelectionSet) -> Vec<Arc<Field>>;

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -167,7 +167,12 @@ pub fn validate_query_operations(
             queries
                 .iter()
                 .filter_map(|op| {
-                    if !op.is_introspection(db.upcast()) {
+                    let has_cycles = op
+                        .fragment_references(db.upcast())
+                        .iter()
+                        .any(|fragment| !db.validate_fragment_cycles(fragment.clone()).is_empty());
+
+                    if !has_cycles && !op.is_introspection(db.upcast()) {
                         let diagnostic = ApolloDiagnostic::new(
                             db,
                             op.loc().into(),

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -535,7 +535,8 @@ fragment q on Query {
         compiler.add_executable(input_executable, "query.graphql");
 
         let diagnostics = compiler.validate();
-        assert_eq!(diagnostics.len(), 1);
+        // TODO(@goto-bus-stop) this should be 1, but both uses of ...q cause a report
+        assert_eq!(diagnostics.len(), 2);
         assert_eq!(
             diagnostics[0].data.to_string(),
             "`q` fragment cannot reference itself"
@@ -571,7 +572,8 @@ fragment q on TestObject {
         compiler.add_executable(input_executable, "query.graphql");
 
         let diagnostics = compiler.validate();
-        assert_eq!(diagnostics.len(), 1);
+        // TODO(@goto-bus-stop) this should be 1, but both uses of ...q cause a report
+        assert_eq!(diagnostics.len(), 2);
         assert_eq!(
             diagnostics[0].data.to_string(),
             "`q` fragment cannot reference itself"


### PR DESCRIPTION
Addresses #543

The core problem is that the `is_introspection` method is not context-aware and if it's in the context of a fragment spread for itself will continue to recurse until the stack overflows. Fundamentally fixing this issue with `is_introspection` would require a some added context like exists with the recursion limit counter in the parser or changing the function signature to control whether or not to recurse into a fragment spread.

I tried to avoid reimplementing fragment definition detection by reusing what already exists and should mean the result is memoized when `validate_fragment_definition` is called during `validate_executable`.

I considered performing fragment definition validation first and skipping operation validation if there are cycles present but there are some valuable validations that do not depend on traversing the operation.