### PR TITLE
fix(compiler): prevent recursion cycle inside is_introspection

### DIFF
--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -174,12 +174,7 @@ pub fn validate_query_operations(
             queries
                 .iter()
                 .filter_map(|op| {
-                    let has_cycles = op
-                        .fragment_references(db.upcast())
-                        .iter()
-                        .any(|fragment| !db.validate_fragment_cycles(fragment.clone()).is_empty());
-
-                    if !has_cycles && !op.is_introspection(db.upcast()) {
+                    if !op.is_introspection(db.upcast()) {
                         let diagnostic = ApolloDiagnostic::new(
                             db,
                             op.loc().into(),


### PR DESCRIPTION
follow-up to https://github.com/apollographql/apollo-rs/pull/544

this moves the possible recursion cases into `SelectionSet::is_introspection` and bails out if a used fragment contains a cycle. For fragments that dont have a definition or that are cyclical, `is_introspection` returns false.

We can keep the tests and the new DB query introduced by #544 :)