### PR TITLE
fix(parser): variable definitions cannot be empty

### DIFF
--- a/crates/apollo-parser/src/parser/grammar/variable.rs
+++ b/crates/apollo-parser/src/parser/grammar/variable.rs
@@ -11,9 +11,10 @@ pub(crate) fn variable_definitions(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::VARIABLE_DEFINITIONS);
     p.bump(S!['(']);
 
-    // TODO @lrlna error: expected a variable definition to follow an opening brace
     if let Some(T![$]) = p.peek() {
         variable_definition(p, false);
+    } else {
+        p.err("expected a Variable Definition")
     }
     p.expect(T![')'], S![')']);
 }

--- a/crates/apollo-parser/test_data/parser/err/0047_empty_variable_definition.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0047_empty_variable_definition.graphql
@@ -1,0 +1,3 @@
+query Op() {
+  field
+}

--- a/crates/apollo-parser/test_data/parser/err/0047_empty_variable_definition.txt
+++ b/crates/apollo-parser/test_data/parser/err/0047_empty_variable_definition.txt
@@ -1,0 +1,21 @@
+- DOCUMENT@0..22
+    - OPERATION_DEFINITION@0..22
+        - OPERATION_TYPE@0..5
+            - query_KW@0..5 "query"
+        - WHITESPACE@5..6 " "
+        - NAME@6..8
+            - IDENT@6..8 "Op"
+        - VARIABLE_DEFINITIONS@8..10
+            - L_PAREN@8..9 "("
+            - R_PAREN@9..10 ")"
+        - WHITESPACE@10..11 " "
+        - SELECTION_SET@11..22
+            - L_CURLY@11..12 "{"
+            - WHITESPACE@12..15 "\n  "
+            - FIELD@15..20
+                - NAME@15..20
+                    - IDENT@15..20 "field"
+            - WHITESPACE@20..21 "\n"
+            - R_CURLY@21..22 "}"
+- ERROR@9:10 "expected a Variable Definition" )
+recursion limit: 4096, high: 1


### PR DESCRIPTION
fixes #546 