### PR TITLE
fix(compiler): update apollo-parser version requirement

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -17,7 +17,7 @@ categories = [
 edition = "2021"
 
 [dependencies]
-apollo-parser = { path = "../apollo-parser", version = "0.5.0" }
+apollo-parser = { path = "../apollo-parser", version = "0.5.3" }
 ariadne = { package = "apollo-ariadne", version = "0.2.0-alpha.0" }
 indexmap = "1.9.2"
 rowan = "0.15.5"


### PR DESCRIPTION
apollo-compiler@0.9.0 relies on new apollo-parser methods but didn't declare the correct minimum version.
