### PR TITLE
`cargo add` is now built in

### DIFF
--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -24,7 +24,7 @@
 
 ## Getting started
 Add the dependency to start using `apollo-compiler`:
-```
+```bash
 cargo add apollo-compiler
 ```
 

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -23,16 +23,17 @@
     * Validation is a work in progress, stay tuned for further validation rules implementation.
 
 ## Getting started
-Add this to your `Cargo.toml` to start using `apollo-compiler`:
+Add the dependency to start using `apollo-compiler`:
+```
+cargo add apollo-compiler
+```
+
+Or add this to your `Cargo.toml` for a manual installation:
+
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
 apollo-compiler = "0.9.0"
-```
-
-Or using [cargo-edit]:
-```bash
-cargo add apollo-compiler
 ```
 
 ## Rust versions
@@ -299,5 +300,4 @@ Licensed under either of
 
 at your option.
 
-[cargo-edit]: https://github.com/killercup/cargo-edit
 [`salsa`]: https://docs.rs/salsa/latest/salsa/

--- a/crates/apollo-encoder/README.md
+++ b/crates/apollo-encoder/README.md
@@ -19,7 +19,7 @@
 
 ## Getting started
 Add the dependency to start using `apollo-encoder`:
-```
+```bash
 cargo add apollo-encoder
 ```
 

--- a/crates/apollo-encoder/README.md
+++ b/crates/apollo-encoder/README.md
@@ -18,19 +18,17 @@
 </div>
 
 ## Getting started
+Add the dependency to start using `apollo-encoder`:
+```
+cargo add apollo-encoder
+```
 
-Add this to your `Cargo.toml` to start using `apollo-encoder`:
+Or add this to your `Cargo.toml` for a manual installation:
 
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
 apollo-encoder = "0.5.1"
-```
-
-Or using [cargo-edit]:
-
-```bash
-cargo add apollo-encoder
 ```
 
 ## Rust versions
@@ -171,4 +169,3 @@ Licensed under either of
 
 at your option.
 
-[cargo-edit]: https://github.com/killercup/cargo-edit

--- a/crates/apollo-parser/README.md
+++ b/crates/apollo-parser/README.md
@@ -26,7 +26,7 @@
 
 ## Getting started
 Add the dependency to start using `apollo-parser`:
-```
+```bash
 cargo add apollo-parser
 ```
 

--- a/crates/apollo-parser/README.md
+++ b/crates/apollo-parser/README.md
@@ -25,16 +25,17 @@
 * GraphQL parser
 
 ## Getting started
-Add this to your `Cargo.toml` to start using `apollo-parser`:
+Add the dependency to start using `apollo-parser`:
+```
+cargo add apollo-parser
+```
+
+Or add this to your `Cargo.toml` for a manual installation:
+
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
 apollo-parser = "0.5.3"
-```
-
-Or using [cargo-edit]:
-```bash
-cargo add apollo-parser
 ```
 
 ## Rust versions
@@ -160,7 +161,6 @@ Licensed under either of
 
 at your option.
 
-[cargo-edit]: https://github.com/killercup/cargo-edit
 [apollo-rs: spec-compliant GraphQL Tools in Rust]: https://www.apollographql.com/blog/announcement/tooling/apollo-rs-graphql-tools-in-rust/
 [examples directory]: https://github.com/apollographql/apollo-rs/tree/main/crates/apollo-parser/examples
 [Get field names in an object]: https://github.com/apollographql/apollo-rs#get-field-names-in-an-object


### PR DESCRIPTION
Remove references to cargo-edit.
