### PR TITLE
fix(compiler): add a specific UndefinedVariable diagnostic

### DIFF
--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -190,6 +190,11 @@ pub enum DiagnosticData {
         /// Name of the type not in scope
         name: String,
     },
+    #[error("variable `{name}` is not defined")]
+    UndefinedVariable {
+        /// Name of the variable not in scope
+        name: String,
+    },
     #[error("cannot find fragment `{name}` in this document")]
     UndefinedFragment {
         /// Name of the fragment not in scope

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -170,7 +170,7 @@ pub fn validate_variable_usage(
             return Err(ApolloDiagnostic::new(
                 db,
                 arg.loc().into(),
-                DiagnosticData::UndefinedDefinition {
+                DiagnosticData::UndefinedVariable {
                     name: var.name().into(),
                 },
             )

--- a/crates/apollo-compiler/test_data/diagnostics/0007_operation_with_undefined_variables.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0007_operation_with_undefined_variables.txt
@@ -24,7 +24,7 @@
             },
         ],
         help: None,
-        data: UndefinedDefinition {
+        data: UndefinedVariable {
             name: "undefinedVariable",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0008_operation_with_undefined_variables_in_inline_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0008_operation_with_undefined_variables_in_inline_fragment.txt
@@ -24,7 +24,7 @@
             },
         ],
         help: None,
-        data: UndefinedDefinition {
+        data: UndefinedVariable {
             name: "value",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0009_operation_with_undefined_variables_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0009_operation_with_undefined_variables_in_fragment.txt
@@ -24,7 +24,7 @@
             },
         ],
         help: None,
-        data: UndefinedDefinition {
+        data: UndefinedVariable {
             name: "value",
         },
     },


### PR DESCRIPTION
The diagnostic message for undefined variables read like this:

> `varName` type not found in this document

which is a bit wrong. This adds a specific message for variables so it
instead reports:

> variable `varName` is not defined
