### PR TITLE
chore(compiler): use official ariadne release

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [dependencies]
 apollo-parser = { path = "../apollo-parser", version = "0.5.3" }
-ariadne = { package = "apollo-ariadne", version = "0.2.0-alpha.0" }
+ariadne = "0.2.0"
 indexmap = "1.9.2"
 rowan = "0.15.5"
 salsa = "0.16.1"


### PR DESCRIPTION
we used a temp crate while waiting for a PR to be released, it's been out for a while now so we can switch to plain ariadne.