### PR TITLE
breaking(compiler): rename `SelectionSet::merge` to `concat`

### DIFF
--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -1454,7 +1454,7 @@ impl SelectionSet {
     ///
     /// This does not deduplicate fields: if the two selection sets both select a field `a`, the
     /// merged set will select field `a` twice.
-    pub fn merge(&self, other: &SelectionSet) -> SelectionSet {
+    pub fn concat(&self, other: &SelectionSet) -> SelectionSet {
         let mut merged: Vec<Selection> =
             Vec::with_capacity(self.selection.len() + other.selection.len());
         merged.append(&mut self.selection.as_ref().clone());

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -104,7 +104,7 @@ pub(crate) fn same_response_shape(
         }
         // 6. Assert: typeA and typeB are both composite types.
         (def_a, def_b) if def_a.is_composite_definition() && def_b.is_composite_definition() => {
-            let merged_set = field_a.selection_set().merge(field_b.selection_set());
+            let merged_set = field_a.selection_set().concat(field_b.selection_set());
             let fields = db.flattened_operation_fields(merged_set);
             let grouped_by_name = group_fields_by_name(fields);
 
@@ -284,7 +284,7 @@ pub(crate) fn fields_in_set_can_merge(
                     continue;
                 }
                 // 2biii. Let mergedSet be the result of adding the selection set of fieldA and the selection set of fieldB.
-                let merged_set = field_a.selection_set().merge(field_b.selection_set());
+                let merged_set = field_a.selection_set().concat(field_b.selection_set());
                 // 2biv. FieldsInSetCanMerge(mergedSet) must be true.
                 if let Err(sub_diagnostics) = db.fields_in_set_can_merge(merged_set) {
                     diagnostics.extend(sub_diagnostics);


### PR DESCRIPTION
As brought up by Sylvain. The comment already talked about concatenation instead of merging. The `merge` name suggests it's doing field merging which is not happening. We may add an actual field merging method in the future. 