### PR TITLE
chore(deps): Update to github-issue-pull-api-hook@v2.0.1

### DIFF
--- a/.github/workflows/github_projects_tagger.yml
+++ b/.github/workflows/github_projects_tagger.yml
@@ -8,7 +8,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: abernix/github-issue-pull-api-hook@v1.0.0
+      - uses: abernix/github-issue-pull-api-hook@v2.0.1
         with:
           # These are both set in Org level secrets and work on a safe-listed
           # set of repositories that affect the Polaris team.  This allows them to


### PR DESCRIPTION
This updates a dependency which handles automation of internal team tracking tooling.  The version we were using was merely bit outdated and this repository doesn't have Renovate setup to automatically bump it. 😄   (It doesn't actually change very often.)