### PR TITLE
feat(compiler): add type name to `UndefinedField` error message

### DIFF
--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -178,10 +178,12 @@ pub enum DiagnosticData {
         // current operation type: subscription, mutation, query
         ty: &'static str,
     },
-    #[error("cannot query `{field}` field")]
+    #[error("cannot query field `{field}` on type `{ty}`")]
     UndefinedField {
         /// Field name
         field: String,
+        /// Type name being queried
+        ty: String,
     },
     #[error("the argument `{name}` is not supported")]
     UndefinedArgument { name: String },

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -113,6 +113,7 @@ pub fn validate_field(
             field.loc().into(),
             DiagnosticData::UndefinedField {
                 field: fname.into(),
+                ty: field.parent_obj.clone().unwrap(),
             },
         )
         .label(Label::new(

--- a/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.txt
@@ -38,6 +38,7 @@
         ),
         data: UndefinedField {
             field: "size",
+            ty: "Query",
         },
     },
     ApolloDiagnostic {
@@ -79,6 +80,7 @@
         ),
         data: UndefinedField {
             field: "weight",
+            ty: "Query",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0041_subscription_operation_with_undefined_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0041_subscription_operation_with_undefined_fields.txt
@@ -38,6 +38,7 @@
         ),
         data: UndefinedField {
             field: "undefinedSubscriptionField",
+            ty: "Subscription",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.txt
@@ -96,6 +96,7 @@
         ),
         data: UndefinedField {
             field: "undefinedMutationField",
+            ty: "Mutation",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0082_introspection_types_in_mutation.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0082_introspection_types_in_mutation.txt
@@ -38,6 +38,7 @@
         ),
         data: UndefinedField {
             field: "__type",
+            ty: "MyMutationRootType",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0083_type_introspection_from_disallowed_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0083_type_introspection_from_disallowed_type.txt
@@ -38,6 +38,7 @@
         ),
         data: UndefinedField {
             field: "__type",
+            ty: "Product",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0088_fragment_selection_set.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0088_fragment_selection_set.txt
@@ -38,6 +38,7 @@
         ),
         data: UndefinedField {
             field: "topProduct",
+            ty: "Query",
         },
     },
     ApolloDiagnostic {
@@ -79,6 +80,7 @@
         ),
         data: UndefinedField {
             field: "notExistingField",
+            ty: "Product",
         },
     },
 ]


### PR DESCRIPTION
This adds a bit more context to the "main" error message for
UndefinedField diagnostics. It was already there in the pretty-printed
version but for use cases like an HTTP backend, it's nice to have as
much context as possible in the main message, so it can just dump that
as a JSON string.
