### PR TITLE
Add `schema.root_operation_name(OperationType)` HIR helper method

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -16,6 +16,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Maintenance
 ## Documentation -->
+
+# [x.x.x] (unreleased) - 2023-mm-dd
+
+## Features
+- add `root_operation_name(OperationType)` helper method on `hir::SchemaDefinition` by [SimonSapin] in [pull/579]
+
+[pull/579]: https://github.com/apollographql/apollo-rs/pull/579
+
 # [0.9.4](https://crates.io/crates/apollo-compiler/0.9.4) - 2023-06-05
 
 ## Features

--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -2134,6 +2134,19 @@ impl SchemaDefinition {
         &self.extensions
     }
 
+    /// Returns the name of the object type for the root operation of the given kind,
+    /// defined either on this schema defintion or its extensions.
+    ///
+    /// The corresponding object type definition can be found
+    /// at [`compiler.db.object_types().get(name)`][HirDatabase::object_types].
+    pub fn root_operation_name(&self, ty: OperationType) -> Option<&str> {
+        match ty {
+            OperationType::Query => self.query(),
+            OperationType::Mutation => self.mutation(),
+            OperationType::Subscription => self.subscription(),
+        }
+    }
+
     /// Returns the name of the object type for the `query` root operation,
     /// defined either on this schema defintion or its extensions.
     ///


### PR DESCRIPTION
I’ve recently needed this in a couple different places of Apollo Router. (For now I’ve used the explicit `match` instead.)