### PR TITLE
dependency updates

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -18,11 +18,11 @@ edition = "2021"
 
 [dependencies]
 apollo-parser = { path = "../apollo-parser", version = "0.5.3" }
-ariadne = "0.2.0"
+ariadne = "0.3.0"
 indexmap = "1.9.2"
 rowan = "0.15.5"
 salsa = "0.16.1"
-ordered-float = { version = "2.10.0", features = ["std"] }
+ordered-float = { version = "3.7.0", features = ["std"] }
 thiserror = "1.0.31"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -33,8 +33,8 @@ anyhow = "1.0"
 expect-test = "1.1"
 miette = "5.0"
 notify = "4.0.0"
-criterion = "0.3.0"
-pretty_assertions = "0.7.1"
+criterion = "0.5.0"
+pretty_assertions = "1.3.0"
 
 [[bench]]
 name = "multi-source"

--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -28,5 +28,5 @@ thiserror = "1.0.37"
 default = ["apollo-parser", "apollo-compiler"]
 
 [dev-dependencies]
-pretty_assertions = "0.7.1"
-indoc = "1.0.3"
+pretty_assertions = "1.3.0"
+indoc = "2.0.0"

--- a/crates/apollo-encoder/README.md
+++ b/crates/apollo-encoder/README.md
@@ -80,7 +80,7 @@ Older version may or may not be compatible.
 
   assert_eq!(
       document.to_string(),
-      indoc! { r#"
+      indoc! {r#"
           query HeroForEpisode {
             hero {
               name
@@ -141,23 +141,22 @@ document.union(union_def);
 
 assert_eq!(
     document.to_string(),
-    indoc! { r#"
-"A union of all pets represented within a household."
-union Pet = Cat | Dog
-"""
-Favourite cat
-nap spots.
-"""
-enum NapSpots {
-  "Top bunk of a cat tree."
-  CatTree
-  Bed
-  CardboardBox @deprecated(reason: "Box was recycled.")
-}
-"Ensures cats get treats."
-directive @provideTreat on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-
-"#}
+    indoc! {r#"
+        "A union of all pets represented within a household."
+        union Pet = Cat | Dog
+        """
+        Favourite cat
+        nap spots.
+        """
+        enum NapSpots {
+          "Top bunk of a cat tree."
+          CatTree
+          Bed
+          CardboardBox @deprecated(reason: "Box was recycled.")
+        }
+        "Ensures cats get treats."
+        directive @provideTreat on OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+    "#},
 );
 ```
 ## License

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -27,11 +27,11 @@ apollo-encoder = { path = "../apollo-encoder", version = "0.5.0", features = [
     "apollo-parser",
 ] }
 anyhow = "1.0.66"
-pretty_assertions = "0.7.1"
+pretty_assertions = "1.3.0"
 annotate-snippets = "0.9.1"
 expect-test = "1.1"
-unindent = "0.1.7"
-criterion = "0.3.0"
+unindent = "0.2.1"
+criterion = "0.5.0"
 
 [[bench]]
 name = "query"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 apollo-smith = { path = "../crates/apollo-smith" }
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 log = "0.4.14"
 
 [dependencies.apollo-parser]


### PR DESCRIPTION
just bumping pretty much everything, except `miette` in apollo-parser and `notify` in apollo-compiler. both are only used in examples and not trivial to update.

would maybe be nice to enable dependabot after 😇  for semver-major updates at least.