### PR TITLE
fix: schema extension without root fields should skip empty {} block

### DIFF
--- a/crates/apollo-encoder/src/schema_def.rs
+++ b/crates/apollo-encoder/src/schema_def.rs
@@ -113,21 +113,25 @@ impl fmt::Display for SchemaDefinition {
             write!(f, " {directive}")?;
         }
 
-        writeln!(f, " {{")?;
+        if self.query.is_some() || self.mutation.is_some() || self.subscription.is_some() {
+            writeln!(f, " {{")?;
 
-        if let Some(query) = &self.query {
-            writeln!(f, "  query: {query}")?;
+            if let Some(query) = &self.query {
+                writeln!(f, "  query: {query}")?;
+            }
+
+            if let Some(mutation) = &self.mutation {
+                writeln!(f, "  mutation: {mutation}")?;
+            }
+
+            if let Some(subscription) = &self.subscription {
+                writeln!(f, "  subscription: {subscription}")?;
+            }
+
+            writeln!(f, "}}")
+        } else {
+            writeln!(f)
         }
-
-        if let Some(mutation) = &self.mutation {
-            writeln!(f, "  mutation: {mutation}")?;
-        }
-
-        if let Some(subscription) = &self.subscription {
-            writeln!(f, "  subscription: {subscription}")?;
-        }
-
-        writeln!(f, "}}")
     }
 }
 
@@ -174,5 +178,19 @@ mod tests {
             }
         "#}
         );
+    }
+
+    #[test]
+    fn it_encodes_extend_schema_with_directives_only() {
+        let mut schema_def = SchemaDefinition::new();
+        schema_def.directive(Directive::new("foo".to_string()));
+        schema_def.extend();
+
+        assert_eq!(
+            schema_def.to_string(),
+            indoc! { r#"
+            extend schema @foo
+        "#}
+        )
     }
 }


### PR DESCRIPTION
Per [GraphQL spec](https://spec.graphql.org/draft/#sec-Schema-Extension)

>Schema extensions without additional operation type definitions must not be followed by a { (such as a query shorthand) to avoid parsing ambiguity.

Currently generated definition cannot be parsed by `apollo-compiler`.

```
extend schema @foo {
}
```