### PR TITLE
breaking(compiler): improve type condition handling on inline fragments

### DIFF
--- a/crates/apollo-compiler/src/database/hir.rs
+++ b/crates/apollo-compiler/src/database/hir.rs
@@ -1746,44 +1746,95 @@ impl InlineFragment {
         self.type_condition.as_ref().map(|t| t.src())
     }
 
-    /// Get the type this fragment is spread onto.
+    /// Get the type this inline fragment is spread onto.
+    ///
+    /// This method does not look up type conditions, so in the example below `b.parent_type()`
+    /// returns the type for "Intf", not "X". To look up the type that an inline fragment *applies*
+    /// to, use [`InlineFragment::type_def`][InlineFragment::type_def].
     ///
     /// ## Examples
     /// ```rust
     /// # fn main() { example().expect("unexpected None") }
     /// # fn example() -> Option<()> { use apollo_compiler::*;
+    /// # use apollo_compiler::validation::ValidationDatabase;
     /// let mut compiler = ApolloCompiler::new();
     /// compiler.add_type_system(r#"
-    ///     type X {
+    ///     interface Intf {
     ///         subField: Int!
     ///     }
+    ///     type X implements Intf {
+    ///         subField: Int!
+    ///         subField2: Int!
+    ///     }
     ///     type Query {
-    ///         field: X
+    ///         field: Intf
     ///     }
     /// "#, "schema.graphql");
     /// let id = compiler.add_executable(r#"
     ///     query {
-    ///         ... on Query { field } # spread A
+    ///         ... on Query { field { subField } } # spread A
     ///         field {
-    ///             ... on X { subField } # spread B
+    ///             ... on X { subField2 } # spread B
     ///         }
     ///     }
     /// "#, "query.graphql");
+    /// # assert!(compiler.db.validate().is_empty());
+    ///
     /// let query = compiler.db.find_operation(id, None)?;
     /// let a = &query.selection_set().inline_fragments()[0];
     /// let b = &query.selection_set().fields()[0].selection_set().inline_fragments()[0];
-    /// assert_eq!(
-    ///     a.parent_type(&compiler.db)?.name(),
-    ///     "Query",
-    /// );
-    /// assert_eq!(
-    ///     b.parent_type(&compiler.db)?.name(),
-    ///     "X",
-    /// );
+    /// assert_eq!(a.parent_type(&compiler.db)?.name(), "Query");
+    /// assert_eq!(b.parent_type(&compiler.db)?.name(), "Intf");
     /// # Some(()) }
     /// ```
     pub fn parent_type(&self, db: &dyn HirDatabase) -> Option<TypeDefinition> {
         db.find_type_definition_by_name(self.parent_obj.as_ref()?.to_string())
+    }
+
+    /// Get the type this inline fragment applies to: the type condition, or the parent type if a
+    /// type condition is not given.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # fn main() { example().expect("unexpected None") }
+    /// # fn example() -> Option<()> { use apollo_compiler::*;
+    /// # use apollo_compiler::validation::ValidationDatabase;
+    /// let mut compiler = ApolloCompiler::new();
+    /// compiler.add_type_system(r#"
+    ///     interface Intf {
+    ///         subField: Int!
+    ///     }
+    ///     type X implements Intf {
+    ///         subField: Int!
+    ///         subField2: Int!
+    ///     }
+    ///     type Query {
+    ///         field: Intf
+    ///     }
+    /// "#, "schema.graphql");
+    /// let id = compiler.add_executable(r#"
+    ///     query {
+    ///         ... on Query { field { subField } } # spread A
+    ///         field {
+    ///             ... on X { subField2 } # spread B
+    ///         }
+    ///     }
+    /// "#, "query.graphql");
+    /// # assert!(compiler.db.validate().is_empty());
+    ///
+    /// let query = compiler.db.find_operation(id, None)?;
+    /// let a = &query.selection_set().inline_fragments()[0];
+    /// let b = &query.selection_set().fields()[0].selection_set().inline_fragments()[0];
+    /// assert_eq!(a.type_def(&compiler.db)?.name(), "Query");
+    /// assert_eq!(b.type_def(&compiler.db)?.name(), "X");
+    /// # Some(()) }
+    /// ```
+    pub fn type_def(&self, db: &dyn HirDatabase) -> Option<TypeDefinition> {
+        db.find_type_definition_by_name(
+            self.type_condition()
+                .or(self.parent_obj.as_deref())?
+                .to_string(),
+        )
     }
 
     /// Get a reference to inline fragment's directives.

--- a/crates/apollo-compiler/src/database/hir_db.rs
+++ b/crates/apollo-compiler/src/database/hir_db.rs
@@ -1576,7 +1576,7 @@ fn inline_fragment(
     let fragment_data = InlineFragment {
         // for implicit inline fragments, the type condition is implied to be
         // that of the current scope
-        type_condition: type_condition.or(parent_obj.clone().map(|o| Name { src: o, loc: None })),
+        type_condition,
         directives,
         selection_set,
         parent_obj,

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -210,7 +210,7 @@ pub trait ValidationDatabase:
     #[salsa::invoke(fragment::validate_fragment_type_condition)]
     fn validate_fragment_type_condition(
         &self,
-        type_cond: Option<String>,
+        type_cond: String,
         loc: HirNodeLocation,
     ) -> Vec<ApolloDiagnostic>;
 


### PR DESCRIPTION
Fixes #584 and some things @SimonSapin brought up in Slack 

- `InlineFragment::type_condition()` now returns `None` if a type condition was not explicitly written.
- `InlineFragment::parent_type()` returns the type definition of the selection set that an inline fragment is used in
- `InlineFragment::type_def()` returns the type definition for the fragment itself: the type condition if given, or else the selection set that it's used in
- `validate_fragment_type_condition` does not take an `Option` anymore. This used to only happen for inline fragments without a type condition, in theory, but that would never actually happen because we inferred the type condition if it wasn't set. So we can get rid of that case entirely and skip the validation for inline fragments without type conditions.