### PR TITLE
chore(compiler): separate `UndefinedDirective` diagnostic

### DIFF
--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -192,6 +192,11 @@ pub enum DiagnosticData {
         /// Name of the type not in scope
         name: String,
     },
+    #[error("cannot find directive `{name}` in this document")]
+    UndefinedDirective {
+        /// Name of the missing directive
+        name: String,
+    },
     #[error("variable `{name}` is not defined")]
     UndefinedVariable {
         /// Name of the variable not in scope

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -295,9 +295,9 @@ pub fn validate_directives(
                 ApolloDiagnostic::new(
                     db,
                     loc.into(),
-                    DiagnosticData::UndefinedDefinition { name: name.into() },
+                    DiagnosticData::UndefinedDirective { name: name.into() },
                 )
-                .label(Label::new(loc, "not found in this scope")),
+                .label(Label::new(loc, "directive not defined")),
             )
         }
     }

--- a/crates/apollo-compiler/test_data/diagnostics/0052_undefined_directive.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0052_undefined_directive.txt
@@ -20,11 +20,11 @@
                     offset: 46,
                     length: 11,
                 },
-                text: "not found in this scope",
+                text: "directive not defined",
             },
         ],
         help: None,
-        data: UndefinedDefinition {
+        data: UndefinedDirective {
             name: "directiveA",
         },
     },


### PR DESCRIPTION
Improve the error message so it doesn't say `"cannot find type @directive"`
