### PR TITLE
chore(examples): update notify to v6

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -32,8 +32,9 @@ uuid = { version = "1.4", features = ["serde", "v4", "js"] }
 anyhow = "1.0"
 expect-test = "1.4"
 miette = "5.0"
-notify = "4.0.0"
-criterion = "0.5.0"
+notify = "6.0.0"
+notify-debouncer-full = "0.1.0"
+criterion = "0.5.1"
 pretty_assertions = "1.3.0"
 
 [[bench]]

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -33,7 +33,6 @@ anyhow = "1.0"
 expect-test = "1.4"
 miette = "5.0"
 notify = "6.0.0"
-notify-debouncer-full = "0.1.0"
 criterion = "0.5.1"
 pretty_assertions = "1.3.0"
 

--- a/crates/apollo-compiler/examples/file_watcher.rs
+++ b/crates/apollo-compiler/examples/file_watcher.rs
@@ -8,7 +8,10 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use apollo_compiler::{ApolloCompiler, FileId};
-use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
+use notify_debouncer_full::{
+    new_debouncer,
+    notify::{EventKind, RecursiveMode, Watcher},
+};
 
 fn main() -> Result<()> {
     let dir = Path::new("crates/apollo-compiler/examples/documents");
@@ -44,72 +47,87 @@ impl FileWatcher {
 
         self.validate();
 
-        self.watch_broadcast(dir)
+        self.watch_broadcast(dir.as_ref())
     }
 
-    fn watch_broadcast(&mut self, dir: impl AsRef<Path>) -> Result<()> {
+    fn watch_broadcast(&mut self, dir: &Path) -> Result<()> {
         let (broadcaster, listener) = channel();
-        let mut watcher = watcher(broadcaster, Duration::from_secs(1))?;
-        watcher.watch(&dir, RecursiveMode::NonRecursive)?;
-        println!("watching {} for changes", dir.as_ref().display());
+        let mut watcher = new_debouncer(Duration::from_secs(1), None, move |res| match res {
+            Ok(events) => {
+                for event in events {
+                    broadcaster.send(Ok(event)).unwrap();
+                }
+            }
+            Err(errors) => {
+                for error in errors {
+                    broadcaster.send(Err(error)).unwrap();
+                }
+            }
+        })?;
+        watcher.watcher().watch(&dir, RecursiveMode::NonRecursive)?;
+        println!("watching {} for changes", dir.display());
         loop {
             match listener.recv() {
-                Ok(event) => match &event {
-                    DebouncedEvent::NoticeWrite(path) => {
-                        println!("changes detected in {}", &path.display())
-                    }
-                    DebouncedEvent::Create(path) => match fs::read_to_string(path) {
-                        Ok(contents) => {
-                            println!("detected a new file {}", &path.display());
-                            let file_id = self.manifest.get(path);
-                            if let Some(file_id) = file_id {
-                                self.compiler.update_document(*file_id, &contents);
-                            } else {
-                                self.add_document(contents, path.to_path_buf())?;
+                Ok(Ok(event)) => {
+                    for path in event.paths {
+                        match event.kind {
+                            EventKind::Any => {
+                                println!("changes detected in {}", path.display())
                             }
-                            self.validate();
-                        }
-                        Err(e) => {
-                            println!(
-                                "could not read {} from disk, {:?}",
-                                &dir.as_ref().display(),
-                                Some(anyhow!("{}", e)),
-                            );
-                        }
-                    },
-                    DebouncedEvent::Write(path) => {
-                        match fs::read_to_string(path) {
-                            Ok(contents) => {
-                                let file_id = self.manifest.get(path);
-                                if let Some(file_id) = file_id {
-                                    self.compiler.update_document(*file_id, &contents);
-                                } else {
-                                    self.add_document(contents, path.to_path_buf())?;
+                            EventKind::Create(_) => match fs::read_to_string(&path) {
+                                Ok(contents) => {
+                                    println!("detected a new file {}", path.display());
+                                    let file_id = self.manifest.get(&path);
+                                    if let Some(file_id) = file_id {
+                                        self.compiler.update_document(*file_id, &contents);
+                                    } else {
+                                        self.add_document(contents, path)?;
+                                    }
+                                    self.validate();
                                 }
-                                self.validate();
+                                Err(e) => {
+                                    println!(
+                                        "could not read {} from disk, {:?}",
+                                        dir.display(),
+                                        Some(anyhow!("{}", e)),
+                                    );
+                                }
+                            },
+                            EventKind::Modify(_) => {
+                                match fs::read_to_string(&path) {
+                                    Ok(contents) => {
+                                        let file_id = self.manifest.get(&path);
+                                        if let Some(file_id) = file_id {
+                                            self.compiler.update_document(*file_id, &contents);
+                                        } else {
+                                            self.add_document(contents, path)?;
+                                        }
+                                        self.validate();
+                                    }
+                                    Err(e) => {
+                                        println!(
+                                            "could not read {} from disk, {:?}",
+                                            dir.display(),
+                                            Some(anyhow!("{}", e)),
+                                        );
+                                    }
+                                };
                             }
-                            Err(e) => {
-                                println!(
-                                    "could not read {} from disk, {:?}",
-                                    &dir.as_ref().display(),
-                                    Some(anyhow!("{}", e)),
-                                );
-                            }
-                        };
+                            _ => {}
+                        }
                     }
-                    DebouncedEvent::Error(e, _) => {
-                        println!(
-                            "unknown error while watching {},  {:?}",
-                            &dir.as_ref().display(),
-                            Some(anyhow!("{}", e)),
-                        );
-                    }
-                    _ => {}
-                },
+                }
+                Ok(Err(e)) => {
+                    println!(
+                        "unknown error while watching {},  {:?}",
+                        &dir.display(),
+                        Some(anyhow!("{}", e)),
+                    );
+                }
                 Err(e) => {
                     println!(
                         "unknown error while watching {},  {:?}",
-                        &dir.as_ref().display(),
+                        &dir.display(),
                         Some(anyhow!("{}", e)),
                     );
                 }

--- a/crates/apollo-compiler/examples/file_watcher.rs
+++ b/crates/apollo-compiler/examples/file_watcher.rs
@@ -55,7 +55,7 @@ impl FileWatcher {
             },
             Config::default().with_poll_interval(Duration::from_secs(1)),
         )?;
-        watcher.watch(&dir, RecursiveMode::NonRecursive)?;
+        watcher.watch(dir, RecursiveMode::NonRecursive)?;
         println!("watching {} for changes", dir.display());
         loop {
             match listener.recv() {


### PR DESCRIPTION
notify v6 doesn't include debounce functionality anymore. There's separate crates for that but its much easier to just use polling instead of the fancy system specific watching implementations & the necessarily leaky abstractions on top of them. So this rewrites and slightly simplifies the `file_watcher` example using notify v6's `PollWatcher`.