### PR TITLE
chore(parser): test reaching token limit exactly

### DIFF
--- a/crates/apollo-parser/src/lexer/token.rs
+++ b/crates/apollo-parser/src/lexer/token.rs
@@ -11,14 +11,6 @@ pub struct Token<'a> {
 }
 
 impl<'a> Token<'a> {
-    pub(crate) fn new(kind: TokenKind, data: &'a str) -> Self {
-        Self {
-            kind,
-            data,
-            index: 0,
-        }
-    }
-
     /// Get a reference to the token's kind.
     pub fn kind(&self) -> TokenKind {
         self.kind


### PR DESCRIPTION
The separate `self.input` check should be unnecessary as the cursor will produce the token now. That's also the only place that used `Token::new` and `self.input` so we can remove that constructor + the `input`/`index` fields in the Lexer struct (that is tracked in Cursor as well).

Closes https://github.com/apollographql/apollo-rs/issues/610