### PR TITLE
apollo-encoder@0.7.0

### DIFF
--- a/crates/apollo-encoder/CHANGELOG.md
+++ b/crates/apollo-encoder/CHANGELOG.md
@@ -17,6 +17,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 ## Documentation -->
+# [0.7.0](https://crates.io/crates/apollo-encoder/0.7.0) - 2023-08-18
+
+## BREAKING
+- **apollo-parser@0.6.0 - [goto-bus-stop], [pull/621]**
+
+  This updates the version of `apollo-parser` required by the `TryFrom`
+  implementations in this crate.
+
+- **apollo-compiler@0.11.0 - [goto-bus-stop], [pull/622]**
+
+  This updates the version of `apollo-compiler` required by the `TryFrom`
+  implementations in this crate.
+
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/621]: https://github.com/apollographql/apollo-rs/pull/621
+[pull/622]: https://github.com/apollographql/apollo-rs/pull/622
+
 # [0.6.0](https://crates.io/crates/apollo-encoder/0.6.0) - 2023-06-20
 
 ## BREAKING

--- a/crates/apollo-encoder/Cargo.toml
+++ b/crates/apollo-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-encoder"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Irina Shestak <shestak.irina@gmail.com>",
     "Benjamin Coenen <benjamin.coenen@apollographql.com>",

--- a/crates/apollo-encoder/README.md
+++ b/crates/apollo-encoder/README.md
@@ -28,7 +28,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
-apollo-encoder = "0.5.1"
+apollo-encoder = "0.7.0"
 ```
 
 ## Rust versions

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0.30"
 [dev-dependencies]
 indexmap = "2.0.0"
 miette = { version = "3.2.0", features = ["fancy"] }
-apollo-encoder = { path = "../apollo-encoder", version = "0.6.0", features = [
+apollo-encoder = { path = "../apollo-encoder", version = "0.7.0", features = [
     "apollo-parser",
 ] }
 anyhow = "1.0.66"

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -24,7 +24,7 @@ categories = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-apollo-encoder = { path = "../apollo-encoder", version = "0.6.0" }
+apollo-encoder = { path = "../apollo-encoder", version = "0.7.0" }
 apollo-parser = { path = "../apollo-parser", version = "0.6.0", optional = true }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 once_cell = "1.9.0"


### PR DESCRIPTION
it's a bit annoying that we have to release this every time we have a new parser or compiler version. It will get easier with the MIR work being directly serializable :)