### PR TITLE
feat: support NO_COLOR when emitting diagnostics

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [dependencies]
 apollo-parser = { path = "../apollo-parser", version = "0.6.0" }
-ariadne = "0.3.0"
+ariadne = { version = "0.3.0", features = ["auto-color"] }
 indexmap = "2.0.0"
 rowan = "0.15.5"
 salsa = "0.16.1"


### PR DESCRIPTION
fixes #499 by enabling the `auto-color` feature of the `ariadne` dependency which supports `NO_COLOR` and detects if a TTY is attached before coloring the diagnostic output.

I'm happy to put this behind an optional feature in `apollo-rs` as well if that is desired, though I think enabling it by default is useful enough to leave it around - interested in thoughts.
