### PR TITLE
Support validating standalone operations without a known schema

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -16,6 +16,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Maintenance
 ## Documentation -->
+# [x.x.x] (unreleased) - 2021-mm-dd
+
+## Features
+- Add `validate_standalone_executable` function to validate an executable document without access to a schema, by [goto-bus-stop] in [pull/631], [issue/629]
+
+  This runs just those validations that can be done on operations without knowing the types of things.
+  ```rust
+  let compiler = ApolloCompiler::new();
+  let file_id = compiler.add_executable(r#"
+  {
+    user { ...userData }
+  }
+  "#, "query.graphql");
+  let diagnostics = compiler.db.validate_standalone_executable(file_id);
+  // Complains about `userData` fragment not existing, but does not complain about `user` being an unknown query.
+  ```
+
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/631]: https://github.com/apollographql/apollo-rs/pull/631
+[issue/629]: https://github.com/apollographql/apollo-rs/issues/629
 
 # [0.11.1](https://crates.io/crates/apollo-compiler/0.11.1) - 2023-08-24
 

--- a/crates/apollo-compiler/src/tests.rs
+++ b/crates/apollo-compiler/src/tests.rs
@@ -30,8 +30,9 @@ fn compiler_tests() {
         let file_id = compiler.add_document(text, path.file_name().unwrap());
 
         let errors = compiler.validate();
-        let ast = compiler.db.ast(file_id);
         assert_diagnostics_are_absent(&errors, path);
+
+        let ast = compiler.db.ast(file_id);
         format!("{ast:?}")
     });
 

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -6,15 +6,17 @@ use crate::{
     validation::ValidationDatabase,
 };
 
+use super::operation::OperationValidationConfig;
+
 pub fn validate_field(
     db: &dyn ValidationDatabase,
     field: Arc<hir::Field>,
-    var_defs: Arc<Vec<hir::VariableDefinition>>,
+    context: OperationValidationConfig,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = db.validate_directives(
         field.directives().to_vec(),
         hir::DirectiveLocation::Field,
-        var_defs.clone(),
+        context.variables.clone(),
     );
 
     if let Some(field_definition) = field.field_definition(db.upcast()) {
@@ -29,13 +31,17 @@ pub fn validate_field(
                     .cloned();
                 if let Some(input_val) = input_val {
                     if let Some(diag) = db
-                        .validate_variable_usage(input_val.clone(), var_defs.clone(), arg.clone())
+                        .validate_variable_usage(
+                            input_val.clone(),
+                            context.variables.clone(),
+                            arg.clone(),
+                        )
                         .err()
                     {
                         diagnostics.push(diag)
                     } else {
                         let value_of_correct_type =
-                            db.validate_values(input_val.ty(), arg, var_defs.clone());
+                            db.validate_values(input_val.ty(), arg, context.variables.clone());
 
                         if let Err(diag) = value_of_correct_type {
                             diagnostics.extend(diag);
@@ -94,47 +100,45 @@ pub fn validate_field(
         }
     }
 
-    let field_type = field.ty(db.upcast());
-    if let Some(field_type) = field_type {
-        match db.validate_leaf_field_selection(field.clone(), field_type) {
-            Err(diag) => diagnostics.push(diag),
-            Ok(_) => diagnostics
-                .extend(db.validate_selection_set(field.selection_set().clone(), var_defs)),
-        }
-    } else {
-        let help = format!(
-            "`{}` is not defined on `{}` type",
-            field.name(),
-            field.parent_obj.as_ref().unwrap(),
-        );
-        let fname = field.name();
-        let diagnostic = ApolloDiagnostic::new(
-            db,
-            field.loc().into(),
-            DiagnosticData::UndefinedField {
-                field: fname.into(),
-                ty: field.parent_obj.clone().unwrap(),
-            },
-        )
-        .label(Label::new(
-            field.loc(),
-            format!("`{fname}` field is not defined"),
-        ))
-        .help(help);
-
-        let parent_type_loc = db
-            .find_type_definition_by_name(field.parent_obj.clone().unwrap())
-            .map(|type_def| type_def.loc());
-
-        let diagnostic = if let Some(parent_type_loc) = parent_type_loc {
-            diagnostic.label(Label::new(
-                parent_type_loc,
-                format!("`{}` declared here", field.parent_obj.as_ref().unwrap()),
+    if context.has_schema {
+        let field_type = field.ty(db.upcast());
+        if let Some(field_type) = field_type {
+            match db.validate_leaf_field_selection(field.clone(), field_type) {
+                Err(diag) => diagnostics.push(diag),
+                Ok(_) => diagnostics
+                    .extend(db.validate_selection_set(field.selection_set().clone(), context)),
+            }
+        } else if let Some(parent_obj) = field.parent_obj.as_ref() {
+            let help = format!("`{}` is not defined on `{}` type", field.name(), parent_obj,);
+            let fname = field.name();
+            let diagnostic = ApolloDiagnostic::new(
+                db,
+                field.loc().into(),
+                DiagnosticData::UndefinedField {
+                    field: fname.into(),
+                    ty: field.parent_obj.clone().unwrap(),
+                },
+            )
+            .label(Label::new(
+                field.loc(),
+                format!("`{fname}` field is not defined"),
             ))
-        } else {
-            diagnostic
-        };
-        diagnostics.push(diagnostic);
+            .help(help);
+
+            let parent_type_loc = db
+                .find_type_definition_by_name(field.parent_obj.clone().unwrap())
+                .map(|type_def| type_def.loc());
+
+            let diagnostic = if let Some(parent_type_loc) = parent_type_loc {
+                diagnostic.label(Label::new(
+                    parent_type_loc,
+                    format!("`{}` declared here", field.parent_obj.as_ref().unwrap()),
+                ))
+            } else {
+                diagnostic
+            };
+            diagnostics.push(diagnostic);
+        }
     }
 
     diagnostics
@@ -148,7 +152,7 @@ pub fn validate_field_definition(
         field.directives().to_vec(),
         hir::DirectiveLocation::FieldDefinition,
         // field definitions don't have variables
-        Arc::new(Vec::new()),
+        Default::default(),
     );
 
     diagnostics.extend(db.validate_arguments_definition(

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use std::{collections::HashSet, sync::Arc};
 
+use super::operation::OperationValidationConfig;
+
 /// Given a type definition, find all the types that can be used for fragment spreading.
 ///
 /// Spec: https://spec.graphql.org/October2021/#GetPossibleTypes()
@@ -152,28 +154,33 @@ pub fn validate_fragment_selection(
 pub fn validate_inline_fragment(
     db: &dyn ValidationDatabase,
     inline: Arc<hir::InlineFragment>,
-    var_defs: Arc<Vec<hir::VariableDefinition>>,
+    context: OperationValidationConfig,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     diagnostics.extend(db.validate_directives(
         inline.directives().to_vec(),
         hir::DirectiveLocation::InlineFragment,
-        var_defs.clone(),
+        context.variables.clone(),
     ));
 
-    let type_cond_diagnostics = if let Some(t) = inline.type_condition() {
-        db.validate_fragment_type_condition(t.to_string(), inline.loc())
+    let has_type_error = if context.has_schema {
+        let type_cond_diagnostics = if let Some(t) = inline.type_condition() {
+            db.validate_fragment_type_condition(t.to_string(), inline.loc())
+        } else {
+            Default::default()
+        };
+        let has_type_error = !type_cond_diagnostics.is_empty();
+        diagnostics.extend(type_cond_diagnostics);
+        has_type_error
     } else {
-        Default::default()
+        false
     };
-    let has_type_error = !type_cond_diagnostics.is_empty();
-    diagnostics.extend(type_cond_diagnostics);
 
     // If there was an error with the type condition, it makes no sense to validate the selection,
     // as every field would be an error.
     if !has_type_error {
-        diagnostics.extend(db.validate_selection_set(inline.selection_set.clone(), var_defs));
+        diagnostics.extend(db.validate_selection_set(inline.selection_set.clone(), context));
         diagnostics
             .extend(db.validate_fragment_selection(hir::FragmentSelection::InlineFragment(inline)));
     }
@@ -184,14 +191,14 @@ pub fn validate_inline_fragment(
 pub fn validate_fragment_spread(
     db: &dyn ValidationDatabase,
     spread: Arc<hir::FragmentSpread>,
-    var_defs: Arc<Vec<hir::VariableDefinition>>,
+    context: OperationValidationConfig,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     diagnostics.extend(db.validate_directives(
         spread.directives().to_vec(),
         hir::DirectiveLocation::FragmentSpread,
-        var_defs.clone(),
+        context.variables.clone(),
     ));
 
     match spread.fragment(db.upcast()) {
@@ -199,7 +206,7 @@ pub fn validate_fragment_spread(
             diagnostics.extend(
                 db.validate_fragment_selection(hir::FragmentSelection::FragmentSpread(spread)),
             );
-            diagnostics.extend(db.validate_fragment_definition(def, var_defs));
+            diagnostics.extend(db.validate_fragment_definition(def, context));
         }
         None => {
             diagnostics.push(
@@ -224,26 +231,31 @@ pub fn validate_fragment_spread(
 pub fn validate_fragment_definition(
     db: &dyn ValidationDatabase,
     def: Arc<hir::FragmentDefinition>,
-    var_defs: Arc<Vec<hir::VariableDefinition>>,
+    context: OperationValidationConfig,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
     diagnostics.extend(db.validate_directives(
         def.directives().to_vec(),
         hir::DirectiveLocation::FragmentDefinition,
-        var_defs.clone(),
+        context.variables.clone(),
     ));
 
-    let type_cond_diagnostics =
-        db.validate_fragment_type_condition(def.type_condition().to_string(), def.loc());
-    let has_type_error = !type_cond_diagnostics.is_empty();
-    diagnostics.extend(type_cond_diagnostics);
+    let has_type_error = if context.has_schema {
+        let type_cond_diagnostics =
+            db.validate_fragment_type_condition(def.type_condition().to_string(), def.loc());
+        let has_type_error = !type_cond_diagnostics.is_empty();
+        diagnostics.extend(type_cond_diagnostics);
+        has_type_error
+    } else {
+        false
+    };
 
     let fragment_cycles_diagnostics = db.validate_fragment_cycles(def.clone());
     let has_cycles = !fragment_cycles_diagnostics.is_empty();
     diagnostics.extend(fragment_cycles_diagnostics);
 
     if !has_type_error && !has_cycles {
-        diagnostics.extend(db.validate_selection_set(def.selection_set().clone(), var_defs));
+        diagnostics.extend(db.validate_selection_set(def.selection_set().clone(), context));
     }
 
     diagnostics

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -5,42 +5,28 @@ use crate::{
     hir, FileId, ValidationDatabase,
 };
 
-pub fn validate_operation_definitions_against_type_system(
-    db: &dyn ValidationDatabase,
-    file_id: FileId,
-) -> Vec<ApolloDiagnostic> {
-    let mut diagnostics = Vec::new();
-
-    let operations = db.operations(file_id);
-    for def in operations.iter() {
-        // Validate the Selection Set recursively
-        // Check that the root type exists
-        if def.object_type(db.upcast()).is_some() {
-            diagnostics.extend(
-                db.validate_selection_set(def.selection_set().clone(), def.variables.clone()),
-            );
-        }
-    }
-
-    let subscription_operations = db.upcast().subscription_operations(file_id);
-    let query_operations = db.upcast().query_operations(file_id);
-    let mutation_operations = db.upcast().mutation_operations(file_id);
-
-    diagnostics.extend(db.validate_subscription_operations(subscription_operations));
-    diagnostics.extend(db.validate_query_operations(query_operations));
-    diagnostics.extend(db.validate_mutation_operations(mutation_operations));
-
-    diagnostics
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct OperationValidationConfig {
+    /// When false, rules that require a schema to validate are disabled.
+    pub has_schema: bool,
+    /// The variables defined for this operation.
+    pub variables: Arc<Vec<hir::VariableDefinition>>,
 }
 
-pub fn validate_operation_definitions(
+pub(crate) fn validate_operation_definitions_inner(
     db: &dyn ValidationDatabase,
     file_id: FileId,
+    has_schema: bool,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     let operations = db.operations(file_id);
     for def in operations.iter() {
+        let config = OperationValidationConfig {
+            has_schema,
+            variables: def.variables.clone(),
+        };
+
         diagnostics.extend(db.validate_directives(
             def.directives().to_vec(),
             def.operation_ty().into(),
@@ -48,9 +34,12 @@ pub fn validate_operation_definitions(
             // use already defined variables
             def.variables.clone(),
         ));
-        diagnostics.extend(db.validate_variable_definitions(def.variables.as_ref().clone()));
+        diagnostics.extend(db.validate_variable_definitions(def.variables.clone(), has_schema));
 
         diagnostics.extend(db.validate_unused_variable(def.clone()));
+
+        // Validate the Selection Set recursively
+        diagnostics.extend(db.validate_selection_set(def.selection_set().clone(), config));
     }
 
     // It is possible to have an unnamed (anonymous) operation definition only
@@ -76,7 +65,24 @@ pub fn validate_operation_definitions(
         diagnostics.extend(missing_ident);
     }
 
+    if has_schema {
+        let subscription_operations = db.upcast().subscription_operations(file_id);
+        let query_operations = db.upcast().query_operations(file_id);
+        let mutation_operations = db.upcast().mutation_operations(file_id);
+
+        diagnostics.extend(db.validate_subscription_operations(subscription_operations));
+        diagnostics.extend(db.validate_query_operations(query_operations));
+        diagnostics.extend(db.validate_mutation_operations(mutation_operations));
+    }
+
     diagnostics
+}
+
+pub fn validate_operation_definitions(
+    db: &dyn ValidationDatabase,
+    file_id: FileId,
+) -> Vec<ApolloDiagnostic> {
+    validate_operation_definitions_inner(db, file_id, false)
 }
 
 pub fn validate_subscription_operations(

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -7,6 +7,8 @@ use crate::{
     validation::ValidationDatabase,
 };
 
+use super::operation::OperationValidationConfig;
+
 /// Check if two fields will output the same type.
 ///
 /// Spec: https://spec.graphql.org/October2021/#SameResponseShape()
@@ -308,22 +310,22 @@ pub(crate) fn fields_in_set_can_merge(
 pub fn validate_selection(
     db: &dyn ValidationDatabase,
     selection: Arc<Vec<hir::Selection>>,
-    var_defs: Arc<Vec<hir::VariableDefinition>>,
+    context: OperationValidationConfig,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
     for sel in selection.iter() {
         match sel {
             hir::Selection::Field(field) => {
-                diagnostics.extend(db.validate_field(field.clone(), var_defs.clone()));
+                diagnostics.extend(db.validate_field(field.clone(), context.clone()));
             }
             hir::Selection::FragmentSpread(spread) => {
                 diagnostics
-                    .extend(db.validate_fragment_spread(Arc::clone(spread), var_defs.clone()));
+                    .extend(db.validate_fragment_spread(Arc::clone(spread), context.clone()));
             }
             hir::Selection::InlineFragment(inline) => {
                 diagnostics
-                    .extend(db.validate_inline_fragment(Arc::clone(inline), var_defs.clone()));
+                    .extend(db.validate_inline_fragment(Arc::clone(inline), context.clone()));
             }
         }
     }
@@ -334,7 +336,7 @@ pub fn validate_selection(
 pub fn validate_selection_set(
     db: &dyn ValidationDatabase,
     selection_set: hir::SelectionSet,
-    vars: Arc<Vec<hir::VariableDefinition>>,
+    context: OperationValidationConfig,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -342,7 +344,7 @@ pub fn validate_selection_set(
         diagnostics.extend(diagnostic);
     }
 
-    diagnostics.extend(db.validate_selection(selection_set.selection, vars));
+    diagnostics.extend(db.validate_selection(selection_set.selection, context));
 
     diagnostics
 }

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -445,19 +445,19 @@ fn validate_executable_names(
         .syntax()
         .children()
         .filter_map(ast::Definition::cast)
-        // Extension names are allowed to be duplicates,
-        // and schema definitions don't have names.
         .filter(|def| def.is_executable_definition());
 
     for ast_def in executable_definitions {
         let ty_ = match ast_def {
             ast::Definition::OperationDefinition(_) => "operation",
             ast::Definition::FragmentDefinition(_) => "fragment",
+            // Type system definitions are not checked here.
             _ => unreachable!(),
         };
         let scope = match ast_def {
             ast::Definition::OperationDefinition(_) => &mut operation_scope,
             ast::Definition::FragmentDefinition(_) => &mut fragment_scope,
+            // Type system definitions are not checked here.
             _ => unreachable!(),
         };
 

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -770,5 +770,13 @@ type TestObject {
             diagnostics[0].data.to_string(),
             "the fragment `A` is defined multiple times in the document"
         );
+
+        let unknown_frag_id = compiler.add_executable(r#"{ ...A }"#, "unknown_frag.graphql");
+        let diagnostics = compiler.db.validate_standalone_executable(unknown_frag_id);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].data.to_string(),
+            "the fragment `A` is not defined in the document"
+        );
     }
 }

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -492,6 +492,10 @@ fn validate_executable_names(db: &dyn ValidationDatabase, file_id: FileId) -> Ve
     diagnostics
 }
 
+fn location_sort_key(diagnostic: &ApolloDiagnostic) -> (FileId, usize) {
+    (diagnostic.location.file_id(), diagnostic.location.offset())
+}
+
 pub fn validate_type_system(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -510,6 +514,7 @@ pub fn validate_type_system(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic
 
     diagnostics.extend(db.validate_extensions());
 
+    diagnostics.sort_by_key(location_sort_key);
     diagnostics
 }
 
@@ -542,6 +547,7 @@ pub fn validate_executable(db: &dyn ValidationDatabase, file_id: FileId) -> Vec<
         diagnostics.extend(db.validate_fragment_used(Arc::clone(def), file_id));
     }
 
+    diagnostics.sort_by_key(location_sort_key);
     diagnostics
 }
 

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -12,7 +12,8 @@ use crate::{
 
 pub fn validate_variable_definitions(
     db: &dyn ValidationDatabase,
-    variables: Vec<hir::VariableDefinition>,
+    variables: Arc<Vec<hir::VariableDefinition>>,
+    has_schema: bool,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -26,12 +27,13 @@ pub fn validate_variable_definitions(
             Arc::new(Vec::new()),
         ));
 
-        let ty = variable.ty();
-        if !ty.is_input_type(db.upcast()) {
-            let type_def = ty.type_def(db.upcast());
-            if let Some(type_def) = type_def {
-                let ty_name = type_def.kind();
-                diagnostics.push(
+        if has_schema {
+            let ty = variable.ty();
+            if !ty.is_input_type(db.upcast()) {
+                let type_def = ty.type_def(db.upcast());
+                if let Some(type_def) = type_def {
+                    let ty_name = type_def.kind();
+                    diagnostics.push(
                     ApolloDiagnostic::new(db, variable.loc().into(), DiagnosticData::InputType {
                         name: variable.name().into(),
                         ty: ty_name,
@@ -39,15 +41,16 @@ pub fn validate_variable_definitions(
                     .label(Label::new(ty.loc().unwrap(), format!("this is of `{ty_name}` type")))
                     .help("objects, unions, and interfaces cannot be used because variables can only be of input type"),
                 );
-            } else {
-                diagnostics.push(
-                    ApolloDiagnostic::new(
-                        db,
-                        variable.loc.into(),
-                        DiagnosticData::UndefinedDefinition { name: ty.name() },
+                } else {
+                    diagnostics.push(
+                        ApolloDiagnostic::new(
+                            db,
+                            variable.loc.into(),
+                            DiagnosticData::UndefinedDefinition { name: ty.name() },
+                        )
+                        .label(Label::new(variable.loc, "not found in the type system")),
                     )
-                    .label(Label::new(variable.loc, "not found in the type system")),
-                )
+                }
             }
         }
 

--- a/crates/apollo-compiler/test_data/diagnostics/0003_anonymous_and_named_operation.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0003_anonymous_and_named_operation.txt
@@ -8,6 +8,35 @@
             file_id: FileId {
                 id: 3,
             },
+            offset: 0,
+            length: 15,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 3,
+                    },
+                    offset: 0,
+                    length: 15,
+                },
+                text: "provide a name for this definition",
+            },
+        ],
+        help: Some(
+            "GraphQL allows a short-hand form for defining query operations when only that one operation exists in the document. There are 2 operations in this document.",
+        ),
+        data: MissingIdent,
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            3: "0003_anonymous_and_named_operation.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 3,
+            },
             offset: 38,
             length: 25,
         },
@@ -37,34 +66,5 @@
         data: RequiredArgument {
             name: "name",
         },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            3: "0003_anonymous_and_named_operation.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 3,
-            },
-            offset: 0,
-            length: 15,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 3,
-                    },
-                    offset: 0,
-                    length: 15,
-                },
-                text: "provide a name for this definition",
-            },
-        ],
-        help: Some(
-            "GraphQL allows a short-hand form for defining query operations when only that one operation exists in the document. There are 2 operations in this document.",
-        ),
-        data: MissingIdent,
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
@@ -8,8 +8,8 @@
             file_id: FileId {
                 id: 28,
             },
-            offset: 173,
-            length: 3,
+            offset: 135,
+            length: 74,
         },
         labels: [
             Label {
@@ -17,15 +17,27 @@
                     file_id: FileId {
                         id: 28,
                     },
-                    offset: 173,
-                    length: 3,
+                    offset: 72,
+                    length: 61,
                 },
-                text: "not found in this scope",
+                text: "`width` was originally defined here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 28,
+                    },
+                    offset: 135,
+                    length: 74,
+                },
+                text: "add `width` field to this interface",
             },
         ],
-        help: None,
-        data: UndefinedDefinition {
-            name: "Url",
+        help: Some(
+            "An interface must be a super-set of all interfaces it implements",
+        ),
+        data: MissingField {
+            field: "width",
         },
     },
     ApolloDiagnostic {
@@ -66,8 +78,8 @@
             file_id: FileId {
                 id: 28,
             },
-            offset: 135,
-            length: 74,
+            offset: 173,
+            length: 3,
         },
         labels: [
             Label {
@@ -75,27 +87,15 @@
                     file_id: FileId {
                         id: 28,
                     },
-                    offset: 72,
-                    length: 61,
+                    offset: 173,
+                    length: 3,
                 },
-                text: "`width` was originally defined here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 28,
-                    },
-                    offset: 135,
-                    length: 74,
-                },
-                text: "add `width` field to this interface",
+                text: "not found in this scope",
             },
         ],
-        help: Some(
-            "An interface must be a super-set of all interfaces it implements",
-        ),
-        data: MissingField {
-            field: "width",
+        help: None,
+        data: UndefinedDefinition {
+            name: "Url",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0035_object_type_definition_with_missing_implements_interfaces_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0035_object_type_definition_with_missing_implements_interfaces_definition.txt
@@ -8,35 +8,6 @@
             file_id: FileId {
                 id: 35,
             },
-            offset: 239,
-            length: 8,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 35,
-                    },
-                    offset: 239,
-                    length: 8,
-                },
-                text: "Node must also be implemented here",
-            },
-        ],
-        help: None,
-        data: TransitiveImplementedInterfaces {
-            missing_interface: "Node",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            35: "0035_object_type_definition_with_missing_implements_interfaces_definition.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 35,
-            },
             offset: 22,
             length: 5,
         },
@@ -55,6 +26,35 @@
         help: None,
         data: TransitiveImplementedInterfaces {
             missing_interface: "Resource",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            35: "0035_object_type_definition_with_missing_implements_interfaces_definition.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 35,
+            },
+            offset: 239,
+            length: 8,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 35,
+                    },
+                    offset: 239,
+                    length: 8,
+                },
+                text: "Node must also be implemented here",
+            },
+        ],
+        help: None,
+        data: TransitiveImplementedInterfaces {
+            missing_interface: "Node",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
@@ -8,35 +8,6 @@
             file_id: FileId {
                 id: 36,
             },
-            offset: 425,
-            length: 5,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 36,
-                    },
-                    offset: 425,
-                    length: 5,
-                },
-                text: "not found in this scope",
-            },
-        ],
-        help: None,
-        data: UndefinedDefinition {
-            name: "Photo",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            36: "0036_object_type_with_non_output_field_types.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 36,
-            },
             offset: 240,
             length: 4,
         },
@@ -116,6 +87,35 @@
         help: None,
         data: UndefinedDefinition {
             name: "main",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            36: "0036_object_type_with_non_output_field_types.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 36,
+            },
+            offset: 425,
+            length: 5,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 36,
+                    },
+                    offset: 425,
+                    length: 5,
+                },
+                text: "not found in this scope",
+            },
+        ],
+        help: None,
+        data: UndefinedDefinition {
+            name: "Photo",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
@@ -8,35 +8,6 @@
             file_id: FileId {
                 id: 37,
             },
-            offset: 415,
-            length: 5,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 37,
-                    },
-                    offset: 415,
-                    length: 5,
-                },
-                text: "not found in this scope",
-            },
-        ],
-        help: None,
-        data: UndefinedDefinition {
-            name: "Photo",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            37: "0037_interface_with_non_output_fields.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 37,
-            },
             offset: 230,
             length: 4,
         },
@@ -116,6 +87,35 @@
         help: None,
         data: UndefinedDefinition {
             name: "main",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            37: "0037_interface_with_non_output_fields.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 37,
+            },
+            offset: 415,
+            length: 5,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 37,
+                    },
+                    offset: 415,
+                    length: 5,
+                },
+                text: "not found in this scope",
+            },
+        ],
+        help: None,
+        data: UndefinedDefinition {
+            name: "Photo",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0039_interface_with_undefined_field_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0039_interface_with_undefined_field_type.txt
@@ -8,35 +8,6 @@
             file_id: FileId {
                 id: 39,
             },
-            offset: 79,
-            length: 6,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 39,
-                    },
-                    offset: 79,
-                    length: 6,
-                },
-                text: "not found in this scope",
-            },
-        ],
-        help: None,
-        data: UndefinedDefinition {
-            name: "relationship",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            39: "0039_interface_with_undefined_field_type.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 39,
-            },
             offset: 33,
             length: 3,
         },
@@ -55,6 +26,35 @@
         help: None,
         data: UndefinedDefinition {
             name: "img",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            39: "0039_interface_with_undefined_field_type.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 39,
+            },
+            offset: 79,
+            length: 6,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 39,
+                    },
+                    offset: 79,
+                    length: 6,
+                },
+                text: "not found in this scope",
+            },
+        ],
+        help: None,
+        data: UndefinedDefinition {
+            name: "relationship",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
@@ -8,7 +8,95 @@
             file_id: FileId {
                 id: 50,
             },
-            offset: 1156,
+            offset: 446,
+            length: 15,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 50,
+                    },
+                    offset: 446,
+                    length: 15,
+                },
+                text: "INTERFACE is not a valid location",
+            },
+        ],
+        help: Some(
+            "the directive must be used in a location that the service has declared support for",
+        ),
+        data: UnsupportedLocation {
+            name: "skip",
+            dir_loc: Interface,
+            directive_def: DiagnosticLocation {
+                file_id: FileId {
+                    id: 0,
+                },
+                offset: 1957,
+                length: 187,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            50: "0050_directives_in_invalid_locations.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 50,
+            },
+            offset: 523,
+            length: 11,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 50,
+                    },
+                    offset: 523,
+                    length: 11,
+                },
+                text: "FIELD_DEFINITION is not a valid location",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 50,
+                    },
+                    offset: 1398,
+                    length: 29,
+                },
+                text: "consider adding FIELD_DEFINITION directive location here",
+            },
+        ],
+        help: Some(
+            "the directive must be used in a location that the service has declared support for",
+        ),
+        data: UnsupportedLocation {
+            name: "directiveB",
+            dir_loc: FieldDefinition,
+            directive_def: DiagnosticLocation {
+                file_id: FileId {
+                    id: 50,
+                },
+                offset: 1398,
+                length: 29,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            50: "0050_directives_in_invalid_locations.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 50,
+            },
+            offset: 670,
             length: 18,
         },
         labels: [
@@ -17,10 +105,10 @@
                     file_id: FileId {
                         id: 50,
                     },
-                    offset: 1156,
+                    offset: 670,
                     length: 18,
                 },
-                text: "SCHEMA is not a valid location",
+                text: "INPUT_OBJECT is not a valid location",
             },
         ],
         help: Some(
@@ -28,7 +116,7 @@
         ),
         data: UnsupportedLocation {
             name: "include",
-            dir_loc: Schema,
+            dir_loc: InputObject,
             directive_def: DiagnosticLocation {
                 file_id: FileId {
                     id: 0,
@@ -47,7 +135,46 @@
             file_id: FileId {
                 id: 50,
             },
-            offset: 1307,
+            offset: 707,
+            length: 18,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 50,
+                    },
+                    offset: 707,
+                    length: 18,
+                },
+                text: "INPUT_FIELD_DEFINITION is not a valid location",
+            },
+        ],
+        help: Some(
+            "the directive must be used in a location that the service has declared support for",
+        ),
+        data: UnsupportedLocation {
+            name: "include",
+            dir_loc: InputFieldDefinition,
+            directive_def: DiagnosticLocation {
+                file_id: FileId {
+                    id: 0,
+                },
+                offset: 2146,
+                length: 199,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            50: "0050_directives_in_invalid_locations.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 50,
+            },
+            offset: 760,
             length: 11,
         },
         labels: [
@@ -56,10 +183,10 @@
                     file_id: FileId {
                         id: 50,
                     },
-                    offset: 1307,
+                    offset: 760,
                     length: 11,
                 },
-                text: "SCALAR is not a valid location",
+                text: "UNION is not a valid location",
             },
             Label {
                 location: DiagnosticLocation {
@@ -69,7 +196,7 @@
                     offset: 1398,
                     length: 29,
                 },
-                text: "consider adding SCALAR directive location here",
+                text: "consider adding UNION directive location here",
             },
         ],
         help: Some(
@@ -77,7 +204,7 @@
         ),
         data: UnsupportedLocation {
             name: "directiveB",
-            dir_loc: Scalar,
+            dir_loc: Union,
             directive_def: DiagnosticLocation {
                 file_id: FileId {
                     id: 50,
@@ -194,221 +321,6 @@
             file_id: FileId {
                 id: 50,
             },
-            offset: 760,
-            length: 11,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 50,
-                    },
-                    offset: 760,
-                    length: 11,
-                },
-                text: "UNION is not a valid location",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 50,
-                    },
-                    offset: 1398,
-                    length: 29,
-                },
-                text: "consider adding UNION directive location here",
-            },
-        ],
-        help: Some(
-            "the directive must be used in a location that the service has declared support for",
-        ),
-        data: UnsupportedLocation {
-            name: "directiveB",
-            dir_loc: Union,
-            directive_def: DiagnosticLocation {
-                file_id: FileId {
-                    id: 50,
-                },
-                offset: 1398,
-                length: 29,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            50: "0050_directives_in_invalid_locations.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 50,
-            },
-            offset: 446,
-            length: 15,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 50,
-                    },
-                    offset: 446,
-                    length: 15,
-                },
-                text: "INTERFACE is not a valid location",
-            },
-        ],
-        help: Some(
-            "the directive must be used in a location that the service has declared support for",
-        ),
-        data: UnsupportedLocation {
-            name: "skip",
-            dir_loc: Interface,
-            directive_def: DiagnosticLocation {
-                file_id: FileId {
-                    id: 0,
-                },
-                offset: 1957,
-                length: 187,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            50: "0050_directives_in_invalid_locations.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 50,
-            },
-            offset: 670,
-            length: 18,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 50,
-                    },
-                    offset: 670,
-                    length: 18,
-                },
-                text: "INPUT_OBJECT is not a valid location",
-            },
-        ],
-        help: Some(
-            "the directive must be used in a location that the service has declared support for",
-        ),
-        data: UnsupportedLocation {
-            name: "include",
-            dir_loc: InputObject,
-            directive_def: DiagnosticLocation {
-                file_id: FileId {
-                    id: 0,
-                },
-                offset: 2146,
-                length: 199,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            50: "0050_directives_in_invalid_locations.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 50,
-            },
-            offset: 707,
-            length: 18,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 50,
-                    },
-                    offset: 707,
-                    length: 18,
-                },
-                text: "INPUT_FIELD_DEFINITION is not a valid location",
-            },
-        ],
-        help: Some(
-            "the directive must be used in a location that the service has declared support for",
-        ),
-        data: UnsupportedLocation {
-            name: "include",
-            dir_loc: InputFieldDefinition,
-            directive_def: DiagnosticLocation {
-                file_id: FileId {
-                    id: 0,
-                },
-                offset: 2146,
-                length: 199,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            50: "0050_directives_in_invalid_locations.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 50,
-            },
-            offset: 523,
-            length: 11,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 50,
-                    },
-                    offset: 523,
-                    length: 11,
-                },
-                text: "FIELD_DEFINITION is not a valid location",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 50,
-                    },
-                    offset: 1398,
-                    length: 29,
-                },
-                text: "consider adding FIELD_DEFINITION directive location here",
-            },
-        ],
-        help: Some(
-            "the directive must be used in a location that the service has declared support for",
-        ),
-        data: UnsupportedLocation {
-            name: "directiveB",
-            dir_loc: FieldDefinition,
-            directive_def: DiagnosticLocation {
-                file_id: FileId {
-                    id: 50,
-                },
-                offset: 1398,
-                length: 29,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            50: "0050_directives_in_invalid_locations.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 50,
-            },
             offset: 907,
             length: 11,
         },
@@ -487,8 +399,8 @@
             file_id: FileId {
                 id: 50,
             },
-            offset: 46,
-            length: 16,
+            offset: 1156,
+            length: 18,
         },
         labels: [
             Label {
@@ -496,24 +408,73 @@
                     file_id: FileId {
                         id: 50,
                     },
-                    offset: 46,
-                    length: 16,
+                    offset: 1156,
+                    length: 18,
                 },
-                text: "QUERY is not a valid location",
+                text: "SCHEMA is not a valid location",
             },
         ],
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
         data: UnsupportedLocation {
-            name: "skip",
-            dir_loc: Query,
+            name: "include",
+            dir_loc: Schema,
             directive_def: DiagnosticLocation {
                 file_id: FileId {
                     id: 0,
                 },
-                offset: 1957,
-                length: 187,
+                offset: 2146,
+                length: 199,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            50: "0050_directives_in_invalid_locations.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 50,
+            },
+            offset: 1307,
+            length: 11,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 50,
+                    },
+                    offset: 1307,
+                    length: 11,
+                },
+                text: "SCALAR is not a valid location",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 50,
+                    },
+                    offset: 1398,
+                    length: 29,
+                },
+                text: "consider adding SCALAR directive location here",
+            },
+        ],
+        help: Some(
+            "the directive must be used in a location that the service has declared support for",
+        ),
+        data: UnsupportedLocation {
+            name: "directiveB",
+            dir_loc: Scalar,
+            directive_def: DiagnosticLocation {
+                file_id: FileId {
+                    id: 50,
+                },
+                offset: 1398,
+                length: 29,
             },
         },
     },
@@ -547,6 +508,45 @@
         data: UnsupportedLocation {
             name: "skip",
             dir_loc: VariableDefinition,
+            directive_def: DiagnosticLocation {
+                file_id: FileId {
+                    id: 0,
+                },
+                offset: 1957,
+                length: 187,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            50: "0050_directives_in_invalid_locations.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 50,
+            },
+            offset: 46,
+            length: 16,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 50,
+                    },
+                    offset: 46,
+                    length: 16,
+                },
+                text: "QUERY is not a valid location",
+            },
+        ],
+        help: Some(
+            "the directive must be used in a location that the service has declared support for",
+        ),
+        data: UnsupportedLocation {
+            name: "skip",
+            dir_loc: Query,
             directive_def: DiagnosticLocation {
                 file_id: FileId {
                     id: 0,

--- a/crates/apollo-compiler/test_data/diagnostics/0053_argument_name_is_not_defined.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0053_argument_name_is_not_defined.txt
@@ -8,45 +8,6 @@
             file_id: FileId {
                 id: 53,
             },
-            offset: 176,
-            length: 7,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 53,
-                    },
-                    offset: 176,
-                    length: 7,
-                },
-                text: "argument name not found",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 53,
-                    },
-                    offset: 15,
-                    length: 21,
-                },
-                text: "field declared here",
-            },
-        ],
-        help: None,
-        data: UndefinedArgument {
-            name: "arg2",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            53: "0053_argument_name_is_not_defined.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 53,
-            },
             offset: 133,
             length: 7,
         },
@@ -114,6 +75,45 @@
         help: None,
         data: UndefinedArgument {
             name: "arg3",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            53: "0053_argument_name_is_not_defined.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 53,
+            },
+            offset: 176,
+            length: 7,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 53,
+                    },
+                    offset: 176,
+                    length: 7,
+                },
+                text: "argument name not found",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 53,
+                    },
+                    offset: 15,
+                    length: 21,
+                },
+                text: "field declared here",
+            },
+        ],
+        help: None,
+        data: UndefinedArgument {
+            name: "arg2",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
@@ -8,6 +8,178 @@
             file_id: FileId {
                 id: 54,
             },
+            offset: 281,
+            length: 12,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 281,
+                    length: 12,
+                },
+                text: "missing value for argument `req1`",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 38,
+                    length: 10,
+                },
+                text: "argument defined here",
+            },
+        ],
+        help: None,
+        data: RequiredArgument {
+            name: "req1",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            54: "0054_argument_not_provided.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 54,
+            },
+            offset: 281,
+            length: 12,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 281,
+                    length: 12,
+                },
+                text: "missing value for argument `req2`",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 50,
+                    length: 10,
+                },
+                text: "argument defined here",
+            },
+        ],
+        help: None,
+        data: RequiredArgument {
+            name: "req2",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            54: "0054_argument_not_provided.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 54,
+            },
+            offset: 332,
+            length: 21,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 345,
+                    length: 7,
+                },
+                text: "field `multipleReqs` is selected with argument `req2` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 281,
+                    length: 12,
+                },
+                text: "but argument `req2` is not provided here",
+            },
+        ],
+        help: Some(
+            "Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.",
+        ),
+        data: ConflictingField {
+            field: "multipleReqs",
+            original_selection: DiagnosticLocation {
+                file_id: FileId {
+                    id: 54,
+                },
+                offset: 281,
+                length: 12,
+            },
+            redefined_selection: DiagnosticLocation {
+                file_id: FileId {
+                    id: 54,
+                },
+                offset: 332,
+                length: 21,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            54: "0054_argument_not_provided.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 54,
+            },
+            offset: 332,
+            length: 21,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 332,
+                    length: 21,
+                },
+                text: "missing value for argument `req1`",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 38,
+                    length: 10,
+                },
+                text: "argument defined here",
+            },
+        ],
+        help: None,
+        data: RequiredArgument {
+            name: "req1",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            54: "0054_argument_not_provided.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 54,
+            },
             offset: 389,
             length: 5,
         },
@@ -29,6 +201,45 @@
                     },
                     offset: 2062,
                     length: 35,
+                },
+                text: "argument defined here",
+            },
+        ],
+        help: None,
+        data: RequiredArgument {
+            name: "if",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            54: "0054_argument_not_provided.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 54,
+            },
+            offset: 395,
+            length: 22,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 54,
+                    },
+                    offset: 395,
+                    length: 22,
+                },
+                text: "missing value for argument `if`",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 0,
+                    },
+                    offset: 2262,
+                    length: 36,
                 },
                 text: "argument defined here",
             },
@@ -75,45 +286,6 @@
         help: None,
         data: UndefinedArgument {
             name: "wrong",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            54: "0054_argument_not_provided.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 54,
-            },
-            offset: 395,
-            length: 22,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 395,
-                    length: 22,
-                },
-                text: "missing value for argument `if`",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 0,
-                    },
-                    offset: 2262,
-                    length: 36,
-                },
-                text: "argument defined here",
-            },
-        ],
-        help: None,
-        data: RequiredArgument {
-            name: "if",
         },
     },
     ApolloDiagnostic {
@@ -231,178 +403,6 @@
         help: None,
         data: RequiredArgument {
             name: "req2",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            54: "0054_argument_not_provided.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 54,
-            },
-            offset: 332,
-            length: 21,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 345,
-                    length: 7,
-                },
-                text: "field `multipleReqs` is selected with argument `req2` here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 281,
-                    length: 12,
-                },
-                text: "but argument `req2` is not provided here",
-            },
-        ],
-        help: Some(
-            "Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.",
-        ),
-        data: ConflictingField {
-            field: "multipleReqs",
-            original_selection: DiagnosticLocation {
-                file_id: FileId {
-                    id: 54,
-                },
-                offset: 281,
-                length: 12,
-            },
-            redefined_selection: DiagnosticLocation {
-                file_id: FileId {
-                    id: 54,
-                },
-                offset: 332,
-                length: 21,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            54: "0054_argument_not_provided.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 54,
-            },
-            offset: 281,
-            length: 12,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 281,
-                    length: 12,
-                },
-                text: "missing value for argument `req1`",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 38,
-                    length: 10,
-                },
-                text: "argument defined here",
-            },
-        ],
-        help: None,
-        data: RequiredArgument {
-            name: "req1",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            54: "0054_argument_not_provided.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 54,
-            },
-            offset: 281,
-            length: 12,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 281,
-                    length: 12,
-                },
-                text: "missing value for argument `req2`",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 50,
-                    length: 10,
-                },
-                text: "argument defined here",
-            },
-        ],
-        help: None,
-        data: RequiredArgument {
-            name: "req2",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            54: "0054_argument_not_provided.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 54,
-            },
-            offset: 332,
-            length: 21,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 332,
-                    length: 21,
-                },
-                text: "missing value for argument `req1`",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 54,
-                    },
-                    offset: 38,
-                    length: 10,
-                },
-                text: "argument defined here",
-            },
-        ],
-        help: None,
-        data: RequiredArgument {
-            name: "req1",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0074_merge_identical_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0074_merge_identical_fields.txt
@@ -61,59 +61,6 @@
             file_id: FileId {
                 id: 71,
             },
-            offset: 325,
-            length: 14,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 71,
-                    },
-                    offset: 312,
-                    length: 10,
-                },
-                text: "`fido` has type `String!` here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 71,
-                    },
-                    offset: 325,
-                    length: 14,
-                },
-                text: "but the same field name has type `String` here",
-            },
-        ],
-        help: None,
-        data: ConflictingField {
-            field: "name",
-            original_selection: DiagnosticLocation {
-                file_id: FileId {
-                    id: 71,
-                },
-                offset: 312,
-                length: 10,
-            },
-            redefined_selection: DiagnosticLocation {
-                file_id: FileId {
-                    id: 71,
-                },
-                offset: 325,
-                length: 14,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            71: "0074_merge_identical_fields.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 71,
-            },
             offset: 247,
             length: 4,
         },
@@ -155,6 +102,59 @@
                 },
                 offset: 247,
                 length: 4,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            71: "0074_merge_identical_fields.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 71,
+            },
+            offset: 325,
+            length: 14,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 71,
+                    },
+                    offset: 312,
+                    length: 10,
+                },
+                text: "`fido` has type `String!` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 71,
+                    },
+                    offset: 325,
+                    length: 14,
+                },
+                text: "but the same field name has type `String` here",
+            },
+        ],
+        help: None,
+        data: ConflictingField {
+            field: "name",
+            original_selection: DiagnosticLocation {
+                file_id: FileId {
+                    id: 71,
+                },
+                offset: 312,
+                length: 10,
+            },
+            redefined_selection: DiagnosticLocation {
+                file_id: FileId {
+                    id: 71,
+                },
+                offset: 325,
+                length: 14,
             },
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0078_merge_conflict_nested_fragments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0078_merge_conflict_nested_fragments.txt
@@ -8,61 +8,6 @@
             file_id: FileId {
                 id: 75,
             },
-            offset: 240,
-            length: 4,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 75,
-                    },
-                    offset: 145,
-                    length: 4,
-                },
-                text: "field `x` is selected from field `a` here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 75,
-                    },
-                    offset: 240,
-                    length: 4,
-                },
-                text: "but the same field `x` is also selected from field `b` here",
-            },
-        ],
-        help: Some(
-            "Alias is already used for a different field",
-        ),
-        data: ConflictingField {
-            field: "b",
-            original_selection: DiagnosticLocation {
-                file_id: FileId {
-                    id: 75,
-                },
-                offset: 145,
-                length: 4,
-            },
-            redefined_selection: DiagnosticLocation {
-                file_id: FileId {
-                    id: 75,
-                },
-                offset: 240,
-                length: 4,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            75: "0078_merge_conflict_nested_fragments.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 75,
-            },
             offset: 206,
             length: 4,
         },
@@ -105,6 +50,61 @@
                     id: 75,
                 },
                 offset: 206,
+                length: 4,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            75: "0078_merge_conflict_nested_fragments.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 75,
+            },
+            offset: 240,
+            length: 4,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 75,
+                    },
+                    offset: 145,
+                    length: 4,
+                },
+                text: "field `x` is selected from field `a` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 75,
+                    },
+                    offset: 240,
+                    length: 4,
+                },
+                text: "but the same field `x` is also selected from field `b` here",
+            },
+        ],
+        help: Some(
+            "Alias is already used for a different field",
+        ),
+        data: ConflictingField {
+            field: "b",
+            original_selection: DiagnosticLocation {
+                file_id: FileId {
+                    id: 75,
+                },
+                offset: 145,
+                length: 4,
+            },
+            redefined_selection: DiagnosticLocation {
+                file_id: FileId {
+                    id: 75,
+                },
+                offset: 240,
                 length: 4,
             },
         },

--- a/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
@@ -8,115 +8,6 @@
             file_id: FileId {
                 id: 77,
             },
-            offset: 323,
-            length: 4,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 77,
-                    },
-                    offset: 273,
-                    length: 4,
-                },
-                text: "previous definition of `Intf` here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 77,
-                    },
-                    offset: 323,
-                    length: 4,
-                },
-                text: "`Intf` redefined here",
-            },
-        ],
-        help: Some(
-            "`Intf` must only be defined once in this document.",
-        ),
-        data: UniqueDefinition {
-            ty: "type",
-            name: "Intf",
-            original_definition: DiagnosticLocation {
-                file_id: FileId {
-                    id: 77,
-                },
-                offset: 273,
-                length: 4,
-            },
-            redefined_definition: DiagnosticLocation {
-                file_id: FileId {
-                    id: 77,
-                },
-                offset: 323,
-                length: 4,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            77: "0080_directive_is_unique_with_extensions.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 77,
-            },
-            offset: 214,
-            length: 14,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 77,
-                    },
-                    offset: 178,
-                    length: 14,
-                },
-                text: "directive nonRepeatable first called here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 77,
-                    },
-                    offset: 214,
-                    length: 14,
-                },
-                text: "directive nonRepeatable called again here",
-            },
-        ],
-        help: None,
-        data: UniqueDirective {
-            name: "nonRepeatable",
-            original_call: DiagnosticLocation {
-                file_id: FileId {
-                    id: 77,
-                },
-                offset: 178,
-                length: 14,
-            },
-            conflicting_call: DiagnosticLocation {
-                file_id: FileId {
-                    id: 77,
-                },
-                offset: 214,
-                length: 14,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            77: "0080_directive_is_unique_with_extensions.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 77,
-            },
             offset: 79,
             length: 14,
         },
@@ -211,6 +102,115 @@
                 },
                 offset: 148,
                 length: 14,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            77: "0080_directive_is_unique_with_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 77,
+            },
+            offset: 214,
+            length: 14,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 77,
+                    },
+                    offset: 178,
+                    length: 14,
+                },
+                text: "directive nonRepeatable first called here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 77,
+                    },
+                    offset: 214,
+                    length: 14,
+                },
+                text: "directive nonRepeatable called again here",
+            },
+        ],
+        help: None,
+        data: UniqueDirective {
+            name: "nonRepeatable",
+            original_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 77,
+                },
+                offset: 178,
+                length: 14,
+            },
+            conflicting_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 77,
+                },
+                offset: 214,
+                length: 14,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            77: "0080_directive_is_unique_with_extensions.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 77,
+            },
+            offset: 323,
+            length: 4,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 77,
+                    },
+                    offset: 273,
+                    length: 4,
+                },
+                text: "previous definition of `Intf` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 77,
+                    },
+                    offset: 323,
+                    length: 4,
+                },
+                text: "`Intf` redefined here",
+            },
+        ],
+        help: Some(
+            "`Intf` must only be defined once in this document.",
+        ),
+        data: UniqueDefinition {
+            ty: "type",
+            name: "Intf",
+            original_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 77,
+                },
+                offset: 273,
+                length: 4,
+            },
+            redefined_definition: DiagnosticLocation {
+                file_id: FileId {
+                    id: 77,
+                },
+                offset: 323,
+                length: 4,
             },
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
@@ -114,7 +114,7 @@
             file_id: FileId {
                 id: 78,
             },
-            offset: 351,
+            offset: 251,
             length: 14,
         },
         labels: [
@@ -123,7 +123,7 @@
                     file_id: FileId {
                         id: 78,
                     },
-                    offset: 336,
+                    offset: 236,
                     length: 14,
                 },
                 text: "directive nonRepeatable first called here",
@@ -133,7 +133,7 @@
                     file_id: FileId {
                         id: 78,
                     },
-                    offset: 351,
+                    offset: 251,
                     length: 14,
                 },
                 text: "directive nonRepeatable called again here",
@@ -146,14 +146,14 @@
                 file_id: FileId {
                     id: 78,
                 },
-                offset: 336,
+                offset: 236,
                 length: 14,
             },
             conflicting_call: DiagnosticLocation {
                 file_id: FileId {
                     id: 78,
                 },
-                offset: 351,
+                offset: 251,
                 length: 14,
             },
         },
@@ -220,6 +220,59 @@
             file_id: FileId {
                 id: 78,
             },
+            offset: 351,
+            length: 14,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 78,
+                    },
+                    offset: 336,
+                    length: 14,
+                },
+                text: "directive nonRepeatable first called here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 78,
+                    },
+                    offset: 351,
+                    length: 14,
+                },
+                text: "directive nonRepeatable called again here",
+            },
+        ],
+        help: None,
+        data: UniqueDirective {
+            name: "nonRepeatable",
+            original_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 78,
+                },
+                offset: 336,
+                length: 14,
+            },
+            conflicting_call: DiagnosticLocation {
+                file_id: FileId {
+                    id: 78,
+                },
+                offset: 351,
+                length: 14,
+            },
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            78: "0081_directive_is_unique_type_system.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 78,
+            },
             offset: 397,
             length: 14,
         },
@@ -260,59 +313,6 @@
                     id: 78,
                 },
                 offset: 397,
-                length: 14,
-            },
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            78: "0081_directive_is_unique_type_system.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 78,
-            },
-            offset: 251,
-            length: 14,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 78,
-                    },
-                    offset: 236,
-                    length: 14,
-                },
-                text: "directive nonRepeatable first called here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 78,
-                    },
-                    offset: 251,
-                    length: 14,
-                },
-                text: "directive nonRepeatable called again here",
-            },
-        ],
-        help: None,
-        data: UniqueDirective {
-            name: "nonRepeatable",
-            original_call: DiagnosticLocation {
-                file_id: FileId {
-                    id: 78,
-                },
-                offset: 236,
-                length: 14,
-            },
-            conflicting_call: DiagnosticLocation {
-                file_id: FileId {
-                    id: 78,
-                },
-                offset: 251,
                 length: 14,
             },
         },

--- a/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
@@ -45,8 +45,8 @@
             file_id: FileId {
                 id: 84,
             },
-            offset: 328,
-            length: 25,
+            offset: 108,
+            length: 29,
         },
         labels: [
             Label {
@@ -54,8 +54,8 @@
                     file_id: FileId {
                         id: 84,
                     },
-                    offset: 328,
-                    length: 25,
+                    offset: 108,
+                    length: 29,
                 },
                 text: "fragment declares unsupported type condition `Int`",
             },
@@ -86,8 +86,8 @@
             file_id: FileId {
                 id: 84,
             },
-            offset: 108,
-            length: 29,
+            offset: 328,
+            length: 25,
         },
         labels: [
             Label {
@@ -95,8 +95,8 @@
                     file_id: FileId {
                         id: 84,
                     },
-                    offset: 108,
-                    length: 29,
+                    offset: 328,
+                    length: 25,
                 },
                 text: "fragment declares unsupported type condition `Int`",
             },

--- a/crates/apollo-compiler/test_data/diagnostics/0089_fragment_type_condition_on_non_existent_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0089_fragment_type_condition_on_non_existent_types.txt
@@ -8,8 +8,8 @@
             file_id: FileId {
                 id: 86,
             },
-            offset: 301,
-            length: 55,
+            offset: 93,
+            length: 40,
         },
         labels: [
             Label {
@@ -17,18 +17,18 @@
                     file_id: FileId {
                         id: 86,
                     },
-                    offset: 301,
-                    length: 55,
+                    offset: 93,
+                    length: 40,
                 },
-                text: "`Interface2` is defined here but not declared in the schema",
+                text: "`MissingSecondType` is defined here but not declared in the schema",
             },
         ],
         help: Some(
-            "consider defining `Interface2` in the schema",
+            "consider defining `MissingSecondType` in the schema",
         ),
         data: InvalidFragment {
             ty: Some(
-                "Interface2",
+                "MissingSecondType",
             ),
         },
     },
@@ -74,8 +74,8 @@
             file_id: FileId {
                 id: 86,
             },
-            offset: 93,
-            length: 40,
+            offset: 301,
+            length: 55,
         },
         labels: [
             Label {
@@ -83,18 +83,18 @@
                     file_id: FileId {
                         id: 86,
                     },
-                    offset: 93,
-                    length: 40,
+                    offset: 301,
+                    length: 55,
                 },
-                text: "`MissingSecondType` is defined here but not declared in the schema",
+                text: "`Interface2` is defined here but not declared in the schema",
             },
         ],
         help: Some(
-            "consider defining `MissingSecondType` in the schema",
+            "consider defining `Interface2` in the schema",
         ),
         data: InvalidFragment {
             ty: Some(
-                "MissingSecondType",
+                "Interface2",
             ),
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0090_fragment_spread_impossible.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0090_fragment_spread_impossible.txt
@@ -60,6 +60,58 @@
             file_id: FileId {
                 id: 87,
             },
+            offset: 571,
+            length: 28,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 87,
+                    },
+                    offset: 571,
+                    length: 28,
+                },
+                text: "fragment `nonIntersectingInterfaces` cannot be applied",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 87,
+                    },
+                    offset: 879,
+                    length: 68,
+                },
+                text: "fragment declared with type condition `Pet` here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 87,
+                    },
+                    offset: 262,
+                    length: 65,
+                },
+                text: "type condition `Pet` is not assignable to this type",
+            },
+        ],
+        help: None,
+        data: InvalidFragmentSpread {
+            name: Some(
+                "nonIntersectingInterfaces",
+            ),
+            type_name: "Human",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            87: "0090_fragment_spread_impossible.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 87,
+            },
             offset: 682,
             length: 31,
         },
@@ -169,58 +221,6 @@
         data: InvalidFragmentSpread {
             name: None,
             type_name: "HumanOrAlien",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            87: "0090_fragment_spread_impossible.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 87,
-            },
-            offset: 571,
-            length: 28,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 87,
-                    },
-                    offset: 571,
-                    length: 28,
-                },
-                text: "fragment `nonIntersectingInterfaces` cannot be applied",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 87,
-                    },
-                    offset: 879,
-                    length: 68,
-                },
-                text: "fragment declared with type condition `Pet` here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 87,
-                    },
-                    offset: 262,
-                    length: 65,
-                },
-                text: "type condition `Pet` is not assignable to this type",
-            },
-        ],
-        help: None,
-        data: InvalidFragmentSpread {
-            name: Some(
-                "nonIntersectingInterfaces",
-            ),
-            type_name: "Human",
         },
     },
     ApolloDiagnostic {

--- a/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.txt
@@ -8,46 +8,6 @@
             file_id: FileId {
                 id: 92,
             },
-            offset: 216,
-            length: 4,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 92,
-                    },
-                    offset: 209,
-                    length: 4,
-                },
-                text: "`Intf` interface implementation previously declared here",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 92,
-                    },
-                    offset: 216,
-                    length: 4,
-                },
-                text: "`Intf` interface implementation declared again here",
-            },
-        ],
-        help: None,
-        data: DuplicateImplementsInterface {
-            ty: "SubIntf",
-            interface: "Intf",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            92: "0095_interface_implementation_declared_once.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 92,
-            },
             offset: 66,
             length: 4,
         },
@@ -116,6 +76,46 @@
         help: None,
         data: DuplicateImplementsInterface {
             ty: "Extended",
+            interface: "Intf",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            92: "0095_interface_implementation_declared_once.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 92,
+            },
+            offset: 216,
+            length: 4,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 92,
+                    },
+                    offset: 209,
+                    length: 4,
+                },
+                text: "`Intf` interface implementation previously declared here",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 92,
+                    },
+                    offset: 216,
+                    length: 4,
+                },
+                text: "`Intf` interface implementation declared again here",
+            },
+        ],
+        help: None,
+        data: DuplicateImplementsInterface {
+            ty: "SubIntf",
             interface: "Intf",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
@@ -1137,6 +1137,45 @@
             file_id: FileId {
                 id: 99,
             },
+            offset: 3968,
+            length: 25,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 99,
+                    },
+                    offset: 3968,
+                    length: 25,
+                },
+                text: "missing value for argument `req2`",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 99,
+                    },
+                    offset: 567,
+                    length: 10,
+                },
+                text: "argument defined here",
+            },
+        ],
+        help: None,
+        data: RequiredArgument {
+            name: "req2",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            99: "0102_invalid_string_values.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 99,
+            },
             offset: 3987,
             length: 5,
         },
@@ -1166,45 +1205,6 @@
         data: UnsupportedValueType {
             value: "String",
             ty: "Int",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            99: "0102_invalid_string_values.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 99,
-            },
-            offset: 3968,
-            length: 25,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 99,
-                    },
-                    offset: 3968,
-                    length: 25,
-                },
-                text: "missing value for argument `req2`",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 99,
-                    },
-                    offset: 567,
-                    length: 10,
-                },
-                text: "argument defined here",
-            },
-        ],
-        help: None,
-        data: RequiredArgument {
-            name: "req2",
         },
     },
     ApolloDiagnostic {
@@ -1483,45 +1483,6 @@
             file_id: FileId {
                 id: 99,
             },
-            offset: 4955,
-            length: 39,
-        },
-        labels: [
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 99,
-                    },
-                    offset: 4955,
-                    length: 39,
-                },
-                text: "missing value for argument `requiredField`",
-            },
-            Label {
-                location: DiagnosticLocation {
-                    file_id: FileId {
-                        id: 99,
-                    },
-                    offset: 882,
-                    length: 7,
-                },
-                text: "argument defined here",
-            },
-        ],
-        help: None,
-        data: RequiredArgument {
-            name: "requiredField",
-        },
-    },
-    ApolloDiagnostic {
-        cache: {
-            0: "built_in_types.graphql",
-            99: "0102_invalid_string_values.graphql",
-        },
-        location: DiagnosticLocation {
-            file_id: FileId {
-                id: 99,
-            },
             offset: 4906,
             length: 4,
         },
@@ -1602,8 +1563,8 @@
             file_id: FileId {
                 id: 99,
             },
-            offset: 5223,
-            length: 16,
+            offset: 4955,
+            length: 39,
         },
         labels: [
             Label {
@@ -1611,26 +1572,25 @@
                     file_id: FileId {
                         id: 99,
                     },
-                    offset: 5208,
-                    length: 12,
+                    offset: 4955,
+                    length: 39,
                 },
-                text: "field declared here as ComplexInput type",
+                text: "missing value for argument `requiredField`",
             },
             Label {
                 location: DiagnosticLocation {
                     file_id: FileId {
                         id: 99,
                     },
-                    offset: 5223,
-                    length: 16,
+                    offset: 882,
+                    length: 7,
                 },
-                text: "argument declared here is of String type",
+                text: "argument defined here",
             },
         ],
         help: None,
-        data: UnsupportedValueType {
-            value: "String",
-            ty: "ComplexInput",
+        data: RequiredArgument {
+            name: "requiredField",
         },
     },
     ApolloDiagnostic {
@@ -1711,6 +1671,46 @@
         data: UnsupportedValueType {
             value: "Int",
             ty: "String",
+        },
+    },
+    ApolloDiagnostic {
+        cache: {
+            0: "built_in_types.graphql",
+            99: "0102_invalid_string_values.graphql",
+        },
+        location: DiagnosticLocation {
+            file_id: FileId {
+                id: 99,
+            },
+            offset: 5223,
+            length: 16,
+        },
+        labels: [
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 99,
+                    },
+                    offset: 5208,
+                    length: 12,
+                },
+                text: "field declared here as ComplexInput type",
+            },
+            Label {
+                location: DiagnosticLocation {
+                    file_id: FileId {
+                        id: 99,
+                    },
+                    offset: 5223,
+                    length: 16,
+                },
+                text: "argument declared here is of String type",
+            },
+        ],
+        help: None,
+        data: UnsupportedValueType {
+            value: "String",
+            ty: "ComplexInput",
         },
     },
     ApolloDiagnostic {


### PR DESCRIPTION
Fixes #629 

This adds a `compiler.db.validate_standalone_executable(file_id)` function that only runs those validations that do not require a schema. Including variable usage, name uniqueness, fragment usage, things like that. I think "standalone" is a decent name but open to bikeshedding.

Also includes a fix for name collisions in executable documents--these actually did not raise an error before.

There are many changes in the test data because this PR sorts the diagnostics by location. There are no changes in the actual diagnostics reported (as test data all uses the validation function that checks against schema.

- [x] Forgot about some nested selection set validations, eg spreading a named fragment that's not defined