### PR TITLE
fix(parser): fix some escape sequences in strings and indentation in block strings

### DIFF
--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -17,6 +17,7 @@ categories = [
 edition = "2021"
 
 [dependencies]
+memchr = "2.6.1"
 rowan = "0.15.5"
 thiserror = "1.0.30"
 

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -438,11 +438,40 @@ fn text_of_first_token(node: &SyntaxNode) -> TokenText {
 }
 
 #[cfg(test)]
+mod string_tests {
+    use super::unescape_string;
+
+    #[test]
+    fn it_parses_strings() {
+        assert_eq!(unescape_string(r"simple"), "simple");
+        assert_eq!(unescape_string(r" white space "), " white space ");
+    }
+
+    #[test]
+    fn it_unescapes_strings() {
+        assert_eq!(unescape_string(r#"quote \""#), "quote \"");
+        assert_eq!(
+            unescape_string(r"escaped \n\r\b\t\f"),
+            "escaped \n\r\u{0008}\t\u{000c}"
+        );
+        assert_eq!(unescape_string(r"slashes \\ \/"), r"slashes \ /");
+        assert_eq!(
+            unescape_string("unescaped unicode outside BMP \u{1f600}"),
+            "unescaped unicode outside BMP \u{1f600}"
+        );
+        assert_eq!(
+            unescape_string(r"unicode \u1234\u5678\u90AB\uCDEF"),
+            "unicode \u{1234}\u{5678}\u{90AB}\u{CDEF}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod block_string_tests {
     use super::{split_lines, unescape_block_string};
 
     #[test]
-    fn test_split_graphql_lines() {
+    fn it_splits_lines_by_graphql_newline_definition() {
         let plain_newlines: Vec<_> = split_lines(
             r#"source text
     with some

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -281,6 +281,8 @@ fn unescape_block_string(raw_value: &str) -> String {
         line.chars().take_while(|&c| is_whitespace(c)).count()
     }
 
+    // 1. Let lines be the result of splitting rawValue by LineTerminator.
+    // 2. Let commonIndent be null.
     // 3. For each line in lines:
     let common_indent = split_lines(raw_value)
         // 3.a. If line is the first item in lines, continue to the next line.
@@ -312,6 +314,8 @@ fn unescape_block_string(raw_value: &str) -> String {
         // 5.a. Remove the first item from lines.
         .skip_while(|line| is_whitespace_line(line));
 
+    // (Step 6 is done at the end so we don't need an intermediate allocation.)
+
     // 7. Let formatted be the empty character sequence.
     let mut formatted = String::with_capacity(raw_value.len());
 
@@ -331,12 +335,13 @@ fn unescape_block_string(raw_value: &str) -> String {
         // 8.b.ii. Append formatted with line.
         replace_into(line, ESCAPED_TRIPLE_QUOTE, TRIPLE_QUOTE, &mut formatted);
 
+        // Track the last non-whitespace line for implementing step 6 in the spec.
         if !is_whitespace_line(line) {
             final_char_index = formatted.len();
         }
     }
 
-    // Remove WhiteSpace-only lines from the end.
+    // 6. Implemented differently: remove WhiteSpace-only lines from the end.
     formatted.truncate(final_char_index);
 
     // 9. Return formatted.

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -491,13 +491,10 @@ mod block_string_tests {
     #[test]
     fn it_does_not_unescape_block_strings() {
         assert_eq!(
-            unescape_block_string(r#"escaped \n\r\b\t\f"#),
-            r#"escaped \n\r\b\t\f"#
+            unescape_block_string(r"escaped \n\r\b\t\f"),
+            r"escaped \n\r\b\t\f"
         );
-        assert_eq!(
-            unescape_block_string(r#"slashes \\ \/"#),
-            r#"slashes \\ \/"#
-        );
+        assert_eq!(unescape_block_string(r"slashes \\ \/"), r"slashes \\ \/");
         assert_eq!(
             unescape_block_string("unescaped unicode outside BMP \u{1f600}"),
             "unescaped unicode outside BMP \u{1f600}"
@@ -513,30 +510,30 @@ mod block_string_tests {
 
         assert_eq!(
             unescape_block_string(
-                r#"
+                r"
             This is
             indented
             quite a lot
-    "#
+    "
             ),
-            r#"This is
+            r"This is
 indented
-quite a lot"#
+quite a lot"
         );
 
         assert_eq!(
             unescape_block_string(
-                r#"
+                r"
 
         spans
           multiple
             lines
 
-    "#
+    "
             ),
-            r#"spans
+            r"spans
   multiple
-    lines"#
+    lines"
         );
     }
 }

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -456,8 +456,8 @@ mod string_tests {
         );
         assert_eq!(unescape_string(r"slashes \\ \/"), r"slashes \ /");
         assert_eq!(
-            unescape_string("unescaped unicode outside BMP \u{1f600}"),
-            "unescaped unicode outside BMP \u{1f600}"
+            unescape_string("unescaped unicode outside BMP 😀"),
+            "unescaped unicode outside BMP 😀"
         );
         assert_eq!(
             unescape_string(r"unicode \u1234\u5678\u90AB\uCDEF"),

--- a/crates/apollo-parser/src/ast/node_ext.rs
+++ b/crates/apollo-parser/src/ast/node_ext.rs
@@ -289,6 +289,8 @@ fn unescape_block_string(raw_value: &str) -> String {
         .skip(1)
         .filter_map(|line| {
             // 3.b. Let length be the number of characters in line.
+            // We will compare this byte length to a character length below, but
+            // `count_indent` only ever counts one-byte characters, so it's equivalent.
             let length = line.len();
             // 3.c. Let indent be the number of leading consecutive WhiteSpace characters in line.
             let indent = count_indent(line);

--- a/crates/apollo-parser/src/parser/grammar/description.rs
+++ b/crates/apollo-parser/src/parser/grammar/description.rs
@@ -39,7 +39,7 @@ type Query {
                     .string_value()
                     .unwrap()
                     .into();
-                assert_eq!(desc, String::from("\ndescription for Query object type\n"));
+                assert_eq!(desc, "description for Query object type");
                 return;
             }
         }

--- a/crates/apollo-parser/src/parser/grammar/value.rs
+++ b/crates/apollo-parser/src/parser/grammar/value.rs
@@ -193,11 +193,11 @@ enum Test @dir__one(string: "string value", int_value: -10, float_value: -1.123e
 scalar StringWithEscapes
 "String with unicode \uadf8\ub77c\ud504\ud050\uc5d8"
 scalar StringWithUnicode
-    """
-    Escapes\nshould\nnot\nmatter
-    including \q nonexistent \W ones
-    \""" is the only one \""
-    """
+"""
+Escapes\nshould\nnot\nmatter
+including \q nonexistent \W ones
+\""" is the only one \""
+"""
 scalar BlockStringRaw
 "#;
         let parser = Parser::new(schema);
@@ -224,7 +224,6 @@ including \q nonexistent \W ones
             };
             let description = scalar.description().unwrap().string_value().unwrap();
             let s = String::from(description);
-            println!("{s}");
             assert_eq!(s, expected.next().unwrap());
         }
     }

--- a/crates/apollo-parser/src/parser/grammar/value.rs
+++ b/crates/apollo-parser/src/parser/grammar/value.rs
@@ -193,11 +193,11 @@ enum Test @dir__one(string: "string value", int_value: -10, float_value: -1.123e
 scalar StringWithEscapes
 "String with unicode \uadf8\ub77c\ud504\ud050\uc5d8"
 scalar StringWithUnicode
-"""
-Escapes\nshould\nnot\nmatter
-including \q nonexistent \W ones
-\""" is the only one \""
-"""
+    """
+    Escapes\nshould\nnot\nmatter
+    including \q nonexistent \W ones
+    \""" is the only one \""
+    """
 scalar BlockStringRaw
 "#;
         let parser = Parser::new(schema);

--- a/crates/apollo-parser/src/parser/grammar/value.rs
+++ b/crates/apollo-parser/src/parser/grammar/value.rs
@@ -187,6 +187,49 @@ enum Test @dir__one(string: "string value", int_value: -10, float_value: -1.123e
     }
 
     #[test]
+    fn it_unescapes_strings() {
+        let schema = r#"
+"String with\tescapes\r\n"
+scalar StringWithEscapes
+"String with unicode \uadf8\ub77c\ud504\ud050\uc5d8"
+scalar StringWithUnicode
+"""
+Escapes\nshould\nnot\nmatter
+including \q nonexistent \W ones
+\""" is the only one \""
+"""
+scalar BlockStringRaw
+"#;
+        let parser = Parser::new(schema);
+        let ast = parser.parse();
+
+        assert!(ast.errors.is_empty());
+
+        let mut expected = vec![
+            "String with\tescapes\r\n",
+            "String with unicode 그라프큐엘",
+            r#"
+Escapes\nshould\nnot\nmatter
+including \q nonexistent \W ones
+""" is the only one \""
+"#
+            .trim(),
+        ]
+        .into_iter();
+
+        let document = ast.document();
+        for definition in document.definitions() {
+            let ast::Definition::ScalarTypeDefinition(scalar) = definition else {
+                continue;
+            };
+            let description = scalar.description().unwrap().string_value().unwrap();
+            let s = String::from(description);
+            println!("{s}");
+            assert_eq!(s, expected.next().unwrap());
+        }
+    }
+
+    #[test]
     fn it_returns_i64_for_int_values() {
         let schema = r#"
 enum Test @dir__one(int_value: -10) {


### PR DESCRIPTION
Follow-up to #638, fixing conversion of StringValue nodes to Rust strings.

Fixes #609
Fixes #611


 This handles
- [x] escape sequences in single-quoted strings and
- [x] indentation in block strings #609
- [x] wrong behaviours when a string ends with an escaped `"` #611 

This does not handle these unicode escape issues:
- https://github.com/apollographql/apollo-rs/issues/608
- https://github.com/apollographql/apollo-rs/issues/640