### PR TITLE
fix(parser): fix lexing escape sequences in block strings

### DIFF
--- a/crates/apollo-parser/CHANGELOG.md
+++ b/crates/apollo-parser/CHANGELOG.md
@@ -17,6 +17,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Documentation -->
 
+# [0.6.1](https://crates.io/crates/apollo-parser/0.6.1) (unreleased)
+## Fixes
+- **fix lexing escape-sequence-like text in block strings - [goto-bus-stop], [pull/638], [issue/632]**
+  Fixes a regression in 0.6.0 that could cause apollo-parser to reject valid input if a
+  block string contained backslashes. Block strings do not support escape sequences so
+  backslashes are normally literal, but 0.6.0 tried to lex them as escape sequences,
+  which could be invalid (eg. `\W` is not a supported escape sequence).
+
+  Now block strings are lexed like in 0.5.3. Only the `\"""` sequence is treated as an
+  escape sequence.
+
 # [0.6.0](https://crates.io/crates/apollo-parser/0.6.0) - 2023-08-18
 ## Features
 - **zero-alloc lexer - [allancalix], [pull/322]**


### PR DESCRIPTION
This is the most basic fix for #632, but there are other parse bugs left that may be we should address with a bunch more tests. This fixes a regression in apollo-parser 0.6.0.

Block strings are not meant to support escape sequences in general. But the lexer handled strings and block strings the same way, so an invalid escape sequence in a block string 
would cause a lex error. This rips out all the escape sequence handling from block strings except for `\"""`.

I'm running it through the corpus of Apollo schemas right now, about 75% done without problems, so it looks good.