### PR TITLE
WIP: New crate implementing execution and schema introspection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "crates/apollo-parser",
     "crates/apollo-compiler",
     "crates/apollo-smith",
+    "crates/apollo-introspection",
     "fuzz",
 ]

--- a/crates/apollo-introspection/Cargo.toml
+++ b/crates/apollo-introspection/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "apollo-introspection"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+apollo-compiler = { path = "..//apollo-compiler" }
+async-recursion = "1.0.5"
+futures = "0.3.28"
+indexmap = "2.0.0"
+serde_json_bytes = { version = "0.2.2", features = ["preserve_order"] }
+serde = { version = "1.0.188", features = ["derive"] }
+
+[dev-dependencies]
+expect-test = "1.4"
+serde_json = "1.0"

--- a/crates/apollo-introspection/src/execution.rs
+++ b/crates/apollo-introspection/src/execution.rs
@@ -1,0 +1,360 @@
+#![allow(clippy::too_many_arguments)]
+
+use crate::input_coercion::coerce_argument_values;
+use crate::input_coercion::VariableValues;
+use crate::resolver::ObjectValue;
+use crate::response::field_error;
+use crate::response::request_error;
+use crate::response::Error;
+use crate::response::LinkedPath;
+use crate::response::LinkedPathElement;
+use crate::response::PathElement;
+use crate::response::RequestErrorResponse;
+use crate::response::Response;
+use crate::result_coercion::complete_value;
+use crate::JsonMap;
+use apollo_compiler::executable::Field;
+use apollo_compiler::executable::Operation;
+use apollo_compiler::executable::OperationRef;
+use apollo_compiler::executable::OperationType;
+use apollo_compiler::executable::Selection;
+use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::schema::FieldDefinition;
+use apollo_compiler::schema::Name;
+use apollo_compiler::schema::ObjectType;
+use apollo_compiler::schema::Type;
+use apollo_compiler::schema::Value;
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use futures::future::join_all;
+use indexmap::IndexMap;
+use serde_json_bytes::Value as JsonValue;
+use std::collections::HashSet;
+
+/// <https://spec.graphql.org/October2021/#sec-Normal-and-Serial-Execution>
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum ExecutionMode {
+    /// Allowed to resolve fields in any order, including in parellel
+    Normal,
+    Sequential,
+}
+
+/// Return in `Err` when a field error occurred at some non-nullable place
+///
+/// <https://spec.graphql.org/October2021/#sec-Handling-Field-Errors>
+pub(crate) struct PropagateNull;
+
+/// Select one operation from a document, based on an optional requested operation name
+///
+/// <https://spec.graphql.org/October2021/#GetOperation()>
+pub fn get_operation<'doc>(
+    document: &'doc ExecutableDocument,
+    operation_name: Option<&str>,
+) -> Result<OperationRef<'doc>, RequestErrorResponse> {
+    document.get_operation(operation_name).map_err(|_| {
+        if let Some(name) = operation_name {
+            request_error(format!("no operation named '{name}'"))
+        } else {
+            request_error("multiple operations but no `operationName`")
+        }
+    })
+}
+
+/// The entry point of execution, after preparing with [`get_operation`]
+/// and [`VariableValues::coerce`]
+///
+/// * <https://spec.graphql.org/October2021/#ExecuteQuery()>
+/// * <https://spec.graphql.org/October2021/#ExecuteQuery()>
+///
+/// `schema` and `document` are presumed valid
+pub(crate) async fn execute_query_or_mutation(
+    schema: &Schema,
+    document: &ExecutableDocument,
+    variable_values: &VariableValues,
+    initial_value: &ObjectValue<'_>,
+    operation: &Operation,
+) -> Result<Response, RequestErrorResponse> {
+    let object_type_name = operation.object_type();
+    let object_type_def = schema.get_object(object_type_name).ok_or_else(|| {
+        request_error(format!(
+            "Root operation type {object_type_name} is undefined or not an object type."
+        ))
+        .validation_should_have_caught_this()
+    })?;
+    let mut errors = Vec::new();
+    let path = None; // root: empty path
+    let mode = if operation.operation_type == OperationType::Mutation {
+        ExecutionMode::Sequential
+    } else {
+        ExecutionMode::Normal
+    };
+    let data = execute_selection_set(
+        schema,
+        document,
+        variable_values,
+        &mut errors,
+        path,
+        mode,
+        object_type_name,
+        object_type_def,
+        initial_value,
+        &operation.selection_set.selections,
+    )
+    .await
+    .ok();
+    Ok(Response { data, errors })
+}
+
+/// <https://spec.graphql.org/October2021/#ExecuteSelectionSet()>
+pub(crate) async fn execute_selection_set<'a>(
+    schema: &Schema,
+    document: &'a ExecutableDocument,
+    variable_values: &VariableValues,
+    errors: &mut Vec<Error>,
+    path: LinkedPath<'_>,
+    mode: ExecutionMode,
+    object_type_name: &str,
+    object_type: &ObjectType,
+    object_value: &ObjectValue<'_>,
+    selections: impl IntoIterator<Item = &'a Selection>,
+) -> Result<JsonMap, PropagateNull> {
+    let mut grouped_field_set = IndexMap::new();
+    collect_fields(
+        schema,
+        document,
+        variable_values,
+        object_type_name,
+        object_type,
+        selections,
+        &mut HashSet::new(),
+        &mut grouped_field_set,
+    );
+    let futures = grouped_field_set
+        .iter()
+        .filter_map(|(&response_key, fields)| {
+            // Indexing should not panic: `collect_fields` only creates a `Vec` to push to it
+            let field_name = &fields[0].name;
+            let Ok(field_def) = schema.type_field(object_type_name, field_name) else {
+                // TODO: Return a validation_should_have_caught_this field error here?
+                // The spec specifically has a “If fieldType is defined” condition,
+                // but it being undefined would make the request invalid, right?
+                return None;
+            };
+            Some(async move {
+                let mut errors = Vec::new();
+                let result = if field_name == "__typename" {
+                    Ok(object_type_name.into())
+                } else {
+                    let field_path = LinkedPathElement {
+                        element: PathElement::Field(response_key.clone()),
+                        next: path,
+                    };
+                    execute_field(
+                        schema,
+                        document,
+                        variable_values,
+                        &mut errors,
+                        Some(&field_path),
+                        mode,
+                        object_value,
+                        field_def,
+                        fields,
+                    )
+                    .await
+                };
+                (response_key, result, errors)
+            })
+        });
+    let mut response_map = JsonMap::with_capacity(grouped_field_set.len());
+    match mode {
+        ExecutionMode::Normal => {
+            // `join_all` executes fields concurrently but preserves their ordering
+            let outputs = join_all(futures).await;
+            for (response_key, result, mut field_errors) in outputs {
+                errors.append(&mut field_errors);
+                response_map.insert(response_key.as_str(), result?);
+            }
+        }
+        ExecutionMode::Sequential => {
+            // Only start executing one field after the previous on is finished
+            for future in futures {
+                let (response_key, result, mut field_errors) = future.await;
+                errors.append(&mut field_errors);
+                response_map.insert(response_key.as_str(), result?);
+            }
+        }
+    }
+    Ok(response_map)
+}
+
+/// <https://spec.graphql.org/October2021/#CollectFields()>
+fn collect_fields<'a>(
+    schema: &Schema,
+    document: &'a ExecutableDocument,
+    variable_values: &VariableValues,
+    object_type_name: &str,
+    object_type: &ObjectType,
+    selections: impl IntoIterator<Item = &'a Selection>,
+    visited_fragments: &mut HashSet<&'a Name>,
+    grouped_fields: &mut IndexMap<&'a Name, Vec<&'a Field>>,
+) {
+    for selection in selections {
+        if eval_if_arg(selection, "skip", variable_values).unwrap_or(false)
+            || !eval_if_arg(selection, "include", variable_values).unwrap_or(true)
+        {
+            continue;
+        }
+        match selection {
+            Selection::Field(field) => grouped_fields
+                .entry(field.response_key())
+                .or_default()
+                .push(field.as_ref()),
+            Selection::FragmentSpread(spread) => {
+                let new = visited_fragments.insert(&spread.fragment_name);
+                if !new {
+                    continue;
+                }
+                let Some(fragment) = document.fragments.get(&spread.fragment_name) else {
+                    continue;
+                };
+                if !does_fragment_type_apply(
+                    schema,
+                    object_type_name,
+                    object_type,
+                    fragment.type_condition(),
+                ) {
+                    continue;
+                }
+                collect_fields(
+                    schema,
+                    document,
+                    variable_values,
+                    object_type_name,
+                    object_type,
+                    &fragment.selection_set.selections,
+                    visited_fragments,
+                    grouped_fields,
+                )
+            }
+            Selection::InlineFragment(inline) => {
+                if let Some(condition) = &inline.type_condition {
+                    if !does_fragment_type_apply(schema, object_type_name, object_type, condition) {
+                        continue;
+                    }
+                }
+                collect_fields(
+                    schema,
+                    document,
+                    variable_values,
+                    object_type_name,
+                    object_type,
+                    &inline.selection_set.selections,
+                    visited_fragments,
+                    grouped_fields,
+                )
+            }
+        }
+    }
+}
+
+/// <https://spec.graphql.org/October2021/#DoesFragmentTypeApply()>
+fn does_fragment_type_apply(
+    schema: &Schema,
+    object_type_name: &str,
+    object_type: &ObjectType,
+    fragment_type: &Name,
+) -> bool {
+    match schema.types.get(fragment_type) {
+        Some(ExtendedType::Object(_)) => fragment_type == object_type_name,
+        Some(ExtendedType::Interface(_)) => {
+            object_type.implements_interfaces.contains(fragment_type)
+        }
+        Some(ExtendedType::Union(def)) => def.members.contains(object_type_name),
+        // Undefined or not an output type: validation should have caught this
+        _ => false,
+    }
+}
+
+fn eval_if_arg(
+    selection: &Selection,
+    directive_name: &str,
+    variable_values: &VariableValues,
+) -> Option<bool> {
+    match selection
+        .directives()
+        .get(directive_name)?
+        .argument_by_name("if")?
+        .as_ref()
+    {
+        Value::Boolean(value) => Some(*value),
+        Value::Variable(var) => variable_values.get(var.as_str())?.as_bool(),
+        _ => None,
+    }
+}
+
+/// <https://spec.graphql.org/October2021/#ExecuteField()>
+async fn execute_field(
+    schema: &Schema,
+    document: &ExecutableDocument,
+    variable_values: &VariableValues,
+    errors: &mut Vec<Error>,
+    path: LinkedPath<'_>,
+    mode: ExecutionMode,
+    object_value: &ObjectValue<'_>,
+    field_def: &FieldDefinition,
+    fields: &[&Field],
+) -> Result<JsonValue, PropagateNull> {
+    let field = fields[0];
+    let argument_values =
+        match coerce_argument_values(schema, variable_values, errors, path, field_def, field) {
+            Ok(argument_values) => argument_values,
+            Err(PropagateNull) => return try_nullify(&field_def.ty, Err(PropagateNull)),
+        };
+    let resolved_result = object_value
+        .resolve_field(&field.name, &argument_values)
+        .await;
+    let completed_result = match resolved_result {
+        Ok(resolved) => {
+            complete_value(
+                schema,
+                document,
+                variable_values,
+                errors,
+                path,
+                mode,
+                &field.ty(),
+                resolved,
+                fields,
+            )
+            .await
+        }
+        Err(message) => {
+            errors.push(field_error(
+                format!("resolver error: {message}"),
+                path,
+                field.name.location(),
+            ));
+            Err(PropagateNull)
+        }
+    };
+    try_nullify(&field_def.ty, completed_result)
+}
+
+/// Try to insert a propagated null if possible, or keep propagating it.
+///
+/// <https://spec.graphql.org/October2021/#sec-Handling-Field-Errors>
+pub(crate) fn try_nullify(
+    ty: &Type,
+    result: Result<JsonValue, PropagateNull>,
+) -> Result<JsonValue, PropagateNull> {
+    match result {
+        Ok(json) => Ok(json),
+        Err(PropagateNull) => {
+            if ty.is_non_null() {
+                Err(PropagateNull)
+            } else {
+                Ok(JsonValue::Null)
+            }
+        }
+    }
+}

--- a/crates/apollo-introspection/src/execution.rs
+++ b/crates/apollo-introspection/src/execution.rs
@@ -15,7 +15,6 @@ use crate::result_coercion::complete_value;
 use crate::JsonMap;
 use apollo_compiler::executable::Field;
 use apollo_compiler::executable::Operation;
-use apollo_compiler::executable::OperationRef;
 use apollo_compiler::executable::OperationType;
 use apollo_compiler::executable::Selection;
 use apollo_compiler::schema::ExtendedType;
@@ -25,6 +24,7 @@ use apollo_compiler::schema::ObjectType;
 use apollo_compiler::schema::Type;
 use apollo_compiler::schema::Value;
 use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Node;
 use apollo_compiler::Schema;
 use futures::future::join_all;
 use indexmap::IndexMap;
@@ -50,7 +50,7 @@ pub(crate) struct PropagateNull;
 pub fn get_operation<'doc>(
     document: &'doc ExecutableDocument,
     operation_name: Option<&str>,
-) -> Result<OperationRef<'doc>, RequestErrorResponse> {
+) -> Result<&'doc Node<Operation>, RequestErrorResponse> {
     document.get_operation(operation_name).map_err(|_| {
         if let Some(name) = operation_name {
             request_error(format!("no operation named '{name}'"))
@@ -322,7 +322,7 @@ async fn execute_field(
                 errors,
                 path,
                 mode,
-                &field.ty(),
+                field.ty(),
                 resolved,
                 fields,
             )

--- a/crates/apollo-introspection/src/input_coercion.rs
+++ b/crates/apollo-introspection/src/input_coercion.rs
@@ -335,6 +335,7 @@ pub(crate) fn coerce_argument_values(
     Ok(coerced_values)
 }
 
+#[allow(clippy::too_many_arguments)] // yes it’s not a nice API but it’s internal
 fn coerce_argument_value(
     schema: &Schema,
     variable_values: &VariableValues,

--- a/crates/apollo-introspection/src/input_coercion.rs
+++ b/crates/apollo-introspection/src/input_coercion.rs
@@ -1,0 +1,493 @@
+use crate::execution::PropagateNull;
+use crate::response::field_error;
+use crate::response::request_error;
+use crate::response::to_locations;
+use crate::response::Error;
+use crate::response::LinkedPath;
+use crate::response::RequestErrorResponse;
+use crate::JsonMap;
+use apollo_compiler::executable::Field;
+use apollo_compiler::executable::Operation;
+use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::schema::FieldDefinition;
+use apollo_compiler::schema::Type;
+use apollo_compiler::schema::Value;
+use apollo_compiler::Node;
+use apollo_compiler::Schema;
+use serde_json_bytes::Value as JsonValue;
+use std::collections::HashMap;
+
+/// Values of variables from a given GraphQL request, after coercion to types expected by the operation.
+pub struct VariableValues(JsonMap);
+
+impl std::ops::Deref for VariableValues {
+    type Target = JsonMap;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl VariableValues {
+    /// <https://spec.graphql.org/October2021/#sec-Coercing-Variable-Values>
+    ///
+    /// `schema` and `document` are presumed valid
+    pub fn coerce(
+        schema: &Schema,
+        operation: &Operation,
+        values: &JsonMap,
+    ) -> Result<Self, RequestErrorResponse> {
+        coerce_variable_values(schema, operation, values)
+    }
+}
+
+macro_rules! request_error {
+    ($($arg: tt)+) => {
+        return Err(request_error(format!($($arg)+)))
+    };
+}
+
+macro_rules! validation_should_have_caught_this {
+    ($($arg: tt)+) => {
+        return Err(request_error(format!($($arg)+)).validation_should_have_caught_this())
+    };
+}
+
+/// <https://spec.graphql.org/October2021/#CoerceVariableValues()>
+fn coerce_variable_values(
+    schema: &Schema,
+    operation: &Operation,
+    values: &JsonMap,
+) -> Result<VariableValues, RequestErrorResponse> {
+    let mut coerced_values = JsonMap::new();
+    for variable_def in &operation.variables {
+        let name = variable_def.name.as_str();
+        if let Some((key, value)) = values.get_key_value(name) {
+            let value =
+                coerce_variable_value(schema, "variable", "", "", name, &variable_def.ty, value)?;
+            coerced_values.insert(key.clone(), value);
+        } else if let Some(default) = &variable_def.default_value {
+            let value =
+                graphql_value_to_json("variable", "", "", name, default).map_err(|mut err| {
+                    err.errors[0].locations = to_locations(default.location());
+                    err
+                })?;
+            coerced_values.insert(name, value);
+        } else if variable_def.ty.is_non_null() {
+            request_error!("missing value for non-null variable '{name}'")
+        } else {
+            // Nullable variable with no provided value nor explicit default.
+            // Spec says nothing for this case, but for the similar case in input objects:
+            //
+            // > there is a semantic difference between the explicitly provided value null
+            // > versus having not provided a value
+        }
+    }
+    Ok(VariableValues(coerced_values))
+}
+
+fn coerce_variable_value(
+    schema: &Schema,
+    kind: &str,
+    parent: &str,
+    sep: &str,
+    name: &str,
+    ty: &Type,
+    value: &JsonValue,
+) -> Result<JsonValue, RequestErrorResponse> {
+    if value.is_null() {
+        if ty.is_non_null() {
+            request_error!("null value for non-null {kind} {parent}{sep}{name}")
+        } else {
+            return Ok(JsonValue::Null);
+        }
+    }
+    let ty_name = match ty {
+        Type::List(inner) | Type::NonNullList(inner) => {
+            // https://spec.graphql.org/October2021/#sec-List.Input-Coercion
+            return value
+                .as_array()
+                .map(Vec::as_slice)
+                // If not an array, treat the value as an array of size one:
+                .unwrap_or(std::slice::from_ref(value))
+                .iter()
+                .map(|item| coerce_variable_value(schema, kind, parent, sep, name, inner, item))
+                .collect();
+        }
+        Type::Named(ty_name) | Type::NonNullNamed(ty_name) => ty_name,
+    };
+    let Some(ty_def) = schema.types.get(ty_name) else {
+        validation_should_have_caught_this!(
+            "Undefined type {ty_name} for {kind} {parent}{sep}{name}"
+        )
+    };
+    match ty_def {
+        ExtendedType::Object(_) | ExtendedType::Interface(_) | ExtendedType::Union(_) => {
+            validation_should_have_caught_this!(
+                "Non-input type {ty_name} for {kind} {parent}{sep}{name}."
+            )
+        }
+        ExtendedType::Scalar(_) => match ty_name.as_str() {
+            "Int" => {
+                // https://spec.graphql.org/October2021/#sec-Int.Input-Coercion
+                if value
+                    .as_i64()
+                    .is_some_and(|value| i32::try_from(value).is_ok())
+                {
+                    return Ok(value.clone());
+                }
+            }
+            "Float" => {
+                // https://spec.graphql.org/October2021/#sec-Float.Input-Coercion
+                if value.is_f64() {
+                    return Ok(value.clone());
+                }
+            }
+            "String" => {
+                // https://spec.graphql.org/October2021/#sec-String.Input-Coercion
+                if value.is_string() {
+                    return Ok(value.clone());
+                }
+            }
+            "Boolean" => {
+                // https://spec.graphql.org/October2021/#sec-Boolean.Input-Coercion
+                if value.is_boolean() {
+                    return Ok(value.clone());
+                }
+            }
+            "ID" => {
+                // https://spec.graphql.org/October2021/#sec-ID.Input-Coercion
+                if value.is_string() || value.is_i64() {
+                    return Ok(value.clone());
+                }
+            }
+            _ => {
+                // Custom scalar
+                // TODO: have a hook for coercion of custom scalars?
+                return Ok(value.clone());
+            }
+        },
+        ExtendedType::Enum(ty_def) => {
+            // https://spec.graphql.org/October2021/#sec-Enums.Input-Coercion
+            if let Some(str) = value.as_str() {
+                if ty_def.values.keys().any(|value_name| value_name == str) {
+                    return Ok(value.clone());
+                }
+            }
+        }
+        ExtendedType::InputObject(ty_def) => {
+            // https://spec.graphql.org/October2021/#sec-Input-Objects.Input-Coercion
+            if let Some(object) = value.as_object() {
+                if let Some(key) = object
+                    .keys()
+                    .find(|key| !ty_def.fields.contains_key(key.as_str()))
+                {
+                    request_error!(
+                        "Input object has key {} not in type {ty_name}",
+                        key.as_str()
+                    )
+                }
+                let mut object = object.clone();
+                for (field_name, field_def) in &ty_def.fields {
+                    if let Some(field_value) = object.get_mut(field_name.as_str()) {
+                        *field_value = coerce_variable_value(
+                            schema,
+                            "input field",
+                            ty_name,
+                            ".",
+                            field_name,
+                            &field_def.ty,
+                            field_value,
+                        )?
+                    } else if let Some(default) = &field_def.default_value {
+                        let default =
+                            graphql_value_to_json("input field", ty_name, ".", field_name, default)
+                                .map_err(|mut err| {
+                                    err.errors[0].locations = to_locations(default.location());
+                                    err
+                                })?;
+                        object.insert(field_name.as_str(), default);
+                    } else if field_def.ty.is_non_null() {
+                        request_error!(
+                            "Missing value for non-null input object field {ty_name}.{field_name}"
+                        )
+                    } else {
+                        // Field not required
+                    }
+                }
+                return Ok(object.into());
+            }
+        }
+    }
+    request_error!("Could not coerce {kind} {parent}{sep}{name}: {value} to type {ty_name}")
+}
+
+fn graphql_value_to_json(
+    kind: &str,
+    parent: &str,
+    sep: &str,
+    name: &str,
+    value: &Value,
+) -> Result<JsonValue, RequestErrorResponse> {
+    match value {
+        Value::Null => Ok(JsonValue::Null),
+        Value::Variable(_) => {
+            // TODO: separate `ContValue` enum without this variant?
+            validation_should_have_caught_this!(
+                "Variable in default value of {kind} {parent}{sep}{name}."
+            )
+        }
+        Value::Enum(value) => Ok(value.as_str().into()),
+        Value::String(value) => Ok(value.as_str().into()),
+        Value::Boolean(value) => Ok((*value).into()),
+        // Rely on `serde_json::Number`’s own parser to use whateven precision it supports
+        Value::Int(value) => Ok(JsonValue::Number(value.as_str().parse().or_else(|_| {
+            request_error!("Int value overflow in {kind} {parent}{sep}{name}")
+        })?)),
+        Value::Float(value) => Ok(JsonValue::Number(value.as_str().parse().or_else(|_| {
+            request_error!("Float value overflow in {kind} {parent}{sep}{name}")
+        })?)),
+        Value::List(value) => value
+            .iter()
+            .map(|value| graphql_value_to_json(kind, parent, sep, name, value))
+            .collect(),
+        Value::Object(value) => value
+            .iter()
+            .map(|(key, value)| {
+                Ok((
+                    key.as_str(),
+                    graphql_value_to_json(kind, parent, sep, name, value)?,
+                ))
+            })
+            .collect(),
+    }
+}
+
+/// <https://spec.graphql.org/October2021/#sec-Coercing-Field-Arguments>
+pub(crate) fn coerce_argument_values(
+    schema: &Schema,
+    variable_values: &VariableValues,
+    errors: &mut Vec<Error>,
+    path: LinkedPath<'_>,
+    field_def: &FieldDefinition,
+    field: &Field,
+) -> Result<JsonMap, PropagateNull> {
+    let mut coerced_values = JsonMap::new();
+    for arg_def in &field_def.arguments {
+        let arg_name = &arg_def.name;
+        if let Some(arg) = field.arguments.iter().find(|arg| arg.name == *arg_name) {
+            if let Value::Variable(var_name) = arg.value.as_ref() {
+                if let Some(var_value) = variable_values.get(var_name.as_str()) {
+                    if var_value.is_null() && arg_def.ty.is_non_null() {
+                        errors.push(field_error(
+                            format!("null value for non-nullable argument {arg_name}"),
+                            path,
+                            arg_def.location(),
+                        ));
+                        return Err(PropagateNull);
+                    } else {
+                        coerced_values.insert(arg_name.as_str(), var_value.clone());
+                        continue;
+                    }
+                }
+            } else if arg.value.is_null() && arg_def.ty.is_non_null() {
+                errors.push(field_error(
+                    format!("null value for non-nullable argument {arg_name}"),
+                    path,
+                    arg_def.location(),
+                ));
+                return Err(PropagateNull);
+            } else {
+                let coerced_value = coerce_argument_value(
+                    schema,
+                    variable_values,
+                    errors,
+                    path,
+                    "argument",
+                    "",
+                    "",
+                    arg_name,
+                    &arg_def.ty,
+                    &arg.value,
+                )?;
+                coerced_values.insert(arg_name.as_str(), coerced_value);
+                continue;
+            }
+        }
+        if let Some(default) = &arg_def.default_value {
+            let value =
+                graphql_value_to_json("argument", "", "", arg_name, default).map_err(|err| {
+                    errors.push(err.into_field_error(path, arg_def.location()));
+                    PropagateNull
+                })?;
+            coerced_values.insert(arg_def.name.as_str(), value);
+            continue;
+        }
+        if arg_def.ty.is_non_null() {
+            errors.push(field_error(
+                format!("missing value for required argument {arg_name}"),
+                path,
+                arg_def.location(),
+            ));
+            return Err(PropagateNull);
+        }
+    }
+    Ok(coerced_values)
+}
+
+fn coerce_argument_value(
+    schema: &Schema,
+    variable_values: &VariableValues,
+    errors: &mut Vec<Error>,
+    path: LinkedPath<'_>,
+    kind: &str,
+    parent: &str,
+    sep: &str,
+    name: &str,
+    ty: &Type,
+    value: &Node<Value>,
+) -> Result<JsonValue, PropagateNull> {
+    if value.is_null() {
+        if ty.is_non_null() {
+            errors.push(field_error(
+                format!("null value for non-null {kind} {parent}{sep}{name}"),
+                path,
+                value.location(),
+            ));
+            return Err(PropagateNull);
+        } else {
+            return Ok(JsonValue::Null);
+        }
+    }
+    if let Some(var_name) = value.as_variable() {
+        if let Some(var_value) = variable_values.get(var_name.as_str()) {
+            if var_value.is_null() && ty.is_non_null() {
+                errors.push(field_error(
+                    format!("null variable value for non-null {kind} {parent}{sep}{name}"),
+                    path,
+                    value.location(),
+                ));
+                return Err(PropagateNull);
+            } else {
+                return Ok(var_value.clone());
+            }
+        } else if ty.is_non_null() {
+            errors.push(field_error(
+                format!("missing variable for non-null {kind} {parent}{sep}{name}"),
+                path,
+                value.location(),
+            ));
+            return Err(PropagateNull);
+        } else {
+            return Ok(JsonValue::Null);
+        }
+    }
+    let ty_name = match ty {
+        Type::List(inner_ty) | Type::NonNullList(inner_ty) => {
+            // https://spec.graphql.org/October2021/#sec-List.Input-Coercion
+            return value
+                .as_list()
+                // If not an array, treat the value as an array of size one:
+                .unwrap_or(std::slice::from_ref(value))
+                .iter()
+                .map(|item| {
+                    coerce_argument_value(
+                        schema,
+                        variable_values,
+                        errors,
+                        path,
+                        kind,
+                        parent,
+                        sep,
+                        name,
+                        inner_ty,
+                        item,
+                    )
+                })
+                .collect();
+        }
+        Type::Named(ty_name) | Type::NonNullNamed(ty_name) => ty_name,
+    };
+    let Some(ty_def) = schema.types.get(ty_name) else {
+        errors.push(
+            field_error(
+                format!("Undefined type {ty_name} for {kind} {parent}{sep}{name}"),
+                path,
+                value.location(),
+            )
+            .validation_should_have_caught_this(),
+        );
+        return Err(PropagateNull);
+    };
+    match ty_def {
+        ExtendedType::InputObject(ty_def) => {
+            // https://spec.graphql.org/October2021/#sec-Input-Objects.Input-Coercion
+            if let Some(object) = value.as_object() {
+                if let Some((key, _value)) = object
+                    .iter()
+                    .find(|(key, _value)| !ty_def.fields.contains_key(key))
+                {
+                    errors.push(field_error(
+                        format!("Input object has key {key} not in type {ty_name}",),
+                        path,
+                        value.location(),
+                    ));
+                    return Err(PropagateNull);
+                }
+                // `map` converts `&(k, v)` to `(&k, &v)`
+                let object: HashMap<_, _> = object.iter().map(|(k, v)| (k, v)).collect();
+                let mut coerced_object = JsonMap::new();
+                for (field_name, field_def) in &ty_def.fields {
+                    if let Some(field_value) = object.get(field_name) {
+                        let coerced_value = coerce_argument_value(
+                            schema,
+                            variable_values,
+                            errors,
+                            path,
+                            "input field",
+                            ty_name,
+                            ".",
+                            field_name,
+                            &field_def.ty,
+                            field_value,
+                        )?;
+                        coerced_object.insert(field_name.as_str(), coerced_value);
+                    } else if let Some(default) = &field_def.default_value {
+                        let default =
+                            graphql_value_to_json("input field", ty_name, ".", field_name, default)
+                                .map_err(|err| {
+                                    errors.push(err.into_field_error(path, value.location()));
+                                    PropagateNull
+                                })?;
+                        coerced_object.insert(field_name.as_str(), default);
+                    } else if field_def.ty.is_non_null() {
+                        errors.push(field_error(
+                            format!(
+                                "Missing value for non-null input object field {ty_name}.{field_name}"
+                            ),
+                            path,
+                            value.location(),
+                        ));
+                        return Err(PropagateNull);
+                    } else {
+                        // Field not required
+                    }
+                }
+                return Ok(coerced_object.into());
+            }
+        }
+        _ => {
+            // For scalar and enums, rely and validation and just convert between Rust types
+            return graphql_value_to_json(kind, parent, sep, name, value).map_err(|err| {
+                errors.push(err.into_field_error(path, value.location()));
+                PropagateNull
+            });
+        }
+    }
+    errors.push(field_error(
+        format!("Could not coerce {kind} {parent}{sep}{name}: {value} to type {ty_name}"),
+        path,
+        value.location(),
+    ));
+    Err(PropagateNull)
+}

--- a/crates/apollo-introspection/src/lib.rs
+++ b/crates/apollo-introspection/src/lib.rs
@@ -1,0 +1,28 @@
+//! Example usage:
+//!
+//! ```
+#![doc = include_str!("../tests/doc_example.rs")]
+//! ```
+
+#[macro_use]
+mod resolver;
+mod execution;
+mod input_coercion;
+mod response;
+mod result_coercion;
+mod schema_introspection;
+
+pub use self::execution::get_operation;
+pub use self::input_coercion::VariableValues;
+pub use self::response::Error;
+pub use self::response::Location;
+pub use self::response::PathElement;
+pub use self::response::RequestErrorResponse;
+pub use self::response::Response;
+pub use self::response::EXTENSION_VALIDATION_SHOULD_HAVE_CAUGHT_THIS;
+pub use self::schema_introspection::SchemaIntrospectionQuery;
+pub use serde_json_bytes::ByteString;
+pub use serde_json_bytes::Value as JsonValue;
+
+/// Represents a JSON object
+pub type JsonMap = serde_json_bytes::Map<ByteString, JsonValue>;

--- a/crates/apollo-introspection/src/resolver.rs
+++ b/crates/apollo-introspection/src/resolver.rs
@@ -1,0 +1,221 @@
+use crate::JsonMap;
+use futures::future::BoxFuture;
+use futures::stream;
+use futures::stream::BoxStream;
+use futures::Stream;
+use serde_json_bytes::Value as JsonValue;
+
+/// A GraphQL object whose fields can be resolved during execution
+pub(crate) type ObjectValue<'a> = dyn Resolver + Send + 'a;
+
+/// Abstraction for implementing field resolvers. Used through [`ObjectValue`].
+///
+/// Use the [`impl_resolver!`][crate::impl_resolver] macro to implement this trait
+/// with reduced boilerplate
+pub(crate) trait Resolver: Sync {
+    /// Returns the name of the concrete object type this resolver represents
+    ///
+    /// That name expected to be that of an object type defined in the schema.
+    /// This is called when the schema indicates an abstract (interface or union) type.
+    fn type_name(&self) -> &'static str;
+
+    /// Resolves a field of this object with the given arguments
+    ///
+    /// The resolved is expected to match the type of the corresponding field definition
+    /// in the schema.
+    fn resolve_field<'a>(
+        &'a self,
+        field_name: &'a str,
+        arguments: &'a JsonMap,
+    ) -> BoxFuture<'a, Result<ResolvedValue<'_>, String>>;
+}
+
+/// Implements the [`Resolver`] trait with reduced boilerplate
+///
+/// Define:
+///
+/// * The implementing Rust type
+/// * The __typename string
+/// * One async pseudo-method per field. Types are omitted in the signature for brevity.
+///   - Takes two optional arguments: `&self` (which must be spelled something else because macros)
+///     and `args: `[`&JsonMap`][crate::JsonMap] for the field arguments.
+///     Field arguments are coerced according to their definition in the schema.
+///   - Returns `Result<ResolvedValue, String>`, `Err` it turned into a field error
+macro_rules! impl_resolver {
+    (
+        for $ty: ty:
+        __typename = $type_name: expr;
+        $(
+            async fn $field_name: ident(
+                $( &$self_: ident $(, $( $args: ident $(,)? )? )? )?
+            ) $block: block
+        )*
+
+    ) => {
+        impl $crate::resolver::Resolver for $ty {
+            fn type_name(&self) -> &'static str {
+                $type_name
+            }
+
+            fn resolve_field<'a>(
+                &'a self,
+                field_name: &'a str,
+                arguments: &'a $crate::JsonMap,
+            ) -> futures::future::BoxFuture<'a, Result<$crate::resolver::ResolvedValue<'_>, String>> {
+                Box::pin(async move {
+                    let _allow_unused = arguments;
+                    match field_name {
+                        $(
+                            stringify!($field_name) => {
+                                $(
+                                    let $self_ = self;
+                                    $($(
+                                        let $args = arguments;
+                                    )?)?
+                                )?
+                                return $block
+                            },
+                        )*
+                        _ => Err(format!("unexpected field name: {field_name}")),
+                    }
+                })
+            }
+        }
+    };
+}
+
+/// The value of a resolved field
+pub(crate) enum ResolvedValue<'a> {
+    /// * JSON null represents GraphQL null
+    /// * A GraphQL enum value is represented as a JSON string
+    /// * GraphQL built-in scalars are coerced according to their respective *Result Coercion* spec
+    /// * For custom scalars, any JSON value is passed through as-is (including array or object)
+    Leaf(JsonValue),
+
+    /// Expected where the GraphQL type is an object, interface, or union type
+    Object(Box<ObjectValue<'a>>),
+
+    /// Expected for GrapQL list types
+    List(BoxStream<'a, ResolvedValue<'a>>),
+}
+
+impl<'a> ResolvedValue<'a> {
+    /// Construct a null leaf resolved value
+    pub(crate) fn null() -> Self {
+        Self::Leaf(JsonValue::Null)
+    }
+
+    /// Construct a leaf resolved value from something that is convertible to JSON
+    pub(crate) fn leaf(json: impl Into<JsonValue>) -> Self {
+        Self::Leaf(json.into())
+    }
+
+    /// Construct an object resolved value from the resolver for that object
+    pub(crate) fn object(resolver: impl Resolver + Send + 'a) -> Self {
+        Self::Object(Box::new(resolver))
+    }
+
+    /// Construct an object resolved value or null, from an optional resolver
+    pub(crate) fn opt_object(opt_resolver: Option<impl Resolver + Send + 'a>) -> Self {
+        match opt_resolver {
+            Some(resolver) => Self::Object(Box::new(resolver)),
+            None => Self::null(),
+        }
+    }
+
+    /// Construct a list resolved value from an asynchronous stream
+    pub(crate) fn list_stream<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Self> + Send + 'a,
+    {
+        Self::List(Box::pin(stream))
+    }
+
+    /// Construct a list resolved value from an iterator
+    pub(crate) fn list<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Self>,
+        I::IntoIter: Send + 'a,
+    {
+        Self::list_stream(stream::iter(iter))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::execution::execute_query_or_mutation;
+    use crate::execution::get_operation;
+    use crate::resolver::ResolvedValue;
+    use crate::JsonMap;
+    use crate::RequestErrorResponse;
+    use crate::Response;
+    use crate::SchemaIntrospectionQuery;
+    use crate::VariableValues;
+    use apollo_compiler::executable::OperationType;
+    use apollo_compiler::ExecutableDocument;
+    use apollo_compiler::Schema;
+
+    struct QueryResolver {
+        world: String,
+    }
+
+    impl_resolver! {
+        for &'_ QueryResolver:
+
+        __typename = "Query";
+
+        async fn null() {
+            Ok(ResolvedValue::null())
+        }
+
+        async fn hello(&self_) {
+            Ok(ResolvedValue::list([
+                ResolvedValue::leaf(format!("Hello {}!", self_.world)),
+                ResolvedValue::leaf(format!("Hello {}!", self_.world)),
+            ]))
+        }
+
+        async fn echo(&_self, args) {
+            Ok(ResolvedValue::leaf(args["value"].clone()))
+        }
+
+        async fn myself_again(&self_) {
+            Ok(ResolvedValue::object(*self_))
+        }
+    }
+
+    /// <https://spec.graphql.org/October2021/#sec-Executing-Requests>
+    ///
+    /// `schema` and `document` are presumed valid
+    #[allow(unused)]
+    async fn execute_request(
+        schema: &Schema,
+        mut document: ExecutableDocument,
+        operation_name: Option<&str>,
+        variable_values: &JsonMap,
+    ) -> Result<Response, RequestErrorResponse> {
+        let introspection = SchemaIntrospectionQuery::split_from(&mut document, operation_name)?;
+        let operation = get_operation(&document, operation_name)?
+            .definition()
+            .clone();
+        let coerced_variable_values = VariableValues::coerce(schema, &operation, variable_values)?;
+        let initial_value = match operation.operation_type {
+            OperationType::Query => QueryResolver {
+                world: "World".into(),
+            },
+            _ => unimplemented!(),
+        };
+        let response = execute_query_or_mutation(
+            schema,
+            &document,
+            &coerced_variable_values,
+            &&initial_value,
+            &operation,
+        )
+        .await?;
+        let intropsection_response = introspection
+            .execute(schema, &coerced_variable_values)
+            .await?;
+        Ok(response.merge(intropsection_response))
+    }
+}

--- a/crates/apollo-introspection/src/resolver.rs
+++ b/crates/apollo-introspection/src/resolver.rs
@@ -195,10 +195,8 @@ mod tests {
         variable_values: &JsonMap,
     ) -> Result<Response, RequestErrorResponse> {
         let introspection = SchemaIntrospectionQuery::split_from(&mut document, operation_name)?;
-        let operation = get_operation(&document, operation_name)?
-            .definition()
-            .clone();
-        let coerced_variable_values = VariableValues::coerce(schema, &operation, variable_values)?;
+        let operation = get_operation(&document, operation_name)?;
+        let coerced_variable_values = VariableValues::coerce(schema, operation, variable_values)?;
         let initial_value = match operation.operation_type {
             OperationType::Query => QueryResolver {
                 world: "World".into(),
@@ -210,7 +208,7 @@ mod tests {
             &document,
             &coerced_variable_values,
             &&initial_value,
-            &operation,
+            operation,
         )
         .await?;
         let intropsection_response = introspection

--- a/crates/apollo-introspection/src/response.rs
+++ b/crates/apollo-introspection/src/response.rs
@@ -1,0 +1,163 @@
+use super::JsonMap;
+use apollo_compiler::schema::Name;
+use apollo_compiler::NodeLocation;
+use serde::Serialize;
+
+/// <https://spec.graphql.org/October2021/#sec-Response-Format>
+#[derive(Debug, Clone, Serialize)]
+pub struct Response {
+    /// None/null if a field error was propagated all the way to the root
+    pub data: Option<JsonMap>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<Error>,
+}
+
+/// A response that contains a [request error].
+///
+/// Does not contain a `data` entry. This is different from `data: null`.
+///
+/// [request error]: https://spec.graphql.org/October2021/#sec-Errors.Request-errors
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestErrorResponse {
+    pub errors: [Error; 1],
+}
+
+/// <https://spec.graphql.org/October2021/#sec-Errors.Error-result-format>
+#[derive(Debug, Clone, Serialize)]
+pub struct Error {
+    pub message: String,
+
+    /// Empty for request errors
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub path: Vec<PathElement>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub locations: Vec<Location>,
+
+    #[serde(skip_serializing_if = "JsonMap::is_empty")]
+    pub extensions: JsonMap,
+}
+
+/// Possible key in the `Error::extensions` map
+pub const EXTENSION_VALIDATION_SHOULD_HAVE_CAUGHT_THIS: &str =
+    "APOLLO_VALIDATION_SHOULD_HAVE_CAUGHT_THIS";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct Location {
+    line: u32,
+    column: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PathElement {
+    Field(Name),
+    ListItem { index: usize },
+}
+
+pub(crate) type LinkedPath<'a> = Option<&'a LinkedPathElement<'a>>;
+
+pub(crate) struct LinkedPathElement<'a> {
+    pub(crate) element: PathElement,
+    pub(crate) next: LinkedPath<'a>,
+}
+
+pub(crate) fn request_error(message: impl Into<String>) -> RequestErrorResponse {
+    Error {
+        message: message.into(),
+        path: Vec::new(),
+        locations: Vec::new(),
+        extensions: JsonMap::new(),
+    }
+    .into_request_error()
+}
+
+pub(crate) fn field_error(
+    message: impl Into<String>,
+    path: LinkedPath<'_>,
+    location: Option<NodeLocation>,
+) -> Error {
+    Error {
+        message: message.into(),
+        path: path_to_vec(path),
+        locations: to_locations(location),
+        extensions: JsonMap::new(),
+    }
+}
+
+pub(crate) fn path_to_vec(mut link: LinkedPath<'_>) -> Vec<PathElement> {
+    let mut path = Vec::new();
+    while let Some(node) = link {
+        path.push(node.element.clone());
+        link = node.next;
+    }
+    path.reverse();
+    path
+}
+
+pub(crate) fn to_locations(location: Option<NodeLocation>) -> Vec<Location> {
+    location
+        .into_iter()
+        .filter_map(|_loc| {
+            // TODO
+            None
+        })
+        .collect()
+}
+
+impl Error {
+    pub(crate) fn validation_should_have_caught_this(mut self) -> Self {
+        self.extensions
+            .insert(EXTENSION_VALIDATION_SHOULD_HAVE_CAUGHT_THIS, true.into());
+        self
+    }
+
+    pub(crate) fn into_request_error(self) -> RequestErrorResponse {
+        RequestErrorResponse { errors: [self] }
+    }
+}
+
+impl RequestErrorResponse {
+    pub(crate) fn validation_should_have_caught_this(mut self) -> Self {
+        self.errors[0]
+            .extensions
+            .insert(EXTENSION_VALIDATION_SHOULD_HAVE_CAUGHT_THIS, true.into());
+        self
+    }
+
+    pub(crate) fn into_field_error(
+        self,
+        path: LinkedPath<'_>,
+        location: Option<NodeLocation>,
+    ) -> Error {
+        let [mut err] = self.errors;
+        err.path = path_to_vec(path);
+        err.locations = to_locations(location);
+        err
+    }
+}
+
+impl Response {
+    pub fn merge(mut self, mut other: Self) -> Self {
+        if let (Some(self_data), Some(other_data)) = (&mut self.data, other.data) {
+            self_data.extend(other_data)
+        } else {
+            // null was propagated to the root:
+            self.data = None
+        }
+        self.errors.append(&mut other.errors);
+        self
+    }
+}
+
+impl Serialize for PathElement {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            PathElement::Field(name) => name.as_str().serialize(serializer),
+            PathElement::ListItem { index } => index.serialize(serializer),
+        }
+    }
+}

--- a/crates/apollo-introspection/src/result_coercion.rs
+++ b/crates/apollo-introspection/src/result_coercion.rs
@@ -1,0 +1,217 @@
+use crate::execution::execute_selection_set;
+use crate::execution::try_nullify;
+use crate::execution::ExecutionMode;
+use crate::execution::PropagateNull;
+use crate::resolver::ResolvedValue;
+use crate::response::field_error;
+use crate::response::Error;
+use crate::response::LinkedPath;
+use crate::response::LinkedPathElement;
+use crate::response::PathElement;
+use crate::VariableValues;
+use apollo_compiler::executable::Field;
+use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::schema::Type;
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use futures::Stream;
+use futures::StreamExt;
+use serde_json_bytes::Value as JsonValue;
+
+/// <https://spec.graphql.org/October2021/#CompleteValue()>
+///
+/// Returns `Err` for a field error being propagated upwards to find a nullable place
+#[async_recursion::async_recursion]
+pub(crate) async fn complete_value<'a, 'b>(
+    schema: &'a Schema,
+    document: &'a ExecutableDocument,
+    variable_values: &'a VariableValues,
+    errors: &'b mut Vec<Error>,
+    path: LinkedPath<'b>,
+    mode: ExecutionMode,
+    ty: &'a Type,
+    resolved: ResolvedValue<'a>,
+    fields: &'a [&'a Field],
+) -> Result<JsonValue, PropagateNull> {
+    let new_field_error = |message| field_error(message, path, fields[0].name.location());
+    macro_rules! field_error {
+        ($($arg: tt)+) => {
+            {
+                errors.push(new_field_error(format!($($arg)+)));
+                return Err(PropagateNull);
+            }
+        };
+    }
+    if let ResolvedValue::Leaf(JsonValue::Null) = resolved {
+        if ty.is_non_null() {
+            field_error!("Non-null type {ty} resolved to null")
+        } else {
+            return Ok(JsonValue::Null);
+        }
+    }
+    if let ResolvedValue::List(stream) = resolved {
+        match ty {
+            Type::Named(_) | Type::NonNullNamed(_) => {
+                field_error!("Non-list type {ty} resolved to a list")
+            }
+            Type::List(inner_ty) | Type::NonNullList(inner_ty) => {
+                let mut completed_list = Vec::with_capacity(stream.size_hint().0);
+                let mut stream = stream.enumerate();
+                while let Some((index, inner_resolved)) = stream.next().await {
+                    let inner_path = LinkedPathElement {
+                        element: PathElement::ListItem { index },
+                        next: path,
+                    };
+                    let inner_result = complete_value(
+                        schema,
+                        document,
+                        variable_values,
+                        errors,
+                        Some(&inner_path),
+                        mode,
+                        inner_ty,
+                        inner_resolved,
+                        fields,
+                    )
+                    .await;
+                    // On field error, try to nullify that item
+                    match try_nullify(inner_ty, inner_result) {
+                        Ok(inner_value) => completed_list.push(inner_value),
+                        // If the item is non-null, try to nullify the list
+                        Err(PropagateNull) => return try_nullify(ty, Err(PropagateNull)),
+                    }
+                }
+                return Ok(completed_list.into());
+            }
+        }
+    }
+    let ty_name = match ty {
+        Type::List(_) | Type::NonNullList(_) => {
+            field_error!("List type {ty} resolved to an object")
+        }
+        Type::Named(name) | Type::NonNullNamed(name) => name,
+    };
+    let Some(ty_def) = schema.types.get(ty_name) else {
+        errors.push(
+            new_field_error(format!("Undefined type {ty_name}"))
+                .validation_should_have_caught_this(),
+        );
+        return Err(PropagateNull);
+    };
+    if let ExtendedType::InputObject(_) = ty_def {
+        errors.push(
+            new_field_error(format!("Field with input object type {ty_name}"))
+                .validation_should_have_caught_this(),
+        );
+        return Err(PropagateNull);
+    }
+    let resolved_obj = match resolved {
+        ResolvedValue::List(_) => unreachable!(), // early return above
+        ResolvedValue::Leaf(json_value) => {
+            match ty_def {
+                ExtendedType::InputObject(_) => unreachable!(), // early return above
+                ExtendedType::Object(_) | ExtendedType::Interface(_) | ExtendedType::Union(_) => {
+                    field_error!(
+                        "Resolver returned a leaf value \
+                         but expected an object for type {ty_name}"
+                    )
+                }
+                ExtendedType::Enum(enum_def) => {
+                    // https://spec.graphql.org/October2021/#sec-Enums.Result-Coercion
+                    if !json_value
+                        .as_str()
+                        .is_some_and(|str| enum_def.values.contains_key(str))
+                    {
+                        field_error!("Resolver returned {json_value}, expected enum {ty_name}")
+                    }
+                }
+                ExtendedType::Scalar(_) => match ty_name.as_str() {
+                    "Int" => {
+                        // https://spec.graphql.org/October2021/#sec-Int.Result-Coercion
+                        // > GraphQL services may coerce non-integer internal values to integers
+                        // > when reasonable without losing information
+                        //
+                        // We choose not to, to keep with Rust’s strong typing
+                        if let Some(int) = json_value.as_i64() {
+                            if i32::try_from(int).is_err() {
+                                field_error!("Resolver returned {json_value} which overflows Int")
+                            }
+                        } else {
+                            field_error!("Resolver returned {json_value}, expected Int")
+                        }
+                    }
+                    "Float" => {
+                        // https://spec.graphql.org/October2021/#sec-Float.Result-Coercion
+                        if !json_value.is_f64() {
+                            field_error!("Resolver returned {json_value}, expected Float")
+                        }
+                    }
+                    "String" => {
+                        // https://spec.graphql.org/October2021/#sec-String.Result-Coercion
+                        if !json_value.is_string() {
+                            field_error!("Resolver returned {json_value}, expected String")
+                        }
+                    }
+                    "Boolean" => {
+                        // https://spec.graphql.org/October2021/#sec-Boolean.Result-Coercion
+                        if !json_value.is_boolean() {
+                            field_error!("Resolver returned {json_value}, expected Boolean")
+                        }
+                    }
+                    "ID" => {
+                        // https://spec.graphql.org/October2021/#sec-ID.Result-Coercion
+                        if !(json_value.is_string() || json_value.is_i64()) {
+                            field_error!("Resolver returned {json_value}, expected ID")
+                        }
+                    }
+                    _ => {
+                        // Custom scalar: accept any JSON value (including an array or object,
+                        // despite this being a "leaf" as far as GraphQL resolution is concerned)
+                    }
+                },
+            };
+            return Ok(json_value);
+        }
+        ResolvedValue::Object(resolved_obj) => resolved_obj,
+    };
+    let (object_type_name, object_type) = match ty_def {
+        ExtendedType::InputObject(_) => unreachable!(), // early return above
+        ExtendedType::Enum(_) | ExtendedType::Scalar(_) => {
+            field_error!(
+                "Resolver returned a an object of type {}, expected {ty_name}",
+                resolved_obj.type_name()
+            )
+        }
+        ExtendedType::Interface(_) | ExtendedType::Union(_) => {
+            let object_type_name = resolved_obj.type_name();
+            if let Some(def) = schema.get_object(object_type_name) {
+                (object_type_name, def)
+            } else {
+                field_error!(
+                    "Resolver returned an object of type {object_type_name} \
+                     not defined in the schema"
+                )
+            }
+        }
+        ExtendedType::Object(def) => {
+            debug_assert_eq!(ty_name, resolved_obj.type_name());
+            (ty_name.as_str(), def)
+        }
+    };
+    execute_selection_set(
+        schema,
+        document,
+        variable_values,
+        errors,
+        path,
+        mode,
+        object_type_name,
+        object_type,
+        &*resolved_obj,
+        fields
+            .iter()
+            .flat_map(|field| &field.selection_set.selections),
+    )
+    .await
+    .map(JsonValue::Object)
+}

--- a/crates/apollo-introspection/src/result_coercion.rs
+++ b/crates/apollo-introspection/src/result_coercion.rs
@@ -22,6 +22,7 @@ use serde_json_bytes::Value as JsonValue;
 ///
 /// Returns `Err` for a field error being propagated upwards to find a nullable place
 #[async_recursion::async_recursion]
+#[allow(clippy::too_many_arguments)] // yes it’s not a nice API but it’s internal
 pub(crate) async fn complete_value<'a, 'b>(
     schema: &'a Schema,
     document: &'a ExecutableDocument,

--- a/crates/apollo-introspection/src/schema_introspection.rs
+++ b/crates/apollo-introspection/src/schema_introspection.rs
@@ -1,0 +1,708 @@
+use crate::execution::execute_query_or_mutation;
+use crate::execution::get_operation;
+use crate::input_coercion::VariableValues;
+use crate::resolver::ResolvedValue;
+use crate::response::request_error;
+use crate::response::RequestErrorResponse;
+use crate::response::Response;
+use crate::JsonMap;
+use apollo_compiler::executable::Fragment;
+use apollo_compiler::executable::InlineFragment;
+use apollo_compiler::executable::Operation;
+use apollo_compiler::executable::OperationType;
+use apollo_compiler::executable::Selection;
+use apollo_compiler::executable::SelectionSet;
+use apollo_compiler::schema;
+use apollo_compiler::schema::Name;
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Node;
+use apollo_compiler::Schema;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+/// The [schema introspection] selections that have been removed from an `Operation`.
+///
+/// Schema introspection selections are those for the `__schema` or `__type` meta-fields.
+///
+/// See [`Self::split_from`]
+///
+/// [schema introspection]: https://spec.graphql.org/October2021/#sec-Schema-Introspection
+pub struct SchemaIntrospectionQuery {
+    document: Option<ExecutableDocument>,
+}
+
+impl SchemaIntrospectionQuery {
+    /// Remove and return [schema introspection] selections at the root of a query operation.
+    ///
+    /// Schema introspection selections are those for the `__schema` or `__type` meta-fields.
+    ///
+    /// Returns an error if schema introspection selections are found nested in a field sub-selection.
+    /// This is possible (while keeping the operation valid) with an unconventional schema
+    /// where the root query type is also the type of a field.
+    ///
+    /// May leave behind empty fragment definitions.
+    /// (TODO: fix this? it means also finding and removing corresponding spreads.)
+    ///
+    /// [schema introspection]: https://spec.graphql.org/October2021/#sec-Schema-Introspection
+    pub fn split_from(
+        document: &mut ExecutableDocument,
+        operation_name: Option<&str>,
+    ) -> Result<Self, RequestErrorResponse> {
+        let operation = get_operation(document, operation_name)?;
+        if operation.operation_type != OperationType::Query {
+            return Ok(Self::empty());
+        }
+        let mut fragments_to_visit: HashSet<_> = document.fragments.keys().collect();
+        let mut fragments_to_split = HashSet::new();
+        let mut at_root = false;
+        let mut nested = false;
+        contains_root(
+            document,
+            &mut fragments_to_visit,
+            &mut fragments_to_split,
+            &mut at_root,
+            &mut nested,
+            &operation.selection_set,
+        );
+        if nested {
+            return Err(request_error(
+                "Schema introspection meta-fields are only supported at the root of a query",
+            ));
+        }
+        if !at_root {
+            // This query does not select any schema introspection meta-fields
+            return Ok(Self::empty());
+        }
+        let operation = document.get_operation_mut(operation_name).unwrap();
+        let ty = operation.selection_set.ty.clone();
+        let selections = collect_from(&mut operation.selection_set.selections);
+        let mut introspection_document = ExecutableDocument::new();
+        introspection_document.anonymous_operation = Some(Node::new(Operation {
+            operation_type: OperationType::Query,
+            variables: Vec::new(),          // unused by execution
+            directives: Default::default(), // unused by execution
+            selection_set: SelectionSet { ty, selections },
+        }));
+        introspection_document
+            .fragments
+            .extend(fragments_to_split.into_iter().map(|name| {
+                let fragment = document.fragments[&name].make_mut();
+                let ty = fragment.selection_set.ty.clone();
+                let selections = collect_from(&mut fragment.selection_set.selections);
+                let new_fragment = Fragment {
+                    directives: Default::default(), // unused by execution
+                    selection_set: SelectionSet { ty, selections },
+                };
+                (name, Node::new(new_fragment))
+            }));
+        let intropsection_fragments: Vec<_> = document
+            .fragments
+            .iter()
+            .filter(|(_name, def)| def.type_condition().starts_with("__"))
+            .map(|(name, _def)| name.clone())
+            .collect();
+        introspection_document
+            .fragments
+            .extend(intropsection_fragments.into_iter().map(|name| {
+                let def = document.fragments.remove(&name).unwrap();
+                (name, def)
+            }));
+        Ok(Self {
+            document: Some(introspection_document),
+        })
+    }
+
+    fn empty() -> Self {
+        Self { document: None }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.document.is_none()
+    }
+
+    pub fn document(&self) -> Option<&ExecutableDocument> {
+        self.document.as_ref()
+    }
+
+    /// Execute this schema intropsection query in a synchronous context.
+    ///
+    /// Because execution uses `async` internally, this uses a single-threaded executor.
+    /// If calling from another executor, call [`execute`][Self::execute] instead.
+    pub fn execute_sync(
+        &self,
+        schema: &Schema,
+        variable_values: &VariableValues,
+    ) -> Result<Response, RequestErrorResponse> {
+        futures::executor::block_on(self.execute(schema, variable_values))
+    }
+
+    /// Execute this schema intropsection query in an asynchronous context
+    pub async fn execute(
+        &self,
+        schema: &Schema,
+        variable_values: &VariableValues,
+    ) -> Result<Response, RequestErrorResponse> {
+        if let Some(document) = &self.document {
+            let operation = document.anonymous_operation.as_ref().unwrap();
+            let implementers_map = &OnceLock::new();
+            let initial_value = &IntrospectionRoot(SchemaWithCache {
+                schema,
+                implementers_map,
+            });
+            execute_query_or_mutation(schema, document, variable_values, initial_value, operation)
+                .await
+        } else {
+            Ok(Response {
+                data: Some(JsonMap::new()),
+                errors: Vec::new(),
+            })
+        }
+    }
+}
+
+/// Returns (contains at the root, contains nested)
+fn contains_root(
+    document: &ExecutableDocument,
+    fragments_to_visit: &mut HashSet<&Name>,
+    fragments_to_split: &mut HashSet<Name>,
+    at_root: &mut bool,
+    nested: &mut bool,
+    selection_set: &SelectionSet,
+) {
+    for selection in &selection_set.selections {
+        match selection {
+            Selection::Field(field) => {
+                *at_root |= field.name == "__schema" || field.name == "__type";
+                *nested |= contains(document, &field.selection_set);
+            }
+            Selection::FragmentSpread(spread) => {
+                // Remove to break cycles
+                if fragments_to_visit.remove(&spread.fragment_name) {
+                    let fragment = &document.fragments[&spread.fragment_name];
+                    let mut at_root_in_this_fragment = false;
+                    contains_root(
+                        document,
+                        fragments_to_visit,
+                        fragments_to_split,
+                        &mut at_root_in_this_fragment,
+                        nested,
+                        &fragment.selection_set,
+                    );
+                    if at_root_in_this_fragment {
+                        *at_root = true;
+                        fragments_to_split.insert(spread.fragment_name.clone());
+                    }
+                }
+            }
+            Selection::InlineFragment(inline) => {
+                contains_root(
+                    document,
+                    fragments_to_visit,
+                    fragments_to_split,
+                    at_root,
+                    nested,
+                    &inline.selection_set,
+                );
+            }
+        }
+    }
+}
+
+fn contains(document: &ExecutableDocument, selection_set: &SelectionSet) -> bool {
+    selection_set
+        .selections
+        .iter()
+        .any(|selection| match selection {
+            Selection::Field(field) => {
+                field.name == "__schema"
+                    || field.name == "__type"
+                    || contains(document, &field.selection_set)
+            }
+            Selection::FragmentSpread(spread) => document
+                .fragments
+                .get(&spread.fragment_name)
+                .is_some_and(|fragment| contains(document, &fragment.selection_set)),
+            Selection::InlineFragment(inline) => contains(document, &inline.selection_set),
+        })
+}
+
+fn collect_from(selections: &mut Vec<Selection>) -> Vec<Selection> {
+    // TODO: use Vec::extract_if when available https://github.com/rust-lang/rust/issues/43244
+    let mut extracted = Vec::new();
+    let mut index = 0;
+    while index < selections.len() {
+        let selection = &mut selections[index];
+        match selection {
+            Selection::Field(field) => {
+                if field.name == "__schema" || field.name == "__type" {
+                    extracted.push(selections.remove(index));
+                    // Don’t increment `index` as `remove` shifts remaining selections
+                    continue;
+                }
+            }
+            Selection::FragmentSpread(_) => extracted.push(selection.clone()),
+            Selection::InlineFragment(inline) => {
+                let collected = collect_from(&mut inline.make_mut().selection_set.selections);
+                if !collected.is_empty() {
+                    extracted.push(Selection::InlineFragment(Node::new(InlineFragment {
+                        type_condition: inline.type_condition.clone(),
+                        directives: inline.directives.clone(),
+                        selection_set: SelectionSet {
+                            ty: inline.selection_set.ty.clone(),
+                            selections: collected,
+                        },
+                    })))
+                }
+            }
+        }
+        index += 1;
+    }
+    extracted
+}
+
+#[derive(Clone, Copy)]
+struct SchemaWithCache<'a> {
+    schema: &'a Schema,
+    implementers_map: &'a OnceLock<HashMap<Name, HashSet<Name>>>,
+}
+
+impl<'a> SchemaWithCache<'a> {
+    fn implementers_of(&self, interface_name: &str) -> impl Iterator<Item = &'a Name> {
+        self.implementers_map
+            .get_or_init(|| self.schema.implementers_map())
+            .get(interface_name)
+            .into_iter()
+            .flatten()
+    }
+}
+
+impl<'a> std::ops::Deref for SchemaWithCache<'a> {
+    type Target = &'a Schema;
+
+    fn deref(&self) -> &Self::Target {
+        &self.schema
+    }
+}
+
+struct IntrospectionRoot<'a>(SchemaWithCache<'a>);
+
+struct TypeDef<'a> {
+    schema: SchemaWithCache<'a>,
+    name: &'a str,
+    def: &'a schema::ExtendedType,
+}
+
+/// Only used for non-null and list types. `TypeDef` is used for everything else.
+struct Type<'a> {
+    schema: SchemaWithCache<'a>,
+    ty: Cow<'a, schema::Type>,
+}
+
+struct Directive<'a> {
+    schema: SchemaWithCache<'a>,
+    def: &'a schema::DirectiveDefinition,
+}
+
+struct Field<'a> {
+    schema: SchemaWithCache<'a>,
+    def: &'a schema::FieldDefinition,
+}
+
+struct EnumValue<'a> {
+    def: &'a schema::EnumValueDefinition,
+}
+
+struct InputValue<'a> {
+    schema: SchemaWithCache<'a>,
+    def: &'a schema::InputValueDefinition,
+}
+
+fn type_def(schema: SchemaWithCache<'_>, name: impl AsRef<str>) -> ResolvedValue<'_> {
+    ResolvedValue::opt_object(
+        schema
+            .types
+            .get_key_value(name.as_ref())
+            .map(|(name, def)| TypeDef { schema, name, def }),
+    )
+}
+
+fn type_def_opt<'a>(
+    schema: SchemaWithCache<'a>,
+    name: &Option<impl AsRef<str>>,
+) -> ResolvedValue<'a> {
+    if let Some(name) = name.as_ref() {
+        type_def(schema, name)
+    } else {
+        ResolvedValue::null()
+    }
+}
+
+fn ty<'a>(schema: SchemaWithCache<'a>, ty: &'a schema::Type) -> ResolvedValue<'a> {
+    if let schema::Type::Named(name) = ty {
+        type_def(schema, name)
+    } else {
+        ResolvedValue::object(Type {
+            schema,
+            ty: Cow::Borrowed(ty),
+        })
+    }
+}
+
+fn deprecation_reason(opt_directive: Option<&Node<schema::Directive>>) -> ResolvedValue<'_> {
+    ResolvedValue::leaf(
+        opt_directive
+            .and_then(|directive| directive.argument_by_name("reason"))
+            .and_then(|arg| arg.as_str()),
+    )
+}
+
+impl_resolver! {
+    for IntrospectionRoot<'_>:
+
+    __typename = unreachable!();
+
+    async fn __schema(&self_) {
+        Ok(ResolvedValue::object(self_.0))
+    }
+
+    async fn __type(&self_, args) {
+        let name = args["name"].as_str().unwrap();
+        Ok(type_def(self_.0, name))
+    }
+}
+
+impl_resolver! {
+    for SchemaWithCache<'_>:
+
+    __typename = "__Schema";
+
+    async fn description(&self_) {
+        Ok(ResolvedValue::leaf(self_.schema_definition.description.as_deref()))
+    }
+
+    async fn types(&self_) {
+        Ok(ResolvedValue::list(self_.types.iter().map(|(name, def)| {
+            ResolvedValue::object(TypeDef { schema: *self_, name, def })
+        })))
+    }
+
+    async fn directives(&self_) {
+        Ok(ResolvedValue::list(self_.directive_definitions.values().map(|def| {
+            ResolvedValue::object(Directive { schema: *self_, def })
+        })))
+    }
+
+    async fn queryType(&self_) {
+        Ok(type_def_opt(*self_, &self_.schema_definition.query))
+    }
+
+    async fn mutationType(&self_) {
+        Ok(type_def_opt(*self_, &self_.schema_definition.mutation))
+    }
+
+    async fn subscriptionType(&self_) {
+        Ok(type_def_opt(*self_, &self_.schema_definition.subscription))
+    }
+}
+
+impl_resolver! {
+    for TypeDef<'_>:
+
+    __typename = "__Type";
+
+    async fn kind(&self_) {
+        Ok(ResolvedValue::leaf(match self_.def {
+            schema::ExtendedType::Scalar(_) => "SCALAR",
+            schema::ExtendedType::Object(_) => "OBJECT",
+            schema::ExtendedType::Interface(_) => "INTERFACE",
+            schema::ExtendedType::Union(_) => "UNION",
+            schema::ExtendedType::Enum(_) => "ENUM",
+            schema::ExtendedType::InputObject(_) => "INPUT_OBJECT",
+        }))
+    }
+
+    async fn name(&self_) {
+        Ok(ResolvedValue::leaf(self_.name))
+    }
+
+    async fn description(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.description().map(|desc| desc.as_str())))
+    }
+
+    async fn fields(&self_, args) {
+        let fields = match self_.def {
+            schema::ExtendedType::Object(def) => &def.fields,
+            schema::ExtendedType::Interface(def) => &def.fields,
+            schema::ExtendedType::Scalar(_) |
+            schema::ExtendedType::Union(_) |
+            schema::ExtendedType::Enum(_) |
+            schema::ExtendedType::InputObject(_) => return Ok(ResolvedValue::null()),
+        };
+        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        Ok(ResolvedValue::list(fields
+            .values()
+            .filter(move |def| {
+                include_deprecated || def.directives.get("deprecated").is_none()
+            })
+            .map(|def| {
+                ResolvedValue::object(Field { schema: self_.schema, def })
+            })
+        ))
+    }
+
+    async fn interfaces(&self_) {
+        let implements_interfaces = match self_.def {
+            schema::ExtendedType::Object(def) => &def.implements_interfaces,
+            schema::ExtendedType::Interface(def) => &def.implements_interfaces,
+            schema::ExtendedType::Scalar(_) |
+            schema::ExtendedType::Union(_) |
+            schema::ExtendedType::Enum(_) |
+            schema::ExtendedType::InputObject(_) => return Ok(ResolvedValue::null()),
+        };
+        Ok(ResolvedValue::list(implements_interfaces.iter().filter_map(|name| {
+            self_.schema.types.get(&name.node).map(|def| {
+                ResolvedValue::object(TypeDef { schema: self_.schema, name, def })
+            })
+        })))
+    }
+
+    async fn possibleTypes(&self_) {
+        macro_rules! types {
+            ($names: expr) => {
+                Ok(ResolvedValue::list($names.filter_map(move |name| {
+                    self_.schema.types.get(name).map(move |def| {
+                        ResolvedValue::object(TypeDef { schema: self_.schema, name, def })
+                    })
+                })))
+            }
+        }
+        match self_.def {
+            schema::ExtendedType::Interface(_) => types!(self_.schema.implementers_of(self_.name)),
+            schema::ExtendedType::Union(def) => types!(def.members.iter().map(|c| &c.node)),
+            schema::ExtendedType::Object(_) |
+            schema::ExtendedType::Scalar(_) |
+            schema::ExtendedType::Enum(_) |
+            schema::ExtendedType::InputObject(_) => Ok(ResolvedValue::null()),
+        }
+    }
+
+    async fn enumValues(&self_, args) {
+        let schema::ExtendedType::Enum(def) = self_.def else {
+            return Ok(ResolvedValue::null());
+        };
+        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        Ok(ResolvedValue::list(def
+            .values
+            .values()
+            .filter(move |def| {
+                include_deprecated || def.directives.get("deprecated").is_none()
+            })
+            .map(|def| {
+                ResolvedValue::object(EnumValue { def })
+            })
+        ))
+    }
+
+    async fn inputFields(&self_, args) {
+        let schema::ExtendedType::InputObject(def) = self_.def else {
+            return Ok(ResolvedValue::null());
+        };
+        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        Ok(ResolvedValue::list(def
+            .fields
+            .values()
+            .filter(move |def| {
+                include_deprecated || def.directives.get("deprecated").is_none()
+            })
+            .map(|def| {
+                ResolvedValue::object(InputValue { schema: self_.schema, def })
+            })
+        ))
+    }
+
+    async fn ofType() {
+        Ok(ResolvedValue::null())
+    }
+
+    async fn specifiedByURL(&self_) {
+        let schema::ExtendedType::Scalar(def) = self_.def else {
+            return Ok(ResolvedValue::null())
+        };
+        Ok(ResolvedValue::leaf(def
+            .directives.get("specifiedBy")
+            .and_then(|dir| dir.argument_by_name("url"))
+            .and_then(|arg| arg.as_str())
+        ))
+    }
+}
+
+// Only used for non-null and list types
+impl_resolver! {
+    for Type<'_>:
+
+    __typename = "__Type";
+
+    async fn kind(&self_) {
+        Ok(ResolvedValue::leaf(match &*self_.ty {
+            schema::Type::Named(_) => unreachable!(),
+            schema::Type::List(_) => "LIST",
+            schema::Type::NonNullNamed(_) |
+            schema::Type::NonNullList(_) => "NON_NULL",
+        }))
+    }
+
+    async fn ofType(&self_) {
+        Ok(match &*self_.ty {
+            schema::Type::Named(_) => unreachable!(),
+            schema::Type::List(inner) => ty(self_.schema, inner),
+            schema::Type::NonNullNamed(inner) => type_def(self_.schema, inner),
+            schema::Type::NonNullList(inner) => ResolvedValue::object(Self {
+                schema: self_.schema,
+                ty: Cow::Owned(schema::Type::List(inner.clone()))
+            }),
+        })
+    }
+
+    async fn name() { Ok(ResolvedValue::null()) }
+    async fn description() { Ok(ResolvedValue::null()) }
+    async fn fields() { Ok(ResolvedValue::null()) }
+    async fn interfaces() { Ok(ResolvedValue::null()) }
+    async fn possibleTypes() { Ok(ResolvedValue::null()) }
+    async fn enumValues() { Ok(ResolvedValue::null()) }
+    async fn inputFields() { Ok(ResolvedValue::null()) }
+    async fn specifiedBy() { Ok(ResolvedValue::null()) }
+}
+
+impl_resolver! {
+    for Directive<'_>:
+
+    __typename = "__Directive";
+
+    async fn name(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.name.as_str()))
+    }
+
+    async fn description(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.description.as_deref()))
+    }
+
+    async fn args(&self_, args) {
+        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        Ok(ResolvedValue::list(self_
+            .def
+            .arguments
+            .iter()
+            .filter(move |def| {
+                include_deprecated || def.directives.get("deprecated").is_none()
+            })
+            .map(|def| {
+                ResolvedValue::object(InputValue { schema: self_.schema, def })
+            })
+        ))
+    }
+
+    async fn locations(&self_) {
+        Ok(ResolvedValue::list(self_.def.locations.iter().map(|loc| {
+            ResolvedValue::leaf(loc.name())
+        })))
+    }
+
+    async fn isRepeatable(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.repeatable))
+    }
+}
+
+impl_resolver! {
+    for Field<'_>:
+
+    __typename = "__Field";
+
+    async fn name(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.name.as_str()))
+    }
+
+    async fn description(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.description.as_deref()))
+    }
+
+    async fn args(&self_, args) {
+        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        Ok(ResolvedValue::list(self_
+            .def
+            .arguments
+            .iter()
+            .filter(move |def| {
+                include_deprecated || def.directives.get("deprecated").is_none()
+            })
+            .map(|def| {
+                ResolvedValue::object(InputValue { schema: self_.schema, def })
+            })
+        ))
+    }
+
+    async fn type(&self_) {
+        Ok(ty(self_.schema, &self_.def.ty))
+    }
+
+    async fn isDeprecated(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.directives.get("deprecated").is_some()))
+    }
+
+    async fn deprecationReason(&self_) {
+        Ok(deprecation_reason(self_.def.directives.get("deprecated")))
+    }
+}
+
+impl_resolver! {
+    for EnumValue<'_>:
+
+    __typename = "__EnumValue";
+
+    async fn name(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.value.as_str()))
+    }
+
+    async fn description(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.description.as_deref()))
+    }
+
+    async fn isDeprecated(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.directives.get("deprecated").is_some()))
+    }
+
+    async fn deprecationReason(&self_) {
+        Ok(deprecation_reason(self_.def.directives.get("deprecated")))
+    }
+}
+
+impl_resolver! {
+    for InputValue<'_>:
+
+    __typename = "__InputValue";
+
+    async fn name(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.name.as_ref()))
+    }
+
+    async fn description(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.description.as_deref()))
+    }
+
+    async fn type(&self_) {
+        Ok(ty(self_.schema, &self_.def.ty))
+    }
+
+    async fn defaultValue(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.default_value.as_ref().map(|val| val.to_string())))
+    }
+
+    async fn isDeprecated(&self_) {
+        Ok(ResolvedValue::leaf(self_.def.directives.get("deprecated").is_some()))
+    }
+
+    async fn deprecationReason(&self_) {
+        Ok(deprecation_reason(self_.def.directives.get("deprecated")))
+    }
+}

--- a/crates/apollo-introspection/tests/doc_example.rs
+++ b/crates/apollo-introspection/tests/doc_example.rs
@@ -1,0 +1,35 @@
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use apollo_introspection::get_operation;
+use apollo_introspection::JsonMap;
+use apollo_introspection::RequestErrorResponse;
+use apollo_introspection::Response;
+use apollo_introspection::SchemaIntrospectionQuery;
+use apollo_introspection::VariableValues;
+
+/// `schema` and `document` are presumed valid
+pub fn execute_request(
+    schema: &Schema,
+    mut document: ExecutableDocument,
+    operation_name: Option<&str>,
+    variable_values: &JsonMap,
+) -> Result<Response, RequestErrorResponse> {
+    let introspection = SchemaIntrospectionQuery::split_from(&mut document, operation_name)?;
+    let operation = get_operation(&document, operation_name)?
+        .definition()
+        .clone();
+    let coerced_variable_values = VariableValues::coerce(schema, &operation, variable_values)?;
+    let response =
+        execute_non_introspection(schema, &document, operation_name, &coerced_variable_values)?;
+    let intropsection_response = introspection.execute_sync(schema, &coerced_variable_values)?;
+    Ok(response.merge(intropsection_response))
+}
+
+fn execute_non_introspection(
+    _schema: &Schema,
+    _document: &ExecutableDocument,
+    _operation_name: Option<&str>,
+    _variable_values: &VariableValues,
+) -> Result<Response, RequestErrorResponse> {
+    unimplemented!()
+}

--- a/crates/apollo-introspection/tests/doc_example.rs
+++ b/crates/apollo-introspection/tests/doc_example.rs
@@ -15,10 +15,8 @@ pub fn execute_request(
     variable_values: &JsonMap,
 ) -> Result<Response, RequestErrorResponse> {
     let introspection = SchemaIntrospectionQuery::split_from(&mut document, operation_name)?;
-    let operation = get_operation(&document, operation_name)?
-        .definition()
-        .clone();
-    let coerced_variable_values = VariableValues::coerce(schema, &operation, variable_values)?;
+    let operation = get_operation(&document, operation_name)?;
+    let coerced_variable_values = VariableValues::coerce(schema, operation, variable_values)?;
     let response =
         execute_non_introspection(schema, &document, operation_name, &coerced_variable_values)?;
     let introspection_response = introspection.execute_sync(schema, &coerced_variable_values)?;

--- a/crates/apollo-introspection/tests/doc_example.rs
+++ b/crates/apollo-introspection/tests/doc_example.rs
@@ -21,8 +21,8 @@ pub fn execute_request(
     let coerced_variable_values = VariableValues::coerce(schema, &operation, variable_values)?;
     let response =
         execute_non_introspection(schema, &document, operation_name, &coerced_variable_values)?;
-    let intropsection_response = introspection.execute_sync(schema, &coerced_variable_values)?;
-    Ok(response.merge(intropsection_response))
+    let introspection_response = introspection.execute_sync(schema, &coerced_variable_values)?;
+    Ok(response.merge(introspection_response))
 }
 
 fn execute_non_introspection(

--- a/crates/apollo-introspection/tests/introspect_full_schema.graphql
+++ b/crates/apollo-introspection/tests/introspect_full_schema.graphql
@@ -1,0 +1,98 @@
+query IntrospectionQuery {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args(includeDeprecated: true) {
+        ...InputValue
+      }
+    }
+  }
+}
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args(includeDeprecated: true) {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields(includeDeprecated: true) {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ...TypeRef
+  }
+  defaultValue
+  isDeprecated
+  deprecationReason
+}
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/apollo-introspection/tests/response_full.json
+++ b/crates/apollo-introspection/tests/response_full.json
@@ -1,0 +1,1179 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": null,
+          "fields": [
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "types",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": null,
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "specifiedByURL",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isRepeatable",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VARIABLE_DEFINITION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int\ncan represent values between -(2^31) and 2^31 - 1.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as\nspecified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character\nsequences. The String type is most often used by GraphQL to represent free-form\nhuman-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an\nobject or as key for a cache. The ID type appears in a JSON response as a\nString; however, it is not intended to be human-readable. When expected as an\ninput type, any string (such as `\\\"4\\\"`) or integer (such as `4`) input value\nwill be accepted as an ID.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "int",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "…"
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Url",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "I",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "I",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Query",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Url",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ARGUMENT_DEFINITION",
+            "INPUT_FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a\nsuggestion for how to access supported similar data. Formatted using\nthe Markdown syntax, as specified by\n[CommonMark](https://commonmark.org/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\"",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "name": "specifiedBy",
+          "description": "Exposes a URL that specifies the behaviour of this scalar.",
+          "locations": [
+            "SCALAR"
+          ],
+          "args": [
+            {
+              "name": "url",
+              "description": "The URL that specifies the behaviour of this scalar.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/crates/apollo-introspection/tests/snapshots.rs
+++ b/crates/apollo-introspection/tests/snapshots.rs
@@ -10,7 +10,7 @@ use serde_json_bytes::Value as JsonValue;
 #[test]
 fn test() {
     let schema = r#"
-        type Query implements I { 
+        type Query implements I {
             id: ID!
             int: Int! @deprecated(reason: "…")
             url: Url
@@ -30,7 +30,7 @@ fn test() {
         document.validate(&schema).unwrap();
         let operation = document.get_operation(None).unwrap();
         let variables = JsonValue::as_object(&variables).unwrap();
-        let variables = VariableValues::coerce(&schema, &operation, &variables).unwrap();
+        let variables = VariableValues::coerce(&schema, operation, variables).unwrap();
         let introspection = SchemaIntrospectionQuery::split_from(&mut document, None).unwrap();
         let response = introspection.execute_sync(&schema, &variables).unwrap();
         serde_json::to_string_pretty(&response).unwrap()

--- a/crates/apollo-introspection/tests/snapshots.rs
+++ b/crates/apollo-introspection/tests/snapshots.rs
@@ -1,0 +1,115 @@
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use apollo_introspection::SchemaIntrospectionQuery;
+use apollo_introspection::VariableValues;
+use expect_test::expect;
+use expect_test::expect_file;
+use serde_json_bytes::json;
+use serde_json_bytes::Value as JsonValue;
+
+#[test]
+fn test() {
+    let schema = r#"
+        type Query implements I { 
+            id: ID!
+            int: Int! @deprecated(reason: "…")
+            url: Url
+        }
+
+        interface I {
+            id: ID!
+        }
+
+        scalar Url @specifiedBy(url: "https://url.spec.whatwg.org/")
+    "#;
+    let schema = Schema::parse(schema, "schema.graphql");
+    schema.validate().unwrap();
+
+    let introspect = |query, variables| {
+        let mut document = ExecutableDocument::parse(&schema, query, "query.graphql");
+        document.validate(&schema).unwrap();
+        let operation = document.get_operation(None).unwrap();
+        let variables = JsonValue::as_object(&variables).unwrap();
+        let variables = VariableValues::coerce(&schema, &operation, &variables).unwrap();
+        let introspection = SchemaIntrospectionQuery::split_from(&mut document, None).unwrap();
+        let response = introspection.execute_sync(&schema, &variables).unwrap();
+        serde_json::to_string_pretty(&response).unwrap()
+    };
+
+    let response = introspect(include_str!("introspect_full_schema.graphql"), json!({}));
+    expect_file!("response_full.json").assert_eq(&response);
+
+    let query = r#"
+        query WithVarible($verbose: Boolean!) {
+            I: __type(name: "I") {
+                possibleTypes {
+                    name
+                    fields @skip(if: $verbose) {
+                        name
+                    }
+                    verboseFields: fields(includeDeprecated: true) @include(if: $verbose) {
+                        name
+                        deprecationReason
+                    }
+                }
+            }
+            Url: __type(name: "Url") @include(if: $verbose) {
+                specifiedByURL
+            }
+        }
+    "#;
+    let expected = expect!([r#"
+        {
+          "data": {
+            "I": {
+              "possibleTypes": [
+                {
+                  "name": "Query",
+                  "fields": [
+                    {
+                      "name": "id"
+                    },
+                    {
+                      "name": "url"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }"#]);
+    let response = introspect(query, json!({"verbose": false}));
+    expected.assert_eq(&response);
+
+    let response = introspect(query, json!({"verbose": true}));
+    let expected = expect!([r#"
+        {
+          "data": {
+            "I": {
+              "possibleTypes": [
+                {
+                  "name": "Query",
+                  "verboseFields": [
+                    {
+                      "name": "id",
+                      "deprecationReason": null
+                    },
+                    {
+                      "name": "int",
+                      "deprecationReason": "…"
+                    },
+                    {
+                      "name": "url",
+                      "deprecationReason": null
+                    }
+                  ]
+                }
+              ]
+            },
+            "Url": {
+              "specifiedByURL": "https://url.spec.whatwg.org/"
+            }
+          }
+        }"#]);
+    expected.assert_eq(&response);
+}


### PR DESCRIPTION
**Note:** this depends on ongoing work for https://github.com/apollographql/apollo-rs/issues/641, so for now this PR targets a temporary branch in order to only show relevant diffs.

---

This is an initial draft implementation of (trying to be) spec-compliant:

* [Execution](https://spec.graphql.org/October2021/#sec-Execution):
  - A trait abstraction for objects with asynchronously resolvable fields
  - Input coercion / type checking of variable values and argument values
  - Field collection (handling `@skip`, `@include`, and type conditions)
  - Handling of field error (collecting the relevant path, propagating `null`), raised by a resolver or otherwise
  - Result coercion / type checking of response data
  - `serde`-serializable data structures of a GraphQL response, request errors, field errors, and field error path
  - JSON data for variable values and response data is represented with `serde_json_bytes::Value` (which uses a wrapper of reference-counted [`Bytes`](https://crates.io/crates/bytes) for strings)

* [Schema introspection](https://spec.graphql.org/October2021/#sec-Schema-Introspection):
  - Removing and collecting schema introspection selections (`__schema` and `__type`) from an executable document, so the rest can be executed separately (whether with the above, or not like in Apollo Router)
  - Execution of those collected selections, returning a response that can be merged with the response for the rest of the request

See `crates/apollo-introspection/tests/doc_example.rs` for an API usage example.

Testing is minimal. Experience integrating with Apollo Router would be good to have before merging this PR. Execution is included in support of introspection and not exposed in the public API. If/when another use case comes we can expose it, with some more thought on the API design (especially for the resolver trait).