### PR TITLE
Introduce ast::IntValue and FloatValue containing a String

### DIFF
--- a/crates/apollo-compiler/src/ast/from_cst.rs
+++ b/crates/apollo-compiler/src/ast/from_cst.rs
@@ -677,27 +677,10 @@ impl Convert for cst::Value {
                 &String::from(v),
                 NodeLocation::new(file_id, self.syntax()),
             )),
-            C::FloatValue(v) => A::Float(f64::try_from(v).ok()?.into()),
-            C::IntValue(v) => {
-                if let Ok(i) = i32::try_from(v) {
-                    A::Int(i)
-                } else {
-                    let token = &v.syntax().first_token()?;
-                    let text = token.text();
-                    debug_assert!(
-                        text.strip_prefix('-')
-                            .unwrap_or(text)
-                            .chars()
-                            .all(|c| c.is_ascii_digit()),
-                        "{:?}",
-                        text
-                    );
-                    A::BigInt(ast::NodeStr::new_parsed(
-                        text,
-                        NodeLocation::new(file_id, self.syntax()),
-                    ))
-                }
-            }
+            C::FloatValue(v) => A::Float(ast::FloatValue::new_parsed(
+                v.syntax().first_token()?.text(),
+            )),
+            C::IntValue(v) => A::Int(ast::IntValue::new_parsed(v.syntax().first_token()?.text())),
             C::BooleanValue(v) => A::Boolean(bool::try_from(v).ok()?),
             C::NullValue(_) => A::Null,
             C::EnumValue(v) => A::Enum(v.name()?.convert(file_id)?),

--- a/crates/apollo-compiler/src/ast/mod.rs
+++ b/crates/apollo-compiler/src/ast/mod.rs
@@ -340,18 +340,18 @@ pub enum Value {
         /// The value after escape sequences are resolved
         NodeStr,
     ),
-    Float(ordered_float::OrderedFloat<f64>),
-    Int(i32),
-    /// Integer syntax (without a decimal point) but overflows `i32`.
-    /// Valid in contexts where the expected GraphQL type is `Float`.
-    BigInt(
-        /// Must only contain ASCII decimal digits
-        NodeStr,
-    ),
+    Float(FloatValue),
+    Int(IntValue),
     Boolean(bool),
     List(Vec<Node<Value>>),
     Object(Vec<(Name, Node<Value>)>),
 }
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct IntValue(String);
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct FloatValue(String);
 
 /// Trait implemented by extensible type definitions, to associate the extension type with the base
 /// definition type.

--- a/crates/apollo-compiler/src/ast/mod.rs
+++ b/crates/apollo-compiler/src/ast/mod.rs
@@ -353,6 +353,11 @@ pub struct IntValue(String);
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct FloatValue(String);
 
+/// `IntValue` or `FloatValue` magnitude too large to be converted to `f64`.
+#[derive(Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct FloatOverflowError {}
+
 /// Trait implemented by extensible type definitions, to associate the extension type with the base
 /// definition type.
 pub trait Extensible {

--- a/crates/apollo-compiler/src/ast/serialize.rs
+++ b/crates/apollo-compiler/src/ast/serialize.rs
@@ -706,16 +706,8 @@ impl Value {
             Value::Enum(name) => state.write(name),
             Value::String(value) => serialize_string_value(state, value),
             Value::Variable(name) => display!(state, "${}", name),
-            Value::Float(value) => {
-                let value = value.to_string();
-                state.write(&value)?;
-                if !value.contains('.') {
-                    state.write(".0")?
-                }
-                Ok(())
-            }
+            Value::Float(value) => display!(state, value),
             Value::Int(value) => display!(state, value),
-            Value::BigInt(value) => display!(state, value),
             Value::List(value) => comma_separated(state, "[", "]", value, |state, value| {
                 value.serialize_impl(state)
             }),

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -324,6 +324,11 @@ pub enum DiagnosticData {
         /// The int value that cannot be coerced
         value: String,
     },
+    #[error("float cannot represent non-finite 64-bit floating point value")]
+    FloatCoercionError {
+        /// The float value that cannot be coerced
+        value: String,
+    },
     #[error("non-repeatable directive {name} can only be used once per location")]
     UniqueDirective {
         /// Name of the non-unique directive.


### PR DESCRIPTION
Rather converting to i32 or f64 during parsing, we preserve the parsed token as-is. Conversion is left for input value coercion, when the expected type is known (`Float`, `Int`, `ID`, custom scalar, …)