### PR TITLE
chore(compiler): rewrite RecursionStack to avoid copies to String

### DIFF
--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -114,9 +114,8 @@ impl FindRecursiveDirective<'_> {
         mut seen: RecursionGuard<'_>,
         def: &Node<ast::DirectiveDefinition>,
     ) -> Result<(), Node<ast::Directive>> {
-        let mut guard = seen.push(&def.name);
         for input_value in &def.arguments {
-            self.input_value(&mut guard, input_value)?;
+            self.input_value(&mut seen, input_value)?;
         }
 
         Ok(())
@@ -126,7 +125,7 @@ impl FindRecursiveDirective<'_> {
         schema: &schema::Schema,
         directive_def: &Node<ast::DirectiveDefinition>,
     ) -> Result<(), Node<ast::Directive>> {
-        let mut recursion_stack = RecursionStack::new();
+        let mut recursion_stack = RecursionStack::with_root(directive_def.name.clone());
         FindRecursiveDirective { schema }
             .directive_definition(recursion_stack.guard(), directive_def)
     }

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -44,9 +44,8 @@ impl FindRecursiveInputValue<'_> {
         mut seen: RecursionGuard<'_>,
         input_object: &ast::TypeWithExtensions<ast::InputObjectTypeDefinition>,
     ) -> Result<(), Node<ast::InputValueDefinition>> {
-        let mut guard = seen.push(&input_object.definition.name);
         for input_value in input_object.fields() {
-            self.input_value_definition(&mut guard, input_value)?;
+            self.input_value_definition(&mut seen, input_value)?;
         }
 
         Ok(())
@@ -56,7 +55,7 @@ impl FindRecursiveInputValue<'_> {
         db: &dyn ValidationDatabase,
         input_object: &ast::TypeWithExtensions<ast::InputObjectTypeDefinition>,
     ) -> Result<(), Node<ast::InputValueDefinition>> {
-        let mut recursion_stack = RecursionStack::new();
+        let mut recursion_stack = RecursionStack::with_root(input_object.definition.name.clone());
         FindRecursiveInputValue { db }
             .input_object_definition(recursion_stack.guard(), input_object)
     }

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -17,27 +17,56 @@ mod union_;
 mod value;
 mod variable;
 
+use crate::NodeStr;
 pub use validation_db::{ValidationDatabase, ValidationStorage};
 
 /// Track used names in a recursive function.
-///
-/// Pass the result of `stack.push(name)` to recursive calls. Use `stack.contains(name)` to check
-/// if the name was used somewhere up the call stack.
-struct RecursionStack<'a>(&'a mut Vec<String>);
-impl RecursionStack<'_> {
-    fn push(&mut self, name: String) -> RecursionStack<'_> {
-        self.0.push(name);
-        RecursionStack(self.0)
+struct RecursionStack {
+    seen: Vec<NodeStr>,
+}
+
+impl RecursionStack {
+    fn new() -> Self {
+        Self {
+            seen: Default::default(),
+        }
     }
+
+    fn with_root(root: NodeStr) -> Self {
+        Self { seen: vec![root] }
+    }
+
+    /// Return the actual API for tracking recursive uses.
+    pub fn guard(&mut self) -> RecursionGuard<'_> {
+        RecursionGuard(&mut self.seen)
+    }
+}
+
+/// Track used names in a recursive function.
+///
+/// Pass the result of `guard.push(name)` to recursive calls. Use `guard.contains(name)` to check
+/// if the name was used somewhere up the call stack. When a guard is dropped, its name is removed
+/// from the list.
+struct RecursionGuard<'a>(&'a mut Vec<NodeStr>);
+impl RecursionGuard<'_> {
+    /// Mark that we saw a name.
+    fn push(&mut self, name: &NodeStr) -> RecursionGuard<'_> {
+        self.0.push(name.clone());
+        RecursionGuard(self.0)
+    }
+    /// Check if we saw a name somewhere up the call stack.
     fn contains(&self, name: &str) -> bool {
         self.0.iter().any(|seen| seen == name)
     }
+    /// Return the name where we started.
     fn first(&self) -> Option<&str> {
         self.0.get(0).map(|s| s.as_str())
     }
 }
-impl Drop for RecursionStack<'_> {
+
+impl Drop for RecursionGuard<'_> {
     fn drop(&mut self) {
+        // This may already be empty if it's the original `stack.guard()` result, but that's fine
         self.0.pop();
     }
 }


### PR DESCRIPTION
Now that this is only used with the new `NodeStr` type, it's wasteful and inconvenient to have it use String instances.

Also split it into `RecursionStack`/`RecursionGuard` types so you can't write something that has lifetime errors as easily, and so you don't have to create your own vec for storage.