### PR TITLE
fix(parser): apply recursion limit everywhere, reduce default to 500

### DIFF
--- a/crates/apollo-compiler/src/database/ast.rs
+++ b/crates/apollo-compiler/src/database/ast.rs
@@ -190,7 +190,10 @@ mod tests {
         assert_eq!(ast.errors().len(), 1);
         assert_eq!(
             ast.errors().next(),
-            Some(&apollo_parser::Error::limit("parser limit(3) reached", 121))
+            Some(&apollo_parser::Error::limit(
+                "parser recursion limit reached",
+                121
+            ))
         );
     }
 

--- a/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
@@ -61,4 +61,4 @@
                         - IDENT@79..85 "String"
             - WHITESPACE@85..86 "\n"
             - R_CURLY@86..87 "}"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 2

--- a/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
@@ -128,4 +128,4 @@
             - WHITESPACE@214..215 "\n"
             - R_CURLY@215..216 "}"
     - WHITESPACE@216..217 "\n"
-recursion limit: 4096, high: 3
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
@@ -173,4 +173,4 @@
             - WHITESPACE@358..359 "\n"
             - R_CURLY@359..360 "}"
     - WHITESPACE@360..361 "\n"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
+++ b/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
@@ -50,4 +50,4 @@
                         - STRING_VALUE@75..112
                             - STRING@75..112 "\"https://tools.ietf.org/html/rfc3986\""
                     - R_PAREN@112..113 ")"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
@@ -81,4 +81,4 @@
                         - IDENT@139..144 "ACANA"
             - WHITESPACE@144..145 "\n"
             - R_CURLY@145..146 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
@@ -111,4 +111,4 @@
                         - IDENT@196..208 "SearchResult"
             - WHITESPACE@208..209 "\n"
             - R_CURLY@209..210 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
@@ -158,4 +158,4 @@
                         - IDENT@246..252 "String"
             - WHITESPACE@252..253 "\n"
             - R_CURLY@253..254 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
@@ -104,4 +104,4 @@
                     - BANG@196..197 "!"
             - WHITESPACE@197..198 "\n"
             - R_CURLY@198..199 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
@@ -79,4 +79,4 @@
                         - IDENT@147..152 "Float"
             - WHITESPACE@152..153 "\n"
             - R_CURLY@153..154 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -218,4 +218,4 @@
             - WHITESPACE@421..422 "\n"
             - R_CURLY@422..423 "}"
     - WHITESPACE@423..424 "\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 2

--- a/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
@@ -143,4 +143,4 @@
             - WHITESPACE@204..205 "\n"
             - R_CURLY@205..206 "}"
     - WHITESPACE@206..207 "\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 2

--- a/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
+++ b/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
@@ -477,4 +477,4 @@
                     - R_CURLY@1262..1263 "}"
             - WHITESPACE@1263..1264 "\n"
             - R_CURLY@1264..1265 "}"
-recursion limit: 4096, high: 8
+recursion limit: 500, high: 8

--- a/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
@@ -229,4 +229,4 @@
             - WHITESPACE@397..398 "\n"
             - R_CURLY@398..399 "}"
     - WHITESPACE@399..400 "\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0014_float_values.txt
+++ b/crates/apollo-compiler/test_data/ok/0014_float_values.txt
@@ -115,4 +115,4 @@
             - WHITESPACE@269..270 "\n"
             - R_CURLY@270..271 "}"
     - WHITESPACE@271..272 "\n"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 4

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
@@ -4200,4 +4200,4 @@
                         - IDENT@7533..7539 "String"
             - WHITESPACE@7539..7540 "\n"
             - R_CURLY@7540..7541 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 7

--- a/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
+++ b/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
@@ -186,4 +186,4 @@
                     - BANG@369..370 "!"
             - WHITESPACE@370..371 "\n"
             - R_CURLY@371..372 "}"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
@@ -300,4 +300,4 @@
                         - IDENT@591..598 "Boolean"
             - WHITESPACE@598..599 "\n"
             - R_CURLY@599..600 "}"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
+++ b/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
@@ -110,4 +110,4 @@
             - WHITESPACE@201..202 "\n"
             - R_CURLY@202..203 "}"
     - WHITESPACE@203..204 "\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 2

--- a/crates/apollo-compiler/test_data/ok/0019_extensions.txt
+++ b/crates/apollo-compiler/test_data/ok/0019_extensions.txt
@@ -225,4 +225,4 @@
             - WHITESPACE@407..408 "\n"
             - R_CURLY@408..409 "}"
     - WHITESPACE@409..410 "\n"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
@@ -147,4 +147,4 @@
             - WHITESPACE@317..318 "\n"
             - R_CURLY@318..319 "}"
     - WHITESPACE@319..320 "\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 2

--- a/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
+++ b/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
@@ -238,4 +238,4 @@
             - WHITESPACE@590..591 "\n"
             - R_CURLY@591..592 "}"
     - WHITESPACE@592..593 "\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 2

--- a/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
+++ b/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
@@ -541,4 +541,4 @@
             - WHITESPACE@979..980 "\n"
             - R_CURLY@980..981 "}"
     - WHITESPACE@981..982 "\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
@@ -281,4 +281,4 @@
             - WHITESPACE@503..504 "\n"
             - R_CURLY@504..505 "}"
     - WHITESPACE@505..506 "\n"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 5

--- a/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
@@ -88,4 +88,4 @@
             - WHITESPACE@164..165 "\n"
             - R_CURLY@165..166 "}"
     - WHITESPACE@166..167 "\n"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
+++ b/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
@@ -113,4 +113,4 @@
                     - R_CURLY@210..211 "}"
             - WHITESPACE@211..212 "\n"
             - R_CURLY@212..213 "}"
-recursion limit: 4096, high: 4
+recursion limit: 500, high: 4

--- a/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
@@ -72,4 +72,4 @@
                     - IDENT@123..133 "__typename"
             - WHITESPACE@133..134 "\n"
             - R_CURLY@134..135 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
@@ -152,4 +152,4 @@
                     - R_CURLY@289..290 "}"
             - WHITESPACE@290..291 "\n"
             - R_CURLY@291..292 "}"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
+++ b/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
@@ -214,4 +214,4 @@
             - WHITESPACE@300..301 "\n"
             - R_CURLY@301..302 "}"
     - WHITESPACE@302..303 "\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 4

--- a/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
+++ b/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
@@ -152,4 +152,4 @@
                         - IDENT@239..244 "First"
             - WHITESPACE@244..245 "\n"
             - R_CURLY@245..246 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
+++ b/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
@@ -712,4 +712,4 @@
             - WHITESPACE@1925..1926 "\n"
             - R_CURLY@1926..1927 "}"
     - WHITESPACE@1927..1928 "\n"
-recursion limit: 4096, high: 3
+recursion limit: 500, high: 3

--- a/crates/apollo-compiler/test_data/ok/0032_valid_of_correct_type.txt
+++ b/crates/apollo-compiler/test_data/ok/0032_valid_of_correct_type.txt
@@ -2808,4 +2808,4 @@
             - WHITESPACE@6366..6367 "\n"
             - R_CURLY@6367..6368 "}"
     - WHITESPACE@6368..6369 "\n"
-recursion limit: 4096, high: 3
+recursion limit: 500, high: 8

--- a/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
+++ b/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
@@ -224,4 +224,4 @@
             - WHITESPACE@508..509 "\n"
             - R_CURLY@509..510 "}"
     - WHITESPACE@510..512 "\n\n"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 4

--- a/crates/apollo-parser/src/lexer/mod.rs
+++ b/crates/apollo-parser/src/lexer/mod.rs
@@ -107,8 +107,7 @@ impl<'a> Iterator for Lexer<'a> {
             return None;
         }
 
-        self.limit_tracker.consume();
-        if self.limit_tracker.limited() {
+        if self.limit_tracker.check_and_increment() {
             self.finished = true;
             return Some(Err(Error::limit(
                 "token limit reached, aborting lexing",

--- a/crates/apollo-parser/src/parser/grammar/argument.rs
+++ b/crates/apollo-parser/src/parser/grammar/argument.rs
@@ -17,7 +17,14 @@ pub(crate) fn argument(p: &mut Parser, mut is_argument: bool) {
             is_argument = true;
             if p.peek().is_some() {
                 guard.finish_node();
-                return argument(p, is_argument);
+                // TODO: use a loop instead of recursion
+                if p.recursion_limit.check_and_increment() {
+                    p.limit_err("parser recursion limit reached");
+                    return;
+                }
+                argument(p, is_argument);
+                p.recursion_limit.decrement();
+                return;
             }
         }
     }

--- a/crates/apollo-parser/src/parser/grammar/document.rs
+++ b/crates/apollo-parser/src/parser/grammar/document.rs
@@ -14,9 +14,10 @@ pub(crate) fn document(p: &mut Parser) {
     let doc = p.start_node(SyntaxKind::DOCUMENT);
 
     while let Some(node) = p.peek() {
-        if p.recursion_limit.limited() {
-            break;
-        }
+        assert_eq!(
+            p.recursion_limit.current, 0,
+            "unbalanced limit increment / decrement"
+        );
 
         match node {
             TokenKind::StringValue => {

--- a/crates/apollo-parser/src/parser/grammar/enum_.rs
+++ b/crates/apollo-parser/src/parser/grammar/enum_.rs
@@ -101,7 +101,14 @@ pub(crate) fn enum_value_definition(p: &mut Parser) {
         }
         if p.peek().is_some() {
             guard.finish_node();
-            return enum_value_definition(p);
+            // TODO: use a loop instead of recursion
+            if p.recursion_limit.check_and_increment() {
+                p.limit_err("parser recursion limit reached");
+                return;
+            }
+            enum_value_definition(p);
+            p.recursion_limit.decrement();
+            return;
         }
     }
 

--- a/crates/apollo-parser/src/parser/grammar/fragment.rs
+++ b/crates/apollo-parser/src/parser/grammar/fragment.rs
@@ -19,7 +19,7 @@ pub(crate) fn fragment_definition(p: &mut Parser) {
     }
 
     match p.peek() {
-        Some(T!['{']) => selection::top_selection_set(p),
+        Some(T!['{']) => selection::selection_set(p),
         _ => p.err("expected a Selection Set"),
     }
 }
@@ -77,7 +77,7 @@ pub(crate) fn inline_fragment(p: &mut Parser) {
     }
 
     match p.peek() {
-        Some(T!['{']) => selection::top_selection_set(p),
+        Some(T!['{']) => selection::selection_set(p),
         _ => p.err("expected Selection Set"),
     }
 }

--- a/crates/apollo-parser/src/parser/grammar/input.rs
+++ b/crates/apollo-parser/src/parser/grammar/input.rs
@@ -105,7 +105,14 @@ pub(crate) fn input_value_definition(p: &mut Parser, is_input: bool) {
 
                     if p.peek().is_some() {
                         guard.finish_node();
-                        return input_value_definition(p, true);
+                        // TODO: use a loop instead of recursion
+                        if p.recursion_limit.check_and_increment() {
+                            p.limit_err("parser recursion limit reached");
+                            return;
+                        }
+                        input_value_definition(p, true);
+                        p.recursion_limit.decrement();
+                        return;
                     }
                 }
                 _ => p.err("expected a Type"),

--- a/crates/apollo-parser/src/parser/grammar/object.rs
+++ b/crates/apollo-parser/src/parser/grammar/object.rs
@@ -104,7 +104,13 @@ fn implements_interface(p: &mut Parser, is_interfaces: bool) {
             ty::named_type(p);
             if let Some(node) = p.peek_data() {
                 if !is_definition(node) {
+                    // TODO: use a loop instead of recursion
+                    if p.recursion_limit.check_and_increment() {
+                        p.limit_err("parser recursion limit reached");
+                        return;
+                    }
                     implements_interface(p, true);
+                    p.recursion_limit.decrement()
                 }
 
                 return;

--- a/crates/apollo-parser/src/parser/grammar/selection.rs
+++ b/crates/apollo-parser/src/parser/grammar/selection.rs
@@ -3,32 +3,25 @@ use crate::{
     Parser, SyntaxKind, TokenKind, S, T,
 };
 
-/// In order to control recursion, we need to have a way to
-/// specify the "top" of a selection_set tree. This is the
-/// function which must be used to do this.
-pub(crate) fn top_selection_set(p: &mut Parser) {
-    p.recursion_limit.reset();
-    selection_set(p)
-}
-
 /// See: https://spec.graphql.org/October2021/#SelectionSet
 ///
 /// *SelectionSet*:
 ///     **{** Selection* **}**
 pub(crate) fn selection_set(p: &mut Parser) {
-    p.recursion_limit.consume();
-
     if let Some(T!['{']) = p.peek() {
         let _g = p.start_node(SyntaxKind::SELECTION_SET);
         p.bump(S!['{']);
+
         // We need to enforce recursion limits to prevent
         // excessive resource consumption or (more seriously)
         // stack overflows.
-        if p.recursion_limit.limited() {
-            p.limit_err(format!("parser limit({}) reached", p.recursion_limit.limit));
+        if p.recursion_limit.check_and_increment() {
+            p.limit_err("parser recursion limit reached");
             return;
         }
         selection(p);
+        p.recursion_limit.decrement();
+
         p.expect(T!['}'], S!['}']);
     }
 }
@@ -43,9 +36,6 @@ pub(crate) fn selection(p: &mut Parser) {
     let mut has_selection = false;
 
     while let Some(node) = p.peek() {
-        if p.recursion_limit.limited() {
-            break;
-        }
         match node {
             T![...] => {
                 let next_token = p.peek_token_n(2);
@@ -415,7 +405,7 @@ query SomeQuery(
 
         assert_eq!(ast.recursion_limit().high, 2);
         assert_eq!(ast.errors().len(), 1);
-        assert_eq!(ast.document().definitions().count(), 1);
+        assert_eq!(ast.document().definitions().count(), 2);
     }
 
     #[test]

--- a/crates/apollo-parser/src/parser/grammar/ty.rs
+++ b/crates/apollo-parser/src/parser/grammar/ty.rs
@@ -36,12 +36,20 @@ fn parse<'a>(p: &mut Parser<'a>) -> Result<(), Token<'a>> {
         Some(T!['[']) => {
             let _guard = p.start_node(SyntaxKind::LIST_TYPE);
             p.bump(S!['[']);
-            if let Err(token) = parse(p) {
+
+            if p.recursion_limit.check_and_increment() {
+                p.limit_err("parser recursion limit reached");
+                return Ok(()); // TODO: is this right?
+            }
+            let result = parse(p);
+            p.recursion_limit.decrement();
+
+            if let Err(token) = result {
                 // TODO(@goto-bus-stop) ideally the span here would point to the entire list
                 // type, so both opening and closing brackets `[]`.
                 p.err_at_token(&token, "expected item type");
             }
-            p.expect(T![']'], S![']'])
+            p.expect(T![']'], S![']']);
         }
         Some(TokenKind::Name) => {
             let _guard = p.start_node(SyntaxKind::NAMED_TYPE);

--- a/crates/apollo-parser/src/parser/grammar/union_.rs
+++ b/crates/apollo-parser/src/parser/grammar/union_.rs
@@ -88,7 +88,13 @@ fn union_member_type(p: &mut Parser, is_union: bool) {
             ty::named_type(p);
             if let Some(node) = p.peek_data() {
                 if !is_definition(node) {
+                    // TODO: use a loop instead of recursion
+                    if p.recursion_limit.check_and_increment() {
+                        p.limit_err("parser recursion limit reached");
+                        return;
+                    }
                     union_member_type(p, true);
+                    p.recursion_limit.decrement();
                 }
 
                 return;

--- a/crates/apollo-parser/src/parser/grammar/variable.rs
+++ b/crates/apollo-parser/src/parser/grammar/variable.rs
@@ -40,7 +40,14 @@ pub(crate) fn variable_definition(p: &mut Parser, is_variable: bool) {
                 }
                 if p.peek().is_some() {
                     guard.finish_node();
-                    return variable_definition(p, true);
+                    // TODO: use a loop instead of recursion
+                    if p.recursion_limit.check_and_increment() {
+                        p.limit_err("parser recursion limit reached");
+                        return;
+                    }
+                    variable_definition(p, true);
+                    p.recursion_limit.decrement();
+                    return;
                 }
             }
             p.err("expected a Type");

--- a/crates/apollo-parser/test_data/parser/err/0001_directive_definition_missing_location.txt
+++ b/crates/apollo-parser/test_data/parser/err/0001_directive_definition_missing_location.txt
@@ -8,4 +8,4 @@
         - WHITESPACE@18..19 " "
         - on_KW@19..21 "on"
 - ERROR@21:21 "expected valid Directive Location" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0002_enum_definition_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0002_enum_definition_with_missing_name.txt
@@ -27,4 +27,4 @@
             - WHITESPACE@44..45 "\n"
             - R_CURLY@45..46 "}"
 - ERROR@5:6 "expected a Name" {
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 4

--- a/crates/apollo-parser/test_data/parser/err/0003_enum_definition_with_missing_values.txt
+++ b/crates/apollo-parser/test_data/parser/err/0003_enum_definition_with_missing_values.txt
@@ -10,4 +10,4 @@
             - WHITESPACE@16..17 "\n"
             - R_CURLY@17..18 "}"
 - ERROR@17:18 "expected Enum Value Definition" }
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0004_enum_definition_with_missing_curly.txt
+++ b/crates/apollo-parser/test_data/parser/err/0004_enum_definition_with_missing_curly.txt
@@ -18,4 +18,4 @@
                     - NAME@23..27
                         - IDENT@23..27 "WEST"
 - ERROR@27:27 "expected R_CURLY, got EOF" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0005_enum_extension_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0005_enum_extension_with_missing_name.txt
@@ -19,4 +19,4 @@
             - WHITESPACE@32..33 "\n"
             - R_CURLY@33..34 "}"
 - ERROR@12:13 "expected a Name" {
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0006_enum_extension_with_missing_requirements.txt
+++ b/crates/apollo-parser/test_data/parser/err/0006_enum_extension_with_missing_requirements.txt
@@ -7,4 +7,4 @@
         - NAME@12..21
             - IDENT@12..21 "Direction"
 - ERROR@21:21 "expected Directive or Enum Values Definition" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0007_fragment_definition_with_invalid_fragment_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0007_fragment_definition_with_invalid_fragment_name.txt
@@ -25,4 +25,4 @@
             - WHITESPACE@34..35 "\n"
             - R_CURLY@35..36 "}"
 - ERROR@9:11 "Fragment Name cannot be 'on'" on
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0008_fragment_definition_with_invalid_type_condition.txt
+++ b/crates/apollo-parser/test_data/parser/err/0008_fragment_definition_with_invalid_type_condition.txt
@@ -26,4 +26,4 @@
             - WHITESPACE@44..45 "\n"
             - R_CURLY@45..46 "}"
 - ERROR@22:26 "exptected 'on'" User
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0009_fragment_definition_with_invalid_selection_set.txt
+++ b/crates/apollo-parser/test_data/parser/err/0009_fragment_definition_with_invalid_selection_set.txt
@@ -13,4 +13,4 @@
                 - NAME@25..29
                     - IDENT@25..29 "User"
 - ERROR@29:29 "expected a Selection Set" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0010_input_definition_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0010_input_definition_with_missing_name.txt
@@ -27,4 +27,4 @@
             - WHITESPACE@33..34 "\n"
             - R_CURLY@34..35 "}"
 - ERROR@6:7 "expected a Name" {
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0011_input_definition_with_missing_input_values.txt
+++ b/crates/apollo-parser/test_data/parser/err/0011_input_definition_with_missing_input_values.txt
@@ -9,4 +9,4 @@
             - L_CURLY@25..26 "{"
             - R_CURLY@26..27 "}"
 - ERROR@26:27 "expected an Input Value Definition" }
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0012_input_extension_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0012_input_extension_with_missing_name.txt
@@ -18,4 +18,4 @@
             - WHITESPACE@28..29 "\n"
             - R_CURLY@29..30 "}"
 - ERROR@13:14 "expected a Name" {
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0013_input_extension_with_missing_requirements.txt
+++ b/crates/apollo-parser/test_data/parser/err/0013_input_extension_with_missing_requirements.txt
@@ -7,4 +7,4 @@
         - NAME@13..31
             - IDENT@13..31 "ExampleInputObject"
 - ERROR@31:31 "expected Directives or an Input Fields Definition" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0014_interface_extension_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0014_interface_extension_with_missing_name.txt
@@ -18,4 +18,4 @@
             - WHITESPACE@33..34 "\n"
             - R_CURLY@34..35 "}"
 - ERROR@17:18 "expected a Name" {
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0015_interface_extension_with_missing_requirements.txt
+++ b/crates/apollo-parser/test_data/parser/err/0015_interface_extension_with_missing_requirements.txt
@@ -7,4 +7,4 @@
         - NAME@17..29
             - IDENT@17..29 "ValuedEntity"
 - ERROR@29:29 "exptected an Implements Interfaces, Directives, or a Fields Definition" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0016_object_type_extension_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0016_object_type_extension_with_missing_name.txt
@@ -36,4 +36,4 @@
             - WHITESPACE@60..61 "\n"
             - R_CURLY@61..62 "}"
 - ERROR@12:13 "expected a Name" {
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0017_object_type_extension_with_missing_requirements.txt
+++ b/crates/apollo-parser/test_data/parser/err/0017_object_type_extension_with_missing_requirements.txt
@@ -7,4 +7,4 @@
         - NAME@12..18
             - IDENT@12..18 "Person"
 - ERROR@18:18 "expected an Implements Interface, Directives or a Fields Definition" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0018_scalar_definition_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0018_scalar_definition_with_missing_name.txt
@@ -8,4 +8,4 @@
                 - NAME@8..18
                     - IDENT@8..18 "deprecated"
 - ERROR@7:8 "expected a Name" @
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0019_scalar_extension_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0019_scalar_extension_with_missing_name.txt
@@ -10,4 +10,4 @@
                 - NAME@15..25
                     - IDENT@15..25 "deprecated"
 - ERROR@14:15 "expected a Name" @
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0020_union_definition_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0020_union_definition_with_missing_name.txt
@@ -15,4 +15,4 @@
                 - NAME@16..22
                     - IDENT@16..22 "Person"
 - ERROR@6:7 "expected a Name" =
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0021_union_definition_with_missing_union_members.txt
+++ b/crates/apollo-parser/test_data/parser/err/0021_union_definition_with_missing_union_members.txt
@@ -6,4 +6,4 @@
             - EQ@6..7 "="
 - ERROR@6:7 "expected a Name" =
 - ERROR@7:7 "expected Union Member Types" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0022_union_extension_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0022_union_extension_with_missing_name.txt
@@ -17,4 +17,4 @@
                 - NAME@23..29
                     - IDENT@23..29 "Person"
 - ERROR@13:14 "expected a Name" =
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0023_union_extension_with_missing_requirements.txt
+++ b/crates/apollo-parser/test_data/parser/err/0023_union_extension_with_missing_requirements.txt
@@ -7,4 +7,4 @@
         - NAME@13..25
             - IDENT@13..25 "SearchResult"
 - ERROR@25:25 "expected Directives or Union Member Types" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0024_document_with_incorrect_definition.txt
+++ b/crates/apollo-parser/test_data/parser/err/0024_document_with_incorrect_definition.txt
@@ -1,4 +1,4 @@
 - DOCUMENT@0..21
     - ERROR@0..21 "awsas8d2934213hkj0987"
 - ERROR@0:21 "expected definition" awsas8d2934213hkj0987
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0025_document_with_incorrect_definition_and_selection_set.txt
+++ b/crates/apollo-parser/test_data/parser/err/0025_document_with_incorrect_definition_and_selection_set.txt
@@ -15,4 +15,4 @@
             - WHITESPACE@39..40 "\n"
             - R_CURLY@40..41 "}"
 - ERROR@0:14 "expected definition" uasdf21230jkdw
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0026_invalid_definition_squished_between_two_valid_definitions.txt
+++ b/crates/apollo-parser/test_data/parser/err/0026_invalid_definition_squished_between_two_valid_definitions.txt
@@ -56,4 +56,4 @@
             - WHITESPACE@138..139 "\n"
             - R_CURLY@139..140 "}"
 - ERROR@99:113 "expected definition" uasdf21230jkdw
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 4

--- a/crates/apollo-parser/test_data/parser/err/0027_invalid_type_system_extension.txt
+++ b/crates/apollo-parser/test_data/parser/err/0027_invalid_type_system_extension.txt
@@ -4,4 +4,4 @@
     - ERROR@7..10 "Cat"
 - ERROR@0:6 "Invalid Type System Extension. This extension cannot be applied." extend
 - ERROR@7:10 "expected definition" Cat
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0028_invalid_type_system_extension_followed_by_valid.txt
+++ b/crates/apollo-parser/test_data/parser/err/0028_invalid_type_system_extension_followed_by_valid.txt
@@ -26,4 +26,4 @@
             - R_CURLY@60..61 "}"
 - ERROR@0:6 "Invalid Type System Extension. This extension cannot be applied." extend
 - ERROR@7:10 "expected definition" Cat
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0029_operation_definition_with_empty_selection_set.txt
+++ b/crates/apollo-parser/test_data/parser/err/0029_operation_definition_with_empty_selection_set.txt
@@ -7,4 +7,4 @@
             - L_CURLY@6..7 "{"
             - R_CURLY@7..8 "}"
 - ERROR@7:8 "expected at least one Selection in Selection Set" }
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0030_operation_definition_with_description.txt
+++ b/crates/apollo-parser/test_data/parser/err/0030_operation_definition_with_description.txt
@@ -13,4 +13,4 @@
             - R_CURLY@107..108 "}"
 - ERROR@0:93 "expected an Operation Type or a Selection Set" "after this PR this should not be an issue: https://github.com/graphql/graphql-spec/pull/892"
 - ERROR@107:108 "expected at least one Selection in Selection Set" }
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0031_argument_with_erronous_string_value.txt
+++ b/crates/apollo-parser/test_data/parser/err/0031_argument_with_erronous_string_value.txt
@@ -18,4 +18,4 @@
             - R_CURLY@15..16 "}"
 - ERROR@13:25 "unexpected escaped character" "\string ID"
 - ERROR@25:26 "expected a valid Value" )
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0032_input_value_with_erronous_string_value.txt
+++ b/crates/apollo-parser/test_data/parser/err/0032_input_value_with_erronous_string_value.txt
@@ -38,4 +38,4 @@
 - ERROR@50:70 "unexpected escaped character" "\a reference image"
 - ERROR@70:71 "expected a Type" )
 - ERROR@70:71 "expected an Input Value Definition" )
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0033_directive_with_erronous_string_value.txt
+++ b/crates/apollo-parser/test_data/parser/err/0033_directive_with_erronous_string_value.txt
@@ -68,4 +68,4 @@
             - R_CURLY@118..119 "}"
 - ERROR@105:128 "unexpected escaped character" "\ errronous string \""
 - ERROR@128:129 "expected a valid Value" )
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0034_unterminated_string_value_in_list.txt
+++ b/crates/apollo-parser/test_data/parser/err/0034_unterminated_string_value_in_list.txt
@@ -47,4 +47,4 @@ type Vehicle @key(fields: "
 }
 
 - ERROR@237:237 "expected R_PAREN, got EOF" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0035_unterminated_string_value_in_object_value.txt
+++ b/crates/apollo-parser/test_data/parser/err/0035_unterminated_string_value_in_object_value.txt
@@ -56,4 +56,4 @@
 - ERROR@116:116 "expected }" EOF
 - ERROR@116:116 "expected R_PAREN, got EOF" EOF
 - ERROR@116:116 "expected R_CURLY, got EOF" EOF
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 6

--- a/crates/apollo-parser/test_data/parser/err/0036_unterminated_string_in_default_value.txt
+++ b/crates/apollo-parser/test_data/parser/err/0036_unterminated_string_in_default_value.txt
@@ -40,4 +40,4 @@
 - ERROR@112:112 "expected R_PAREN, got EOF" EOF
 - ERROR@112:112 "expected a type" EOF
 - ERROR@112:112 "expected R_CURLY, got EOF" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0040_operation_definition_missing_selection_set.txt
+++ b/crates/apollo-parser/test_data/parser/err/0040_operation_definition_missing_selection_set.txt
@@ -8,4 +8,4 @@
         - WHITESPACE@16..17 " "
         - ERROR@17..18 "}"
 - ERROR@17:18 "expected a Selection Set" }
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0041_operation_definition_with_missing_selection_set.txt
+++ b/crates/apollo-parser/test_data/parser/err/0041_operation_definition_with_missing_selection_set.txt
@@ -7,4 +7,4 @@
             - IDENT@6..16 "__typename"
         - ERROR@16..16 ""
 - ERROR@16:16 "expected a Selection Set" EOF
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
+++ b/crates/apollo-parser/test_data/parser/err/0042_document_with_incorrect_token.txt
@@ -42,4 +42,4 @@
             - R_CURLY@82..83 "}"
 - ERROR@0:1 "expected a StringValue, Name or OperationDefinition" @
 - ERROR@49:50 "expected a StringValue, Name or OperationDefinition" }
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0043_type_with_trailing_garbage.txt
+++ b/crates/apollo-parser/test_data/parser/err/0043_type_with_trailing_garbage.txt
@@ -58,4 +58,4 @@
             - R_CURLY@80..81 "}"
     - WHITESPACE@81..82 "\n"
 - ERROR@48:52 "expected a type" name
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0044_list_type_with_no_type.txt
+++ b/crates/apollo-parser/test_data/parser/err/0044_list_type_with_no_type.txt
@@ -57,4 +57,4 @@
 - ERROR@65:66 "expected a StringValue, Name or OperationDefinition" ]
 - ERROR@66:67 "expected a StringValue, Name or OperationDefinition" ]
 - ERROR@68:69 "expected a StringValue, Name or OperationDefinition" }
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 3

--- a/crates/apollo-parser/test_data/parser/err/0045_ignored_token_spans.txt
+++ b/crates/apollo-parser/test_data/parser/err/0045_ignored_token_spans.txt
@@ -37,4 +37,4 @@
     - WHITESPACE@114..115 "\n"
 - ERROR@0:4 "expected definition" cats
 - ERROR@78:82 "expected definition" cats
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0046_incomplete_spreads.txt
+++ b/crates/apollo-parser/test_data/parser/err/0046_incomplete_spreads.txt
@@ -16,4 +16,4 @@
             - R_CURLY@15..16 "}"
     - WHITESPACE@16..17 "\n"
 - ERROR@10:13 "expected an Inline Fragment or a Fragment Spread" ...
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0047_empty_variable_definition.txt
+++ b/crates/apollo-parser/test_data/parser/err/0047_empty_variable_definition.txt
@@ -18,4 +18,4 @@
             - WHITESPACE@20..21 "\n"
             - R_CURLY@21..22 "}"
 - ERROR@9:10 "expected a Variable Definition" )
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/err/0048_unbalanced_list_type_1.txt
+++ b/crates/apollo-parser/test_data/parser/err/0048_unbalanced_list_type_1.txt
@@ -29,4 +29,4 @@
 - ERROR@36:37 "expected R_CURLY, got ]" ]
 - ERROR@36:37 "expected a StringValue, Name or OperationDefinition" ]
 - ERROR@38:39 "expected a StringValue, Name or OperationDefinition" }
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/err/0049_unbalanced_list_type_2.txt
+++ b/crates/apollo-parser/test_data/parser/err/0049_unbalanced_list_type_2.txt
@@ -28,4 +28,4 @@
             - R_CURLY@38..39 "}"
     - WHITESPACE@39..40 "\n"
 - ERROR@38:39 "expected R_BRACK, got }" }
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 3

--- a/crates/apollo-parser/test_data/parser/ok/0001_empty.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0001_empty.txt
@@ -1,2 +1,2 @@
 - DOCUMENT@0..0
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0002_selection_simple.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0002_selection_simple.txt
@@ -12,4 +12,4 @@
                     - IDENT@14..23 "faveSnack"
             - WHITESPACE@23..24 "\n"
             - R_CURLY@24..25 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0003_selection_with_fields.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0003_selection_with_fields.txt
@@ -56,4 +56,4 @@
                     - IDENT@168..177 "faveSnack"
             - WHITESPACE@177..178 "\n"
             - R_CURLY@178..179 "}"
-recursion limit: 4096, high: 4
+recursion limit: 500, high: 3

--- a/crates/apollo-parser/test_data/parser/ok/0004_selection_with_fields_aliases_arguments.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0004_selection_with_fields_aliases_arguments.txt
@@ -71,4 +71,4 @@
                     - R_PAREN@199..200 ")"
             - WHITESPACE@200..201 "\n"
             - R_CURLY@201..202 "}"
-recursion limit: 4096, high: 4
+recursion limit: 500, high: 3

--- a/crates/apollo-parser/test_data/parser/ok/0005_selection_with_inline_fragments.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0005_selection_with_inline_fragments.txt
@@ -40,4 +40,4 @@
                     - R_CURLY@88..89 "}"
             - WHITESPACE@89..90 "\n"
             - R_CURLY@90..91 "}"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 3

--- a/crates/apollo-parser/test_data/parser/ok/0006_selection_with_fragment_spread.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0006_selection_with_fragment_spread.txt
@@ -113,4 +113,4 @@
             - WHITESPACE@207..208 "\n"
             - R_CURLY@208..209 "}"
     - WHITESPACE@209..210 "\n"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0007_directive_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0007_directive_definition.txt
@@ -11,4 +11,4 @@
         - DIRECTIVE_LOCATIONS@22..27
             - DIRECTIVE_LOCATION@22..27
                 - FIELD_KW@22..27 "FIELD"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0008_directive_definition_with_arguments.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0008_directive_definition_with_arguments.txt
@@ -37,4 +37,4 @@
             - WHITESPACE@66..67 " "
             - DIRECTIVE_LOCATION@67..75
                 - MUTATION_KW@67..75 "MUTATION"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0009_directive_definition_repeatable.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0009_directive_definition_repeatable.txt
@@ -39,4 +39,4 @@
             - WHITESPACE@77..78 " "
             - DIRECTIVE_LOCATION@78..86
                 - MUTATION_KW@78..86 "MUTATION"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0010_enum_type_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0010_enum_type_definition.txt
@@ -39,4 +39,4 @@
                         - IDENT@91..95 "WEST"
             - WHITESPACE@95..96 "\n"
             - R_CURLY@96..97 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 4

--- a/crates/apollo-parser/test_data/parser/ok/0011_enum_type_extension.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0011_enum_type_extension.txt
@@ -27,4 +27,4 @@
                         - IDENT@47..51 "WEST"
             - WHITESPACE@51..52 "\n"
             - R_CURLY@52..53 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0012_fragment_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0012_fragment_definition.txt
@@ -45,4 +45,4 @@
                     - R_PAREN@80..81 ")"
             - WHITESPACE@81..82 "\n"
             - R_CURLY@82..83 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0013_fragment_definition_with_fragment_spread.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0013_fragment_definition_with_fragment_spread.txt
@@ -31,4 +31,4 @@
                         - IDENT@55..73 "standardProfilePic"
             - WHITESPACE@73..74 "\n"
             - R_CURLY@74..75 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0014_input_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0014_input_definition.txt
@@ -29,4 +29,4 @@
                     - BANG@51..52 "!"
             - WHITESPACE@52..53 "\n"
             - R_CURLY@53..54 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0015_input_extension.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0015_input_extension.txt
@@ -26,4 +26,4 @@
                         - IDENT@47..53 "String"
             - WHITESPACE@53..54 "\n"
             - R_CURLY@54..55 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0016_interface_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0016_interface_definition.txt
@@ -18,4 +18,4 @@
                         - IDENT@36..39 "Int"
             - WHITESPACE@39..40 "\n"
             - R_CURLY@40..41 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0017_interface_extension.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0017_interface_extension.txt
@@ -26,4 +26,4 @@
                         - IDENT@49..52 "Int"
             - WHITESPACE@52..53 "\n"
             - R_CURLY@53..54 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0018_object_type_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0018_object_type_definition.txt
@@ -51,4 +51,4 @@
                         - IDENT@137..140 "Url"
             - WHITESPACE@140..141 "\n"
             - R_CURLY@141..142 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0019_object_type_extension.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0019_object_type_extension.txt
@@ -51,4 +51,4 @@
                         - IDENT@93..96 "Url"
             - WHITESPACE@96..97 "\n"
             - R_CURLY@97..98 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0020_operation_type_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0020_operation_type_definition.txt
@@ -51,4 +51,4 @@
                     - IDENT@113..117 "lion"
             - WHITESPACE@117..118 "\n"
             - R_CURLY@118..119 "}"
-recursion limit: 4096, high: 3
+recursion limit: 500, high: 3

--- a/crates/apollo-parser/test_data/parser/ok/0021_operation_type_definition_with_arguments.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0021_operation_type_definition_with_arguments.txt
@@ -41,4 +41,4 @@
                     - IDENT@65..70 "treat"
             - WHITESPACE@70..71 "\n"
             - R_CURLY@71..72 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0022_operation_type_definition_with_arguments_and_directives.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0022_operation_type_definition_with_arguments_and_directives.txt
@@ -53,4 +53,4 @@
                     - IDENT@86..91 "treat"
             - WHITESPACE@91..92 "\n"
             - R_CURLY@92..93 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0023_scalar_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0023_scalar_definition.txt
@@ -10,4 +10,4 @@
                 - AT@12..13 "@"
                 - NAME@13..23
                     - IDENT@13..23 "deprecated"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0024_scalar_extension.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0024_scalar_extension.txt
@@ -12,4 +12,4 @@
                 - AT@19..20 "@"
                 - NAME@20..30
                     - IDENT@20..30 "deprecated"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/ok/0025_schema_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0025_schema_definition.txt
@@ -33,4 +33,4 @@
                     - IDENT@82..104 "MySubscriptionRootType"
         - WHITESPACE@104..105 "\n"
         - R_CURLY@105..106 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 3

--- a/crates/apollo-parser/test_data/parser/ok/0026_schema_extension.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0026_schema_extension.txt
@@ -27,4 +27,4 @@
                     - IDENT@42..61 "MyExtendedQueryType"
         - WHITESPACE@61..62 "\n"
         - R_CURLY@62..63 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0027_union_type_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0027_union_type_definition.txt
@@ -17,4 +17,4 @@
             - NAMED_TYPE@29..35
                 - NAME@29..35
                     - IDENT@29..35 "Person"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0028_union_type_definition_followed_by_object_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0028_union_type_definition_followed_by_object_definition.txt
@@ -37,4 +37,4 @@
                         - IDENT@60..63 "Int"
             - WHITESPACE@63..64 "\n"
             - R_CURLY@64..65 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0029_union_type_extension.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0029_union_type_extension.txt
@@ -25,4 +25,4 @@
             - NAMED_TYPE@48..54
                 - NAME@48..54
                     - IDENT@48..54 "Person"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0030_values.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0030_values.txt
@@ -83,4 +83,4 @@
                     - R_PAREN@111..112 ")"
             - WHITESPACE@112..113 "\n"
             - R_CURLY@113..114 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 8

--- a/crates/apollo-parser/test_data/parser/ok/0031_variables_with_default.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0031_variables_with_default.txt
@@ -50,4 +50,4 @@
                     - IDENT@66..72 "animal"
             - WHITESPACE@72..73 "\n"
             - R_CURLY@73..74 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0032_supergraph.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0032_supergraph.txt
@@ -4184,4 +4184,4 @@
                         - IDENT@7486..7492 "String"
             - WHITESPACE@7492..7493 "\n"
             - R_CURLY@7493..7494 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 7

--- a/crates/apollo-parser/test_data/parser/ok/0033_directive_on_argument_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0033_directive_on_argument_definition.txt
@@ -45,4 +45,4 @@
                         - IDENT@85..89 "User"
             - WHITESPACE@89..90 "\n"
             - R_CURLY@90..91 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0034_query_shorthand_followed_by_fragment_definition.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0034_query_shorthand_followed_by_fragment_definition.txt
@@ -37,4 +37,4 @@
                     - IDENT@62..66 "name"
             - WHITESPACE@66..67 "\n"
             - R_CURLY@67..68 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0035_query_with_variables.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0035_query_with_variables.txt
@@ -27,4 +27,4 @@
                     - IDENT@27..31 "name"
             - WHITESPACE@31..32 "\n"
             - R_CURLY@32..33 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 1

--- a/crates/apollo-parser/test_data/parser/ok/0036_parses_variable_definition_with_list_type.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0036_parses_variable_definition_with_list_type.txt
@@ -44,4 +44,4 @@
                     - R_PAREN@57..58 ")"
             - WHITESPACE@58..59 "\n"
             - R_CURLY@59..60 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0037_operation_type_definition_with_inline_fragment.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0037_operation_type_definition_with_inline_fragment.txt
@@ -105,4 +105,4 @@
                     - R_CURLY@190..191 "}"
             - WHITESPACE@191..192 "\n"
             - R_CURLY@192..193 "}"
-recursion limit: 4096, high: 2
+recursion limit: 500, high: 4

--- a/crates/apollo-parser/test_data/parser/ok/0038_wrapped_named_types.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0038_wrapped_named_types.txt
@@ -217,4 +217,4 @@
             - COMMA@221..222 ","
             - WHITESPACE@222..223 "\n"
             - R_CURLY@223..224 "}"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 5

--- a/crates/apollo-parser/test_data/parser/ok/0039_variable_with_directives.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0039_variable_with_directives.txt
@@ -66,4 +66,4 @@
                     - IDENT@103..109 "animal"
             - WHITESPACE@109..110 "\n"
             - R_CURLY@110..111 "}"
-recursion limit: 4096, high: 1
+recursion limit: 500, high: 2

--- a/crates/apollo-parser/test_data/parser/ok/0040_type_token_order.txt
+++ b/crates/apollo-parser/test_data/parser/ok/0040_type_token_order.txt
@@ -58,4 +58,4 @@
             - WHITESPACE@160..161 "\n"
             - R_CURLY@161..162 "}"
     - WHITESPACE@162..163 "\n"
-recursion limit: 4096, high: 0
+recursion limit: 500, high: 1


### PR DESCRIPTION
Sorry for the noisy diff!

This adds a new test in `crates/apollo-parser/src/parser/mod.rs` that would cause stack overflows without the new uses of limits. See also comments in that same file about the change of default limit.