### PR TITLE
Introduce a pair of `Directives` struct

### DIFF
--- a/crates/apollo-compiler/src/ast/from_cst.rs
+++ b/crates/apollo-compiler/src/ast/from_cst.rs
@@ -135,7 +135,9 @@ impl Convert for cst::OperationDefinition {
             variables: collect_opt(file_id, self.variable_definitions(), |x| {
                 x.variable_definitions()
             }),
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             selection_set: self
                 .selection_set()?
                 .selections()
@@ -152,7 +154,9 @@ impl Convert for cst::FragmentDefinition {
         Some(Self::Target {
             name: self.fragment_name()?.name()?.convert(file_id)?,
             type_condition: self.type_condition()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             selection_set: self.selection_set().convert(file_id)??,
         })
     }
@@ -195,7 +199,9 @@ impl Convert for cst::SchemaDefinition {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             // This may represent a syntactically invalid thing: a schema without any root
             // operation definitions. However the presence of a broken schema definition does
             // affect whether a default schema definition should be inserted, so we bubble up the
@@ -215,7 +221,9 @@ impl Convert for cst::ScalarTypeDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
         })
     }
 }
@@ -228,7 +236,9 @@ impl Convert for cst::ObjectTypeDefinition {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
             implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
         })
     }
@@ -242,7 +252,9 @@ impl Convert for cst::InterfaceTypeDefinition {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
             implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
         })
     }
@@ -255,7 +267,9 @@ impl Convert for cst::UnionTypeDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             members: self
                 .union_member_types()
                 .map_or_else(Default::default, |member_types| {
@@ -275,7 +289,9 @@ impl Convert for cst::EnumTypeDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             values: collect_opt(file_id, self.enum_values_definition(), |x| {
                 x.enum_value_definitions()
             }),
@@ -290,7 +306,9 @@ impl Convert for cst::InputObjectTypeDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             fields: collect_opt(file_id, self.input_fields_definition(), |x| {
                 x.input_value_definitions()
             }),
@@ -303,7 +321,9 @@ impl Convert for cst::SchemaExtension {
 
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             root_operations: self
                 .root_operation_type_definitions()
                 .filter_map(|x| x.convert(file_id))
@@ -318,7 +338,9 @@ impl Convert for cst::ScalarTypeExtension {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
         })
     }
 }
@@ -330,7 +352,9 @@ impl Convert for cst::ObjectTypeExtension {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
             implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
         })
     }
@@ -343,7 +367,9 @@ impl Convert for cst::InterfaceTypeExtension {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
             implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
         })
     }
@@ -355,7 +381,9 @@ impl Convert for cst::UnionTypeExtension {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             members: self
                 .union_member_types()
                 .map_or_else(Default::default, |member_types| {
@@ -374,7 +402,9 @@ impl Convert for cst::EnumTypeExtension {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             values: collect_opt(file_id, self.enum_values_definition(), |x| {
                 x.enum_value_definitions()
             }),
@@ -388,7 +418,9 @@ impl Convert for cst::InputObjectTypeExtension {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             fields: collect_opt(file_id, self.input_fields_definition(), |x| {
                 x.input_value_definitions()
             }),
@@ -506,7 +538,9 @@ impl Convert for cst::VariableDefinition {
             name: self.variable()?.name()?.convert(file_id)?,
             ty: with_location(file_id, ty.syntax(), ty.convert(file_id)?),
             default_value,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
         })
     }
 }
@@ -544,7 +578,9 @@ impl Convert for cst::FieldDefinition {
                 x.input_value_definitions()
             }),
             ty: self.ty()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
         })
     }
 }
@@ -580,7 +616,9 @@ impl Convert for cst::InputValueDefinition {
             name: self.name()?.convert(file_id)?,
             ty: with_location(file_id, ty.syntax(), ty.convert(file_id)?),
             default_value,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
         })
     }
 }
@@ -592,7 +630,9 @@ impl Convert for cst::EnumValueDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             value: self.enum_value()?.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
         })
     }
 }
@@ -636,7 +676,9 @@ impl Convert for cst::Field {
             alias: self.alias().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
             arguments: collect_opt(file_id, self.arguments(), |x| x.arguments()),
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             // Use an empty Vec for a field without sub-selections
             selection_set: self.selection_set().convert(file_id)?.unwrap_or_default(),
         })
@@ -649,7 +691,9 @@ impl Convert for cst::FragmentSpread {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             fragment_name: self.fragment_name()?.name()?.convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
         })
     }
 }
@@ -660,7 +704,9 @@ impl Convert for cst::InlineFragment {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             type_condition: self.type_condition().convert(file_id)?,
-            directives: collect_opt(file_id, self.directives(), |x| x.directives()),
+            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+                x.directives()
+            })),
             selection_set: self.selection_set().convert(file_id)??,
         })
     }

--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -9,13 +9,6 @@ use std::fmt;
 use std::hash;
 use std::path::Path;
 
-pub(crate) fn directives_by_name<'def: 'name, 'name>(
-    directives: &'def [Node<Directive>],
-    name: &'name str,
-) -> impl Iterator<Item = &'def Node<Directive>> + 'name {
-    directives.iter().filter(move |dir| dir.name == name)
-}
-
 impl Document {
     /// Create an empty document
     pub fn new() -> Self {
@@ -216,36 +209,29 @@ impl Definition {
         }
     }
 
-    /// Returns an iterator of directives with the given name.
-    ///
-    /// This method is best for repeatable directives. For non-repeatable directives,
-    /// see [`directive_by_name`][Self::directive_by_name] (singular)
-    pub fn directives_by_name<'def: 'name, 'name>(
-        &'def self,
-        name: &'name str,
-    ) -> impl Iterator<Item = &'def Node<Directive>> + 'name {
+    pub fn directives(&self) -> &Directives {
+        static EMPTY: Directives = Directives(Vec::new());
         match self {
-            Self::OperationDefinition(def) => directives_by_name(&def.directives, name),
-            Self::FragmentDefinition(def) => directives_by_name(&def.directives, name),
-            Self::DirectiveDefinition(_) => directives_by_name(&[], name),
-            Self::SchemaDefinition(def) => directives_by_name(&def.directives, name),
-            Self::ScalarTypeDefinition(def) => directives_by_name(&def.directives, name),
-            Self::ObjectTypeDefinition(def) => directives_by_name(&def.directives, name),
-            Self::InterfaceTypeDefinition(def) => directives_by_name(&def.directives, name),
-            Self::UnionTypeDefinition(def) => directives_by_name(&def.directives, name),
-            Self::EnumTypeDefinition(def) => directives_by_name(&def.directives, name),
-            Self::InputObjectTypeDefinition(def) => directives_by_name(&def.directives, name),
-            Self::SchemaExtension(def) => directives_by_name(&def.directives, name),
-            Self::ScalarTypeExtension(def) => directives_by_name(&def.directives, name),
-            Self::ObjectTypeExtension(def) => directives_by_name(&def.directives, name),
-            Self::InterfaceTypeExtension(def) => directives_by_name(&def.directives, name),
-            Self::UnionTypeExtension(def) => directives_by_name(&def.directives, name),
-            Self::EnumTypeExtension(def) => directives_by_name(&def.directives, name),
-            Self::InputObjectTypeExtension(def) => directives_by_name(&def.directives, name),
+            Self::DirectiveDefinition(_) => &EMPTY,
+            Self::OperationDefinition(def) => &def.directives,
+            Self::FragmentDefinition(def) => &def.directives,
+            Self::SchemaDefinition(def) => &def.directives,
+            Self::ScalarTypeDefinition(def) => &def.directives,
+            Self::ObjectTypeDefinition(def) => &def.directives,
+            Self::InterfaceTypeDefinition(def) => &def.directives,
+            Self::UnionTypeDefinition(def) => &def.directives,
+            Self::EnumTypeDefinition(def) => &def.directives,
+            Self::InputObjectTypeDefinition(def) => &def.directives,
+            Self::SchemaExtension(def) => &def.directives,
+            Self::ScalarTypeExtension(def) => &def.directives,
+            Self::ObjectTypeExtension(def) => &def.directives,
+            Self::InterfaceTypeExtension(def) => &def.directives,
+            Self::UnionTypeExtension(def) => &def.directives,
+            Self::EnumTypeExtension(def) => &def.directives,
+            Self::InputObjectTypeExtension(def) => &def.directives,
         }
     }
 
-    directive_by_name_method!();
     serialize_method!();
 }
 
@@ -275,12 +261,10 @@ impl fmt::Debug for Definition {
 }
 
 impl OperationDefinition {
-    directive_methods!();
     serialize_method!();
 }
 
 impl FragmentDefinition {
-    directive_methods!();
     serialize_method!();
 }
 
@@ -289,7 +273,6 @@ impl DirectiveDefinition {
 }
 
 impl SchemaDefinition {
-    directive_methods!();
     serialize_method!();
 }
 impl Extensible for SchemaDefinition {
@@ -297,7 +280,6 @@ impl Extensible for SchemaDefinition {
 }
 
 impl ScalarTypeDefinition {
-    directive_methods!();
     serialize_method!();
 }
 impl Extensible for ScalarTypeDefinition {
@@ -305,7 +287,6 @@ impl Extensible for ScalarTypeDefinition {
 }
 
 impl ObjectTypeDefinition {
-    directive_methods!();
     serialize_method!();
 }
 impl Extensible for ObjectTypeDefinition {
@@ -313,7 +294,6 @@ impl Extensible for ObjectTypeDefinition {
 }
 
 impl InterfaceTypeDefinition {
-    directive_methods!();
     serialize_method!();
 }
 impl Extensible for InterfaceTypeDefinition {
@@ -321,7 +301,6 @@ impl Extensible for InterfaceTypeDefinition {
 }
 
 impl UnionTypeDefinition {
-    directive_methods!();
     serialize_method!();
 }
 impl Extensible for UnionTypeDefinition {
@@ -329,7 +308,6 @@ impl Extensible for UnionTypeDefinition {
 }
 
 impl EnumTypeDefinition {
-    directive_methods!();
     serialize_method!();
 }
 impl Extensible for EnumTypeDefinition {
@@ -337,7 +315,6 @@ impl Extensible for EnumTypeDefinition {
 }
 
 impl InputObjectTypeDefinition {
-    directive_methods!();
     serialize_method!();
 }
 impl Extensible for InputObjectTypeDefinition {
@@ -345,38 +322,92 @@ impl Extensible for InputObjectTypeDefinition {
 }
 
 impl SchemaExtension {
-    directive_methods!();
     serialize_method!();
 }
 
 impl ScalarTypeExtension {
-    directive_methods!();
     serialize_method!();
 }
 
 impl ObjectTypeExtension {
-    directive_methods!();
     serialize_method!();
 }
 
 impl InterfaceTypeExtension {
-    directive_methods!();
     serialize_method!();
 }
 
 impl UnionTypeExtension {
-    directive_methods!();
     serialize_method!();
 }
 
 impl EnumTypeExtension {
-    directive_methods!();
     serialize_method!();
 }
 
 impl InputObjectTypeExtension {
-    directive_methods!();
     serialize_method!();
+}
+
+impl Directives {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Returns an iterator of directives with the given name.
+    ///
+    /// This method is best for repeatable directives. For non-repeatable directives,
+    /// see [`directive_by_name`][Self::directive_by_name] (singular)
+    pub fn get_all<'def: 'name, 'name>(
+        &'def self,
+        name: &'name str,
+    ) -> impl Iterator<Item = &'def Node<Directive>> + 'name {
+        self.0.iter().filter(move |dir| dir.name == name)
+    }
+
+    /// Returns the first directive with the given name, if any.
+    ///
+    /// This method is best for non-repeatable directives. For repeatable directives,
+    /// see [`directives_by_name`][Self::directives_by_name] (plural)
+    pub fn get(&self, name: &str) -> Option<&Node<Directive>> {
+        self.get_all(name).next()
+    }
+
+    serialize_method!();
+}
+
+impl std::ops::Deref for Directives {
+    type Target = Vec<Node<Directive>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Directives {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'a> IntoIterator for &'a Directives {
+    type Item = &'a Node<Directive>;
+
+    type IntoIter = std::slice::Iter<'a, Node<Directive>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Directives {
+    type Item = &'a mut Node<Directive>;
+
+    type IntoIter = std::slice::IterMut<'a, Node<Directive>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
 }
 
 impl Directive {
@@ -455,7 +486,6 @@ impl From<OperationType> for DirectiveLocation {
 }
 
 impl VariableDefinition {
-    directive_methods!();
     serialize_method!();
 }
 
@@ -541,7 +571,6 @@ impl Type {
 }
 
 impl FieldDefinition {
-    directive_methods!();
     serialize_method!();
 }
 
@@ -550,12 +579,10 @@ impl InputValueDefinition {
         matches!(*self.ty, Type::NonNullNamed(_) | Type::NonNullList(_))
     }
 
-    directive_methods!();
     serialize_method!();
 }
 
 impl EnumValueDefinition {
-    directive_methods!();
     serialize_method!();
 }
 
@@ -587,17 +614,14 @@ impl Field {
         self.alias.as_ref().unwrap_or(&self.name)
     }
 
-    directive_methods!();
     serialize_method!();
 }
 
 impl FragmentSpread {
-    directive_methods!();
     serialize_method!();
 }
 
 impl InlineFragment {
-    directive_methods!();
     serialize_method!();
 }
 

--- a/crates/apollo-compiler/src/ast/mod.rs
+++ b/crates/apollo-compiler/src/ast/mod.rs
@@ -93,7 +93,7 @@ pub struct OperationDefinition {
     pub operation_type: OperationType,
     pub name: Option<Name>,
     pub variables: Vec<Node<VariableDefinition>>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub selection_set: Vec<Selection>,
 }
 
@@ -101,7 +101,7 @@ pub struct OperationDefinition {
 pub struct FragmentDefinition {
     pub name: Name,
     pub type_condition: NamedType,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub selection_set: Vec<Selection>,
 }
 
@@ -117,7 +117,7 @@ pub struct DirectiveDefinition {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SchemaDefinition {
     pub description: Option<NodeStr>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub root_operations: Vec<Node<(OperationType, NamedType)>>,
 }
 
@@ -125,7 +125,7 @@ pub struct SchemaDefinition {
 pub struct ScalarTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -133,7 +133,7 @@ pub struct ObjectTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
     pub implements_interfaces: Vec<Name>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub fields: Vec<Node<FieldDefinition>>,
 }
 
@@ -142,7 +142,7 @@ pub struct InterfaceTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
     pub implements_interfaces: Vec<Name>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub fields: Vec<Node<FieldDefinition>>,
 }
 
@@ -150,7 +150,7 @@ pub struct InterfaceTypeDefinition {
 pub struct UnionTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub members: Vec<NamedType>,
 }
 
@@ -158,7 +158,7 @@ pub struct UnionTypeDefinition {
 pub struct EnumTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub values: Vec<Node<EnumValueDefinition>>,
 }
 
@@ -166,27 +166,27 @@ pub struct EnumTypeDefinition {
 pub struct InputObjectTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub fields: Vec<Node<InputValueDefinition>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SchemaExtension {
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub root_operations: Vec<Node<(OperationType, NamedType)>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ScalarTypeExtension {
     pub name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ObjectTypeExtension {
     pub name: Name,
     pub implements_interfaces: Vec<Name>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub fields: Vec<Node<FieldDefinition>>,
 }
 
@@ -194,28 +194,28 @@ pub struct ObjectTypeExtension {
 pub struct InterfaceTypeExtension {
     pub name: Name,
     pub implements_interfaces: Vec<Name>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub fields: Vec<Node<FieldDefinition>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct UnionTypeExtension {
     pub name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub members: Vec<NamedType>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EnumTypeExtension {
     pub name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub values: Vec<Node<EnumValueDefinition>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct InputObjectTypeExtension {
     pub name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub fields: Vec<Node<InputValueDefinition>>,
 }
 
@@ -224,6 +224,9 @@ pub struct Argument {
     pub name: Name,
     pub value: Node<Value>,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Default)]
+pub struct Directives(pub Vec<Node<Directive>>);
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Directive {
@@ -266,7 +269,7 @@ pub struct VariableDefinition {
     pub name: Name,
     pub ty: Node<Type>,
     pub default_value: Option<Node<Value>>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -283,7 +286,7 @@ pub struct FieldDefinition {
     pub name: Name,
     pub arguments: Vec<Node<InputValueDefinition>>,
     pub ty: Type,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -292,14 +295,14 @@ pub struct InputValueDefinition {
     pub name: Name,
     pub ty: Node<Type>,
     pub default_value: Option<Node<Value>>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EnumValueDefinition {
     pub description: Option<NodeStr>,
     pub value: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -314,20 +317,20 @@ pub struct Field {
     pub alias: Option<Name>,
     pub name: Name,
     pub arguments: Vec<Node<Argument>>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub selection_set: Vec<Selection>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct FragmentSpread {
     pub fragment_name: Name,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct InlineFragment {
     pub type_condition: Option<NamedType>,
-    pub directives: Vec<Node<Directive>>,
+    pub directives: Directives,
     pub selection_set: Vec<Selection>,
 }
 

--- a/crates/apollo-compiler/src/macros.rs
+++ b/crates/apollo-compiler/src/macros.rs
@@ -11,32 +11,3 @@ macro_rules! serialize_method {
         }
     };
 }
-
-macro_rules! directive_by_name_method {
-    () => {
-        /// Returns the first directive with the given name, if any.
-        ///
-        /// This method is best for non-repeatable directives. For repeatable directives,
-        /// see [`directives_by_name`][Self::directives_by_name] (plural)
-        pub fn directive_by_name(&self, name: &str) -> Option<&Node<Directive>> {
-            self.directives_by_name(name).next()
-        }
-    };
-}
-
-macro_rules! directive_methods {
-    () => {
-        /// Returns an iterator of directives with the given name.
-        ///
-        /// This method is best for repeatable directives. For non-repeatable directives,
-        /// see [`directive_by_name`][Self::directive_by_name] (singular)
-        pub fn directives_by_name<'def: 'name, 'name>(
-            &'def self,
-            name: &'name str,
-        ) -> impl Iterator<Item = &'def Node<Directive>> + 'name {
-            directives_by_name(&self.directives, name)
-        }
-
-        directive_by_name_method!();
-    };
-}

--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -30,7 +30,7 @@ impl SchemaBuilder {
                 sources: IndexMap::new(),
                 build_errors: Vec::new(),
                 description: None,
-                directives: Vec::new(),
+                directives: Directives::new(),
                 directive_definitions: IndexMap::new(),
                 types: IndexMap::new(),
                 query_type: None,

--- a/crates/apollo-compiler/src/schema/serialize.rs
+++ b/crates/apollo-compiler/src/schema/serialize.rs
@@ -46,7 +46,7 @@ impl Schema {
             Some(ast::Definition::SchemaDefinition(Node::new(
                 ast::SchemaDefinition {
                     description: self.description.clone(),
-                    directives: components(&self.directives, None),
+                    directives: ast::Directives(components(&self.directives, None)),
                     root_operations: root_ops(None),
                 },
             )))
@@ -54,7 +54,7 @@ impl Schema {
         .into_iter()
         .chain(schema_extensions.into_iter().map(move |ext| {
             ast::Definition::SchemaExtension(Node::new(ast::SchemaExtension {
-                directives: components(&self.directives, Some(ext)),
+                directives: ast::Directives(components(&self.directives, Some(ext))),
                 root_operations: root_ops(Some(ext)),
             }))
         }))
@@ -92,13 +92,13 @@ impl ScalarType {
             ast::ScalarTypeDefinition {
                 description: self.description.clone(),
                 name: name.clone(),
-                directives: components(&self.directives, None),
+                directives: ast::Directives(components(&self.directives, None)),
             },
         )))
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::ScalarTypeExtension(Node::new(ast::ScalarTypeExtension {
                 name: name.clone(),
-                directives: components(&self.directives, Some(ext)),
+                directives: ast::Directives(components(&self.directives, Some(ext))),
             }))
         }))
     }
@@ -111,7 +111,7 @@ impl ObjectType {
                 description: self.description.clone(),
                 name: name.clone(),
                 implements_interfaces: names(&self.implements_interfaces, None),
-                directives: components(&self.directives, None),
+                directives: ast::Directives(components(&self.directives, None)),
                 fields: components(self.fields.values(), None),
             },
         )))
@@ -119,7 +119,7 @@ impl ObjectType {
             ast::Definition::ObjectTypeExtension(Node::new(ast::ObjectTypeExtension {
                 name: name.clone(),
                 implements_interfaces: names(&self.implements_interfaces, Some(ext)),
-                directives: components(&self.directives, Some(ext)),
+                directives: ast::Directives(components(&self.directives, Some(ext))),
                 fields: components(self.fields.values(), Some(ext)),
             }))
         }))
@@ -133,7 +133,7 @@ impl InterfaceType {
                 description: self.description.clone(),
                 name: name.clone(),
                 implements_interfaces: names(&self.implements_interfaces, None),
-                directives: components(&self.directives, None),
+                directives: ast::Directives(components(&self.directives, None)),
                 fields: components(self.fields.values(), None),
             },
         )))
@@ -141,7 +141,7 @@ impl InterfaceType {
             ast::Definition::InterfaceTypeExtension(Node::new(ast::InterfaceTypeExtension {
                 name: name.clone(),
                 implements_interfaces: names(&self.implements_interfaces, Some(ext)),
-                directives: components(&self.directives, Some(ext)),
+                directives: ast::Directives(components(&self.directives, Some(ext))),
                 fields: components(self.fields.values(), Some(ext)),
             }))
         }))
@@ -154,14 +154,14 @@ impl UnionType {
             ast::UnionTypeDefinition {
                 description: self.description.clone(),
                 name: name.clone(),
-                directives: components(&self.directives, None),
+                directives: ast::Directives(components(&self.directives, None)),
                 members: names(&self.members, None),
             },
         )))
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::UnionTypeExtension(Node::new(ast::UnionTypeExtension {
                 name: name.clone(),
-                directives: components(&self.directives, Some(ext)),
+                directives: ast::Directives(components(&self.directives, Some(ext))),
                 members: names(&self.members, Some(ext)),
             }))
         }))
@@ -174,14 +174,14 @@ impl EnumType {
             ast::EnumTypeDefinition {
                 description: self.description.clone(),
                 name: name.clone(),
-                directives: components(&self.directives, None),
+                directives: ast::Directives(components(&self.directives, None)),
                 values: components(self.values.values(), None),
             },
         )))
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::EnumTypeExtension(Node::new(ast::EnumTypeExtension {
                 name: name.clone(),
-                directives: components(&self.directives, Some(ext)),
+                directives: ast::Directives(components(&self.directives, Some(ext))),
                 values: components(self.values.values(), Some(ext)),
             }))
         }))
@@ -194,14 +194,14 @@ impl InputObjectType {
             ast::InputObjectTypeDefinition {
                 description: self.description.clone(),
                 name: name.clone(),
-                directives: components(&self.directives, None),
+                directives: ast::Directives(components(&self.directives, None)),
                 fields: components(self.fields.values(), None),
             },
         )))
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::InputObjectTypeExtension(Node::new(ast::InputObjectTypeExtension {
                 name: name.clone(),
-                directives: components(&self.directives, Some(ext)),
+                directives: ast::Directives(components(&self.directives, Some(ext))),
                 fields: components(self.fields.values(), Some(ext)),
             }))
         }))

--- a/crates/apollo-compiler/src/validation/scalar.rs
+++ b/crates/apollo-compiler/src/validation/scalar.rs
@@ -27,10 +27,7 @@ pub fn validate_scalar_definition(
     if !scalar_def.is_built_in() {
         // Custom scalars must provide a scalar specification URL via the
         // @specifiedBy directive
-        let has_specified_by = scalar_def
-            .directives_by_name("specifiedBy")
-            .next()
-            .is_some();
+        let has_specified_by = scalar_def.directives.get("specifiedBy").is_some();
         if !has_specified_by {
             if let Some(location) = scalar_def.location() {
                 diagnostics.push(

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -257,7 +257,7 @@ fn ast_types(db: &dyn ValidationDatabase) -> Arc<ast::TypeSystem> {
         definition: schema_definition.unwrap_or_else(|| {
             Node::new(ast::SchemaDefinition {
                 description: None,
-                directives: vec![],
+                directives: ast::Directives::new(),
                 root_operations: {
                     let mut operations = Vec::with_capacity(3);
                     let query_name = ast::Name::new("Query");


### PR DESCRIPTION
One for the `ast` and `executable` modules, one for the `schema` module. (Containing `Node` v.s. `Component`)

* `x.directive_by_name(n)` becomes `x.directives.get(n)`
* `x.directives_by_name(n)` becomes `x.directives.get_all(n)`
* `x.directives` dereferences to `Vec`

Code that operates on directives of various things can now accept `&Directives` and still use those `get` or `get_all` methods