### PR TITLE
Ignore component origin in == and hash, turn some maps into sets

### DIFF
--- a/crates/apollo-compiler/src/schema/serialize.rs
+++ b/crates/apollo-compiler/src/schema/serialize.rs
@@ -219,10 +219,10 @@ fn components<'a, T: 'a>(
         .collect()
 }
 
-fn names(names: &IndexMap<Name, ComponentOrigin>, ext: Option<&ExtensionId>) -> Vec<Name> {
+fn names(names: &IndexSet<ComponentStr>, ext: Option<&ExtensionId>) -> Vec<Name> {
     names
         .iter()
-        .filter(|(_name, origin)| origin.extension_id() == ext)
-        .map(|(name, _origin)| name.clone())
+        .filter(|component| component.origin.extension_id() == ext)
+        .map(|component| component.node.clone())
         .collect()
 }

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -31,7 +31,7 @@ pub fn get_possible_types<'a>(
                         _ => return None,
                     };
 
-                    if implements.contains_key(&intf.name) {
+                    if implements.contains(&intf.name) {
                         Some(name)
                     } else {
                         None
@@ -40,7 +40,11 @@ pub fn get_possible_types<'a>(
                 .collect()
         }
         // 3. If `type` is a union type, return the set of possible types of `type`.
-        Some(schema::ExtendedType::Union(union_)) => union_.members.keys().collect(),
+        Some(schema::ExtendedType::Union(union_)) => union_
+            .members
+            .iter()
+            .map(|component| &component.node)
+            .collect(),
         _ => Default::default(),
     }
 }

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -179,7 +179,8 @@ pub fn validate_implements_interfaces(
     let transitive_interfaces = interface_definitions.iter().flat_map(|&(name, interface)| {
         interface
             .implements_interfaces
-            .keys()
+            .iter()
+            .map(|component| &component.node)
             .zip(std::iter::repeat(name))
     });
     for (transitive_interface, via_interface) in transitive_interfaces {

--- a/fuzz/fuzz_targets/reparse.rs
+++ b/fuzz/fuzz_targets/reparse.rs
@@ -8,8 +8,8 @@ use log::debug;
 use log::trace;
 use std::fmt::Debug;
 
-const ENABLE_EXECUTABLE: bool = false;
-const ENABLE_SCHEMA: bool = false;
+const ENABLE_EXECUTABLE: bool = true;
+const ENABLE_SCHEMA: bool = true;
 
 fuzz_target!(|input: &str| {
     let _ = env_logger::try_init();


### PR DESCRIPTION
`Component<T>` and `ComponentStr` now compare equal based on their content, without considering anymore whether they come from a definition or an extension.

Because `ExtensionId` is an arbitrary integer, parsing the same SDL twice yields different IDs. This would cause the two `Schema` structs not to compare equal, which made it impossible to use the invariant "serializing and reparsing gives the same tree" for fuzzing.

Additionally, instances of `IndexMap<NodeStr, ComponentOrigin>` have been simplified to the now-equivalent `IndexSet<ComponentStr>`.