### PR TITLE
Add JSON line/column information to diagnostics

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -24,6 +24,7 @@ rowan = "0.15.5"
 salsa = "0.16.1"
 ordered-float = { version = "4.0.0", features = ["std"] }
 thiserror = "1.0.31"
+serde_json = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.4", features = ["serde", "v4", "js"] }

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -24,6 +24,7 @@ rowan = "0.15.5"
 salsa = "0.16.1"
 ordered-float = { version = "4.0.0", features = ["std"] }
 thiserror = "1.0.31"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -9,19 +9,66 @@ use std::sync::Arc;
 #[error("Unknown file ID")]
 struct UnknownFileError;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ByteCharIndex {
+    map: Vec<u32>,
+}
+
+impl ByteCharIndex {
+    fn new(input: &str) -> Self {
+        let mut map = vec![0; input.len() + 1];
+        let mut char_index = 0;
+        for (byte_index, _) in input.char_indices() {
+            map[byte_index] = char_index;
+            char_index += 1;
+        }
+
+        // Support 1 past the end of the string, for use in exclusive ranges.
+        map[input.len()] = char_index;
+
+        Self { map }
+    }
+}
+
+/// Source text structure with a precomputed index from byte offsets to character offsets and to
+/// line/column numbers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MappedSource {
+    ariadne: AriadneSource,
+    index: ByteCharIndex,
+}
+
+impl MappedSource {
+    fn new(input: &str) -> Self {
+        let ariadne = AriadneSource::from(input);
+        let index = ByteCharIndex::new(input);
+
+        Self { ariadne, index }
+    }
+
+    pub(crate) fn map_index(&self, byte_index: usize) -> usize {
+        self.index.map[byte_index] as usize
+    }
+}
+
 /// A Cache implementation for `ariadne` diagnostics.
 ///
 /// Use [`InputDatabase::source_cache`] to construct one.
 #[derive(Clone, PartialEq, Eq)]
 pub struct SourceCache {
-    sources: HashMap<FileId, Arc<AriadneSource>>,
+    sources: HashMap<FileId, Arc<MappedSource>>,
     paths: HashMap<FileId, PathBuf>,
 }
 
 impl SourceCache {
+    pub(crate) fn get_source(&self, id: FileId) -> Option<&'_ MappedSource> {
+        self.sources.get(&id).map(|arc| arc.as_ref())
+    }
+
     pub fn get_line_column(&self, id: FileId, index: usize) -> Option<(usize, usize)> {
         let source = self.sources.get(&id)?;
-        let (_, line, column) = source.get_offset_line(index)?;
+        let char_index = source.map_index(index);
+        let (_, line, column) = source.ariadne.get_offset_line(char_index)?;
         Some((line, column))
     }
 }
@@ -30,7 +77,7 @@ impl AriadneCache<FileId> for &SourceCache {
     fn fetch(&mut self, id: &FileId) -> Result<&AriadneSource, Box<dyn std::fmt::Debug>> {
         let source = self.sources.get(id);
         source
-            .map(|arc| &**arc)
+            .map(|arc| &arc.ariadne)
             .ok_or_else(|| Box::new(UnknownFileError) as Box<dyn std::fmt::Debug>)
     }
     fn display<'a>(&self, id: &'a FileId) -> Option<Box<dyn std::fmt::Display + 'a>> {
@@ -95,7 +142,7 @@ pub trait InputDatabase {
     /// Get the GraphQL source text for a file, split up into lines for
     /// printing diagnostics.
     #[salsa::invoke(source_with_lines)]
-    fn source_with_lines(&self, file_id: FileId) -> Arc<AriadneSource>;
+    fn source_with_lines(&self, file_id: FileId) -> Arc<MappedSource>;
 
     /// Get all GraphQL sources known to the compiler, split up into lines
     /// for printing diagnostics.
@@ -132,9 +179,9 @@ fn source_type(db: &dyn InputDatabase, file_id: FileId) -> SourceType {
     db.input(file_id).source_type()
 }
 
-fn source_with_lines(db: &dyn InputDatabase, file_id: FileId) -> Arc<AriadneSource> {
+fn source_with_lines(db: &dyn InputDatabase, file_id: FileId) -> Arc<MappedSource> {
     let code = db.source_code(file_id);
-    Arc::new(AriadneSource::from(code))
+    Arc::new(MappedSource::new(&code))
 }
 
 fn source_cache(db: &dyn InputDatabase) -> Arc<SourceCache> {

--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -9,13 +9,18 @@ use std::sync::Arc;
 #[error("Unknown file ID")]
 struct UnknownFileError;
 
+/// Source text structure with a precomputed index from byte offsets to character offsets and to
+/// line/column numbers.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ByteCharIndex {
+pub struct MappedSource {
+    ariadne: AriadneSource,
     map: Vec<u32>,
 }
 
-impl ByteCharIndex {
+impl MappedSource {
     fn new(input: &str) -> Self {
+        let ariadne = AriadneSource::from(input);
+
         let mut map = vec![0; input.len() + 1];
         let mut char_index = 0;
         for (byte_index, _) in input.char_indices() {
@@ -26,28 +31,11 @@ impl ByteCharIndex {
         // Support 1 past the end of the string, for use in exclusive ranges.
         map[input.len()] = char_index;
 
-        Self { map }
-    }
-}
-
-/// Source text structure with a precomputed index from byte offsets to character offsets and to
-/// line/column numbers.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MappedSource {
-    ariadne: AriadneSource,
-    index: ByteCharIndex,
-}
-
-impl MappedSource {
-    fn new(input: &str) -> Self {
-        let ariadne = AriadneSource::from(input);
-        let index = ByteCharIndex::new(input);
-
-        Self { ariadne, index }
+        Self { ariadne, map }
     }
 
     pub(crate) fn map_index(&self, byte_index: usize) -> usize {
-        self.index.map[byte_index] as usize
+        self.map[byte_index] as usize
     }
 }
 

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -123,6 +123,11 @@ impl ApolloDiagnostic {
         self.labels.push(label);
         self
     }
+
+    pub fn get_line_column(&self) -> Option<(usize, usize)> {
+        self.cache
+            .get_line_column(self.location.file_id, self.location.offset)
+    }
 }
 
 impl fmt::Display for ApolloDiagnostic {

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -411,4 +411,20 @@ impl ApolloDiagnostic {
         }
         builder.finish()
     }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        let mut locations = vec![];
+
+        if let Some((line, column)) = self.get_line_column() {
+            locations.push(serde_json::json!({
+                "line": line,
+                "column": column,
+            }));
+        }
+
+        serde_json::json!({
+            "message": self.data.to_string(),
+            "locations": locations,
+        })
+    }
 }

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -12,7 +12,7 @@ use salsa::ParallelDatabase;
 use validation::ValidationDatabase;
 
 pub use database::{hir, AstDatabase, FileId, HirDatabase, InputDatabase, RootDatabase, Source};
-pub use diagnostics::ApolloDiagnostic;
+pub use diagnostics::{ApolloDiagnostic, GraphQLError, GraphQLLocation};
 
 pub struct ApolloCompiler {
     pub db: RootDatabase,

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -743,6 +743,17 @@ type TestObject {
             "cannot query field `nickname` on type `TestObject`"
         );
         assert_eq!(diagnostics[0].get_line_column(), Some((4, 8)));
+        let json = expect_test::expect![[r#"
+            {
+              "locations": [
+                {
+                  "column": 8,
+                  "line": 4
+                }
+              ],
+              "message": "cannot query field `nickname` on type `TestObject`"
+            }"#]];
+        json.assert_eq(&serde_json::to_string_pretty(&diagnostics[0].to_json()).unwrap());
     }
 
     #[test]

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -745,13 +745,13 @@ type TestObject {
         assert_eq!(diagnostics[0].get_line_column(), Some((4, 8)));
         let json = expect_test::expect![[r#"
             {
+              "message": "cannot query field `nickname` on type `TestObject`",
               "locations": [
                 {
-                  "column": 8,
-                  "line": 4
+                  "line": 4,
+                  "column": 8
                 }
-              ],
-              "message": "cannot query field `nickname` on type `TestObject`"
+              ]
             }"#]];
         json.assert_eq(&serde_json::to_string_pretty(&diagnostics[0].to_json()).unwrap());
     }

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -637,6 +637,7 @@ query {
             diagnostics[0].data.to_string(),
             "executable documents must not contain ObjectTypeDefinition"
         );
+        assert_eq!(diagnostics[0].get_line_column(), Some((1, 0)));
     }
 
     #[test]
@@ -741,6 +742,7 @@ type TestObject {
             diagnostics[0].data.to_string(),
             "cannot query field `nickname` on type `TestObject`"
         );
+        assert_eq!(diagnostics[0].get_line_column(), Some((4, 8)));
     }
 
     #[test]


### PR DESCRIPTION
This does a few things...
- Work around ariadne using character indices. We build a map of byte indices to character indices to use for this. This takes up to 4x the memory of input source text. Storage could be reduced by only storing for example every 16th character and scan through `char_indices()` from there whenever we look up an index. that would still be easier to do than to patch ariadne.
- Add a `get_line_column()` to diagnostics that uses ariadne to look up the line/column for a byte offset.
- Add a `to_json()` and JSON error structures that match the spec. I'm not sure this belongs in apollo-rs, though JSON is a common output format. This would be used in the router to serialize validation errors.

Targeting main as this is intended for use very soon, likely before the router is ported to the new apollo-rs AST.