### PR TITLE
Add an example measuring parsing time and validation time

### DIFF
--- a/crates/apollo-compiler/examples/timed.rs
+++ b/crates/apollo-compiler/examples/timed.rs
@@ -1,0 +1,52 @@
+//! Parse and validate a schema and executable document provided as files.
+//! Print the time taken by each step.
+
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use std::process::ExitCode;
+use std::time::Instant;
+
+fn main() -> ExitCode {
+    let mut args = std::env::args_os();
+    let _arg_0 = args.next(); // filename of this program
+    let arg_1 = args.next();
+    let arg_2 = args.next();
+    let (Some(schema_filename), Some(executable_filename)) = (arg_1, arg_2) else {
+        eprintln!(
+            "Usage: cargo run --release --example timed <schema.graphql> <executable.graphql>"
+        );
+        return ExitCode::FAILURE;
+    };
+
+    let schema_source = std::fs::read_to_string(&schema_filename).unwrap();
+    let executable_source = std::fs::read_to_string(&executable_filename).unwrap();
+
+    let step = format!("Schema parse ({} bytes)", schema_source.len());
+    let schema = timed(&step, || Schema::parse(schema_source, schema_filename));
+
+    if let Err(errors) = timed("Schema validation", || schema.validate()) {
+        println!("Schema is invalid:\n{errors}")
+    }
+
+    let step = format!(
+        "Executable document parse ({} bytes)",
+        executable_source.len()
+    );
+    let doc = timed(&step, || {
+        ExecutableDocument::parse(&schema, executable_source, executable_filename)
+    });
+
+    if let Err(errors) = timed("Executable document validation", || doc.validate(&schema)) {
+        println!("Executable document is invalid:\n{errors}")
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn timed<T>(step: &str, f: impl FnOnce() -> T) -> T {
+    let start = Instant::now();
+    let result = f();
+    let elapsed = start.elapsed();
+    println!("{step}: {:.3} ms", elapsed.as_secs_f32() * 1_000.);
+    result
+}


### PR DESCRIPTION
This is a rough port to apollo-compiler 1.0 of the reproduction code provided in https://github.com/apollographql/apollo-rs/issues/442

This is **not** a proper benchmark and I expect we still have low-hanging fruit in terms of improving performance, so don’t look at the numbers too closely.

----

Example run with GitLab’s 34k lines schema:

https://www.apollographql.com/docs/rover/commands/graphs/#graph-introspect
```
rover graph introspect https://gitlab.com/api/graphql > /tmp/gitlab_schema.graphql
```

… and a trivial query:

```
cargo run --release --example timed \
    /tmp/gitlab_schema.graphql \
    <(echo '{ __typename }')
```
```
Schema parse (1227833 bytes): 63.997 ms
Schema validation: 10.353 ms
Executable document parse (15 bytes): 0.018 ms
Executable document validation: 1.852 ms
```