### PR TITLE
Revert complier v0.11 changes hard to merge with v1.0

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -24,7 +24,6 @@ rowan = "0.15.5"
 salsa = "0.16.1"
 ordered-float = { version = "4.0.0", features = ["std"] }
 thiserror = "1.0.31"
-serde = { version = "1.0", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.4", features = ["serde", "v4", "js"] }
@@ -36,7 +35,6 @@ miette = "5.0"
 notify = "6.0.0"
 criterion = "0.5.1"
 pretty_assertions = "1.3.0"
-serde_json = "1.0"
 
 [[bench]]
 name = "multi-source"

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -12,7 +12,7 @@ use salsa::ParallelDatabase;
 use validation::ValidationDatabase;
 
 pub use database::{hir, AstDatabase, FileId, HirDatabase, InputDatabase, RootDatabase, Source};
-pub use diagnostics::{ApolloDiagnostic, GraphQLError, GraphQLLocation};
+pub use diagnostics::ApolloDiagnostic;
 
 pub struct ApolloCompiler {
     pub db: RootDatabase,

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -204,7 +204,7 @@ pub fn validate_directives(
                 let mut diag = ApolloDiagnostic::new(
                         db,
                         loc.into(),
-                        DiagnosticData::UnsupportedDirectiveLocation {
+                        DiagnosticData::UnsupportedLocation {
                             name: name.into(),
                             dir_loc,
                             directive_def: directive_definition.loc.into(),
@@ -251,7 +251,6 @@ pub fn validate_directives(
                             arg.loc.into(),
                             DiagnosticData::UndefinedArgument {
                                 name: arg.name().into(),
-                                coordinate: format!("@{}", dir.name.src()),
                             },
                         )
                         .label(Label::new(arg.loc, "argument by this name not found"))
@@ -277,11 +276,7 @@ pub fn validate_directives(
                         db,
                         dir.loc.into(),
                         DiagnosticData::RequiredArgument {
-                            coordinate: format!(
-                                "@{}({}:)",
-                                directive_definition.name(),
-                                arg_def.name()
-                            ),
+                            name: arg_def.name().into(),
                         },
                     );
                     diagnostic = diagnostic.label(Label::new(

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -58,9 +58,9 @@ pub fn validate_enum_definition(
                 ApolloDiagnostic::new(
                     db,
                     redefined_definition.into(),
-                    DiagnosticData::UniqueEnumValue {
+                    DiagnosticData::UniqueDefinition {
+                        ty: "enum value",
                         name: value.into(),
-                        coordinate: enum_def.name().to_string(),
                         original_definition: original_definition.into(),
                         redefined_definition: redefined_definition.into(),
                     },

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -58,13 +58,6 @@ pub fn validate_field(
                             arg.loc.into(),
                             DiagnosticData::UndefinedArgument {
                                 name: arg.name().into(),
-                                coordinate: format!(
-                                    "{}.{}",
-                                    // Guaranteed to exist because `field.field_definition()`
-                                    // worked.
-                                    field.parent_obj.as_ref().unwrap(),
-                                    field.name.src(),
-                                ),
                             },
                         )
                         .labels(labels),
@@ -91,14 +84,7 @@ pub fn validate_field(
                     db,
                     field.loc.into(),
                     DiagnosticData::RequiredArgument {
-                        coordinate: format!(
-                            "{}.{}({}:)",
-                            // Guaranteed to exist as we wouldn't know about the expected arguments
-                            // for this field otherwise.
-                            field.parent_obj.as_ref().unwrap(),
-                            field.name(),
-                            arg_def.name()
-                        ),
+                        name: arg_def.name().into(),
                     },
                 );
                 diagnostic = diagnostic.label(Label::new(
@@ -288,17 +274,11 @@ pub fn validate_leaf_field_selection(
                 format!("field `{fname}` type `{tname}` is an interface and must select fields")
             }
             hir::TypeDefinition::UnionTypeDefinition(_) => {
-                format!("field `{fname}` type `{tname}` is a union and must select fields")
+                format!("field `{fname}` type `{tname}` is an union and must select fields")
             }
             _ => return Ok(()),
         };
-        (
-            label,
-            DiagnosticData::MissingSubselection {
-                field: fname,
-                ty: tname.clone(),
-            },
-        )
+        (label, DiagnosticData::MissingSubselection)
     } else {
         let label = match type_def {
             hir::TypeDefinition::EnumTypeDefinition(_) => {
@@ -309,13 +289,7 @@ pub fn validate_leaf_field_selection(
             ),
             _ => return Ok(()),
         };
-        (
-            label,
-            DiagnosticData::DisallowedSubselection {
-                field: fname,
-                ty: tname.clone(),
-            },
-        )
+        (label, DiagnosticData::DisallowedSubselection)
     };
 
     Err(ApolloDiagnostic::new(db, field.loc.into(), diagnostic_data)

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -193,7 +193,7 @@ pub fn validate_input_values(
                 diagnostics.push(
                     ApolloDiagnostic::new(db, loc.into(), DiagnosticData::InputType {
                         name: input_value.name().into(),
-                        ty: input_value.ty().name(),
+                        ty: field_ty.kind(),
                     })
                         .label(Label::new(loc, format!("this is of `{}` type", field_ty.kind())))
                         .help(format!("Scalars, Enums, and Input Objects are input types. Change `{}` field to take one of these input types.", input_value.name())),

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -132,8 +132,6 @@ pub fn validate_interface_definition(
                         db,
                         interface_def.loc().into(),
                         DiagnosticData::MissingField {
-                            name: interface_def.name().to_string(),
-                            interface: super_interface.name().to_string(),
                             field: name.clone(),
                         },
                     )
@@ -234,7 +232,6 @@ pub fn validate_implements_interfaces(
                 db,
                 loc.into(),
                 DiagnosticData::TransitiveImplementedInterfaces {
-                    ty: implementor_name.clone(),
                     missing_interface: undefined.name.clone(),
                 },
             )

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -103,8 +103,6 @@ pub fn validate_object_type_definition(
                     db,
                     object.loc().into(),
                     DiagnosticData::MissingField {
-                        name: object.name().to_string(),
-                        interface: interface.name().to_string(),
                         field: name.to_string(),
                     },
                 )

--- a/crates/apollo-compiler/src/validation/scalar.rs
+++ b/crates/apollo-compiler/src/validation/scalar.rs
@@ -35,9 +35,7 @@ pub fn validate_scalar_definition(
                 ApolloDiagnostic::new(
                     db,
                     scalar_def.loc.into(),
-                    DiagnosticData::ScalarSpecificationURL {
-                        ty: scalar_def.name().into(),
-                    },
+                    DiagnosticData::ScalarSpecificationURL,
                 )
                 .label(Label::new(
                     scalar_def.loc,

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -589,7 +589,6 @@ pub fn validate_executable(db: &dyn ValidationDatabase, file_id: FileId) -> Vec<
 mod tests {
     use super::ValidationDatabase;
     use crate::ApolloCompiler;
-    use crate::GraphQLLocation;
     use crate::HirDatabase;
 
     #[test]
@@ -640,10 +639,6 @@ query {
         assert_eq!(
             diagnostics[0].data.to_string(),
             "executable documents can only contain executable definitions, but `Object` is a(n) ObjectTypeDefinition"
-        );
-        assert_eq!(
-            diagnostics[0].get_line_column(),
-            Some(GraphQLLocation { line: 2, column: 1 })
         );
     }
 
@@ -749,21 +744,6 @@ type TestObject {
             diagnostics[0].data.to_string(),
             "cannot query field `nickname` on type `TestObject`"
         );
-        assert_eq!(
-            diagnostics[0].get_line_column(),
-            Some(GraphQLLocation { line: 5, column: 9 })
-        );
-        let json = expect_test::expect![[r#"
-            {
-              "message": "cannot query field `nickname` on type `TestObject`",
-              "locations": [
-                {
-                  "line": 5,
-                  "column": 9
-                }
-              ]
-            }"#]];
-        json.assert_eq(&serde_json::to_string_pretty(&diagnostics[0].to_json()).unwrap());
     }
 
     #[test]

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -243,7 +243,7 @@ pub fn value_of_correct_type(
                                 db,
                                 val.loc().into(),
                                 DiagnosticData::RequiredArgument {
-                                    coordinate: format!("{}.{}", input_obj.name(), f.name()),
+                                    name: f.name().into(),
                                 },
                             );
                             diagnostic = diagnostic.label(Label::new(

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -35,8 +35,8 @@ pub fn validate_variable_definitions(
                     let ty_name = type_def.kind();
                     diagnostics.push(
                     ApolloDiagnostic::new(db, variable.loc().into(), DiagnosticData::VariableInputType {
-                        name: variable.name().to_string(),
-                        ty: type_def.name().to_string(),
+                        name: variable.name().into(),
+                        ty: ty_name,
                     })
                     .label(Label::new(ty.loc().unwrap(), format!("this is of `{ty_name}` type")))
                     .help("objects, unions, and interfaces cannot be used because variables can only be of input type"),

--- a/crates/apollo-compiler/test_data/diagnostics/0003_anonymous_and_named_operation.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0003_anonymous_and_named_operation.txt
@@ -93,7 +93,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "Mutation.addPet(name:)",
+            name: "name",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0017_schema_with_unspecified_scalar.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0017_schema_with_unspecified_scalar.txt
@@ -24,8 +24,6 @@
             },
         ],
         help: None,
-        data: ScalarSpecificationURL {
-            ty: "URL",
-        },
+        data: ScalarSpecificationURL,
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0018_schema_with_specified_scalar_missing_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0018_schema_with_specified_scalar_missing_values.txt
@@ -24,8 +24,6 @@
             },
         ],
         help: None,
-        data: ScalarSpecificationURL {
-            ty: "URL",
-        },
+        data: ScalarSpecificationURL,
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0019_enum_definition_with_duplicate_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0019_enum_definition_with_duplicate_values.txt
@@ -36,9 +36,9 @@
         help: Some(
             "CAT must only be defined once in this enum.",
         ),
-        data: UniqueEnumValue {
+        data: UniqueDefinition {
+            ty: "enum value",
             name: "CAT",
-            coordinate: "Pet",
             original_definition: DiagnosticLocation {
                 file_id: FileId {
                     id: 19,
@@ -92,9 +92,9 @@
         help: Some(
             "THRIVE_PET_FOODS must only be defined once in this enum.",
         ),
-        data: UniqueEnumValue {
+        data: UniqueDefinition {
+            ty: "enum value",
             name: "THRIVE_PET_FOODS",
-            coordinate: "Snack",
             original_definition: DiagnosticLocation {
                 file_id: FileId {
                     id: 19,

--- a/crates/apollo-compiler/test_data/diagnostics/0025_interface_definition_with_missing_transitive_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0025_interface_definition_with_missing_transitive_fields.txt
@@ -37,8 +37,6 @@
             "An interface must be a super-set of all interfaces it implements",
         ),
         data: MissingField {
-            name: "Image",
-            interface: "Resource",
             field: "width",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0026_interface_definition_with_missing_implemetns_interface.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0026_interface_definition_with_missing_implemetns_interface.txt
@@ -25,7 +25,6 @@
         ],
         help: None,
         data: TransitiveImplementedInterfaces {
-            ty: "Image",
             missing_interface: "Node",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
@@ -37,8 +37,6 @@
             "An interface must be a super-set of all interfaces it implements",
         ),
         data: MissingField {
-            name: "Image",
-            interface: "Resource",
             field: "width",
         },
     },
@@ -68,7 +66,6 @@
         ],
         help: None,
         data: TransitiveImplementedInterfaces {
-            ty: "Image",
             missing_interface: "Node",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0034_object_type_definition_with_missing_transitive_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0034_object_type_definition_with_missing_transitive_fields.txt
@@ -37,8 +37,6 @@
             "An object must provide all fields required by the interfaces it implements",
         ),
         data: MissingField {
-            name: "Query",
-            interface: "Node",
             field: "id",
         },
     },
@@ -80,8 +78,6 @@
             "An object must provide all fields required by the interfaces it implements",
         ),
         data: MissingField {
-            name: "Query",
-            interface: "Resource",
             field: "width",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0035_object_type_definition_with_missing_implements_interfaces_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0035_object_type_definition_with_missing_implements_interfaces_definition.txt
@@ -25,7 +25,6 @@
         ],
         help: None,
         data: TransitiveImplementedInterfaces {
-            ty: "Query",
             missing_interface: "Resource",
         },
     },
@@ -55,7 +54,6 @@
         ],
         help: None,
         data: TransitiveImplementedInterfaces {
-            ty: "Image",
             missing_interface: "Node",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.txt
@@ -28,7 +28,7 @@
         ),
         data: InputType {
             name: "petType",
-            ty: "PetType",
+            ty: "UnionTypeDefinition",
         },
     },
     ApolloDiagnostic {

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
@@ -26,7 +26,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "skip",
             dir_loc: Interface,
             directive_def: DiagnosticLocation {
@@ -75,7 +75,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveB",
             dir_loc: FieldDefinition,
             directive_def: DiagnosticLocation {
@@ -114,7 +114,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "include",
             dir_loc: InputObject,
             directive_def: DiagnosticLocation {
@@ -153,7 +153,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "include",
             dir_loc: InputFieldDefinition,
             directive_def: DiagnosticLocation {
@@ -202,7 +202,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveB",
             dir_loc: Union,
             directive_def: DiagnosticLocation {
@@ -251,7 +251,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveA",
             dir_loc: Enum,
             directive_def: DiagnosticLocation {
@@ -300,7 +300,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveA",
             dir_loc: EnumValue,
             directive_def: DiagnosticLocation {
@@ -339,7 +339,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "deprecated",
             dir_loc: Object,
             directive_def: DiagnosticLocation {
@@ -378,7 +378,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "specifiedBy",
             dir_loc: ArgumentDefinition,
             directive_def: DiagnosticLocation {
@@ -417,7 +417,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "include",
             dir_loc: Schema,
             directive_def: DiagnosticLocation {
@@ -466,7 +466,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveB",
             dir_loc: Scalar,
             directive_def: DiagnosticLocation {
@@ -505,7 +505,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "skip",
             dir_loc: VariableDefinition,
             directive_def: DiagnosticLocation {
@@ -544,7 +544,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "skip",
             dir_loc: Query,
             directive_def: DiagnosticLocation {
@@ -583,7 +583,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "deprecated",
             dir_loc: Field,
             directive_def: DiagnosticLocation {
@@ -632,7 +632,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveB",
             dir_loc: FragmentSpread,
             directive_def: DiagnosticLocation {
@@ -681,7 +681,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveB",
             dir_loc: FragmentDefinition,
             directive_def: DiagnosticLocation {
@@ -730,7 +730,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveA",
             dir_loc: InlineFragment,
             directive_def: DiagnosticLocation {
@@ -779,7 +779,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "directiveA",
             dir_loc: Subscription,
             directive_def: DiagnosticLocation {
@@ -818,7 +818,7 @@
         help: Some(
             "the directive must be used in a location that the service has declared support for",
         ),
-        data: UnsupportedDirectiveLocation {
+        data: UnsupportedLocation {
             name: "skip",
             dir_loc: Mutation,
             directive_def: DiagnosticLocation {

--- a/crates/apollo-compiler/test_data/diagnostics/0053_argument_name_is_not_defined.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0053_argument_name_is_not_defined.txt
@@ -36,7 +36,6 @@
         help: None,
         data: UndefinedArgument {
             name: "arg2",
-            coordinate: "Field.field",
         },
     },
     ApolloDiagnostic {
@@ -76,7 +75,6 @@
         help: None,
         data: UndefinedArgument {
             name: "arg3",
-            coordinate: "Field.field",
         },
     },
     ApolloDiagnostic {
@@ -116,7 +114,6 @@
         help: None,
         data: UndefinedArgument {
             name: "arg2",
-            coordinate: "Query.field",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
@@ -35,7 +35,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleReqs(req1:)",
+            name: "req1",
         },
     },
     ApolloDiagnostic {
@@ -74,7 +74,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleReqs(req2:)",
+            name: "req2",
         },
     },
     ApolloDiagnostic {
@@ -168,7 +168,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleReqs(req1:)",
+            name: "req1",
         },
     },
     ApolloDiagnostic {
@@ -207,7 +207,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "@skip(if:)",
+            name: "if",
         },
     },
     ApolloDiagnostic {
@@ -246,7 +246,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "@include(if:)",
+            name: "if",
         },
     },
     ApolloDiagnostic {
@@ -286,7 +286,6 @@
         help: None,
         data: UndefinedArgument {
             name: "wrong",
-            coordinate: "@include",
         },
     },
     ApolloDiagnostic {
@@ -325,7 +324,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleReqs(req1:)",
+            name: "req1",
         },
     },
     ApolloDiagnostic {
@@ -364,7 +363,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleOptAndReq(req2:)",
+            name: "req2",
         },
     },
     ApolloDiagnostic {
@@ -403,7 +402,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleOptAndReq(req2:)",
+            name: "req2",
         },
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0056_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0056_variables_are_input_types.txt
@@ -28,7 +28,7 @@
         ),
         data: VariableInputType {
             name: "cat",
-            ty: "Cat",
+            ty: "ObjectTypeDefinition",
         },
     },
     ApolloDiagnostic {
@@ -100,7 +100,7 @@
         ),
         data: VariableInputType {
             name: "dog",
-            ty: "Dog",
+            ty: "ObjectTypeDefinition",
         },
     },
     ApolloDiagnostic {
@@ -172,7 +172,7 @@
         ),
         data: VariableInputType {
             name: "pets",
-            ty: "Pet",
+            ty: "InterfaceTypeDefinition",
         },
     },
     ApolloDiagnostic {
@@ -244,7 +244,7 @@
         ),
         data: VariableInputType {
             name: "catOrDog",
-            ty: "CatOrDog",
+            ty: "UnionTypeDefinition",
         },
     },
     ApolloDiagnostic {

--- a/crates/apollo-compiler/test_data/diagnostics/0065_subselection_of_enum.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0065_subselection_of_enum.txt
@@ -34,10 +34,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "pet1",
-            ty: "Pet",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -74,10 +71,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "pet2",
-            ty: "Pet",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -114,10 +108,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "pet3",
-            ty: "Pet",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -154,10 +145,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "pet4",
-            ty: "Pet",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -194,10 +182,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "pet5",
-            ty: "Pet",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -234,9 +219,6 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "pet6",
-            ty: "Pet",
-        },
+        data: DisallowedSubselection,
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0066_subselection_of_scalar.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0066_subselection_of_scalar.txt
@@ -34,10 +34,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "url1",
-            ty: "URL",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -74,10 +71,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "url2",
-            ty: "URL",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -114,10 +108,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "url3",
-            ty: "URL",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -154,10 +145,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "url4",
-            ty: "URL",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -194,10 +182,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "url5",
-            ty: "URL",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -234,9 +219,6 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "url6",
-            ty: "URL",
-        },
+        data: DisallowedSubselection,
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0067_subselection_of_interface.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0067_subselection_of_interface.txt
@@ -34,10 +34,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet1",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -74,10 +71,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet2",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -114,10 +108,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet3",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -154,10 +145,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet4",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -194,10 +182,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet5",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -234,9 +219,6 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet6",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0068_subselection_of_union.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0068_subselection_of_union.txt
@@ -20,7 +20,7 @@
                     offset: 27,
                     length: 4,
                 },
-                text: "field `pet1` type `CatOrDog` is a union and must select fields",
+                text: "field `pet1` type `CatOrDog` is an union and must select fields",
             },
             Label {
                 location: DiagnosticLocation {
@@ -34,10 +34,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet1",
-            ty: "CatOrDog",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -60,7 +57,7 @@
                     offset: 34,
                     length: 4,
                 },
-                text: "field `pet2` type `CatOrDog` is a union and must select fields",
+                text: "field `pet2` type `CatOrDog` is an union and must select fields",
             },
             Label {
                 location: DiagnosticLocation {
@@ -74,10 +71,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet2",
-            ty: "CatOrDog",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -100,7 +94,7 @@
                     offset: 41,
                     length: 4,
                 },
-                text: "field `pet3` type `CatOrDog` is a union and must select fields",
+                text: "field `pet3` type `CatOrDog` is an union and must select fields",
             },
             Label {
                 location: DiagnosticLocation {
@@ -114,10 +108,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet3",
-            ty: "CatOrDog",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -140,7 +131,7 @@
                     offset: 48,
                     length: 4,
                 },
-                text: "field `pet4` type `CatOrDog` is a union and must select fields",
+                text: "field `pet4` type `CatOrDog` is an union and must select fields",
             },
             Label {
                 location: DiagnosticLocation {
@@ -154,10 +145,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet4",
-            ty: "CatOrDog",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -180,7 +168,7 @@
                     offset: 55,
                     length: 4,
                 },
-                text: "field `pet5` type `CatOrDog` is a union and must select fields",
+                text: "field `pet5` type `CatOrDog` is an union and must select fields",
             },
             Label {
                 location: DiagnosticLocation {
@@ -194,10 +182,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet5",
-            ty: "CatOrDog",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -220,7 +205,7 @@
                     offset: 62,
                     length: 4,
                 },
-                text: "field `pet6` type `CatOrDog` is a union and must select fields",
+                text: "field `pet6` type `CatOrDog` is an union and must select fields",
             },
             Label {
                 location: DiagnosticLocation {
@@ -234,9 +219,6 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet6",
-            ty: "CatOrDog",
-        },
+        data: MissingSubselection,
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0069_subselection_of_object.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0069_subselection_of_object.txt
@@ -34,10 +34,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet1",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -74,10 +71,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet2",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -114,10 +108,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet3",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -154,10 +145,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet4",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -194,10 +182,7 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet5",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
     ApolloDiagnostic {
         cache: {
@@ -234,9 +219,6 @@
             },
         ],
         help: None,
-        data: MissingSubselection {
-            field: "pet6",
-            ty: "Pet",
-        },
+        data: MissingSubselection,
     },
 ]

--- a/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
@@ -34,10 +34,7 @@
             },
         ],
         help: None,
-        data: DisallowedSubselection {
-            field: "price",
-            ty: "Int",
-        },
+        data: DisallowedSubselection,
     },
     ApolloDiagnostic {
         cache: {

--- a/crates/apollo-compiler/test_data/diagnostics/0091_recursive_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0091_recursive_interface_definition.txt
@@ -25,7 +25,6 @@
         ],
         help: None,
         data: TransitiveImplementedInterfaces {
-            ty: "A",
             missing_interface: "A",
         },
     },
@@ -55,7 +54,6 @@
         ],
         help: None,
         data: TransitiveImplementedInterfaces {
-            ty: "B",
             missing_interface: "B",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0093_fragment_validation_with_recursive_type_system.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0093_fragment_validation_with_recursive_type_system.txt
@@ -25,7 +25,6 @@
         ],
         help: None,
         data: TransitiveImplementedInterfaces {
-            ty: "A",
             missing_interface: "A",
         },
     },
@@ -55,7 +54,6 @@
         ],
         help: None,
         data: TransitiveImplementedInterfaces {
-            ty: "B",
             missing_interface: "B",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
@@ -240,8 +240,6 @@
             "An object must provide all fields required by the interfaces it implements",
         ),
         data: MissingField {
-            name: "ImplementsBaseButNotExtension",
-            interface: "ExtendedInterface",
             field: "fail",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
@@ -89,9 +89,9 @@
         help: Some(
             "MEMBER_2 must only be defined once in this enum.",
         ),
-        data: UniqueEnumValue {
+        data: UniqueDefinition {
+            ty: "enum value",
             name: "MEMBER_2",
-            coordinate: "E",
             original_definition: DiagnosticLocation {
                 file_id: FileId {
                     id: 94,
@@ -145,9 +145,9 @@
         help: Some(
             "MEMBER_4 must only be defined once in this enum.",
         ),
-        data: UniqueEnumValue {
+        data: UniqueDefinition {
+            ty: "enum value",
             name: "MEMBER_4",
-            coordinate: "E",
             original_definition: DiagnosticLocation {
                 file_id: FileId {
                     id: 94,

--- a/crates/apollo-compiler/test_data/diagnostics/0098_interface_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0098_interface_extensions.txt
@@ -145,8 +145,6 @@
             "An interface must be a super-set of all interfaces it implements",
         ),
         data: MissingField {
-            name: "Derived",
-            interface: "Base",
             field: "b",
         },
     },

--- a/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
@@ -1164,7 +1164,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleReqs(req2:)",
+            name: "req2",
         },
     },
     ApolloDiagnostic {
@@ -1243,7 +1243,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleReqs(req1:)",
+            name: "req1",
         },
     },
     ApolloDiagnostic {
@@ -1282,7 +1282,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplicatedArgs.multipleReqs(req2:)",
+            name: "req2",
         },
     },
     ApolloDiagnostic {
@@ -1321,7 +1321,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplexInput.requiredField",
+            name: "requiredField",
         },
     },
     ApolloDiagnostic {
@@ -1590,7 +1590,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplexInput.requiredField",
+            name: "requiredField",
         },
     },
     ApolloDiagnostic {
@@ -1829,7 +1829,7 @@
         ],
         help: None,
         data: RequiredArgument {
-            coordinate: "ComplexInput.requiredField",
+            name: "requiredField",
         },
     },
     ApolloDiagnostic {

--- a/crates/apollo-compiler/test_data/diagnostics/0103_invalid_type_in_arg.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0103_invalid_type_in_arg.txt
@@ -28,7 +28,7 @@
         ),
         data: InputType {
             name: "thisIsWrong",
-            ty: "OutputType",
+            ty: "ObjectTypeDefinition",
         },
     },
     ApolloDiagnostic {
@@ -118,7 +118,7 @@
         ),
         data: InputType {
             name: "a",
-            ty: "OutputType",
+            ty: "ObjectTypeDefinition",
         },
     },
     ApolloDiagnostic {
@@ -150,7 +150,7 @@
         ),
         data: InputType {
             name: "b",
-            ty: "OperationResult",
+            ty: "UnionTypeDefinition",
         },
     },
 ]


### PR DESCRIPTION
This reverts (except for changelog):
* https://github.com/apollographql/apollo-rs/pull/674
* https://github.com/apollographql/apollo-rs/pull/668

These PRs have been released in apollo-compiler 0.11.3 (so changelog is still relevant to describe that release), but are hard to merge with git into the `compiler-v1.0` branch because they make large changes to code that has diverged significantly or been rewritten in 1.0. Reverting will allow merging `compiler-v1.0` into `main` soon, with the intent that we’ll manually port the reverted functionality and improvements. I’ve pushed a [`compiler-v0.11`](https://github.com/apollographql/apollo-rs/commits/compiler-v0.11) branch with the current contents of `main` (before this PR) in case we need to make further 0.x versions.