### PR TITLE
Validation: never panic or omit a diagnostic on missing location

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -47,8 +47,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   }
   ```
 
+## Fixes
+
+- **Don’t panic in validation or omit diagnostics when a source location is missing - [SimonSapin], [pull/697]:**
+  In apollo-compiler 0.11 every element of the HIR always had a source location because
+  it always came from a parsed input file.
+  In 1.0 source location is always optional.
+  When a node relevant to some diagnostic does not have a source location,
+  the diagnostic should still be emitted but its labels (each printing a bit of source code)
+  may be missing.
+  Essential information should therefore be in the main message, not only in labels.
+
 [SimonSapin]: https://github.com/SimonSapin
 [pull/696]: https://github.com/apollographql/apollo-rs/pull/696
+[pull/697]: https://github.com/apollographql/apollo-rs/pull/697
 
 # [1.0.0-beta.2](https://crates.io/crates/apollo-compiler/1.0.0-beta.1) - 2023-10-10
 

--- a/crates/apollo-compiler/src/executable/validation.rs
+++ b/crates/apollo-compiler/src/executable/validation.rs
@@ -124,10 +124,7 @@ fn compiler_validation(
         compiler.db.validate_standalone_executable(ast_id)
     };
     for diagnostic in diagnostics {
-        errors.push(
-            Some(diagnostic.location),
-            Details::CompilerDiagnostic(diagnostic),
-        )
+        errors.push(diagnostic.location, Details::CompilerDiagnostic(diagnostic))
     }
 }
 
@@ -192,9 +189,6 @@ pub(crate) fn validate_field_set(errors: &mut Diagnostics, schema: &Schema, fiel
     //     compiler.db.validate_standalone_executable(ast_id)
     // };
     for diagnostic in diagnostics {
-        errors.push(
-            Some(diagnostic.location),
-            Details::CompilerDiagnostic(diagnostic),
-        )
+        errors.push(diagnostic.location, Details::CompilerDiagnostic(diagnostic))
     }
 }

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -315,7 +315,7 @@ impl Schema {
         let valid = errors.is_empty();
         for diagnostic in warnings_and_advice {
             errors.push(
-                Some(diagnostic.location),
+                diagnostic.location,
                 crate::validation::Details::CompilerDiagnostic(diagnostic),
             )
         }

--- a/crates/apollo-compiler/src/schema/validation.rs
+++ b/crates/apollo-compiler/src/schema/validation.rs
@@ -68,10 +68,7 @@ fn compiler_validation(errors: &mut Diagnostics, schema: &Schema) -> Vec<crate::
     let mut warnings_and_advice = Vec::new();
     for diagnostic in compiler.db.validate_type_system() {
         if diagnostic.data.is_error() {
-            errors.push(
-                Some(diagnostic.location),
-                Details::CompilerDiagnostic(diagnostic),
-            )
+            errors.push(diagnostic.location, Details::CompilerDiagnostic(diagnostic))
         } else {
             warnings_and_advice.push(diagnostic)
         }

--- a/crates/apollo-compiler/src/validation/argument.rs
+++ b/crates/apollo-compiler/src/validation/argument.rs
@@ -16,9 +16,8 @@ pub(crate) fn validate_arguments(
 
     for argument in arguments {
         let name = &argument.name;
-        if let Some(original) = seen.get(name) {
-            let original_definition = original.unwrap();
-            let redefined_definition = argument.location().unwrap();
+        if let Some(&original_definition) = seen.get(name) {
+            let redefined_definition = argument.location();
             diagnostics.push(
                 ApolloDiagnostic::new(
                     db,

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -148,16 +148,9 @@ pub(crate) fn validate_directive_definition(
     //
     // Returns Recursive Definition error.
     if let Err(directive) = FindRecursiveDirective::check(&db.schema(), &def) {
-        let Some(definition_location) = def.location() else {
-            return vec![];
-        };
-        let Some(head_location) = NodeLocation::recompose(def.location(), def.name.location())
-        else {
-            return vec![];
-        };
-        let Some(directive_location) = directive.location() else {
-            return vec![];
-        };
+        let definition_location = def.location();
+        let head_location = NodeLocation::recompose(def.location(), def.name.location());
+        let directive_location = directive.location();
 
         diagnostics.push(
             ApolloDiagnostic::new(
@@ -199,16 +192,14 @@ pub(crate) fn validate_directives<'dir>(
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
-    let mut seen_directives = HashMap::<_, NodeLocation>::new();
+    let mut seen_directives = HashMap::<_, Option<NodeLocation>>::new();
 
     let schema = db.schema();
     for dir in dirs {
         diagnostics.extend(super::argument::validate_arguments(db, &dir.arguments));
 
         let name = &dir.name;
-        let Some(loc) = dir.location() else {
-            continue;
-        };
+        let loc = dir.location();
         let directive_definition = schema.directive_definitions.get(name);
 
         if let Some(&original_loc) = seen_directives.get(name) {
@@ -238,7 +229,8 @@ pub(crate) fn validate_directives<'dir>(
                     )),
                 );
             }
-        } else if let Some(loc) = NodeLocation::recompose(dir.location(), dir.name.location()) {
+        } else {
+            let loc = NodeLocation::recompose(dir.location(), dir.name.location());
             seen_directives.insert(&dir.name, loc);
         }
 
@@ -252,14 +244,14 @@ pub(crate) fn validate_directives<'dir>(
                         DiagnosticData::UnsupportedLocation {
                             name: name.to_string(),
                             dir_loc,
-                            directive_def: directive_definition.location().unwrap(),
+                            directive_def: directive_definition.location(),
                         },
                 )
                     .label(Label::new(loc, format!("{dir_loc} is not a valid location")))
                     .help("the directive must be used in a location that the service has declared support for");
                 if !directive_definition.is_built_in() {
                     diag = diag.label(Label::new(
-                        directive_definition.location().unwrap(),
+                        directive_definition.location(),
                         format!("consider adding {dir_loc} directive location here"),
                     ));
                 }
@@ -296,13 +288,13 @@ pub(crate) fn validate_directives<'dir>(
                     diagnostics.push(
                         ApolloDiagnostic::new(
                             db,
-                            argument.location().unwrap(),
+                            argument.location(),
                             DiagnosticData::UndefinedArgument {
                                 name: argument.name.to_string(),
                             },
                         )
                         .label(Label::new(
-                            argument.name.location().unwrap(),
+                            argument.name.location(),
                             "argument by this name not found",
                         ))
                         .label(Label::new(loc, "directive declared here")),
@@ -325,18 +317,17 @@ pub(crate) fn validate_directives<'dir>(
                 if arg_def.is_required() && is_null {
                     let mut diagnostic = ApolloDiagnostic::new(
                         db,
-                        dir.location().unwrap(),
+                        dir.location(),
                         DiagnosticData::RequiredArgument {
                             name: arg_def.name.to_string(),
                         },
                     );
                     diagnostic = diagnostic.label(Label::new(
-                        dir.location().unwrap(),
+                        dir.location(),
                         format!("missing value for argument `{}`", arg_def.name),
                     ));
-                    if let Some(loc) = arg_def.location() {
-                        diagnostic = diagnostic.label(Label::new(loc, "argument defined here"));
-                    }
+                    let loc = arg_def.location();
+                    diagnostic = diagnostic.label(Label::new(loc, "argument defined here"));
 
                     diagnostics.push(diagnostic);
                 }

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -49,7 +49,7 @@ pub(crate) fn validate_enum_value(
     //
     // Return a Capitalized Value warning if enum value is not capitalized.
     if enum_val.value != enum_val.value.to_uppercase().as_str() {
-        let location = enum_val.location().unwrap();
+        let location = enum_val.location();
         diagnostics.push(
             ApolloDiagnostic::new(
                 db,

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -62,17 +62,14 @@ pub(crate) fn validate_field(
                     ));
                 }
             } else {
-                let mut labels = vec![Label::new(
-                    argument.location().unwrap(),
-                    "argument name not found",
-                )];
-                if let Some(loc) = field_definition.location() {
-                    labels.push(Label::new(loc, "field declared here"));
-                };
+                let mut labels = vec![Label::new(argument.location(), "argument name not found")];
+                let loc = field_definition.location();
+                labels.push(Label::new(loc, "field declared here"));
+
                 diagnostics.push(
                     ApolloDiagnostic::new(
                         db,
-                        argument.location().unwrap(),
+                        argument.location(),
                         DiagnosticData::UndefinedArgument {
                             name: argument.name.to_string(),
                         },
@@ -97,18 +94,17 @@ pub(crate) fn validate_field(
             if arg_definition.is_required() && is_null {
                 let mut diagnostic = ApolloDiagnostic::new(
                     db,
-                    field.location().unwrap(),
+                    field.location(),
                     DiagnosticData::RequiredArgument {
                         name: arg_definition.name.to_string(),
                     },
                 );
                 diagnostic = diagnostic.label(Label::new(
-                    field.location().unwrap(),
+                    field.location(),
                     format!("missing value for argument `{}`", arg_definition.name),
                 ));
-                if let Some(loc) = arg_definition.location() {
-                    diagnostic = diagnostic.label(Label::new(loc, "argument defined here"));
-                }
+                let loc = arg_definition.location();
+                diagnostic = diagnostic.label(Label::new(loc, "argument defined here"));
 
                 diagnostics.push(diagnostic);
             }
@@ -162,9 +158,7 @@ pub(crate) fn validate_field_definitions(
         diagnostics.extend(validate_field_definition(db, field));
 
         // Field types in Object Types must be of output type
-        let loc = field
-            .location()
-            .expect("undefined field definition location");
+        let loc = field.location();
         if let Some(field_ty) = schema.types.get(field.ty.inner_named_type()) {
             if !field_ty.is_output_type() {
                 // Output types are unreachable
@@ -185,27 +179,17 @@ pub(crate) fn validate_field_definitions(
                         .help(format!("Scalars, Objects, Interfaces, Unions and Enums are output types. Change `{}` field to return one of these output types.", field.name)),
                 );
             }
-        } else if let Some(field_ty_loc) = field.ty.inner_named_type().location() {
+        } else {
+            let field_ty_loc = field.ty.inner_named_type().location();
             diagnostics.push(
                 ApolloDiagnostic::new(
                     db,
                     field_ty_loc,
                     DiagnosticData::UndefinedDefinition {
-                        name: field.name.to_string(),
+                        name: field.ty.inner_named_type().to_string(),
                     },
                 )
                 .label(Label::new(field_ty_loc, "not found in this scope")),
-            );
-        } else {
-            diagnostics.push(
-                ApolloDiagnostic::new(
-                    db,
-                    loc,
-                    DiagnosticData::UndefinedDefinition {
-                        name: field.ty.to_string(),
-                    },
-                )
-                .label(Label::new(loc, "not found in this scope")),
             );
         }
     }
@@ -247,12 +231,10 @@ pub(crate) fn validate_leaf_field_selection(
         return Ok(());
     };
 
-    Err(
-        ApolloDiagnostic::new(db, field.location().unwrap(), diagnostic_data)
-            .label(Label::new(field.location().unwrap(), label))
-            .label(Label::new(
-                type_def.location().unwrap(),
-                format!("`{tname}` declared here"),
-            )),
-    )
+    Err(ApolloDiagnostic::new(db, field.location(), diagnostic_data)
+        .label(Label::new(field.location(), label))
+        .label(Label::new(
+            type_def.location(),
+            format!("`{tname}` declared here"),
+        )))
 }

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -85,39 +85,39 @@ fn validate_fragment_spread_type(
 
                 ApolloDiagnostic::new(
                     db,
-                    spread.location().unwrap(),
+                    spread.location(),
                     DiagnosticData::InvalidFragmentSpread {
                         name: Some(spread.fragment_name.to_string()),
                         type_name: against_type.to_string(),
                     },
                 )
                 .label(Label::new(
-                    spread.location().unwrap(),
+                    spread.location(),
                     format!("fragment `{}` cannot be applied", spread.fragment_name),
                 ))
                 .label(Label::new(
-                    fragment_definition.location().unwrap(),
+                    fragment_definition.location(),
                     format!("fragment declared with type condition `{type_condition}` here"),
                 ))
                 .label(Label::new(
-                    against_type_definition.location().unwrap(),
+                    against_type_definition.location(),
                     format!("type condition `{type_condition}` is not assignable to this type"),
                 ))
             }
             ast::Selection::InlineFragment(inline) => ApolloDiagnostic::new(
                 db,
-                inline.location().unwrap(),
+                inline.location(),
                 DiagnosticData::InvalidFragmentSpread {
                     name: None,
                     type_name: against_type.to_string(),
                 },
             )
             .label(Label::new(
-                inline.location().unwrap(),
+                inline.location(),
                 format!("fragment applied with type condition `{type_condition}` here"),
             ))
             .label(Label::new(
-                against_type_definition.location().unwrap(),
+                against_type_definition.location(),
                 format!("type condition `{type_condition}` is not assignable to this type"),
             )),
         };
@@ -146,7 +146,7 @@ pub(crate) fn validate_inline_fragment(
 
     let has_type_error = if context.has_schema {
         let type_cond_diagnostics = if let Some(t) = &inline.type_condition {
-            validate_fragment_type_condition(db, t, inline.location().unwrap())
+            validate_fragment_type_condition(db, t, inline.location())
         } else {
             Default::default()
         };
@@ -220,13 +220,13 @@ pub(crate) fn validate_fragment_spread(
             diagnostics.push(
                 ApolloDiagnostic::new(
                     db,
-                    spread.location().unwrap(),
+                    spread.location(),
                     DiagnosticData::UndefinedFragment {
                         name: spread.fragment_name.to_string(),
                     },
                 )
                 .labels(vec![Label::new(
-                    spread.location().unwrap(),
+                    spread.location(),
                     format!("fragment `{}` is not defined", spread.fragment_name),
                 )]),
             );
@@ -253,11 +253,8 @@ pub(crate) fn validate_fragment_definition(
     ));
 
     let has_type_error = if context.has_schema {
-        let type_cond_diagnostics = validate_fragment_type_condition(
-            db,
-            &fragment.type_condition,
-            fragment.location().unwrap(),
-        );
+        let type_cond_diagnostics =
+            validate_fragment_type_condition(db, &fragment.type_condition, fragment.location());
         let has_type_error = !type_cond_diagnostics.is_empty();
         diagnostics.extend(type_cond_diagnostics);
         has_type_error
@@ -344,19 +341,13 @@ pub(crate) fn validate_fragment_cycles(
         diagnostics.push(
             ApolloDiagnostic::new(
                 db,
-                def.location().unwrap(),
+                def.location(),
                 DiagnosticData::RecursiveFragmentDefinition {
                     name: def.name.to_string(),
                 },
             )
-            .label(Label::new(
-                head_location.unwrap(),
-                "recursive fragment definition",
-            ))
-            .label(Label::new(
-                cycle.location().unwrap(),
-                "refers to itself here",
-            )),
+            .label(Label::new(head_location, "recursive fragment definition"))
+            .label(Label::new(cycle.location(), "refers to itself here")),
         );
     }
 
@@ -366,7 +357,7 @@ pub(crate) fn validate_fragment_cycles(
 pub(crate) fn validate_fragment_type_condition(
     db: &dyn ValidationDatabase,
     type_cond: &ast::NamedType,
-    fragment_location: NodeLocation,
+    fragment_location: Option<NodeLocation>,
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
     let schema = db.schema();
@@ -398,7 +389,7 @@ pub(crate) fn validate_fragment_type_condition(
                 format!("fragment declares unsupported type condition `{type_cond}`"),
             ))
             .label(Label::new(
-                def.location().unwrap(),
+                def.location(),
                 format!("`{type_cond}` is defined here"),
             ))
             .help("fragments cannot be defined on enums, scalars and input objects");
@@ -445,13 +436,13 @@ pub(crate) fn validate_fragment_used(
         diagnostics.push(
             ApolloDiagnostic::new(
                 db,
-                fragment.location().unwrap(),
+                fragment.location(),
                 DiagnosticData::UnusedFragment {
                     name: fragment_name.to_string(),
                 },
             )
             .label(Label::new(
-                fragment.location().unwrap(),
+                fragment.location(),
                 format!("`{fragment_name}` is defined here"),
             ))
             .help(format!(

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -51,13 +51,13 @@ pub(crate) fn validate_interface_definition(
             diagnostics.push(
                 ApolloDiagnostic::new(
                     db,
-                    implements_interface.location().unwrap(),
+                    implements_interface.location(),
                     DiagnosticData::RecursiveInterfaceDefinition {
                         name: implements_interface.to_string(),
                     },
                 )
                 .label(Label::new(
-                    implements_interface.location().unwrap(),
+                    implements_interface.location(),
                     format!("interface {implements_interface} cannot implement itself"),
                 )),
             );
@@ -94,7 +94,7 @@ pub(crate) fn validate_interface_definition(
                 diagnostics.push(
                     ApolloDiagnostic::new(
                         db,
-                        interface.definition.location().unwrap(),
+                        interface.definition.location(),
                         DiagnosticData::MissingInterfaceField {
                             interface: implements_interface.to_string(),
                             field: super_field.name.to_string(),
@@ -102,20 +102,20 @@ pub(crate) fn validate_interface_definition(
                     )
                     .labels([
                         Label::new(
-                            implements_interface.location().unwrap(),
+                            implements_interface.location(),
                             format!(
                                 "implementation of interface {implements_interface} declared here"
                             ),
                         ),
                         Label::new(
-                            super_field.location().unwrap(),
+                            super_field.location(),
                             format!(
                                 "`{}` was originally defined by {} here",
                                 super_field.name, implements_interface
                             ),
                         ),
                         Label::new(
-                            interface.definition.location().unwrap(),
+                            interface.definition.location(),
                             format!("add `{}` field to this interface", super_field.name),
                         ),
                     ])
@@ -155,9 +155,7 @@ pub(crate) fn validate_implements_interfaces(
         }
 
         // interface_name.loc should always be Some
-        let loc = interface_name
-            .location()
-            .expect("missing implements interface location");
+        let loc = interface_name.location();
         diagnostics.push(
             ApolloDiagnostic::new(
                 db,
@@ -186,13 +184,10 @@ pub(crate) fn validate_implements_interfaces(
             continue;
         }
 
-        let definition_loc = implementor.location().expect("missing interface location");
+        let definition_loc = implementor.location();
         // let via_loc = via_interface
-        //     .location()
-        //     .expect("missing implements interface location");
-        let transitive_loc = transitive_interface
-            .location()
-            .expect("missing implements interface location");
+        //     .location();
+        let transitive_loc = transitive_interface.location();
         diagnostics.push(
             ApolloDiagnostic::new(
                 db,

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -66,26 +66,25 @@ pub(crate) fn validate_object_type_definition(
 
                 let mut labels = vec![
                     Label::new(
-                        implements_interface.location().unwrap(),
+                        implements_interface.location(),
                         format!("implementation of interface {implements_interface} declared here"),
                     ),
                     Label::new(
-                        object.definition.location().unwrap(),
+                        object.definition.location(),
                         format!("add `{}` field to this object", interface_field.name),
                     ),
                 ];
-                if let Some(loc) = interface_field.location() {
-                    labels.push(Label::new(
-                        loc,
-                        format!(
-                            "`{}` was originally defined by {} here",
-                            interface_field.name, implements_interface
-                        ),
-                    ));
-                };
+                let loc = interface_field.location();
+                labels.push(Label::new(
+                    loc,
+                    format!(
+                        "`{}` was originally defined by {} here",
+                        interface_field.name, implements_interface
+                    ),
+                ));
                 diagnostics.push(ApolloDiagnostic::new(
                     db,
-                    object.definition.location().unwrap(),
+                    object.definition.location(),
                     DiagnosticData::MissingInterfaceField {
                         interface: implements_interface.to_string(),
                         field: interface_field.name.to_string(),

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -42,14 +42,14 @@ pub(crate) fn validate_operation(
             diagnostics.push(
                 ApolloDiagnostic::new(
                     db,
-                    operation.location().unwrap(),
+                    operation.location(),
                     DiagnosticData::SingleRootField {
                         fields: fields.len(),
-                        subscription: (operation.location().unwrap()),
+                        subscription: (operation.location()),
                     },
                 )
                 .label(Label::new(
-                    operation.location().unwrap(),
+                    operation.location(),
                     format!("subscription with {} root fields", fields.len()),
                 ))
                 .help(format!(
@@ -77,13 +77,13 @@ pub(crate) fn validate_operation(
             diagnostics.push(
                 ApolloDiagnostic::new(
                     db,
-                    field.location().unwrap(),
+                    field.location(),
                     DiagnosticData::IntrospectionField {
                         field: field.name.to_string(),
                     },
                 )
                 .label(Label::new(
-                    field.location().unwrap(),
+                    field.location(),
                     format!("{} is an introspection field", field.name),
                 )),
             );

--- a/crates/apollo-compiler/src/validation/scalar.rs
+++ b/crates/apollo-compiler/src/validation/scalar.rs
@@ -29,15 +29,15 @@ pub(crate) fn validate_scalar_definition(
         // @specifiedBy directive
         let has_specified_by = scalar_def.directives.has("specifiedBy");
         if !has_specified_by {
-            if let Some(location) = scalar_def.location() {
-                diagnostics.push(
-                    ApolloDiagnostic::new(db, location, DiagnosticData::ScalarSpecificationURL)
-                        .label(Label::new(
-                            location,
-                            "consider adding a @specifiedBy directive to this scalar definition",
-                        )),
-                );
-            }
+            let location = scalar_def.location();
+            diagnostics.push(
+                ApolloDiagnostic::new(db, location, DiagnosticData::ScalarSpecificationURL).label(
+                    Label::new(
+                        location,
+                        "consider adding a @specifiedBy directive to this scalar definition",
+                    ),
+                ),
+            );
         }
 
         diagnostics.extend(super::directive::validate_directives(

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -16,13 +16,12 @@ pub(crate) fn validate_schema_definition(
         .iter()
         .any(|op| op.0 == ast::OperationType::Query);
     if !has_query {
-        if let Some(location) = schema_definition.definition.location() {
-            diagnostics.push(
-                ApolloDiagnostic::new(db, location, DiagnosticData::QueryRootOperationType).label(
-                    Label::new(location, "`query` root operation type must be defined here"),
-                ),
-            );
-        }
+        let location = schema_definition.definition.location();
+        diagnostics.push(
+            ApolloDiagnostic::new(db, location, DiagnosticData::QueryRootOperationType).label(
+                Label::new(location, "`query` root operation type must be defined here"),
+            ),
+        );
     }
     diagnostics.extend(validate_root_operation_definitions(db, &root_operations));
 
@@ -57,30 +56,30 @@ pub(crate) fn validate_root_operation_definitions(
         let type_def = schema.types.get(name);
         if let Some(type_def) = type_def {
             if !matches!(type_def, schema::ExtendedType::Object(_)) {
-                if let Some(op_loc) = name.location() {
-                    let (particle, kind) = match type_def {
-                        schema::ExtendedType::Scalar(_) => ("an", "scalar"),
-                        schema::ExtendedType::Union(_) => ("an", "union"),
-                        schema::ExtendedType::Enum(_) => ("an", "enum"),
-                        schema::ExtendedType::Interface(_) => ("an", "interface"),
-                        schema::ExtendedType::InputObject(_) => ("an", "input object"),
-                        schema::ExtendedType::Object(_) => unreachable!(),
-                    };
-                    diagnostics.push(
-                        ApolloDiagnostic::new(
-                            db,
-                            op_loc,
-                            DiagnosticData::ObjectType {
-                                name: name.to_string(),
-                                ty: kind,
-                            },
-                        )
-                        .label(Label::new(op_loc, format!("This is {particle} {kind}")))
-                        .help("root operation type must be an object type"),
-                    );
-                }
+                let op_loc = name.location();
+                let (particle, kind) = match type_def {
+                    schema::ExtendedType::Scalar(_) => ("an", "scalar"),
+                    schema::ExtendedType::Union(_) => ("an", "union"),
+                    schema::ExtendedType::Enum(_) => ("an", "enum"),
+                    schema::ExtendedType::Interface(_) => ("an", "interface"),
+                    schema::ExtendedType::InputObject(_) => ("an", "input object"),
+                    schema::ExtendedType::Object(_) => unreachable!(),
+                };
+                diagnostics.push(
+                    ApolloDiagnostic::new(
+                        db,
+                        op_loc,
+                        DiagnosticData::ObjectType {
+                            name: name.to_string(),
+                            ty: kind,
+                        },
+                    )
+                    .label(Label::new(op_loc, format!("This is {particle} {kind}")))
+                    .help("root operation type must be an object type"),
+                );
             }
-        } else if let Some(op_loc) = name.location() {
+        } else {
+            let op_loc = name.location();
             diagnostics.push(
                 ApolloDiagnostic::new(
                     db,

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -103,15 +103,15 @@ pub(crate) fn same_response_shape(
     let mismatching_type_diagnostic = || {
         ApolloDiagnostic::new(
             db,
-            field_b.field.location().unwrap(),
+            field_b.field.location(),
             DiagnosticData::ConflictingField {
                 field: field_a.field.name.to_string(),
-                original_selection: (field_a.field.location().unwrap()),
-                redefined_selection: (field_b.field.location().unwrap()),
+                original_selection: (field_a.field.location()),
+                redefined_selection: (field_b.field.location()),
             },
         )
         .label(Label::new(
-            field_a.field.location().unwrap(),
+            field_a.field.location(),
             format!(
                 "`{}` has type `{}` here",
                 field_a.field.response_name(),
@@ -119,7 +119,7 @@ pub(crate) fn same_response_shape(
             ),
         ))
         .label(Label::new(
-            field_b.field.location().unwrap(),
+            field_b.field.location(),
             format!("but the same field name has type `{}` here", full_type_b.ty),
         ))
     };
@@ -237,8 +237,8 @@ fn identical_arguments(
     let args_a = &field_a.arguments;
     let args_b = &field_b.arguments;
 
-    let loc_a = field_a.location().unwrap();
-    let loc_b = field_b.location().unwrap();
+    let loc_a = field_a.location();
+    let loc_b = field_b.location();
 
     // Check if fieldB provides the same argument names and values as fieldA (order-independent).
     for arg in args_a {
@@ -253,7 +253,7 @@ fn identical_arguments(
                         redefined_selection: loc_b,
                     },
                 )
-                .label(Label::new(arg.location().unwrap(), format!("field `{}` is selected with argument `{}` here", field_a.name, arg.name)))
+                .label(Label::new(arg.location(), format!("field `{}` is selected with argument `{}` here", field_a.name, arg.name)))
                 .label(Label::new(loc_b, format!("but argument `{}` is not provided here", arg.name)))
                 .help("Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.")
             );
@@ -270,8 +270,8 @@ fn identical_arguments(
                         redefined_selection: loc_b,
                     },
                 )
-                .label(Label::new(arg.location().unwrap(), format!("field `{}` provides one argument value here", field_a.name)))
-                .label(Label::new(other_arg.location().unwrap(), "but a different value here"))
+                .label(Label::new(arg.location(), format!("field `{}` provides one argument value here", field_a.name)))
+                .label(Label::new(other_arg.location(), "but a different value here"))
                 .help("Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.")
             );
         }
@@ -289,7 +289,7 @@ fn identical_arguments(
                         redefined_selection: loc_b,
                     },
                 )
-                .label(Label::new(arg.location().unwrap(), format!("field `{}` is selected with argument `{}` here", field_b.name, arg.name)))
+                .label(Label::new(arg.location(), format!("field `{}` is selected with argument `{}` here", field_b.name, arg.name)))
                 .label(Label::new(loc_a, format!("but argument `{}` is not provided here", arg.name)))
                 .help("Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.")
             );
@@ -341,15 +341,15 @@ pub(crate) fn fields_in_set_can_merge(
                     diagnostics.push(
                         ApolloDiagnostic::new(
                             db,
-                            field_b.field.location().unwrap(),
+                            field_b.field.location(),
                             DiagnosticData::ConflictingField {
                                 field: field_b.field.name.to_string(),
-                                original_selection: (field_a.field.location().unwrap()),
-                                redefined_selection: (field_b.field.location().unwrap()),
+                                original_selection: (field_a.field.location()),
+                                redefined_selection: (field_b.field.location()),
                             },
                         )
                         .label(Label::new(
-                            field_a.field.location().unwrap(),
+                            field_a.field.location(),
                             format!(
                                 "field `{}` is selected from field `{}` here",
                                 field_a.field.response_name(),
@@ -357,7 +357,7 @@ pub(crate) fn fields_in_set_can_merge(
                             ),
                         ))
                         .label(Label::new(
-                            field_b.field.location().unwrap(),
+                            field_b.field.location(),
                             format!(
                                 "but the same field `{}` is also selected from field `{}` here",
                                 field_b.field.response_name(),

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -29,7 +29,7 @@ pub(crate) fn validate_union_definition(
     let schema = db.schema();
 
     for union_member in union_def.members() {
-        let member_location = union_member.location().unwrap();
+        let member_location = union_member.location();
         // TODO: (?) A Union type must include one or more unique member types.
 
         match schema.types.get(union_member) {

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -303,10 +303,6 @@ pub(crate) fn validate(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     diagnostics
 }
 
-fn location_sort_key(diagnostic: &ApolloDiagnostic) -> (FileId, usize) {
-    (diagnostic.location.file_id(), diagnostic.location.offset())
-}
-
 pub(crate) fn validate_type_system(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -322,7 +318,6 @@ pub(crate) fn validate_type_system(db: &dyn ValidationDatabase) -> Vec<ApolloDia
     diagnostics.extend(db.validate_input_object_definitions());
     diagnostics.extend(db.validate_object_type_definitions());
 
-    diagnostics.sort_by_key(location_sort_key);
     diagnostics
 }
 
@@ -344,7 +339,6 @@ fn validate_executable_inner(
         ));
     }
 
-    diagnostics.sort_by_key(location_sort_key);
     diagnostics
 }
 

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -20,20 +20,18 @@ fn unsupported_type(
 
     let mut diagnostic = ApolloDiagnostic::new(
         db,
-        value.location().unwrap(),
+        value.location(),
         DiagnosticData::UnsupportedValueType {
             value: value.kind().into(),
             ty: declared_type.to_string(),
         },
     );
-    if let Some(type_location) = type_location {
-        diagnostic = diagnostic.label(Label::new(
-            type_location,
-            format!("field declared here as {} type", declared_type),
-        ));
-    }
+    diagnostic = diagnostic.label(Label::new(
+        type_location,
+        format!("field declared here as {} type", declared_type),
+    ));
     diagnostic.label(Label::new(
-        value.location().unwrap(),
+        value.location(),
         format!("argument declared here is of {} type", value.kind()),
     ))
 }
@@ -82,13 +80,13 @@ pub(crate) fn value_of_correct_type2(
                         diagnostics.push(
                             ApolloDiagnostic::new(
                                 db,
-                                arg_value.location().unwrap(),
+                                arg_value.location(),
                                 DiagnosticData::IntCoercionError {
                                     value: int.as_str().to_owned(),
                                 },
                             )
                             .label(Label::new(
-                                arg_value.location().unwrap(),
+                                arg_value.location(),
                                 "cannot be coerced to an 32-bit integer",
                             )),
                         )
@@ -99,13 +97,13 @@ pub(crate) fn value_of_correct_type2(
                         diagnostics.push(
                             ApolloDiagnostic::new(
                                 db,
-                                arg_value.location().unwrap(),
+                                arg_value.location(),
                                 DiagnosticData::FloatCoercionError {
                                     value: int.as_str().to_owned(),
                                 },
                             )
                             .label(Label::new(
-                                arg_value.location().unwrap(),
+                                arg_value.location(),
                                 "cannot be coerced to a finite 64-bit float",
                             )),
                         )
@@ -126,13 +124,13 @@ pub(crate) fn value_of_correct_type2(
                     diagnostics.push(
                         ApolloDiagnostic::new(
                             db,
-                            arg_value.location().unwrap(),
+                            arg_value.location(),
                             DiagnosticData::FloatCoercionError {
                                 value: float.as_str().to_owned(),
                             },
                         )
                         .label(Label::new(
-                            arg_value.location().unwrap(),
+                            arg_value.location(),
                             "cannot be coerced to a finite 64-bit float",
                         )),
                     )
@@ -215,14 +213,14 @@ pub(crate) fn value_of_correct_type2(
                     diagnostics.push(
                         ApolloDiagnostic::new(
                             db,
-                            value.location().unwrap(),
+                            value.location(),
                             DiagnosticData::UndefinedValue {
                                 value: value.to_string(),
                                 definition: ty.inner_named_type().to_string(),
                             },
                         )
                         .label(Label::new(
-                            arg_value.location().unwrap(),
+                            arg_value.location(),
                             format!("does not exist on `{}` type", ty.inner_named_type()),
                         )),
                     );
@@ -259,14 +257,14 @@ pub(crate) fn value_of_correct_type2(
                     diagnostics.push(
                         ApolloDiagnostic::new(
                             db,
-                            value.location().unwrap(),
+                            value.location(),
                             DiagnosticData::UndefinedValue {
                                 value: name.to_string(),
                                 definition: ty.inner_named_type().to_string(),
                             },
                         )
                         .label(Label::new(
-                            value.location().unwrap(),
+                            value.location(),
                             format!("does not exist on `{}` type", ty.inner_named_type()),
                         )),
                     );
@@ -286,18 +284,17 @@ pub(crate) fn value_of_correct_type2(
                     if (ty.is_non_null() && f.default_value.is_none()) && (is_missing || is_null) {
                         let mut diagnostic = ApolloDiagnostic::new(
                             db,
-                            arg_value.location().unwrap(),
+                            arg_value.location(),
                             DiagnosticData::RequiredArgument {
                                 name: input_name.to_string(),
                             },
                         );
                         diagnostic = diagnostic.label(Label::new(
-                            arg_value.location().unwrap(),
+                            arg_value.location(),
                             format!("missing value for argument `{input_name}`"),
                         ));
-                        if let Some(loc) = f.location() {
-                            diagnostic = diagnostic.label(Label::new(loc, "argument defined here"));
-                        }
+                        let loc = f.location();
+                        diagnostic = diagnostic.label(Label::new(loc, "argument defined here"));
 
                         diagnostics.push(diagnostic)
                     }

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -43,24 +43,24 @@ pub(crate) fn validate_variable_definitions2(
                         schema::ExtendedType::InputObject(_) => "input object",
                     };
                     diagnostics.push(
-                        ApolloDiagnostic::new(db, variable.location().unwrap(), DiagnosticData::InputType {
+                        ApolloDiagnostic::new(db, variable.location(), DiagnosticData::InputType {
                             name: variable.name.to_string(),
                             ty: kind,
                         })
-                        .label(Label::new(ty.inner_named_type().location().unwrap(), format!("this is of `{kind}` type")))
+                        .label(Label::new(ty.inner_named_type().location(), format!("this is of `{kind}` type")))
                         .help("objects, unions, and interfaces cannot be used because variables can only be of input type"),
                         );
                 }
                 None => diagnostics.push(
                     ApolloDiagnostic::new(
                         db,
-                        variable.location().unwrap(),
+                        variable.location(),
                         DiagnosticData::UndefinedDefinition {
                             name: ty.inner_named_type().to_string(),
                         },
                     )
                     .label(Label::new(
-                        ty.inner_named_type().location().unwrap(),
+                        ty.inner_named_type().location(),
                         "not found in the type system",
                     )),
                 ),
@@ -69,8 +69,8 @@ pub(crate) fn validate_variable_definitions2(
 
         match seen.entry(variable.name.clone()) {
             Entry::Occupied(original) => {
-                let original_definition = original.get().location().unwrap();
-                let redefined_definition = variable.location().unwrap();
+                let original_definition = original.get().location();
+                let redefined_definition = variable.location();
                 diagnostics.push(
                     ApolloDiagnostic::new(
                         db,
@@ -258,7 +258,7 @@ pub(crate) fn validate_unused_variables(
     let unused_vars = defined_vars.difference(&used_vars);
 
     diagnostics.extend(unused_vars.map(|unused_var| {
-        let loc = locations[unused_var].expect("missing location information");
+        let loc = locations[unused_var];
         ApolloDiagnostic::new(
             db,
             loc,
@@ -287,7 +287,7 @@ pub(crate) fn validate_variable_usage2(
             if !is_allowed {
                 return Err(ApolloDiagnostic::new(
                     db,
-                    argument.location().unwrap(),
+                    argument.location(),
                     DiagnosticData::DisallowedVariableUsage {
                         var_name: var_def.name.to_string(),
                         arg_name: argument.name.to_string(),
@@ -295,14 +295,14 @@ pub(crate) fn validate_variable_usage2(
                 )
                 .labels([
                     Label::new(
-                        var_def.location().unwrap(),
+                        var_def.location(),
                         format!(
                             "variable `{}` of type `{}` is declared here",
                             var_def.name, var_def.ty,
                         ),
                     ),
                     Label::new(
-                        argument.location().unwrap(),
+                        argument.location(),
                         format!(
                             "argument `{}` of type `{}` is declared here",
                             argument.name, var_usage.ty,
@@ -313,13 +313,13 @@ pub(crate) fn validate_variable_usage2(
         } else {
             return Err(ApolloDiagnostic::new(
                 db,
-                argument.location().unwrap(),
+                argument.location(),
                 DiagnosticData::UndefinedVariable {
                     name: var_name.to_string(),
                 },
             )
             .label(Label::new(
-                argument.value.location().unwrap(),
+                argument.value.location(),
                 "not found in this scope",
             )));
         }

--- a/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
@@ -1,4 +1,4 @@
-Error: cannot find type `permissions` in this document
+Error: cannot find type `Auth` in this document
     ╭─[0036_object_type_with_non_output_field_types.graphql:20:16]
     │
  20 │   permissions: Auth
@@ -14,7 +14,7 @@ Error: `coordinates` field must return an output type
     │ 
     │ Help: Scalars, Objects, Interfaces, Unions and Enums are output types. Change `coordinates` field to return one of these output types.
 ────╯
-Error: cannot find type `main` in this document
+Error: cannot find type `mainPage` in this document
     ╭─[0036_object_type_with_non_output_field_types.graphql:22:9]
     │
  22 │   main: mainPage

--- a/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
@@ -1,4 +1,4 @@
-Error: cannot find type `permissions` in this document
+Error: cannot find type `Auth` in this document
     ╭─[0037_interface_with_non_output_fields.graphql:18:16]
     │
  18 │   permissions: Auth
@@ -14,7 +14,7 @@ Error: `coordinates` field must return an output type
     │ 
     │ Help: Scalars, Objects, Interfaces, Unions and Enums are output types. Change `coordinates` field to return one of these output types.
 ────╯
-Error: cannot find type `main` in this document
+Error: cannot find type `mainPage` in this document
     ╭─[0037_interface_with_non_output_fields.graphql:20:9]
     │
  20 │   main: mainPage

--- a/crates/apollo-compiler/test_data/diagnostics/0038_object_type_with_undefined_field_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0038_object_type_with_undefined_field_type.txt
@@ -1,11 +1,11 @@
-Error: cannot find type `img` in this document
+Error: cannot find type `Url` in this document
    ╭─[0038_object_type_with_undefined_field_type.graphql:3:8]
    │
  3 │   img: Url
    │        ─┬─  
    │         ╰─── not found in this scope
 ───╯
-Error: cannot find type `relationship` in this document
+Error: cannot find type `Person` in this document
    ╭─[0038_object_type_with_undefined_field_type.graphql:4:17]
    │
  4 │   relationship: Person

--- a/crates/apollo-compiler/test_data/diagnostics/0039_interface_with_undefined_field_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0039_interface_with_undefined_field_type.txt
@@ -1,11 +1,11 @@
-Error: cannot find type `img` in this document
+Error: cannot find type `Url` in this document
    ╭─[0039_interface_with_undefined_field_type.graphql:3:8]
    │
  3 │   img: Url
    │        ─┬─  
    │         ╰─── not found in this scope
 ───╯
-Error: cannot find type `relationship` in this document
+Error: cannot find type `Person` in this document
    ╭─[0039_interface_with_undefined_field_type.graphql:7:17]
    │
  7 │   relationship: Person

--- a/crates/apollo-compiler/test_data/diagnostics/0049_duplicate_directive_argument_definition_names.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0049_duplicate_directive_argument_definition_names.graphql
@@ -1,1 +1,4 @@
 directive @example(arg: Boolean, arg: Boolean) on FIELD
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0051_subscription_operation_with_root_introspection_field.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0051_subscription_operation_with_root_introspection_field.graphql
@@ -5,3 +5,7 @@ subscription sub {
 type Subscription {
   __typename: String
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0057_duplicate_type_names.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0057_duplicate_type_names.graphql
@@ -22,3 +22,7 @@ type X {
 }
 
 directive @X(ok: Boolean) on UNION
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0064_extension_wrong_type.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0064_extension_wrong_type.graphql
@@ -26,3 +26,6 @@ extend type Input {
 extend input Enum {
   field2: Scalar,
 }
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.graphql
@@ -10,3 +10,6 @@ interface Intf @nonRepeatable {
   field: String
 }
 interface Intf @nonRepeatable
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.graphql
@@ -41,3 +41,6 @@ type ImplementsBaseButNotExtension implements ExtendedInterface {
 extend interface ExtendedInterface {
   fail: Boolean
 }
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.graphql
@@ -20,3 +20,7 @@ interface SubIntf implements Intf & Intf {
 #   field: String
 # }
 # extend interface ExtendedIntf implements Intf
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.graphql
@@ -14,3 +14,7 @@ extend enum E @nonRepeatable {
   MEMBER_2
   MEMBER_4
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0098_interface_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0098_interface_extensions.graphql
@@ -24,3 +24,7 @@ interface Derived {
 extend interface Derived implements Base {
   c: Int
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.graphql
@@ -10,3 +10,7 @@ input UniqueDirective @nonRepeatable {
   field: String
 }
 extend input UniqueDirective @nonRepeatable
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0100_union_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0100_union_extensions.graphql
@@ -15,3 +15,7 @@ extend union DuplicateMembers = WithFieldA | WithFieldB
 directive @nonRepeatable on UNION
 union DuplicateDirective @nonRepeatable = WithFieldA
 extend union DuplicateDirective @nonRepeatable = WithFieldB
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0103_invalid_directive_on_input_value.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0103_invalid_directive_on_input_value.graphql
@@ -5,3 +5,7 @@ input Input {
 }
 
 directive @directive(arg2: Int @example) on SCHEMA
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0104_invalid_type_in_arg.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0104_invalid_type_in_arg.graphql
@@ -18,3 +18,7 @@ union OperationResult = Operation
 type Operation {
   id: ID!
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0049_duplicate_directive_argument_definition_names.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0049_duplicate_directive_argument_definition_names.graphql
@@ -1,1 +1,5 @@
 directive @example(arg: Boolean, arg: Boolean) on FIELD
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0051_subscription_operation_with_root_introspection_field.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0051_subscription_operation_with_root_introspection_field.graphql
@@ -5,3 +5,7 @@ subscription sub {
 type Subscription {
   __typename: String
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0057_duplicate_type_names.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0057_duplicate_type_names.graphql
@@ -24,3 +24,7 @@ type X {
 }
 
 directive @X(ok: Boolean) on UNION
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0064_extension_wrong_type.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0064_extension_wrong_type.graphql
@@ -35,3 +35,7 @@ extend type Input {
 extend input Enum {
   field2: Scalar
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0080_directive_is_unique_with_extensions.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0080_directive_is_unique_with_extensions.graphql
@@ -15,3 +15,7 @@ interface Intf @nonRepeatable {
 }
 
 interface Intf @nonRepeatable
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0094_object_type_extensions.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0094_object_type_extensions.graphql
@@ -49,3 +49,7 @@ type ImplementsBaseButNotExtension implements ExtendedInterface {
 extend interface ExtendedInterface {
   fail: Boolean
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0095_interface_implementation_declared_once.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0095_interface_implementation_declared_once.graphql
@@ -15,3 +15,7 @@ extend type Extended implements Intf
 interface SubIntf implements Intf & Intf {
   field: String
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0097_enum_extensions.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0097_enum_extensions.graphql
@@ -14,3 +14,7 @@ extend enum E @nonRepeatable {
   MEMBER_2
   MEMBER_4
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0098_interface_extensions.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0098_interface_extensions.graphql
@@ -27,3 +27,7 @@ interface Derived {
 extend interface Derived implements Base {
   c: Int
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0099_input_object_extensions.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0099_input_object_extensions.graphql
@@ -13,3 +13,7 @@ input UniqueDirective @nonRepeatable {
 }
 
 extend input UniqueDirective @nonRepeatable
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0100_union_extensions.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0100_union_extensions.graphql
@@ -21,3 +21,7 @@ directive @nonRepeatable on UNION
 union DuplicateDirective @nonRepeatable = WithFieldA
 
 extend union DuplicateDirective @nonRepeatable = WithFieldB
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0103_invalid_directive_on_input_value.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0103_invalid_directive_on_input_value.graphql
@@ -7,3 +7,7 @@ input Input {
 directive @directive(
   arg2: Int @example,
 ) on SCHEMA
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0104_invalid_type_in_arg.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0104_invalid_type_in_arg.graphql
@@ -19,3 +19,7 @@ union OperationResult = Operation
 type Operation {
   id: ID!
 }
+
+type Query {
+  x: Int
+}

--- a/crates/apollo-compiler/tests/extensions.rs
+++ b/crates/apollo-compiler/tests/extensions.rs
@@ -3,9 +3,10 @@ use apollo_compiler::Schema;
 #[test]
 fn test_orphan_extensions() {
     let input = r#"
-        extend schema @dir
+        extend schema @dir { query: Q }
         extend type Obj @dir
         directive @dir on SCHEMA | OBJECT
+        type Q { x: Int }
     "#;
 
     // By default, orphan extensions are errors:

--- a/crates/apollo-compiler/tests/misc.rs
+++ b/crates/apollo-compiler/tests/misc.rs
@@ -568,6 +568,9 @@ input Point2D {
 #[test]
 fn it_accesses_object_directive_name() {
     let input = r#"
+type Query {
+  theBook: Book
+}
 
 type Book @directiveA(name: "pageCount") @directiveB(name: "author") {
   id: ID!
@@ -589,6 +592,10 @@ directive @directiveB(name: String) on OBJECT | INTERFACE
 #[test]
 fn it_accesses_object_field_types_directive_name() {
     let input = r#"
+type Query {
+  me: Person
+}
+
 type Person {
   name: String
   picture(size: Number): Url
@@ -640,6 +647,10 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
 #[test]
 fn it_accesses_input_object_field_types_directive_name() {
     let input = r#"
+type Query {
+  x: Int
+}
+
 input Person {
   name: String
   picture: Url


### PR DESCRIPTION
The "main" location of the diagnostic defaults to offset zero in a pseudo-file displayed as "(no source file)".

Each label of a diagnostic is omitted when its location is None. For this reason, essential information should be in the main message instead of only in labels.