### PR TITLE
feat(compiler): add get_line_column for Diagnostic

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,49 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+
+# [x.x.x] (unreleased) - 2023-mm-dd
+
+> Important: X breaking changes below, indicated by **BREAKING**
+
+## BREAKING
+## Features
+- **JSON Serialisable compiler diagnostics - [lrlna] and [goto-bus-stop], [pull/698]:**
+  This change brings back [JSON error format] for diagnostics introduced by
+  [goto-bus-stop] in [pull/668] for compiler@0.11.3. As a result, diagnostics'
+  line/column numbers are now also accessible as part of the public API.
+
+  ```rust
+  let json = expect_test::expect![[r#"
+    {
+      "message": "an executable document must not contain an object type definition",
+      "locations": [
+        {
+          "line": 2,
+          "column": 1
+        }
+      ]
+    }"#]];
+  let diagnostics = executable.validate(&schema).unwrap_err();
+  diagnostics.iter().for_each(|diag| {
+      assert_eq!(
+          diag.get_line_column(),
+          Some(GraphQLLocation { line: 2, column: 1 })
+      );
+      json.assert_eq(&serde_json::to_string_pretty(&diag.to_json()).unwrap());
+  });
+  ```
+## Fixes
+
+## Maintenance
+## Documentation
+
+[lrlna]: https://github.com/lrlna
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/698]: https://github.com/apollographql/apollo-rs/pull/698
+[pull/668]: https://github.com/apollographql/apollo-rs/pull/668
+[JSON error format]: https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format
+
 # [1.0.0-beta.3](https://crates.io/crates/apollo-compiler/1.0.0-beta.3) - 2023-10-13
 
 ## BREAKING

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -23,6 +23,7 @@ ariadne = { version = "0.3.0", features = ["auto-color"] }
 indexmap = "2.0.0"
 rowan = "0.15.5"
 salsa = "0.16.1"
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.31"
 triomphe = "0.1.9"
 
@@ -31,12 +32,13 @@ uuid = { version = "1.4", features = ["serde", "v4", "js"] }
 
 [dev-dependencies]
 anyhow = "1.0"
+criterion = "0.5.1"
 expect-test = "1.4"
 miette = "5.0"
 notify = "6.0.0"
-criterion = "0.5.1"
 pretty_assertions = "1.3.0"
 serial_test = "2.0.0"
+serde_json = "1.0"
 
 [[bench]]
 name = "multi-source"

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -22,7 +22,7 @@ pub use self::node::{Node, NodeLocation};
 pub use self::node_str::NodeStr;
 pub use self::parser::{parse_mixed, Parser, SourceFile, SourceMap};
 pub use self::schema::Schema;
-pub use self::validation::Diagnostics;
+pub use self::validation::{Diagnostics, GraphQLError, GraphQLLocation};
 
 pub(crate) struct ApolloCompiler {
     pub db: RootDatabase,

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -309,9 +309,13 @@ impl<'a> Diagnostic<'a> {
         let locations = self.get_line_column().into_iter().collect();
 
         GraphQLError {
-            message: self.data.details.to_string(),
+            message: self.message(),
             locations,
         }
+    }
+
+    pub fn message(&self) -> String {
+        self.data.details.to_string()
     }
 }
 

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -306,11 +306,7 @@ impl<'a> Diagnostic<'a> {
 
     /// Get serde_json serialisable version of the current diagnostic.
     pub fn to_json(&self) -> GraphQLError {
-        let mut locations = vec![];
-
-        if let Some(location) = self.get_line_column() {
-            locations.push(location);
-        }
+        let locations = self.get_line_column().into_iter().collect();
 
         GraphQLError {
             message: self.data.details.to_string(),

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -290,10 +290,6 @@ impl DiagnosticData {
 impl<'a> Diagnostic<'a> {
     /// Get the line and column number where this diagnostic was raised.
     pub fn get_line_column(&self) -> Option<GraphQLLocation> {
-        // let source = self.sources.get(&id)?;
-        // let char_index = source.map_index(index);
-        // let (_, line, column) = source.ariadne.get_offset_line(char_index)?;
-        // Some((line, column))
         let loc = self.data.location?;
         let source = self.sources.get(&loc.file_id)?;
         source

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -309,13 +309,13 @@ impl<'a> Diagnostic<'a> {
         let locations = self.get_line_column().into_iter().collect();
 
         GraphQLError {
-            message: self.message(),
+            message: self.message().to_string(),
             locations,
         }
     }
 
-    pub fn message(&self) -> String {
-        self.data.details.to_string()
+    pub fn message(&self) -> &impl fmt::Display {
+        &self.data.details
     }
 }
 

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -86,7 +86,7 @@ pub(crate) enum Details {
     SchemaBuildError(SchemaBuildError),
     #[error("{0}")]
     ExecutableBuildError(ExecutableBuildError),
-    #[error("syntax error: {0}")]
+    #[error("compiler error: {0}")]
     CompilerDiagnostic(crate::ApolloDiagnostic),
 }
 
@@ -313,9 +313,7 @@ impl<'a> Diagnostic<'a> {
         }
 
         GraphQLError {
-            // TODO(@lrlna): this needs DiagnosticData to have a Display impl
-            // using only diagnostic messages.
-            message: self.to_string(),
+            message: self.data.details.to_string(),
             locations,
         }
     }


### PR DESCRIPTION
This brings back line/column numbers and serialisability to diagnostics. It essentially fits in the work @goto-bus-stop already did into the new version of the compiler.

The PR includes:
- [x] (re-) introduction of `MappedSource` where we store bite indices for source information
- [x] line/column numbers for each `SourceFile`
- [x] (re-) introduction of `get_line_column` to public API, accessible via Diagnostic<'a>
- [x] (re-) introduction of `to_json` public api for Diagnostic<'a>
- [x] (re-) introduction of `GraphQLError` and `GraphQLLocation`
- [x] creation of `Display` for `DiagnosticData` in order to gracefully display seriasable diagnostic message in `to_json` functionality


closes #692 