### PR TITLE
Fix `SyntaxTree` being accidentally `!Send` and `!Sync`

### DIFF
--- a/crates/apollo-parser/CHANGELOG.md
+++ b/crates/apollo-parser/CHANGELOG.md
@@ -17,6 +17,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Documentation -->
 
+# [x.x.x] (unreleased) - 2022-mm-dd
+
+## Fixes
+
+- **Fix `SyntaxTree` being accidentally `!Send` and `!Sync` - [SimonSapin], [pull/704] fixing [issue/702]**
+
+[SimonSapin]: https://github.com/SimonSapin
+[pull/704]: https://github.com/apollographql/apollo-rs/pull/704
+[issue/702]: https://github.com/apollographql/apollo-rs/issues/702
+
 # [0.7.1](https://crates.io/crates/apollo-parser/0.7.1) - 2023-10-10
 
 ## Features

--- a/crates/apollo-parser/src/parser/syntax_tree.rs
+++ b/crates/apollo-parser/src/parser/syntax_tree.rs
@@ -57,8 +57,15 @@ pub struct SyntaxTree<T: CstNode = cst::Document> {
     pub(crate) errors: Vec<crate::Error>,
     pub(crate) recursion_limit: LimitTracker,
     pub(crate) token_limit: LimitTracker,
-    _phantom: PhantomData<T>,
+    _phantom: PhantomData<fn() -> T>,
 }
+
+const _: () = {
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+    let _ = assert_send::<SyntaxTree>;
+    let _ = assert_sync::<SyntaxTree>;
+};
 
 impl<T: CstNode> SyntaxTree<T> {
     /// Get a reference to the syntax tree's errors.


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-rs/issues/702