### PR TITLE
Macroize some redundant code in SchemaBuilder

### DIFF
--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -106,6 +106,63 @@ impl SchemaBuilder {
             sources.insert(*file_id, source_file.clone());
         }
         for definition in &document.definitions {
+            macro_rules! type_definition {
+                ($def: ident, $Type: ident, is_scalar = $is_scalar: literal) => {
+                    match self.schema.types.entry($def.name.clone()) {
+                        Entry::Vacant(entry) => {
+                            let extended_def = $Type::from_ast(
+                                &mut self.schema.build_errors,
+                                $def,
+                                self.orphan_type_extensions
+                                    .remove(&$def.name)
+                                    .unwrap_or_default(),
+                            );
+                            entry.insert(extended_def.into());
+                        }
+                        Entry::Occupied(_) => {
+                            let (_index, prev_name, previous) =
+                                self.schema.types.get_full_mut(&$def.name).unwrap();
+                            let error = if $is_scalar && previous.is_built_in() {
+                                BuildError::BuiltInScalarTypeRedefinition {
+                                    location: $def.location(),
+                                }
+                            } else {
+                                BuildError::TypeDefinitionCollision {
+                                    location: $def.name.location(),
+                                    previous_location: prev_name.location(),
+                                    name: $def.name.clone(),
+                                }
+                            };
+                            self.schema.build_errors.push(error)
+                        }
+                    }
+                };
+            }
+            macro_rules! type_extension {
+                ($ext: ident, $Kind: ident) => {
+                    if let Some((_, ty_name, ty)) = self.schema.types.get_full_mut(&$ext.name) {
+                        if let ExtendedType::$Kind(ty) = ty {
+                            ty.make_mut()
+                                .extend_ast(&mut self.schema.build_errors, $ext)
+                        } else {
+                            self.schema
+                                .build_errors
+                                .push(BuildError::TypeExtensionKindMismatch {
+                                    location: $ext.name.location(),
+                                    name: $ext.name.clone(),
+                                    describe_ext: definition.describe(),
+                                    def_location: ty_name.location(),
+                                    describe_def: ty.describe(),
+                                })
+                        }
+                    } else {
+                        self.orphan_type_extensions
+                            .entry($ext.name.clone())
+                            .or_default()
+                            .push(definition.clone())
+                    }
+                };
+            }
             match definition {
                 ast::Definition::SchemaDefinition(def) => match &self.schema_definition {
                     SchemaDefinitionStatus::NoneSoFar { orphan_extensions } => {
@@ -126,157 +183,47 @@ impl SchemaBuilder {
                     }
                 },
                 ast::Definition::DirectiveDefinition(def) => {
-                    if let Err((_prev_name, previous)) =
-                        insert_sticky(&mut self.schema.directive_definitions, &def.name, || {
-                            def.clone()
-                        })
-                    {
-                        if previous.is_built_in() {
-                            // https://github.com/apollographql/apollo-rs/issues/656
-                            // Re-defining a built-in definition is allowed, but only once.
-                            // (`is_built_in` is based on file ID, not directive name,
-                            // so the new definition won’t be considered built-in.)
-                            *previous = def.clone()
-                        } else {
-                            self.schema.build_errors.push(
-                                BuildError::DirectiveDefinitionCollision {
-                                    location: def.name.location(),
-                                    previous_location: previous.name.location(),
-                                    name: def.name.clone(),
-                                },
-                            )
+                    match self.schema.directive_definitions.entry(def.name.clone()) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(def.clone());
+                        }
+                        Entry::Occupied(mut entry) => {
+                            let previous = entry.get_mut();
+                            if previous.is_built_in() {
+                                // https://github.com/apollographql/apollo-rs/issues/656
+                                // Re-defining a built-in definition is allowed, but only once.
+                                // (`is_built_in` is based on file ID, not directive name,
+                                // so the new definition won’t be considered built-in.)
+                                *previous = def.clone()
+                            } else {
+                                self.schema.build_errors.push(
+                                    BuildError::DirectiveDefinitionCollision {
+                                        location: def.name.location(),
+                                        previous_location: previous.name.location(),
+                                        name: def.name.clone(),
+                                    },
+                                )
+                            }
                         }
                     }
                 }
                 ast::Definition::ScalarTypeDefinition(def) => {
-                    if let Err((prev_name, previous)) =
-                        insert_sticky(&mut self.schema.types, &def.name, || {
-                            ExtendedType::Scalar(ScalarType::from_ast(
-                                &mut self.schema.build_errors,
-                                def,
-                                self.orphan_type_extensions
-                                    .remove(&def.name)
-                                    .unwrap_or_default(),
-                            ))
-                        })
-                    {
-                        self.schema.build_errors.push(if previous.is_built_in() {
-                            BuildError::BuiltInScalarTypeRedefinition {
-                                location: def.location(),
-                            }
-                        } else {
-                            BuildError::TypeDefinitionCollision {
-                                location: def.name.location(),
-                                previous_location: prev_name.location(),
-                                name: def.name.clone(),
-                            }
-                        })
-                    }
+                    type_definition!(def, ScalarType, is_scalar = true)
                 }
                 ast::Definition::ObjectTypeDefinition(def) => {
-                    if let Err((prev_name, _previous)) =
-                        insert_sticky(&mut self.schema.types, &def.name, || {
-                            ExtendedType::Object(ObjectType::from_ast(
-                                &mut self.schema.build_errors,
-                                def,
-                                self.orphan_type_extensions
-                                    .remove(&def.name)
-                                    .unwrap_or_default(),
-                            ))
-                        })
-                    {
-                        self.schema
-                            .build_errors
-                            .push(BuildError::TypeDefinitionCollision {
-                                location: def.name.location(),
-                                previous_location: prev_name.location(),
-                                name: def.name.clone(),
-                            })
-                    }
+                    type_definition!(def, ObjectType, is_scalar = false)
                 }
                 ast::Definition::InterfaceTypeDefinition(def) => {
-                    if let Err((prev_name, _previous)) =
-                        insert_sticky(&mut self.schema.types, &def.name, || {
-                            ExtendedType::Interface(InterfaceType::from_ast(
-                                &mut self.schema.build_errors,
-                                def,
-                                self.orphan_type_extensions
-                                    .remove(&def.name)
-                                    .unwrap_or_default(),
-                            ))
-                        })
-                    {
-                        self.schema
-                            .build_errors
-                            .push(BuildError::TypeDefinitionCollision {
-                                location: def.name.location(),
-                                previous_location: prev_name.location(),
-                                name: def.name.clone(),
-                            })
-                    }
+                    type_definition!(def, InterfaceType, is_scalar = false)
                 }
                 ast::Definition::UnionTypeDefinition(def) => {
-                    if let Err((prev_name, _)) =
-                        insert_sticky(&mut self.schema.types, &def.name, || {
-                            ExtendedType::Union(UnionType::from_ast(
-                                &mut self.schema.build_errors,
-                                def,
-                                self.orphan_type_extensions
-                                    .remove(&def.name)
-                                    .unwrap_or_default(),
-                            ))
-                        })
-                    {
-                        self.schema
-                            .build_errors
-                            .push(BuildError::TypeDefinitionCollision {
-                                location: def.name.location(),
-                                previous_location: prev_name.location(),
-                                name: def.name.clone(),
-                            })
-                    }
+                    type_definition!(def, UnionType, is_scalar = false)
                 }
                 ast::Definition::EnumTypeDefinition(def) => {
-                    if let Err((prev_name, _previous)) =
-                        insert_sticky(&mut self.schema.types, &def.name, || {
-                            ExtendedType::Enum(EnumType::from_ast(
-                                &mut self.schema.build_errors,
-                                def,
-                                self.orphan_type_extensions
-                                    .remove(&def.name)
-                                    .unwrap_or_default(),
-                            ))
-                        })
-                    {
-                        self.schema
-                            .build_errors
-                            .push(BuildError::TypeDefinitionCollision {
-                                location: def.name.location(),
-                                previous_location: prev_name.location(),
-                                name: def.name.clone(),
-                            })
-                    }
+                    type_definition!(def, EnumType, is_scalar = false)
                 }
                 ast::Definition::InputObjectTypeDefinition(def) => {
-                    if let Err((prev_name, _previous)) =
-                        insert_sticky(&mut self.schema.types, &def.name, || {
-                            ExtendedType::InputObject(InputObjectType::from_ast(
-                                &mut self.schema.build_errors,
-                                def,
-                                self.orphan_type_extensions
-                                    .remove(&def.name)
-                                    .unwrap_or_default(),
-                            ))
-                        })
-                    {
-                        self.schema
-                            .build_errors
-                            .push(BuildError::TypeDefinitionCollision {
-                                location: def.name.location(),
-                                previous_location: prev_name.location(),
-                                name: def.name.clone(),
-                            })
-                    }
+                    type_definition!(def, InputObjectType, is_scalar = false)
                 }
                 ast::Definition::SchemaExtension(ext) => match &mut self.schema_definition {
                     SchemaDefinitionStatus::Found => self
@@ -288,138 +235,12 @@ impl SchemaBuilder {
                         orphan_extensions.push(ext.clone())
                     }
                 },
-                ast::Definition::ScalarTypeExtension(ext) => {
-                    if let Some((_, ty_name, ty)) = self.schema.types.get_full_mut(&ext.name) {
-                        if let ExtendedType::Scalar(ty) = ty {
-                            ty.make_mut().extend_ast(&mut self.schema.build_errors, ext)
-                        } else {
-                            self.schema
-                                .build_errors
-                                .push(BuildError::TypeExtensionKindMismatch {
-                                    location: ext.name.location(),
-                                    name: ext.name.clone(),
-                                    describe_ext: definition.describe(),
-                                    def_location: ty_name.location(),
-                                    describe_def: ty.describe(),
-                                })
-                        }
-                    } else {
-                        self.orphan_type_extensions
-                            .entry(ext.name.clone())
-                            .or_default()
-                            .push(definition.clone())
-                    }
-                }
-                ast::Definition::ObjectTypeExtension(ext) => {
-                    if let Some((_, ty_name, ty)) = self.schema.types.get_full_mut(&ext.name) {
-                        if let ExtendedType::Object(ty) = ty {
-                            ty.make_mut().extend_ast(&mut self.schema.build_errors, ext)
-                        } else {
-                            self.schema
-                                .build_errors
-                                .push(BuildError::TypeExtensionKindMismatch {
-                                    location: ext.name.location(),
-                                    name: ext.name.clone(),
-                                    describe_ext: definition.describe(),
-                                    def_location: ty_name.location(),
-                                    describe_def: ty.describe(),
-                                })
-                        }
-                    } else {
-                        self.orphan_type_extensions
-                            .entry(ext.name.clone())
-                            .or_default()
-                            .push(definition.clone())
-                    }
-                }
-                ast::Definition::InterfaceTypeExtension(ext) => {
-                    if let Some((_, ty_name, ty)) = self.schema.types.get_full_mut(&ext.name) {
-                        if let ExtendedType::Interface(ty) = ty {
-                            ty.make_mut().extend_ast(&mut self.schema.build_errors, ext)
-                        } else {
-                            self.schema
-                                .build_errors
-                                .push(BuildError::TypeExtensionKindMismatch {
-                                    location: ext.name.location(),
-                                    name: ext.name.clone(),
-                                    describe_ext: definition.describe(),
-                                    def_location: ty_name.location(),
-                                    describe_def: ty.describe(),
-                                })
-                        }
-                    } else {
-                        self.orphan_type_extensions
-                            .entry(ext.name.clone())
-                            .or_default()
-                            .push(definition.clone())
-                    }
-                }
-                ast::Definition::UnionTypeExtension(ext) => {
-                    if let Some((_, ty_name, ty)) = self.schema.types.get_full_mut(&ext.name) {
-                        if let ExtendedType::Union(ty) = ty {
-                            ty.make_mut().extend_ast(&mut self.schema.build_errors, ext)
-                        } else {
-                            self.schema
-                                .build_errors
-                                .push(BuildError::TypeExtensionKindMismatch {
-                                    location: ext.name.location(),
-                                    name: ext.name.clone(),
-                                    describe_ext: definition.describe(),
-                                    def_location: ty_name.location(),
-                                    describe_def: ty.describe(),
-                                })
-                        }
-                    } else {
-                        self.orphan_type_extensions
-                            .entry(ext.name.clone())
-                            .or_default()
-                            .push(definition.clone())
-                    }
-                }
-                ast::Definition::EnumTypeExtension(ext) => {
-                    if let Some((_, ty_name, ty)) = self.schema.types.get_full_mut(&ext.name) {
-                        if let ExtendedType::Enum(ty) = ty {
-                            ty.make_mut().extend_ast(&mut self.schema.build_errors, ext)
-                        } else {
-                            self.schema
-                                .build_errors
-                                .push(BuildError::TypeExtensionKindMismatch {
-                                    location: ext.name.location(),
-                                    name: ext.name.clone(),
-                                    describe_ext: definition.describe(),
-                                    def_location: ty_name.location(),
-                                    describe_def: ty.describe(),
-                                })
-                        }
-                    } else {
-                        self.orphan_type_extensions
-                            .entry(ext.name.clone())
-                            .or_default()
-                            .push(definition.clone())
-                    }
-                }
-                ast::Definition::InputObjectTypeExtension(ext) => {
-                    if let Some((_, ty_name, ty)) = self.schema.types.get_full_mut(&ext.name) {
-                        if let ExtendedType::InputObject(ty) = ty {
-                            ty.make_mut().extend_ast(&mut self.schema.build_errors, ext)
-                        } else {
-                            self.schema
-                                .build_errors
-                                .push(BuildError::TypeExtensionKindMismatch {
-                                    location: ext.name.location(),
-                                    name: ext.name.clone(),
-                                    describe_ext: definition.describe(),
-                                    def_location: ty_name.location(),
-                                    describe_def: ty.describe(),
-                                })
-                        }
-                    } else {
-                        self.orphan_type_extensions
-                            .entry(ext.name.clone())
-                            .or_default()
-                            .push(definition.clone())
-                    }
-                }
+                ast::Definition::ScalarTypeExtension(ext) => type_extension!(ext, Scalar),
+                ast::Definition::ObjectTypeExtension(ext) => type_extension!(ext, Object),
+                ast::Definition::InterfaceTypeExtension(ext) => type_extension!(ext, Interface),
+                ast::Definition::UnionTypeExtension(ext) => type_extension!(ext, Union),
+                ast::Definition::EnumTypeExtension(ext) => type_extension!(ext, Enum),
+                ast::Definition::InputObjectTypeExtension(ext) => type_extension!(ext, InputObject),
                 ast::Definition::OperationDefinition(_)
                 | ast::Definition::FragmentDefinition(_) => {
                     if executable_definitions_are_errors {
@@ -1060,27 +881,6 @@ impl InputObjectType {
                 })
             },
         )
-    }
-}
-
-/// Like `IndexMap::insert`, but does not replace the value
-/// if an equivalent key is already in the map.
-///
-/// In that (error) case, returns the existing key and value
-fn insert_sticky<'map, V>(
-    map: &'map mut IndexMap<Name, V>,
-    key: &Name,
-    make_value: impl FnOnce() -> V,
-) -> Result<(), (&'map Name, &'map mut V)> {
-    match map.entry(key.clone()) {
-        Entry::Vacant(entry) => {
-            entry.insert(make_value());
-            Ok(())
-        }
-        Entry::Occupied(_) => {
-            let (_index, key, value) = map.get_full_mut(key).unwrap();
-            Err((key, value))
-        }
     }
 }
 


### PR DESCRIPTION
And inline `insert_sticky` to reduce generics saturation, since it only had two callers.