### PR TITLE
Improve error span for lowercase_enum_value

### DIFF
--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -49,7 +49,7 @@ pub(crate) fn validate_enum_value(
     //
     // Return a Capitalized Value warning if enum value is not capitalized.
     if enum_val.value != enum_val.value.to_uppercase().as_str() {
-        let location = enum_val.location();
+        let location = enum_val.value.location();
         diagnostics.push(
             ApolloDiagnostic::new(
                 db,

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -48,7 +48,7 @@ pub(crate) fn validate_enum_value(
     // (convention) Values in an Enum Definition should be capitalized.
     //
     // Return a Capitalized Value warning if enum value is not capitalized.
-    if enum_val.value != enum_val.value.to_uppercase().as_str() {
+    if enum_val.value.chars().any(char::is_lowercase) {
         let location = enum_val.value.location();
         diagnostics.push(
             ApolloDiagnostic::new(


### PR DESCRIPTION
Before:
<img width="1240" alt="image" src="https://github.com/apollographql/apollo-rs/assets/1006268/c9e7f3ab-e812-46a2-8a98-d0bbc569f16d">


After:
<img width="899" alt="image" src="https://github.com/apollographql/apollo-rs/assets/1006268/947d1040-d909-4349-a208-d0d0e2467ec9">

Also removing a temporary string allocation while i'm there