### PR TITLE
Skip schema AST conversion in ExecutableDocument::validate

### DIFF
--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -7,6 +7,9 @@ pub(crate) trait InputDatabase {
     #[salsa::input]
     fn input(&self, file_id: FileId) -> Source;
 
+    #[salsa::input]
+    fn schema_input(&self) -> Option<Arc<crate::Schema>>;
+
     /// Get the GraphQL source text for a file.
     #[salsa::invoke(source_code)]
     fn source_code(&self, file_id: FileId) -> Arc<String>;

--- a/crates/apollo-compiler/src/database/inputs.rs
+++ b/crates/apollo-compiler/src/database/inputs.rs
@@ -1,60 +1,8 @@
 use super::sources::{FileId, Source, SourceType};
-use ariadne::{Cache as AriadneCache, Source as AriadneSource};
-use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 
-#[derive(Debug, thiserror::Error)]
-#[error("Unknown file ID")]
-struct UnknownFileError;
-
-/// A Cache implementation for `ariadne` diagnostics.
-///
-/// Use [`InputDatabase::source_cache`] to construct one.
-#[derive(Clone, PartialEq, Eq)]
-pub struct SourceCache {
-    sources: HashMap<FileId, Arc<AriadneSource>>,
-    paths: HashMap<FileId, PathBuf>,
-}
-impl AriadneCache<FileId> for &SourceCache {
-    fn fetch(&mut self, id: &FileId) -> Result<&AriadneSource, Box<dyn std::fmt::Debug>> {
-        let source = self.sources.get(id);
-        source
-            .map(|arc| &**arc)
-            .ok_or_else(|| Box::new(UnknownFileError) as Box<dyn std::fmt::Debug>)
-    }
-    fn display<'a>(&self, id: &'a FileId) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        // Kinda unfortunate API limitation: we have to use a `Box<String>`
-        // as `Box<str>` doesn't support casting to `dyn Display`. We have to allocate
-        // because the lifetimes on this trait reference the file ID, not `self`.
-        // Ref https://github.com/zesterer/ariadne/issues/10
-        // Ariadne assumes the `id` is meaningful to users, but in apollo-rs it's
-        // an incrementing integer, and file paths are stored separately.
-        self.paths
-            .get(id)
-            .and_then(|path| path.to_str())
-            .map(ToOwned::to_owned)
-            .map(Box::new)
-            .map(|bx| bx as Box<dyn std::fmt::Display + 'static>)
-    }
-}
-
-// The default Debug impl is very verbose. The important part is that all
-// files are in it, so just print those.
-impl std::fmt::Debug for SourceCache {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_map()
-            .entries({
-                let mut paths: Vec<_> = self.paths.iter().collect();
-                paths.sort_by(|a, b| a.0.cmp(b.0));
-                paths.into_iter().map(|(id, path)| (id, path))
-            })
-            .finish()
-    }
-}
-
 #[salsa::query_group(InputStorage)]
-pub trait InputDatabase {
+pub(crate) trait InputDatabase {
     /// Get input source of the corresponding file.
     #[salsa::input]
     fn input(&self, file_id: FileId) -> Source;

--- a/crates/apollo-compiler/src/database/mod.rs
+++ b/crates/apollo-compiler/src/database/mod.rs
@@ -4,8 +4,9 @@ mod inputs;
 mod repr;
 mod sources;
 
-pub use db::RootDatabase;
-pub use inputs::{InputDatabase, InputStorage, SourceCache};
-pub use repr::{ReprDatabase, ReprStorage};
+pub(crate) use db::RootDatabase;
+pub(crate) use inputs::{InputDatabase, InputStorage};
+pub(crate) use repr::{ReprDatabase, ReprStorage};
+pub use sources::FileId;
+pub(crate) use sources::Source;
 pub(crate) use sources::SourceType;
-pub use sources::{FileId, Source};

--- a/crates/apollo-compiler/src/database/repr.rs
+++ b/crates/apollo-compiler/src/database/repr.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 /// Queries for parsing into the various in-memory representations of GraphQL documents
 #[salsa::query_group(ReprStorage)]
-pub trait ReprDatabase: InputDatabase {
+pub(crate) trait ReprDatabase: InputDatabase {
     #[salsa::invoke(ast)]
     #[salsa::transparent]
     fn ast(&self, file_id: FileId) -> Arc<ast::Document>;

--- a/crates/apollo-compiler/src/database/repr.rs
+++ b/crates/apollo-compiler/src/database/repr.rs
@@ -39,6 +39,9 @@ fn ast(db: &dyn ReprDatabase, file_id: FileId) -> Arc<ast::Document> {
 }
 
 fn schema(db: &dyn ReprDatabase) -> Arc<crate::Schema> {
+    if let Some(schema) = db.schema_input() {
+        return schema;
+    }
     let mut builder = crate::Schema::builder();
     for file_id in db.type_definition_files() {
         let executable_definitions_are_errors = db.source_type(file_id) != SourceType::Document;

--- a/crates/apollo-compiler/src/database/sources.rs
+++ b/crates/apollo-compiler/src/database/sources.rs
@@ -67,7 +67,6 @@ impl FileId {
     pub(crate) const NONE: Self = Self::const_new(-2);
 
     pub(crate) const HACK_TMP: Self = Self::const_new(-3);
-    pub(crate) const HACK_TMP_2: Self = Self::const_new(-4);
 
     // Returning a different value every time does not sound like good `impl Default`
     #[allow(clippy::new_without_default)]

--- a/crates/apollo-compiler/src/database/sources.rs
+++ b/crates/apollo-compiler/src/database/sources.rs
@@ -11,7 +11,7 @@ pub enum SourceType {
 
 /// Represents a GraphQL source file.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct Source {
+pub(crate) struct Source {
     pub(crate) ty: SourceType,
     pub(crate) filename: PathBuf,
     pub(crate) text: Arc<String>,

--- a/crates/apollo-compiler/src/executable/validation.rs
+++ b/crates/apollo-compiler/src/executable/validation.rs
@@ -90,22 +90,10 @@ fn compiler_validation(
     }
 
     if let Some(schema) = schema {
-        let schema_ast_id = FileId::HACK_TMP;
-        ids.push(schema_ast_id);
-        let mut ast = crate::ast::Document::new();
-        ast.definitions.extend(schema.to_ast());
-        compiler.db.set_input(
-            schema_ast_id,
-            crate::Source {
-                ty: crate::database::SourceType::Schema,
-                filename: Default::default(),
-                text: Default::default(),
-                ast: Some(Arc::new(ast)),
-            },
-        );
+        compiler.db.set_schema_input(Some(Arc::new(schema.clone())));
     }
 
-    let ast_id = FileId::HACK_TMP_2;
+    let ast_id = FileId::HACK_TMP;
     ids.push(ast_id);
     let ast = document.to_ast();
     compiler.db.set_input(
@@ -146,21 +134,9 @@ pub(crate) fn validate_field_set(errors: &mut Diagnostics, schema: &Schema, fiel
         compiler.db.set_input(*id, source.into());
     }
 
-    let schema_ast_id = FileId::HACK_TMP;
-    ids.push(schema_ast_id);
-    let mut ast = crate::ast::Document::new();
-    ast.definitions.extend(schema.to_ast());
-    compiler.db.set_input(
-        schema_ast_id,
-        crate::Source {
-            ty: crate::database::SourceType::Schema,
-            filename: Default::default(),
-            text: Default::default(),
-            ast: Some(Arc::new(ast)),
-        },
-    );
+    compiler.db.set_schema_input(Some(Arc::new(schema.clone())));
 
-    let ast_id = FileId::HACK_TMP_2;
+    let ast_id = FileId::HACK_TMP;
     ids.push(ast_id);
     let ast = ast::Document::new();
     compiler.db.set_input(

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -37,6 +37,7 @@ impl ApolloCompiler {
         let mut db = RootDatabase::default();
         // TODO(@goto-bus-stop) can we make salsa fill in these defaults for us…?
         db.set_source_files(vec![]);
+        db.set_schema_input(None);
 
         Self { db }
     }

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -430,10 +430,7 @@ impl ariadne::Cache<FileId> for &'_ Sources {
         }
         if let Some(source_file) = self.get(file_id) {
             Ok(source_file.ariadne())
-        } else if *file_id == FileId::NONE
-            || *file_id == FileId::HACK_TMP
-            || *file_id == FileId::HACK_TMP_2
-        {
+        } else if *file_id == FileId::NONE || *file_id == FileId::HACK_TMP {
             static EMPTY: OnceLock<ariadne::Source> = OnceLock::new();
             Ok(EMPTY.get_or_init(|| ariadne::Source::from("")))
         } else {


### PR DESCRIPTION
In the example at https://github.com/apollographql/apollo-rs/pull/676, validation of a trivial (very small) query against a large schema goes from 1.5~2.1 ms to 0.2 ms.