### PR TITLE
Make everything know their own name

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [x.x.x] (unreleased) - 2023-mm-dd
+
+## BREAKING
+
+- **Make everything know their own name - [SimonSapin], [pull/727] fixing [issue/708].**
+
+  In a few places (but not consistently) a `name` field
+  was omitted from some structs used as map values 
+  on the basis that it would have been redundant with the map key.
+  This reverts that decision,
+  making it the user’s responsibility when mutating documents to keep names consistent.
+
+  * Add a `pub name: Name` field to `executable::Fragment` as well as 
+    `ScalarType`, `ObjectType`, `InterfaceType`, `EnumType`, `UnionType`, and `InputObjectType`
+    in `schema`.
+  * Add a `fn name(&self) -> &Name` method to the `schema::ExtendedType` enum
+  * Add a `pub name: Option<Name>` field to `executable::Operation`
+  * Remove `executable::OperationRef<'_>` 
+    (which was equivalent to `(Option<&Name>, &Node<Operation>)`),
+    replacing its uses with `&Node<Operation>`
+
+[SimonSapin]: https://github.com/SimonSapin
+[issue/708]: https://github.com/apollographql/apollo-rs/issues/708
+[pull/727]: https://github.com/apollographql/apollo-rs/pull/727
 
 # [1.0.0-beta.4](https://crates.io/crates/apollo-compiler/1.0.0-beta.4) - 2023-10-16
 

--- a/crates/apollo-compiler/examples/extract_directives_used_by_query.rs
+++ b/crates/apollo-compiler/examples/extract_directives_used_by_query.rs
@@ -9,7 +9,7 @@ fn get_directives_used_in_query(doc: &ExecutableDocument) -> Vec<&Node<Directive
     // seed the stack with top-level fields
     let mut stack: Vec<_> = doc
         .all_operations()
-        .flat_map(|op| op.definition().selection_set.fields())
+        .flat_map(|op| op.selection_set.fields())
         .collect();
 
     let mut directives = vec![];

--- a/crates/apollo-compiler/examples/rename.rs
+++ b/crates/apollo-compiler/examples/rename.rs
@@ -1,0 +1,57 @@
+//! This example shows how to rename a type definition
+
+use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::schema::Name;
+use apollo_compiler::Schema;
+
+#[cfg(not(test))]
+fn main() {
+    print!("{}", renamed())
+}
+
+fn renamed() -> Schema {
+    let input = "type Query { field: Int }";
+    let mut schema = Schema::parse(input, "schema.graphql");
+    schema.validate().unwrap();
+
+    // 1. Remove the definition from the `types` map, using its old name as a key
+    let mut type_def = schema.types.remove("Query").unwrap();
+
+    // 2. Set the new name in the struct
+    let ExtendedType::Object(obj) = &mut type_def else {
+        panic!("expected an object type")
+    };
+    let new_name = Name::from("MyQuery");
+    obj.make_mut().name = new_name.clone();
+
+    // 3. Insert back into the map using the new name as the key
+    // WARNING: it’s your responsibility to make sure to use the same name as in the struct!
+    // Failing to do so make cause code elsewhere to behave incorrectly, or potentially panic.
+    schema.types.insert(new_name.clone(), type_def);
+
+    // 4. Update any existing reference to the old name
+    schema
+        .schema_definition
+        .make_mut()
+        .query
+        .as_mut()
+        .unwrap()
+        .node = new_name;
+
+    schema.validate().unwrap();
+    schema
+}
+
+#[test]
+fn test_renamed() {
+    let expected = expect_test::expect![[r#"
+        schema {
+          query: MyQuery
+        }
+
+        type MyQuery {
+          field: Int
+        }
+    "#]];
+    expected.assert_eq(&renamed().to_string());
+}

--- a/crates/apollo-compiler/src/executable/from_ast.rs
+++ b/crates/apollo-compiler/src/executable/from_ast.rs
@@ -111,10 +111,11 @@ impl Operation {
         let mut selection_set = SelectionSet::new(ty);
         selection_set.extend_from_ast(schema, errors, &ast.selection_set);
         Some(Self {
-            selection_set,
             operation_type: ast.operation_type,
+            name: ast.name.clone(),
             variables: ast.variables.clone(),
             directives: ast.directives.clone(),
+            selection_set,
         })
     }
 }
@@ -140,8 +141,9 @@ impl Fragment {
         let mut selection_set = SelectionSet::new(ast.type_condition.clone());
         selection_set.extend_from_ast(schema, errors, &ast.selection_set);
         Some(Self {
-            selection_set,
+            name: ast.name.clone(),
             directives: ast.directives.clone(),
+            selection_set,
         })
     }
 }

--- a/crates/apollo-compiler/src/executable/serialize.rs
+++ b/crates/apollo-compiler/src/executable/serialize.rs
@@ -12,23 +12,23 @@ impl ExecutableDocument {
     pub(crate) fn to_ast(&self) -> ast::Document {
         let mut doc = ast::Document::new();
         if let Some(operation) = &self.anonymous_operation {
-            doc.definitions.push(operation.to_ast(None))
+            doc.definitions.push(operation.to_ast())
         }
-        for (name, operation) in &self.named_operations {
-            doc.definitions.push(operation.to_ast(Some(name)))
+        for operation in self.named_operations.values() {
+            doc.definitions.push(operation.to_ast())
         }
-        for (name, fragment) in &self.fragments {
-            doc.definitions.push(fragment.to_ast(name))
+        for fragment in self.fragments.values() {
+            doc.definitions.push(fragment.to_ast())
         }
         doc
     }
 }
 
 impl Node<Operation> {
-    fn to_ast(&self, name: Option<&Name>) -> ast::Definition {
+    fn to_ast(&self) -> ast::Definition {
         ast::Definition::OperationDefinition(self.same_location(ast::OperationDefinition {
             operation_type: self.operation_type,
-            name: name.cloned(),
+            name: self.name.clone(),
             variables: self.variables.clone(),
             directives: self.directives.clone(),
             selection_set: self.selection_set.to_ast(),
@@ -37,9 +37,9 @@ impl Node<Operation> {
 }
 
 impl Node<Fragment> {
-    fn to_ast(&self, name: &Name) -> ast::Definition {
+    fn to_ast(&self) -> ast::Definition {
         ast::Definition::FragmentDefinition(self.same_location(ast::FragmentDefinition {
-            name: name.clone(),
+            name: self.name.clone(),
             type_condition: self.selection_set.ty.clone(),
             directives: self.directives.clone(),
             selection_set: self.selection_set.to_ast(),

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -84,12 +84,14 @@ pub enum ExtendedType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ScalarType {
     pub description: Option<NodeStr>,
+    pub name: Name,
     pub directives: Directives,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectType {
     pub description: Option<NodeStr>,
+    pub name: Name,
     pub implements_interfaces: IndexSet<ComponentStr>,
     pub directives: Directives,
 
@@ -103,10 +105,7 @@ pub struct ObjectType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceType {
     pub description: Option<NodeStr>,
-
-    /// * Key: name of an implemented interface
-    /// * Value: which interface type extension defined this implementation,
-    ///   or `None` for the interface type definition.
+    pub name: Name,
     pub implements_interfaces: IndexSet<ComponentStr>,
 
     pub directives: Directives,
@@ -121,6 +120,7 @@ pub struct InterfaceType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnionType {
     pub description: Option<NodeStr>,
+    pub name: Name,
     pub directives: Directives,
 
     /// * Key: name of a member object type
@@ -132,6 +132,7 @@ pub struct UnionType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumType {
     pub description: Option<NodeStr>,
+    pub name: Name,
     pub directives: Directives,
     pub values: IndexMap<Name, Component<EnumValueDefinition>>,
 }
@@ -139,6 +140,7 @@ pub struct EnumType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputObjectType {
     pub description: Option<NodeStr>,
+    pub name: Name,
     pub directives: Directives,
     pub fields: IndexMap<Name, Component<InputValueDefinition>>,
 }
@@ -587,6 +589,17 @@ impl SchemaDefinition {
 }
 
 impl ExtendedType {
+    pub fn name(&self) -> &Name {
+        match self {
+            Self::Scalar(def) => &def.name,
+            Self::Object(def) => &def.name,
+            Self::Interface(def) => &def.name,
+            Self::Union(def) => &def.name,
+            Self::Enum(def) => &def.name,
+            Self::InputObject(def) => &def.name,
+        }
+    }
+
     /// Return the source location of the type's base definition.
     ///
     /// If the type has extensions, those are not covered by this location.

--- a/crates/apollo-compiler/src/schema/serialize.rs
+++ b/crates/apollo-compiler/src/schema/serialize.rs
@@ -22,8 +22,8 @@ impl Schema {
                     .filter(|def| !def.is_built_in())
                     .map(|def| ast::Definition::DirectiveDefinition(def.clone())),
             )
-            .chain(self.types.iter().flat_map(|(name, def)| {
-                let mut iter = def.to_ast(name);
+            .chain(self.types.values().flat_map(|def| {
+                let mut iter = def.to_ast();
                 // skip the definition of built-in scalars but keep extensions if any
                 if def.is_built_in() {
                     iter.next();
@@ -109,30 +109,30 @@ impl Node<SchemaDefinition> {
 }
 
 impl ExtendedType {
-    fn to_ast<'a>(&'a self, name: &'a Name) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
         match self {
-            ExtendedType::Scalar(ty) => Box::new(ty.to_ast(name)) as Box<dyn Iterator<Item = _>>,
-            ExtendedType::Object(ty) => Box::new(ty.to_ast(name)) as _,
-            ExtendedType::Interface(ty) => Box::new(ty.to_ast(name)) as _,
-            ExtendedType::Union(ty) => Box::new(ty.to_ast(name)) as _,
-            ExtendedType::Enum(ty) => Box::new(ty.to_ast(name)) as _,
-            ExtendedType::InputObject(ty) => Box::new(ty.to_ast(name)) as _,
+            ExtendedType::Scalar(ty) => Box::new(ty.to_ast()) as Box<dyn Iterator<Item = _>>,
+            ExtendedType::Object(ty) => Box::new(ty.to_ast()) as _,
+            ExtendedType::Interface(ty) => Box::new(ty.to_ast()) as _,
+            ExtendedType::Union(ty) => Box::new(ty.to_ast()) as _,
+            ExtendedType::Enum(ty) => Box::new(ty.to_ast()) as _,
+            ExtendedType::InputObject(ty) => Box::new(ty.to_ast()) as _,
         }
     }
 }
 
 impl Node<ScalarType> {
-    fn to_ast<'a>(&'a self, name: &'a Name) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
         std::iter::once(ast::Definition::ScalarTypeDefinition(self.same_location(
             ast::ScalarTypeDefinition {
                 description: self.description.clone(),
-                name: name.clone(),
+                name: self.name.clone(),
                 directives: ast::Directives(components(&self.directives, None)),
             },
         )))
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::ScalarTypeExtension(ext.same_location(ast::ScalarTypeExtension {
-                name: name.clone(),
+                name: self.name.clone(),
                 directives: ast::Directives(components(&self.directives, Some(ext))),
             }))
         }))
@@ -140,11 +140,11 @@ impl Node<ScalarType> {
 }
 
 impl Node<ObjectType> {
-    fn to_ast<'a>(&'a self, name: &'a Name) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
         std::iter::once(ast::Definition::ObjectTypeDefinition(self.same_location(
             ast::ObjectTypeDefinition {
                 description: self.description.clone(),
-                name: name.clone(),
+                name: self.name.clone(),
                 implements_interfaces: names(&self.implements_interfaces, None),
                 directives: ast::Directives(components(&self.directives, None)),
                 fields: components(self.fields.values(), None),
@@ -152,7 +152,7 @@ impl Node<ObjectType> {
         )))
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::ObjectTypeExtension(ext.same_location(ast::ObjectTypeExtension {
-                name: name.clone(),
+                name: self.name.clone(),
                 implements_interfaces: names(&self.implements_interfaces, Some(ext)),
                 directives: ast::Directives(components(&self.directives, Some(ext))),
                 fields: components(self.fields.values(), Some(ext)),
@@ -162,11 +162,11 @@ impl Node<ObjectType> {
 }
 
 impl Node<InterfaceType> {
-    fn to_ast<'a>(&'a self, name: &'a Name) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
         std::iter::once(ast::Definition::InterfaceTypeDefinition(
             self.same_location(ast::InterfaceTypeDefinition {
                 description: self.description.clone(),
-                name: name.clone(),
+                name: self.name.clone(),
                 implements_interfaces: names(&self.implements_interfaces, None),
                 directives: ast::Directives(components(&self.directives, None)),
                 fields: components(self.fields.values(), None),
@@ -175,7 +175,7 @@ impl Node<InterfaceType> {
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::InterfaceTypeExtension(ext.same_location(
                 ast::InterfaceTypeExtension {
-                    name: name.clone(),
+                    name: self.name.clone(),
                     implements_interfaces: names(&self.implements_interfaces, Some(ext)),
                     directives: ast::Directives(components(&self.directives, Some(ext))),
                     fields: components(self.fields.values(), Some(ext)),
@@ -186,18 +186,18 @@ impl Node<InterfaceType> {
 }
 
 impl Node<UnionType> {
-    fn to_ast<'a>(&'a self, name: &'a Name) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
         std::iter::once(ast::Definition::UnionTypeDefinition(self.same_location(
             ast::UnionTypeDefinition {
                 description: self.description.clone(),
-                name: name.clone(),
+                name: self.name.clone(),
                 directives: ast::Directives(components(&self.directives, None)),
                 members: names(&self.members, None),
             },
         )))
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::UnionTypeExtension(ext.same_location(ast::UnionTypeExtension {
-                name: name.clone(),
+                name: self.name.clone(),
                 directives: ast::Directives(components(&self.directives, Some(ext))),
                 members: names(&self.members, Some(ext)),
             }))
@@ -206,18 +206,18 @@ impl Node<UnionType> {
 }
 
 impl Node<EnumType> {
-    fn to_ast<'a>(&'a self, name: &'a Name) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
         std::iter::once(ast::Definition::EnumTypeDefinition(self.same_location(
             ast::EnumTypeDefinition {
                 description: self.description.clone(),
-                name: name.clone(),
+                name: self.name.clone(),
                 directives: ast::Directives(components(&self.directives, None)),
                 values: components(self.values.values(), None),
             },
         )))
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::EnumTypeExtension(ext.same_location(ast::EnumTypeExtension {
-                name: name.clone(),
+                name: self.name.clone(),
                 directives: ast::Directives(components(&self.directives, Some(ext))),
                 values: components(self.values.values(), Some(ext)),
             }))
@@ -226,11 +226,11 @@ impl Node<EnumType> {
 }
 
 impl Node<InputObjectType> {
-    fn to_ast<'a>(&'a self, name: &'a Name) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
         std::iter::once(ast::Definition::InputObjectTypeDefinition(
             self.same_location(ast::InputObjectTypeDefinition {
                 description: self.description.clone(),
-                name: name.clone(),
+                name: self.name.clone(),
                 directives: ast::Directives(components(&self.directives, None)),
                 fields: components(self.fields.values(), None),
             }),
@@ -238,7 +238,7 @@ impl Node<InputObjectType> {
         .chain(self.extensions().into_iter().map(move |ext| {
             ast::Definition::InputObjectTypeExtension(ext.same_location(
                 ast::InputObjectTypeExtension {
-                    name: name.clone(),
+                    name: self.name.clone(),
                     directives: ast::Directives(components(&self.directives, Some(ext))),
                     fields: components(self.fields.values(), Some(ext)),
                 },

--- a/crates/apollo-compiler/src/schema/serialize.rs
+++ b/crates/apollo-compiler/src/schema/serialize.rs
@@ -109,7 +109,7 @@ impl Node<SchemaDefinition> {
 }
 
 impl ExtendedType {
-    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast(&self) -> impl Iterator<Item = ast::Definition> + '_ {
         match self {
             ExtendedType::Scalar(ty) => Box::new(ty.to_ast()) as Box<dyn Iterator<Item = _>>,
             ExtendedType::Object(ty) => Box::new(ty.to_ast()) as _,
@@ -122,7 +122,7 @@ impl ExtendedType {
 }
 
 impl Node<ScalarType> {
-    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast(&self) -> impl Iterator<Item = ast::Definition> + '_ {
         std::iter::once(ast::Definition::ScalarTypeDefinition(self.same_location(
             ast::ScalarTypeDefinition {
                 description: self.description.clone(),
@@ -140,7 +140,7 @@ impl Node<ScalarType> {
 }
 
 impl Node<ObjectType> {
-    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast(&self) -> impl Iterator<Item = ast::Definition> + '_ {
         std::iter::once(ast::Definition::ObjectTypeDefinition(self.same_location(
             ast::ObjectTypeDefinition {
                 description: self.description.clone(),
@@ -162,7 +162,7 @@ impl Node<ObjectType> {
 }
 
 impl Node<InterfaceType> {
-    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast(&self) -> impl Iterator<Item = ast::Definition> + '_ {
         std::iter::once(ast::Definition::InterfaceTypeDefinition(
             self.same_location(ast::InterfaceTypeDefinition {
                 description: self.description.clone(),
@@ -186,7 +186,7 @@ impl Node<InterfaceType> {
 }
 
 impl Node<UnionType> {
-    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast(&self) -> impl Iterator<Item = ast::Definition> + '_ {
         std::iter::once(ast::Definition::UnionTypeDefinition(self.same_location(
             ast::UnionTypeDefinition {
                 description: self.description.clone(),
@@ -206,7 +206,7 @@ impl Node<UnionType> {
 }
 
 impl Node<EnumType> {
-    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast(&self) -> impl Iterator<Item = ast::Definition> + '_ {
         std::iter::once(ast::Definition::EnumTypeDefinition(self.same_location(
             ast::EnumTypeDefinition {
                 description: self.description.clone(),
@@ -226,7 +226,7 @@ impl Node<EnumType> {
 }
 
 impl Node<InputObjectType> {
-    fn to_ast<'a>(&'a self) -> impl Iterator<Item = ast::Definition> + 'a {
+    fn to_ast(&self) -> impl Iterator<Item = ast::Definition> + '_ {
         std::iter::once(ast::Definition::InputObjectTypeDefinition(
             self.same_location(ast::InputObjectTypeDefinition {
                 description: self.description.clone(),

--- a/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             33..58 @1 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -68,6 +69,7 @@ Schema {
         "Pet": Object(
             60..87 @1 ObjectType {
                 description: None,
+                name: "Pet",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -100,6 +102,7 @@ ExecutableDocument {
     anonymous_operation: Some(
         1..31 @1 Operation {
             operation_type: Query,
+            name: None,
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             109..134 @2 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -68,6 +69,7 @@ Schema {
         "Pet": Object(
             136..182 @2 ObjectType {
                 description: None,
+                name: "Pet",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -101,6 +103,7 @@ Schema {
         "PetOwner": Object(
             184..216 @2 ObjectType {
                 description: None,
+                name: "PetOwner",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -134,6 +137,9 @@ ExecutableDocument {
     named_operations: {
         "getCatName": 0..41 @2 Operation {
             operation_type: Query,
+            name: Some(
+                "getCatName",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -187,6 +193,9 @@ ExecutableDocument {
         },
         "getOwnerName": 43..106 @2 Operation {
             operation_type: Query,
+            name: Some(
+                "getOwnerName",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
@@ -57,6 +57,7 @@ Schema {
         "PetType": Enum(
             105..135 @3 EnumType {
                 description: None,
+                name: "PetType",
                 directives: [],
                 values: {
                     "CAT": Component {
@@ -81,6 +82,7 @@ Schema {
         "customPetQuery": Object(
             137..187 @3 ObjectType {
                 description: None,
+                name: "customPetQuery",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -114,6 +116,7 @@ Schema {
         "customPetSubscription": Object(
             189..250 @3 ObjectType {
                 description: None,
+                name: "customPetSubscription",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -135,6 +138,7 @@ Schema {
         "customPetMutation": Object(
             252..330 @3 ObjectType {
                 description: None,
+                name: "customPetMutation",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -175,6 +179,7 @@ Schema {
         "Result": Object(
             332..360 @3 ObjectType {
                 description: None,
+                name: "Result",
                 implements_interfaces: {},
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
+++ b/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..44 @4 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -80,6 +81,7 @@ Schema {
         "URL": Scalar(
             46..113 @4 ScalarType {
                 description: None,
+                name: "URL",
                 directives: [
                     Component {
                         origin: Definition,

--- a/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..43 @5 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -80,6 +81,7 @@ Schema {
         "Pet": Enum(
             45..81 @5 EnumType {
                 description: None,
+                name: "Pet",
                 directives: [],
                 values: {
                     "CAT": Component {
@@ -112,6 +114,7 @@ Schema {
         "Snack": Enum(
             83..146 @5 EnumType {
                 description: None,
+                name: "Snack",
                 directives: [],
                 values: {
                     "THRIVE_PET_FOODS": Component {

--- a/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
@@ -47,6 +47,7 @@ Schema {
         "SearchResult": Union(
             33..68 @6 UnionType {
                 description: None,
+                name: "SearchResult",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -63,6 +64,7 @@ Schema {
         "Person": Object(
             70..111 @6 ObjectType {
                 description: None,
+                name: "Person",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -96,6 +98,7 @@ Schema {
         "Photo": Object(
             113..154 @6 ObjectType {
                 description: None,
+                name: "Photo",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -129,6 +132,7 @@ Schema {
         "SearchQuery": Object(
             156..210 @6 ObjectType {
                 description: None,
+                name: "SearchQuery",
                 implements_interfaces: {},
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..42 @7 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -73,6 +74,7 @@ Schema {
         "Node": Interface(
             44..72 @7 InterfaceType {
                 description: None,
+                name: "Node",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -94,6 +96,7 @@ Schema {
         "Resource": Interface(
             74..149 @7 InterfaceType {
                 description: None,
+                name: "Resource",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -144,6 +147,7 @@ Schema {
         "Image": Interface(
             151..254 @7 InterfaceType {
                 description: None,
+                name: "Image",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
@@ -67,6 +67,7 @@ Schema {
         "Query": Object(
             0..35 @8 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -88,6 +89,7 @@ Schema {
         "Book": Object(
             111..199 @8 ObjectType {
                 description: None,
+                name: "Book",
                 implements_interfaces: {},
                 directives: [
                     Component {

--- a/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..44 @9 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -80,6 +81,7 @@ Schema {
         "URL": Scalar(
             46..113 @9 ScalarType {
                 description: None,
+                name: "URL",
                 directives: [
                     Component {
                         origin: Definition,
@@ -101,6 +103,7 @@ Schema {
         "Point2D": InputObject(
             115..154 @9 InputObjectType {
                 description: None,
+                name: "Point2D",
                 directives: [],
                 fields: {
                     "x": Component {

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -66,6 +66,7 @@ Schema {
         "Query": Object(
             70..134 @10 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -111,6 +112,7 @@ Schema {
         "Product": Object(
             136..313 @10 ObjectType {
                 description: None,
+                name: "Product",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -216,6 +218,7 @@ Schema {
         "join__Graph": Enum(
             378..423 @10 EnumType {
                 description: None,
+                name: "join__Graph",
                 directives: [],
                 values: {
                     "INVENTORY": Component {
@@ -252,6 +255,9 @@ ExecutableDocument {
     named_operations: {
         "getProduct": 0..68 @10 Operation {
             operation_type: Query,
+            name: Some(
+                "getProduct",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             133..158 @11 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -68,6 +69,7 @@ Schema {
         "Foo": Object(
             160..183 @11 ObjectType {
                 description: None,
+                name: "Foo",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -89,6 +91,7 @@ Schema {
         "Baz": Object(
             185..206 @11 ObjectType {
                 description: None,
+                name: "Baz",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -122,6 +125,9 @@ ExecutableDocument {
     named_operations: {
         "IntrospectionQuery": 0..51 @11 Operation {
             operation_type: Query,
+            name: Some(
+                "IntrospectionQuery",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -161,6 +167,7 @@ ExecutableDocument {
     },
     fragments: {
         "Bar": 53..100 @11 Fragment {
+            name: "Bar",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Foo",
@@ -197,6 +204,7 @@ ExecutableDocument {
             },
         },
         "Quux": 102..131 @11 Fragment {
+            name: "Quux",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Baz",

--- a/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
+++ b/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             1266..1293 @12 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -80,6 +81,9 @@ ExecutableDocument {
     named_operations: {
         "IntrospectionQuery": 0..271 @12 Operation {
             operation_type: Query,
+            name: Some(
+                "IntrospectionQuery",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -405,6 +409,7 @@ ExecutableDocument {
     },
     fragments: {
         "FullType": 272..723 @12 Fragment {
+            name: "FullType",
             directives: [],
             selection_set: SelectionSet {
                 ty: "__Type",
@@ -910,6 +915,7 @@ ExecutableDocument {
             },
         },
         "InputValue": 724..821 @12 Fragment {
+            name: "InputValue",
             directives: [],
             selection_set: SelectionSet {
                 ty: "__InputValue",
@@ -1009,6 +1015,7 @@ ExecutableDocument {
             },
         },
         "TypeRef": 822..1265 @12 Fragment {
+            name: "TypeRef",
             directives: [],
             selection_set: SelectionSet {
                 ty: "__Type",

--- a/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             165..233 @13 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -90,6 +91,7 @@ Schema {
         "Review": Object(
             235..269 @13 ObjectType {
                 description: None,
+                name: "Review",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -111,6 +113,7 @@ Schema {
         "Message": Object(
             271..338 @13 ObjectType {
                 description: None,
+                name: "Message",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -154,6 +157,7 @@ Schema {
         "Product": Object(
             340..399 @13 ObjectType {
                 description: None,
+                name: "Product",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -209,6 +213,9 @@ ExecutableDocument {
     named_operations: {
         "ExampleQuery": 0..81 @13 Operation {
             operation_type: Query,
+            name: Some(
+                "ExampleQuery",
+            ),
             variables: [
                 19..33 @13 VariableDefinition {
                     name: "variable",
@@ -288,6 +295,7 @@ ExecutableDocument {
     },
     fragments: {
         "subFrag": 83..163 @13 Fragment {
+            name: "subFrag",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Query",

--- a/crates/apollo-compiler/test_data/ok/0014_float_values.txt
+++ b/crates/apollo-compiler/test_data/ok/0014_float_values.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..56 @14 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -78,6 +79,7 @@ Schema {
         "WithAllKindsOfFloats": InputObject(
             58..271 @14 InputObjectType {
                 description: None,
+                name: "WithAllKindsOfFloats",
                 directives: [],
                 fields: {
                     "a_regular_float": Component {

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
@@ -242,6 +242,7 @@ Schema {
         "AccountType": Union(
             627..675 @15 UnionType {
                 description: None,
+                name: "AccountType",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -258,6 +259,7 @@ Schema {
         "Amazon": Object(
             677..711 @15 ObjectType {
                 description: None,
+                name: "Amazon",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -279,6 +281,7 @@ Schema {
         "Body": Union(
             713..738 @15 UnionType {
                 description: None,
+                name: "Body",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -295,6 +298,7 @@ Schema {
         "Book": Object(
             740..1725 @15 ObjectType {
                 description: None,
+                name: "Book",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -774,6 +778,7 @@ Schema {
         "Brand": Union(
             1727..1754 @15 UnionType {
                 description: None,
+                name: "Brand",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -790,6 +795,7 @@ Schema {
         "Car": Object(
             1756..2103 @15 ObjectType {
                 description: None,
+                name: "Car",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -961,6 +967,7 @@ Schema {
         "Error": Object(
             2105..2149 @15 ObjectType {
                 description: None,
+                name: "Error",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -994,6 +1001,7 @@ Schema {
         "Furniture": Object(
             2151..2872 @15 ObjectType {
                 description: None,
+                name: "Furniture",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -1347,6 +1355,7 @@ Schema {
         "Ikea": Object(
             2874..2900 @15 ObjectType {
                 description: None,
+                name: "Ikea",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -1368,6 +1377,7 @@ Schema {
         "Image": Object(
             2902..2986 @15 ObjectType {
                 description: None,
+                name: "Image",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -1406,6 +1416,7 @@ Schema {
         "ImageAttributes": Object(
             2988..3027 @15 ObjectType {
                 description: None,
+                name: "ImageAttributes",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -1427,6 +1438,7 @@ Schema {
         "join__FieldSet": Scalar(
             3029..3097 @15 ScalarType {
                 description: None,
+                name: "join__FieldSet",
                 directives: [
                     Component {
                         origin: Definition,
@@ -1448,6 +1460,7 @@ Schema {
         "join__Graph": Enum(
             3099..3401 @15 EnumType {
                 description: None,
+                name: "join__Graph",
                 directives: [],
                 values: {
                     "ACCOUNTS": Component {
@@ -1612,6 +1625,7 @@ Schema {
         "KeyValue": Object(
             3403..3452 @15 ObjectType {
                 description: None,
+                name: "KeyValue",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -1645,6 +1659,7 @@ Schema {
         "Library": Object(
             3454..3734 @15 ObjectType {
                 description: None,
+                name: "Library",
                 implements_interfaces: {},
                 directives: [
                     Component {
@@ -1801,6 +1816,7 @@ Schema {
         "MetadataOrError": Union(
             3736..3776 @15 UnionType {
                 description: None,
+                name: "MetadataOrError",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -1817,6 +1833,7 @@ Schema {
         "Mutation": Object(
             3778..4102 @15 ObjectType {
                 description: None,
+                name: "Mutation",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -1980,6 +1997,7 @@ Schema {
         "Name": Object(
             4104..4148 @15 ObjectType {
                 description: None,
+                name: "Name",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -2013,6 +2031,7 @@ Schema {
         "NamedObject": Interface(
             4150..4191 @15 InterfaceType {
                 description: None,
+                name: "NamedObject",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -2034,6 +2053,7 @@ Schema {
         "PasswordAccount": Object(
             4193..4337 @15 ObjectType {
                 description: None,
+                name: "PasswordAccount",
                 implements_interfaces: {},
                 directives: [
                     Component {
@@ -2102,6 +2122,7 @@ Schema {
         "Product": Interface(
             4339..4486 @15 InterfaceType {
                 description: None,
+                name: "Product",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -2197,6 +2218,7 @@ Schema {
         "ProductDetails": Interface(
             4488..4534 @15 InterfaceType {
                 description: None,
+                name: "ProductDetails",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -2218,6 +2240,7 @@ Schema {
         "ProductDetailsBook": Object(
             4536..4620 @15 ObjectType {
                 description: None,
+                name: "ProductDetailsBook",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -2256,6 +2279,7 @@ Schema {
         "ProductDetailsFurniture": Object(
             4622..4714 @15 ObjectType {
                 description: None,
+                name: "ProductDetailsFurniture",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -2294,6 +2318,7 @@ Schema {
         "Query": Object(
             4716..5344 @15 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -2667,6 +2692,7 @@ Schema {
         "Review": Object(
             5346..5710 @15 ObjectType {
                 description: None,
+                name: "Review",
                 implements_interfaces: {},
                 directives: [
                     Component {
@@ -2853,6 +2879,7 @@ Schema {
         "SMSAccount": Object(
             5712..5852 @15 ObjectType {
                 description: None,
+                name: "SMSAccount",
                 implements_interfaces: {},
                 directives: [
                     Component {
@@ -2921,6 +2948,7 @@ Schema {
         "Text": Object(
             5854..5936 @15 ObjectType {
                 description: None,
+                name: "Text",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -2959,6 +2987,7 @@ Schema {
         "TextAttributes": Object(
             5938..5992 @15 ObjectType {
                 description: None,
+                name: "TextAttributes",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -2992,6 +3021,7 @@ Schema {
         "Thing": Union(
             5994..6018 @15 UnionType {
                 description: None,
+                name: "Thing",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -3008,6 +3038,7 @@ Schema {
         "UpdateReviewInput": InputObject(
             6020..6072 @15 InputObjectType {
                 description: None,
+                name: "UpdateReviewInput",
                 directives: [],
                 fields: {
                     "id": Component {
@@ -3040,6 +3071,7 @@ Schema {
         "User": Object(
             6074..7017 @15 ObjectType {
                 description: None,
+                name: "User",
                 implements_interfaces: {},
                 directives: [
                     Component {
@@ -3478,6 +3510,7 @@ Schema {
         "UserMetadata": Object(
             7019..7095 @15 ObjectType {
                 description: None,
+                name: "UserMetadata",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -3523,6 +3556,7 @@ Schema {
         "Van": Object(
             7097..7444 @15 ObjectType {
                 description: None,
+                name: "Van",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -3694,6 +3728,7 @@ Schema {
         "Vehicle": Interface(
             7446..7541 @15 InterfaceType {
                 description: None,
+                name: "Vehicle",
                 implements_interfaces: {},
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
+++ b/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             230..255 @16 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -68,6 +69,7 @@ Schema {
         "Dog": Object(
             257..372 @16 ObjectType {
                 description: None,
+                name: "Dog",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -147,6 +149,9 @@ ExecutableDocument {
     named_operations: {
         "A": 0..61 @16 Operation {
             operation_type: Query,
+            name: Some(
+                "A",
+            ),
             variables: [
                 8..30 @16 VariableDefinition {
                     name: "atOtherHomes",
@@ -172,6 +177,9 @@ ExecutableDocument {
         },
         "B": 63..124 @16 Operation {
             operation_type: Query,
+            name: Some(
+                "B",
+            ),
             variables: [
                 71..93 @16 VariableDefinition {
                     name: "atOtherHomes",
@@ -198,6 +206,7 @@ ExecutableDocument {
     },
     fragments: {
         "HouseTrainedFragment": 126..228 @16 Fragment {
+            name: "HouseTrainedFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Query",

--- a/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
@@ -47,6 +47,7 @@ Schema {
         "Dog": Object(
             314..429 @17 ObjectType {
                 description: None,
+                name: "Dog",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -114,6 +115,7 @@ Schema {
         "ComplexInput": InputObject(
             431..484 @17 InputObjectType {
                 description: None,
+                name: "ComplexInput",
                 directives: [],
                 fields: {
                     "name": Component {
@@ -146,6 +148,7 @@ Schema {
         "Query": Object(
             486..600 @17 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -225,6 +228,9 @@ ExecutableDocument {
     named_operations: {
         "takesBoolean": 0..106 @17 Operation {
             operation_type: Query,
+            name: Some(
+                "takesBoolean",
+            ),
             variables: [
                 19..41 @17 VariableDefinition {
                     name: "atOtherHomes",
@@ -304,6 +310,9 @@ ExecutableDocument {
         },
         "takesComplexInput": 108..213 @17 Operation {
             operation_type: Query,
+            name: Some(
+                "takesComplexInput",
+            ),
             variables: [
                 132..159 @17 VariableDefinition {
                     name: "complexInput",
@@ -383,6 +392,9 @@ ExecutableDocument {
         },
         "TakesListOfBooleanBang": 215..311 @17 Operation {
             operation_type: Query,
+            name: Some(
+                "TakesListOfBooleanBang",
+            ),
             variables: [
                 244..265 @17 VariableDefinition {
                     name: "booleans",

--- a/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
+++ b/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
@@ -56,6 +56,7 @@ Schema {
         "A": Object(
             78..100 @18 ObjectType {
                 description: None,
+                name: "A",
                 implements_interfaces: {},
                 directives: [
                     Component {
@@ -85,6 +86,7 @@ Schema {
         "Query": Object(
             101..122 @18 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -118,6 +120,9 @@ ExecutableDocument {
     named_operations: {
         "A": 173..203 @18 Operation {
             operation_type: Query,
+            name: Some(
+                "A",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -157,6 +162,7 @@ ExecutableDocument {
     },
     fragments: {
         "A": 148..171 @18 Fragment {
+            name: "A",
             directives: [],
             selection_set: SelectionSet {
                 ty: "A",

--- a/crates/apollo-compiler/test_data/ok/0019_extensions.txt
+++ b/crates/apollo-compiler/test_data/ok/0019_extensions.txt
@@ -47,6 +47,7 @@ Schema {
         "Scalar": Scalar(
             0..13 @19 ScalarType {
                 description: None,
+                name: "Scalar",
                 directives: [
                     Component {
                         origin: Extension(
@@ -74,6 +75,7 @@ Schema {
         "Object": Object(
             15..60 @19 ObjectType {
                 description: None,
+                name: "Object",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -118,6 +120,7 @@ Schema {
         "Intf": Interface(
             62..94 @19 InterfaceType {
                 description: None,
+                name: "Intf",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -157,6 +160,7 @@ Schema {
         "Input": InputObject(
             96..126 @19 InputObjectType {
                 description: None,
+                name: "Input",
                 directives: [],
                 fields: {
                     "field": Component {
@@ -195,6 +199,7 @@ Schema {
         "Enum": Enum(
             127..150 @19 EnumType {
                 description: None,
+                name: "Enum",
                 directives: [],
                 values: {
                     "MEMBER": Component {
@@ -225,6 +230,7 @@ Schema {
         "Query": Object(
             377..409 @19 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..25 @20 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -68,6 +69,7 @@ Schema {
         "Dog": Object(
             27..74 @20 ObjectType {
                 description: None,
+                name: "Dog",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -113,6 +115,9 @@ ExecutableDocument {
     named_operations: {
         "queryPupper": 76..175 @20 Operation {
             operation_type: Query,
+            name: Some(
+                "queryPupper",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -158,6 +163,7 @@ ExecutableDocument {
     },
     fragments: {
         "mergeIdenticalFields": 177..231 @20 Fragment {
+            name: "mergeIdenticalFields",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Dog",
@@ -208,6 +214,7 @@ ExecutableDocument {
             },
         },
         "mergeIdenticalAliasesAndFields": 233..319 @20 Fragment {
+            name: "mergeIdenticalAliasesAndFields",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Dog",

--- a/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
+++ b/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
@@ -47,6 +47,7 @@ Schema {
         "DogCommand": Enum(
             0..32 @21 EnumType {
                 description: None,
+                name: "DogCommand",
                 directives: [],
                 values: {
                     "SIT": Component {
@@ -71,6 +72,7 @@ Schema {
         "Dog": Object(
             34..97 @21 ObjectType {
                 description: None,
+                name: "Dog",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -102,6 +104,7 @@ Schema {
         "Query": Object(
             99..124 @21 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -135,6 +138,9 @@ ExecutableDocument {
     named_operations: {
         "queryPupper": 126..204 @21 Operation {
             operation_type: Query,
+            name: Some(
+                "queryPupper",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -173,6 +179,9 @@ ExecutableDocument {
         },
         "queryPupperAgain": 206..316 @21 Operation {
             operation_type: Query,
+            name: Some(
+                "queryPupperAgain",
+            ),
             variables: [
                 229..252 @21 VariableDefinition {
                     name: "dogCommand",
@@ -221,6 +230,7 @@ ExecutableDocument {
     },
     fragments: {
         "mergeIdenticalFieldsWithIdenticalArgs": 318..445 @21 Fragment {
+            name: "mergeIdenticalFieldsWithIdenticalArgs",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Dog",
@@ -305,6 +315,7 @@ ExecutableDocument {
             },
         },
         "mergeIdenticalFieldsWithIdenticalValues": 447..592 @21 Fragment {
+            name: "mergeIdenticalFieldsWithIdenticalValues",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Dog",

--- a/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
+++ b/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
@@ -47,6 +47,7 @@ Schema {
         "Pet": Interface(
             0..33 @22 InterfaceType {
                 description: None,
+                name: "Pet",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -68,6 +69,7 @@ Schema {
         "DogCommand": Enum(
             35..67 @22 EnumType {
                 description: None,
+                name: "DogCommand",
                 directives: [],
                 values: {
                     "SIT": Component {
@@ -92,6 +94,7 @@ Schema {
         "CatCommand": Enum(
             69..95 @22 EnumType {
                 description: None,
+                name: "CatCommand",
                 directives: [],
                 values: {
                     "JUMP": Component {
@@ -108,6 +111,7 @@ Schema {
         "Query": Object(
             97..122 @22 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -129,6 +133,7 @@ Schema {
         "Dog": Object(
             124..300 @22 ObjectType {
                 description: None,
+                name: "Dog",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -232,6 +237,7 @@ Schema {
         "Cat": Object(
             302..417 @22 ObjectType {
                 description: None,
+                name: "Cat",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -304,6 +310,9 @@ ExecutableDocument {
     named_operations: {
         "barkVolume": 419..478 @22 Operation {
             operation_type: Query,
+            name: Some(
+                "barkVolume",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -342,6 +351,9 @@ ExecutableDocument {
         },
         "doesKnowCommand": 480..542 @22 Operation {
             operation_type: Query,
+            name: Some(
+                "doesKnowCommand",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -380,6 +392,9 @@ ExecutableDocument {
         },
         "isAtLocation": 544..607 @22 Operation {
             operation_type: Query,
+            name: Some(
+                "isAtLocation",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -419,6 +434,7 @@ ExecutableDocument {
     },
     fragments: {
         "safeDifferingFields": 609..732 @22 Fragment {
+            name: "safeDifferingFields",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Pet",
@@ -499,6 +515,7 @@ ExecutableDocument {
             },
         },
         "safeDifferingArgs": 734..884 @22 Fragment {
+            name: "safeDifferingArgs",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Pet",
@@ -609,6 +626,7 @@ ExecutableDocument {
             },
         },
         "safeDifferingArgOrder": 886..981 @22 Fragment {
+            name: "safeDifferingArgOrder",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Dog",

--- a/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..77 @23 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -113,6 +114,7 @@ ExecutableDocument {
     anonymous_operation: Some(
         156..505 @23 Operation {
             operation_type: Query,
+            name: None,
             variables: [
                 166..197 @23 VariableDefinition {
                     name: "fieldDirective",
@@ -298,6 +300,7 @@ ExecutableDocument {
     named_operations: {},
     fragments: {
         "fragment": 79..154 @23 Fragment {
+            name: "fragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Query",

--- a/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
@@ -65,6 +65,7 @@ Schema {
         "Query": Object(
             70..97 @24 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -97,6 +98,7 @@ ExecutableDocument {
     anonymous_operation: Some(
         99..166 @24 Operation {
             operation_type: Query,
+            name: None,
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
+++ b/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..59 @25 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -92,6 +93,7 @@ Schema {
         "Date": Scalar(
             61..106 @25 ScalarType {
                 description: None,
+                name: "Date",
                 directives: [
                     Component {
                         origin: Definition,
@@ -124,6 +126,7 @@ ExecutableDocument {
     anonymous_operation: Some(
         108..213 @25 Operation {
             operation_type: Query,
+            name: None,
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..59 @26 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -92,6 +93,7 @@ Schema {
         "Date": Scalar(
             61..106 @26 ScalarType {
                 description: None,
+                name: "Date",
                 directives: [
                     Component {
                         origin: Definition,
@@ -124,6 +126,7 @@ ExecutableDocument {
     anonymous_operation: Some(
         108..135 @26 Operation {
             operation_type: Query,
+            name: None,
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
@@ -47,6 +47,7 @@ Schema {
         "SearchResult": Union(
             0..35 @27 UnionType {
                 description: None,
+                name: "SearchResult",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -63,6 +64,7 @@ Schema {
         "Person": Object(
             37..78 @27 ObjectType {
                 description: None,
+                name: "Person",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -96,6 +98,7 @@ Schema {
         "Photo": Object(
             80..121 @27 ObjectType {
                 description: None,
+                name: "Photo",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -129,6 +132,7 @@ Schema {
         "Query": Object(
             123..171 @27 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -161,6 +165,7 @@ ExecutableDocument {
     anonymous_operation: Some(
         173..292 @27 Operation {
             operation_type: Query,
+            name: None,
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
+++ b/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
@@ -47,6 +47,7 @@ Schema {
         "Product": Object(
             0..65 @28 ObjectType {
                 description: None,
+                name: "Product",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -82,6 +83,7 @@ Schema {
         "Opts": InputObject(
             67..99 @28 InputObjectType {
                 description: None,
+                name: "Opts",
                 directives: [],
                 fields: {
                     "prop": Component {
@@ -106,6 +108,7 @@ Schema {
         "Query": Object(
             101..154 @28 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -150,6 +153,7 @@ ExecutableDocument {
     anonymous_operation: Some(
         156..302 @28 Operation {
             operation_type: Query,
+            name: None,
             variables: [
                 163..186 @28 VariableDefinition {
                     name: "attributeName",

--- a/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
+++ b/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..60 @29 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -90,6 +91,7 @@ Schema {
         "First": InputObject(
             62..110 @29 InputObjectType {
                 description: None,
+                name: "First",
                 directives: [],
                 fields: {
                     "second": Component {
@@ -122,6 +124,7 @@ Schema {
         "Second": InputObject(
             112..163 @29 InputObjectType {
                 description: None,
+                name: "Second",
                 directives: [],
                 fields: {
                     "third": Component {
@@ -156,6 +159,7 @@ Schema {
         "Third": InputObject(
             165..213 @29 InputObjectType {
                 description: None,
+                name: "Third",
                 directives: [],
                 fields: {
                     "fourth": Component {
@@ -188,6 +192,7 @@ Schema {
         "Fourth": InputObject(
             215..246 @29 InputObjectType {
                 description: None,
+                name: "Fourth",
                 directives: [],
                 fields: {
                     "first": Component {

--- a/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
+++ b/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
@@ -47,6 +47,7 @@ Schema {
         "Pet": Interface(
             0..33 @30 InterfaceType {
                 description: None,
+                name: "Pet",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -68,6 +69,7 @@ Schema {
         "Dog": Object(
             35..96 @30 ObjectType {
                 description: None,
+                name: "Dog",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -106,6 +108,7 @@ Schema {
         "Cat": Object(
             98..159 @30 ObjectType {
                 description: None,
+                name: "Cat",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -144,6 +147,7 @@ Schema {
         "CatOrDog": Union(
             161..187 @30 UnionType {
                 description: None,
+                name: "CatOrDog",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -160,6 +164,7 @@ Schema {
         "Human": Object(
             189..218 @30 ObjectType {
                 description: None,
+                name: "Human",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -183,6 +188,7 @@ Schema {
         "DogOrHuman": Union(
             220..250 @30 UnionType {
                 description: None,
+                name: "DogOrHuman",
                 directives: [],
                 members: {
                     ComponentStr {
@@ -199,6 +205,7 @@ Schema {
         "Node": Interface(
             1319..1347 @30 InterfaceType {
                 description: None,
+                name: "Node",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -220,6 +227,7 @@ Schema {
         "Resource": Interface(
             1349..1411 @30 InterfaceType {
                 description: None,
+                name: "Resource",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -258,6 +266,7 @@ Schema {
         "ConcreteResource": Object(
             1476..1552 @30 ObjectType {
                 description: None,
+                name: "ConcreteResource",
                 implements_interfaces: {
                     ComponentStr {
                         origin: Definition,
@@ -300,6 +309,7 @@ Schema {
         "Query": Object(
             1711..1757 @30 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -345,6 +355,9 @@ ExecutableDocument {
     named_operations: {
         "UseAllFragments": 1759..2068 @30 Operation {
             operation_type: Query,
+            name: Some(
+                "UseAllFragments",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -488,6 +501,7 @@ ExecutableDocument {
     },
     fragments: {
         "dogFragment": 327..392 @30 Fragment {
+            name: "dogFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Dog",
@@ -530,6 +544,7 @@ ExecutableDocument {
             },
         },
         "petNameFragment": 471..513 @30 Fragment {
+            name: "petNameFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Pet",
@@ -559,6 +574,7 @@ ExecutableDocument {
             },
         },
         "interfaceWithinObjectFragment": 515..585 @30 Fragment {
+            name: "interfaceWithinObjectFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Dog",
@@ -573,6 +589,7 @@ ExecutableDocument {
             },
         },
         "catOrDogNameFragment": 587..666 @30 Fragment {
+            name: "catOrDogNameFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "CatOrDog",
@@ -615,6 +632,7 @@ ExecutableDocument {
             },
         },
         "unionWithObjectFragment": 668..737 @30 Fragment {
+            name: "unionWithObjectFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Dog",
@@ -629,6 +647,7 @@ ExecutableDocument {
             },
         },
         "petFragment": 816..888 @30 Fragment {
+            name: "petFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Pet",
@@ -692,6 +711,7 @@ ExecutableDocument {
             },
         },
         "catOrDogFragment": 890..965 @30 Fragment {
+            name: "catOrDogFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "CatOrDog",
@@ -734,6 +754,7 @@ ExecutableDocument {
             },
         },
         "unionWithInterface": 1046..1108 @30 Fragment {
+            name: "unionWithInterface",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Pet",
@@ -748,6 +769,7 @@ ExecutableDocument {
             },
         },
         "dogOrHumanFragment": 1110..1189 @30 Fragment {
+            name: "dogOrHumanFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "DogOrHuman",
@@ -790,6 +812,7 @@ ExecutableDocument {
             },
         },
         "interfaceWithInterface": 1554..1619 @30 Fragment {
+            name: "interfaceWithInterface",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Node",
@@ -804,6 +827,7 @@ ExecutableDocument {
             },
         },
         "resourceFragment": 1621..1668 @30 Fragment {
+            name: "resourceFragment",
             directives: [],
             selection_set: SelectionSet {
                 ty: "Resource",

--- a/crates/apollo-compiler/test_data/ok/0032_valid_of_correct_type.txt
+++ b/crates/apollo-compiler/test_data/ok/0032_valid_of_correct_type.txt
@@ -47,6 +47,7 @@ Schema {
         "ComplicatedArgs": Object(
             0..816 @31 ObjectType {
                 description: None,
+                name: "ComplicatedArgs",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -455,6 +456,7 @@ Schema {
         "Custom": Scalar(
             818..864 @31 ScalarType {
                 description: None,
+                name: "Custom",
                 directives: [
                     Component {
                         origin: Definition,
@@ -476,6 +478,7 @@ Schema {
         "FurColor": Enum(
             866..934 @31 EnumType {
                 description: None,
+                name: "FurColor",
                 directives: [],
                 values: {
                     "BROWN": Component {
@@ -532,6 +535,7 @@ Schema {
         "ComplexInput": InputObject(
             936..1107 @31 InputObjectType {
                 description: None,
+                name: "ComplexInput",
                 directives: [],
                 fields: {
                     "requiredField": Component {
@@ -618,6 +622,7 @@ Schema {
         "DogCommand": Enum(
             1109..1148 @31 EnumType {
                 description: None,
+                name: "DogCommand",
                 directives: [],
                 values: {
                     "SIT": Component {
@@ -650,6 +655,7 @@ Schema {
         "Dog": Object(
             1150..1302 @31 ObjectType {
                 description: None,
+                name: "Dog",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -729,6 +735,7 @@ Schema {
         "Pet": Interface(
             1304..1354 @31 InterfaceType {
                 description: None,
+                name: "Pet",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -760,6 +767,7 @@ Schema {
         "Query": Object(
             1356..1439 @31 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -815,6 +823,7 @@ Schema {
         "Human": Object(
             1441..1524 @31 ObjectType {
                 description: None,
+                name: "Human",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -886,6 +895,9 @@ ExecutableDocument {
     named_operations: {
         "goodIntValue": 1526..1599 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "goodIntValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -956,6 +968,9 @@ ExecutableDocument {
         },
         "goodNegativeIntValue": 1601..1682 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "goodNegativeIntValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1026,6 +1041,9 @@ ExecutableDocument {
         },
         "goodBooleanValue": 1684..1772 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "goodBooleanValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1096,6 +1114,9 @@ ExecutableDocument {
         },
         "goodStringValue": 1774..1860 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "goodStringValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1166,6 +1187,9 @@ ExecutableDocument {
         },
         "goodFloatValue": 1862..1943 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "goodFloatValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1236,6 +1260,9 @@ ExecutableDocument {
         },
         "goodNegativeFloatValue": 1945..2035 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "goodNegativeFloatValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1306,6 +1333,9 @@ ExecutableDocument {
         },
         "intIntoFloat": 2037..2114 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "intIntoFloat",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1376,6 +1406,9 @@ ExecutableDocument {
         },
         "intIntoID": 2116..2184 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "intIntoID",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1446,6 +1479,9 @@ ExecutableDocument {
         },
         "stringIntoID": 2186..2270 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "stringIntoID",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1516,6 +1552,9 @@ ExecutableDocument {
         },
         "goodEnumValue": 2272..2344 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "goodEnumValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1586,6 +1625,9 @@ ExecutableDocument {
         },
         "enumWithUndefinedValue": 2346..2437 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "enumWithUndefinedValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1656,6 +1698,9 @@ ExecutableDocument {
         },
         "enumWithNullValue": 2439..2522 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "enumWithNullValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1724,6 +1769,9 @@ ExecutableDocument {
         },
         "nullIntoNullableType": 2524..2608 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "nullIntoNullableType",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1792,6 +1840,9 @@ ExecutableDocument {
         },
         "goodListValue": 2610..2717 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "goodListValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1872,6 +1923,9 @@ ExecutableDocument {
         },
         "emptyListValue": 2719..2809 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "emptyListValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -1944,6 +1998,9 @@ ExecutableDocument {
         },
         "nullListValue": 2811..2902 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "nullListValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2014,6 +2071,9 @@ ExecutableDocument {
         },
         "singleValueIntoList": 2904..3002 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "singleValueIntoList",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2086,6 +2146,9 @@ ExecutableDocument {
         },
         "argOnOptionalArg": 3031..3108 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "argOnOptionalArg",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2160,6 +2223,9 @@ ExecutableDocument {
         },
         "noArgOnOptionalArg": 3110..3169 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "noArgOnOptionalArg",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2227,6 +2293,9 @@ ExecutableDocument {
         },
         "multipleArgs": 3171..3252 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "multipleArgs",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2312,6 +2381,9 @@ ExecutableDocument {
         },
         "multiplArgsReverseOrder": 3254..3346 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "multiplArgsReverseOrder",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2397,6 +2469,9 @@ ExecutableDocument {
         },
         "noArgsOnMultipleOptional": 3348..3423 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "noArgsOnMultipleOptional",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2477,6 +2552,9 @@ ExecutableDocument {
         },
         "oneArgOnMultipleOptional": 3425..3509 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "oneArgOnMultipleOptional",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2564,6 +2642,9 @@ ExecutableDocument {
         },
         "secondArgOnMultipleOptional": 3511..3598 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "secondArgOnMultipleOptional",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2651,6 +2732,9 @@ ExecutableDocument {
         },
         "multipleRequiredArgsOnMixedList": 3600..3705 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "multipleRequiredArgsOnMixedList",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2762,6 +2846,9 @@ ExecutableDocument {
         },
         "multipleRequiredAndOneOptionalArgOnMixedList": 3707..3834 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "multipleRequiredAndOneOptionalArgOnMixedList",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -2879,6 +2966,9 @@ ExecutableDocument {
         },
         "AllRequiredAndOptionalArgsOnMixedList": 3836..3965 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "AllRequiredAndOptionalArgsOnMixedList",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -3002,6 +3092,9 @@ ExecutableDocument {
         },
         "optionalArgDespiteRequiredFieldInType": 3994..4085 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "optionalArgDespiteRequiredFieldInType",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -3065,6 +3158,9 @@ ExecutableDocument {
         },
         "partialObjectOnlyRequired": 4087..4203 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "partialObjectOnlyRequired",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -3142,6 +3238,9 @@ ExecutableDocument {
         },
         "partialObjectRequiredFieldCanBeFalse": 4205..4333 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "partialObjectRequiredFieldCanBeFalse",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -3219,6 +3318,9 @@ ExecutableDocument {
         },
         "partialObjectIncludingRequired": 4335..4469 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "partialObjectIncludingRequired",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -3302,6 +3404,9 @@ ExecutableDocument {
         },
         "fullObject": 4471..4693 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "fullObject",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -3410,6 +3515,9 @@ ExecutableDocument {
         },
         "fullObjectWithFieldsInDifferentOrder": 4695..4944 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "fullObjectWithFieldsInDifferentOrder",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -3518,6 +3626,9 @@ ExecutableDocument {
         },
         "withDirectivesOfValidTypes": 4946..5062 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "withDirectivesOfValidTypes",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -3668,6 +3779,9 @@ ExecutableDocument {
         },
         "withDefaultValues": 5091..5337 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "withDefaultValues",
+            ),
             variables: [
                 5118..5129 @31 VariableDefinition {
                     name: "a",
@@ -3864,6 +3978,9 @@ ExecutableDocument {
         },
         "variablesWithDefaultNullValues": 5339..5605 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "variablesWithDefaultNullValues",
+            ),
             variables: [
                 5379..5393 @31 VariableDefinition {
                     name: "a",
@@ -4054,6 +4171,9 @@ ExecutableDocument {
         },
         "customScalarWithStringValue": 5624..5726 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "customScalarWithStringValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -4124,6 +4244,9 @@ ExecutableDocument {
         },
         "customScalarWithIntValue": 5728..5820 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "customScalarWithIntValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -4194,6 +4317,9 @@ ExecutableDocument {
         },
         "customScalarWithBooleanValue": 5822..5921 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "customScalarWithBooleanValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -4264,6 +4390,9 @@ ExecutableDocument {
         },
         "customScalarWithFloatValue": 5923..6019 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "customScalarWithFloatValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -4334,6 +4463,9 @@ ExecutableDocument {
         },
         "customScalarWithVariableValue": 6021..6146 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "customScalarWithVariableValue",
+            ),
             variables: [
                 6057..6076 @31 VariableDefinition {
                     name: "custom",
@@ -4417,6 +4549,9 @@ ExecutableDocument {
         },
         "customScalarWithArbitraryInputObject": 6148..6265 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "customScalarWithArbitraryInputObject",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {
@@ -4494,6 +4629,9 @@ ExecutableDocument {
         },
         "customScalarWithListValue": 6267..6368 @31 Operation {
             operation_type: Query,
+            name: Some(
+                "customScalarWithListValue",
+            ),
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
+++ b/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             298..337 @32 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -68,6 +69,7 @@ Schema {
         "Arguments": Object(
             339..510 @32 ObjectType {
                 description: None,
+                name: "Arguments",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -161,6 +163,9 @@ ExecutableDocument {
     named_operations: {
         "nullableStringArg": 0..296 @32 Operation {
             operation_type: Query,
+            name: Some(
+                "nullableStringArg",
+            ),
             variables: [
                 24..48 @32 VariableDefinition {
                     name: "nonNullableVar",

--- a/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
+++ b/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
@@ -88,6 +88,7 @@ Schema {
         "Query": Object(
             200..235 @33 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0035_implicit_schema_definition_with_query_type.txt
+++ b/crates/apollo-compiler/test_data/ok/0035_implicit_schema_definition_with_query_type.txt
@@ -47,6 +47,7 @@ Schema {
         "Query": Object(
             0..31 @34 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0036_implicit_schema_definition_with_several_default_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0036_implicit_schema_definition_with_several_default_types.txt
@@ -52,6 +52,7 @@ Schema {
         "Query": Object(
             0..31 @35 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -73,6 +74,7 @@ Schema {
         "Mutation": Object(
             33..81 @35 ObjectType {
                 description: None,
+                name: "Mutation",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -104,6 +106,7 @@ Schema {
         "Result": Object(
             83..111 @35 ObjectType {
                 description: None,
+                name: "Result",
                 implements_interfaces: {},
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
@@ -70,6 +70,7 @@ Schema {
         "Query": Object(
             0..31 @36 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
+++ b/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
@@ -80,6 +80,7 @@ Schema {
         "Query": Object(
             96..147 @37 ObjectType {
                 description: None,
+                name: "Query",
                 implements_interfaces: {},
                 directives: [],
                 fields: {
@@ -126,6 +127,7 @@ ExecutableDocument {
     anonymous_operation: Some(
         149..185 @37 Operation {
             operation_type: Query,
+            name: None,
             variables: [],
             directives: [],
             selection_set: SelectionSet {

--- a/crates/apollo-compiler/tests/main.rs
+++ b/crates/apollo-compiler/tests/main.rs
@@ -7,3 +7,6 @@ mod misc;
 mod parser;
 mod schema;
 mod validation;
+
+#[path = "../examples/rename.rs"]
+mod rename;

--- a/crates/apollo-compiler/tests/snapshot_tests.rs
+++ b/crates/apollo-compiler/tests/snapshot_tests.rs
@@ -256,6 +256,7 @@ fn test_invalid_synthetic_node() {
         "Obj".into(),
         schema::ObjectType {
             description: Default::default(),
+            name: "Obj".into(),
             implements_interfaces: Default::default(),
             directives: Default::default(),
             fields: [(


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-rs/issues/708

In a few places (but not consistently) a `name` field was omitted from some structs used as map values
on the basis that it would have been redundant with the map key. This reverts that decision,
making it the user’s responsibility when mutating documents to keep names consistent.

* Add a `pub name: Name` field to `executable::Fragment` as well as `ScalarType`, `ObjectType`, `InterfaceType`, `EnumType`, `UnionType`, and `InputObjectType` in `schema`.
* Add a `fn name(&self) -> &Name` method to the `schema::ExtendedType` enum
* Add a `pub name: Option<Name>` field to `executable::Operation`
* Remove `executable::OperationRef<'_>` (which was equivalent to `(Option<&Name>, &Node<Operation>)`), replacing its uses with `&Node<Operation>`