### PR TITLE
Add serialization support for everything

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -16,24 +16,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Maintenance
 ## Documentation-->
-# [1.0.0-beta.5](https://crates.io/crates/apollo-compiler/1.0.0-beta.5) - 2023-11-08
-
-## Features
-- Diangostic struct is now public by [SimonSapin] in [11fe454]
-- Improve lowercase enum value diagnostic by [goto-bus-stop] in [pull/725]
-
-## Maintenance 
-- Simplify `SchemaBuilder` internals by [SimonSapin] in [pull/722]
-- Remove validation dead code by [SimonSapin] in [bd5d107]
-- Skip schema AST conversion in ExecutableDocument::validate by [SimonSapin] in [pull/726]
-
-[SimonSapin]: https://github.com/SimonSapin
-[goto-bus-stop]: https://github.com/goto-bus-stop
-[11fe454]: https://github.com/apollographql/apollo-rs/commit/11fe454f81b4cfbada4884a22575fa5c812a6ed4
-[bd5d107]: https://github.com/apollographql/apollo-rs/commit/bd5d107eca14a7fc06dd885b2952346326e648cb
-[pull/722]: https://github.com/apollographql/apollo-rs/pull/722
-[pull/725]: https://github.com/apollographql/apollo-rs/pull/725
-[pull/726]: https://github.com/apollographql/apollo-rs/pull/726
 
 # [x.x.x] (unreleased) - 2023-mm-dd
 
@@ -56,9 +38,57 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     (which was equivalent to `(Option<&Name>, &Node<Operation>)`),
     replacing its uses with `&Node<Operation>`
 
+## Features
+
+- **Add serialization support for everything - [SimonSapin], [pull/728].**
+
+  `Schema`, `ExecutableDocument`, and all AST types
+  already supported serialization to GraphQL syntax
+  through the `Display` trait and the `.serialize()` method.
+  This is now also the case of all other Rust types
+  representing some element of a GraphQL document:
+  * `schema::Directives`
+  * `schema::ExtendedType`
+  * `schema::ScalarType`
+  * `schema::ObjectType`
+  * `schema::InterfaceType`
+  * `schema::EnumType`
+  * `schema::UnionType`
+  * `schema::InputObjectType`
+  * `executable::Operation`
+  * `executable::Fragment`
+  * `executable::SelectionSet`
+  * `executable::Selection`
+  * `executable::Field`
+  * `executable::InlineFragment`
+  * `executable::FragmentSpread`
+  * `executable::FieldSet`
+
 [SimonSapin]: https://github.com/SimonSapin
 [issue/708]: https://github.com/apollographql/apollo-rs/issues/708
 [pull/727]: https://github.com/apollographql/apollo-rs/pull/727
+[pull/728]: https://github.com/apollographql/apollo-rs/pull/728
+
+
+# [1.0.0-beta.5](https://crates.io/crates/apollo-compiler/1.0.0-beta.5) - 2023-11-08
+
+## Features
+- Diangostic struct is now public by [SimonSapin] in [11fe454]
+- Improve lowercase enum value diagnostic by [goto-bus-stop] in [pull/725]
+
+## Maintenance 
+- Simplify `SchemaBuilder` internals by [SimonSapin] in [pull/722]
+- Remove validation dead code by [SimonSapin] in [bd5d107]
+- Skip schema AST conversion in ExecutableDocument::validate by [SimonSapin] in [pull/726]
+
+[SimonSapin]: https://github.com/SimonSapin
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[11fe454]: https://github.com/apollographql/apollo-rs/commit/11fe454f81b4cfbada4884a22575fa5c812a6ed4
+[bd5d107]: https://github.com/apollographql/apollo-rs/commit/bd5d107eca14a7fc06dd885b2952346326e648cb
+[pull/722]: https://github.com/apollographql/apollo-rs/pull/722
+[pull/725]: https://github.com/apollographql/apollo-rs/pull/725
+[pull/726]: https://github.com/apollographql/apollo-rs/pull/726
+
 
 # [1.0.0-beta.4](https://crates.io/crates/apollo-compiler/1.0.0-beta.4) - 2023-10-16
 

--- a/crates/apollo-compiler/src/ast/serialize.rs
+++ b/crates/apollo-compiler/src/ast/serialize.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::executable;
+use crate::schema;
 use std::fmt;
 use std::fmt::Display;
 
@@ -546,7 +548,7 @@ impl Directives {
 }
 
 impl Directive {
-    fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
         let Self { name, arguments } = self;
         state.write("@")?;
         state.write(name)?;
@@ -627,7 +629,7 @@ impl EnumValueDefinition {
 }
 
 impl Selection {
-    fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
         match self {
             Selection::Field(x) => x.serialize_impl(state),
             Selection::FragmentSpread(x) => x.serialize_impl(state),
@@ -637,7 +639,7 @@ impl Selection {
 }
 
 impl Field {
-    fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
         let Self {
             alias,
             name,
@@ -663,7 +665,7 @@ impl Field {
 }
 
 impl FragmentSpread {
-    fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
         let Self {
             fragment_name,
             directives,
@@ -675,7 +677,7 @@ impl FragmentSpread {
 }
 
 impl InlineFragment {
-    fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
         let Self {
             type_condition,
             directives,
@@ -780,7 +782,7 @@ fn comma_separated<T>(
 ///     c
 /// }
 /// ```
-fn curly_brackets_space_separated<T>(
+pub(crate) fn curly_brackets_space_separated<T>(
     state: &mut State,
     values: &[T],
     serialize_one: impl Fn(&mut State, &T) -> fmt::Result,
@@ -918,4 +920,20 @@ impl_display! {
     Value
     crate::Schema
     crate::ExecutableDocument
+    schema::Directives
+    schema::ExtendedType
+    schema::ScalarType
+    schema::ObjectType
+    schema::InterfaceType
+    schema::EnumType
+    schema::UnionType
+    schema::InputObjectType
+    executable::Operation
+    executable::Fragment
+    executable::SelectionSet
+    executable::Selection
+    executable::Field
+    executable::InlineFragment
+    executable::FragmentSpread
+    executable::FieldSet
 }

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -362,12 +362,16 @@ impl Operation {
         self.operation_type == OperationType::Query
             && is_introspection_impl(document, &mut HashSet::new(), &self.selection_set)
     }
+
+    serialize_method!();
 }
 
 impl Fragment {
     pub fn type_condition(&self) -> &NamedType {
         &self.selection_set.ty
     }
+
+    serialize_method!();
 }
 
 impl SelectionSet {
@@ -425,6 +429,8 @@ impl SelectionSet {
     pub fn fields(&self) -> impl Iterator<Item = &Node<Field>> {
         self.selections.iter().filter_map(|sel| sel.as_field())
     }
+
+    serialize_method!();
 }
 
 impl Selection {
@@ -435,6 +441,8 @@ impl Selection {
             Self::InlineFragment(sel) => &sel.directives,
         }
     }
+
+    serialize_method!();
 }
 
 impl From<Node<Field>> for Selection {
@@ -577,6 +585,8 @@ impl Field {
     pub fn inner_type_def<'a>(&self, schema: &'a Schema) -> Option<&'a schema::ExtendedType> {
         schema.types.get(self.ty().inner_named_type())
     }
+
+    serialize_method!();
 }
 
 impl InlineFragment {
@@ -623,6 +633,8 @@ impl InlineFragment {
         self.selection_set.extend(selections);
         self
     }
+
+    serialize_method!();
 }
 
 impl FragmentSpread {
@@ -649,6 +661,8 @@ impl FragmentSpread {
     pub fn fragment_def<'a>(&self, document: &'a ExecutableDocument) -> Option<&'a Node<Fragment>> {
         document.fragments.get(&self.fragment_name)
     }
+
+    serialize_method!();
 }
 
 impl FieldSet {
@@ -672,6 +686,8 @@ impl FieldSet {
         validation::validate_field_set(&mut errors, schema, self);
         errors.into_result()
     }
+
+    serialize_method!();
 }
 
 impl fmt::Display for SelectionPath {

--- a/crates/apollo-compiler/src/executable/serialize.rs
+++ b/crates/apollo-compiler/src/executable/serialize.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ast::serialize::curly_brackets_space_separated;
 use crate::ast::serialize::State;
 use std::fmt;
 
@@ -12,38 +13,48 @@ impl ExecutableDocument {
     pub(crate) fn to_ast(&self) -> ast::Document {
         let mut doc = ast::Document::new();
         if let Some(operation) = &self.anonymous_operation {
-            doc.definitions.push(operation.to_ast())
+            doc.definitions.push(operation.to_ast(operation.location()))
         }
         for operation in self.named_operations.values() {
-            doc.definitions.push(operation.to_ast())
+            doc.definitions.push(operation.to_ast(operation.location()))
         }
         for fragment in self.fragments.values() {
-            doc.definitions.push(fragment.to_ast())
+            doc.definitions.push(fragment.to_ast(fragment.location()))
         }
         doc
     }
 }
 
-impl Node<Operation> {
-    fn to_ast(&self) -> ast::Definition {
-        ast::Definition::OperationDefinition(self.same_location(ast::OperationDefinition {
+impl Operation {
+    fn to_ast(&self, location: Option<NodeLocation>) -> ast::Definition {
+        let def = ast::OperationDefinition {
             operation_type: self.operation_type,
             name: self.name.clone(),
             variables: self.variables.clone(),
             directives: self.directives.clone(),
             selection_set: self.selection_set.to_ast(),
-        }))
+        };
+        ast::Definition::OperationDefinition(Node::new_opt_location(def, location))
+    }
+
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+        self.to_ast(None).serialize_impl(state)
     }
 }
 
-impl Node<Fragment> {
-    fn to_ast(&self) -> ast::Definition {
-        ast::Definition::FragmentDefinition(self.same_location(ast::FragmentDefinition {
+impl Fragment {
+    fn to_ast(&self, location: Option<NodeLocation>) -> ast::Definition {
+        let def = ast::FragmentDefinition {
             name: self.name.clone(),
             type_condition: self.selection_set.ty.clone(),
             directives: self.directives.clone(),
             selection_set: self.selection_set.to_ast(),
-        }))
+        };
+        ast::Definition::FragmentDefinition(Node::new_opt_location(def, location))
+    }
+
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+        self.to_ast(None).serialize_impl(state)
     }
 }
 
@@ -51,28 +62,87 @@ impl SelectionSet {
     pub(crate) fn to_ast(&self) -> Vec<ast::Selection> {
         self.selections
             .iter()
-            .map(|selection| match selection {
-                Selection::Field(field) => ast::Selection::Field(field.same_location(ast::Field {
-                    alias: field.alias.clone(),
-                    name: field.name.clone(),
-                    arguments: field.arguments.clone(),
-                    directives: field.directives.clone(),
-                    selection_set: field.selection_set.to_ast(),
-                })),
-                Selection::FragmentSpread(fragment_spread) => ast::Selection::FragmentSpread(
-                    fragment_spread.same_location(ast::FragmentSpread {
-                        fragment_name: fragment_spread.fragment_name.clone(),
-                        directives: fragment_spread.directives.clone(),
-                    }),
-                ),
-                Selection::InlineFragment(inline_fragment) => ast::Selection::InlineFragment(
-                    inline_fragment.same_location(ast::InlineFragment {
-                        type_condition: inline_fragment.type_condition.clone(),
-                        directives: inline_fragment.directives.clone(),
-                        selection_set: inline_fragment.selection_set.to_ast(),
-                    }),
-                ),
-            })
+            .map(|selection| selection.to_ast())
             .collect()
+    }
+
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+        curly_brackets_space_separated(state, &self.selections, |state, sel| {
+            sel.serialize_impl(state)
+        })
+    }
+}
+
+impl Selection {
+    pub(crate) fn to_ast(&self) -> ast::Selection {
+        match self {
+            Selection::Field(field) => ast::Selection::Field(field.same_location(field.to_ast())),
+            Selection::FragmentSpread(fragment_spread) => ast::Selection::FragmentSpread(
+                fragment_spread.same_location(fragment_spread.to_ast()),
+            ),
+            Selection::InlineFragment(inline_fragment) => ast::Selection::InlineFragment(
+                inline_fragment.same_location(inline_fragment.to_ast()),
+            ),
+        }
+    }
+
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+        self.to_ast().serialize_impl(state)
+    }
+}
+
+impl Field {
+    pub(crate) fn to_ast(&self) -> ast::Field {
+        ast::Field {
+            alias: self.alias.clone(),
+            name: self.name.clone(),
+            arguments: self.arguments.clone(),
+            directives: self.directives.clone(),
+            selection_set: self.selection_set.to_ast(),
+        }
+    }
+
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+        self.to_ast().serialize_impl(state)
+    }
+}
+
+impl InlineFragment {
+    pub(crate) fn to_ast(&self) -> ast::InlineFragment {
+        ast::InlineFragment {
+            type_condition: self.type_condition.clone(),
+            directives: self.directives.clone(),
+            selection_set: self.selection_set.to_ast(),
+        }
+    }
+
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+        self.to_ast().serialize_impl(state)
+    }
+}
+
+impl FragmentSpread {
+    pub(crate) fn to_ast(&self) -> ast::FragmentSpread {
+        ast::FragmentSpread {
+            fragment_name: self.fragment_name.clone(),
+            directives: self.directives.clone(),
+        }
+    }
+
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+        self.to_ast().serialize_impl(state)
+    }
+}
+
+impl FieldSet {
+    pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
+        if let Some((first, rest)) = self.selection_set.selections.split_first() {
+            first.serialize_impl(state)?;
+            for value in rest {
+                state.new_line_or_space()?;
+                value.serialize_impl(state)?;
+            }
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
`Schema`, `ExecutableDocument`, and all AST types already supported serialization to GraphQL syntax through the `Display` trait and the `.serialize()` method. This is now also the case of all other Rust types representing some element of a GraphQL document:

* `schema::Directives`
* `schema::ExtendedType`
* `schema::ScalarType`
* `schema::ObjectType`
* `schema::InterfaceType`
* `schema::EnumType`
* `schema::UnionType`
* `schema::InputObjectType`
* `executable::Operation`
* `executable::Fragment`
* `executable::SelectionSet`
* `executable::Selection`
* `executable::Field`
* `executable::InlineFragment`
* `executable::FragmentSpread`
* `executable::FieldSet`