### PR TITLE
Rename `Directives` and `Diagnostics` to `DirectiveList` and `DiagnosticsList`

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -37,7 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   * Remove `executable::OperationRef<'_>` 
     (which was equivalent to `(Option<&Name>, &Node<Operation>)`),
     replacing its uses with `&Node<Operation>`
-- **Rename `Directives` and `Diagnostics` to `DirectiveList` and `DiagnosticsList` - 
+- **Rename `Directives` and `Diagnostics` to `DirectiveList` and `DiagnosticList` - 
   [SimonSapin], [pull/732] fixing [issue/711].**
   The previous names were too similar to `Directive` and `Diagnostic` (singular).
 

--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -37,6 +37,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   * Remove `executable::OperationRef<'_>` 
     (which was equivalent to `(Option<&Name>, &Node<Operation>)`),
     replacing its uses with `&Node<Operation>`
+- **Rename `Directives` and `Diagnostics` to `DirectiveList` and `DiagnosticsList` - 
+  [SimonSapin], [pull/732] fixing [issue/711].**
+  The previous names were too similar to `Directive` and `Diagnostic` (singular).
 
 ## Features
 
@@ -66,8 +69,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 [SimonSapin]: https://github.com/SimonSapin
 [issue/708]: https://github.com/apollographql/apollo-rs/issues/708
+[issue/711]: https://github.com/apollographql/apollo-rs/issues/711
 [pull/727]: https://github.com/apollographql/apollo-rs/pull/727
 [pull/728]: https://github.com/apollographql/apollo-rs/pull/728
+[pull/732]: https://github.com/apollographql/apollo-rs/pull/732
 
 
 # [1.0.0-beta.5](https://crates.io/crates/apollo-compiler/1.0.0-beta.5) - 2023-11-08

--- a/crates/apollo-compiler/src/ast/from_cst.rs
+++ b/crates/apollo-compiler/src/ast/from_cst.rs
@@ -135,7 +135,7 @@ impl Convert for cst::OperationDefinition {
             variables: collect_opt(file_id, self.variable_definitions(), |x| {
                 x.variable_definitions()
             }),
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             selection_set: self
@@ -154,7 +154,7 @@ impl Convert for cst::FragmentDefinition {
         Some(Self::Target {
             name: self.fragment_name()?.name()?.convert(file_id)?,
             type_condition: self.type_condition()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             selection_set: self.selection_set().convert(file_id)??,
@@ -199,7 +199,7 @@ impl Convert for cst::SchemaDefinition {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             // This may represent a syntactically invalid thing: a schema without any root
@@ -221,7 +221,7 @@ impl Convert for cst::ScalarTypeDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
         })
@@ -236,7 +236,7 @@ impl Convert for cst::ObjectTypeDefinition {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
             implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
@@ -252,7 +252,7 @@ impl Convert for cst::InterfaceTypeDefinition {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
             implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
@@ -267,7 +267,7 @@ impl Convert for cst::UnionTypeDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             members: self
@@ -289,7 +289,7 @@ impl Convert for cst::EnumTypeDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             values: collect_opt(file_id, self.enum_values_definition(), |x| {
@@ -306,7 +306,7 @@ impl Convert for cst::InputObjectTypeDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             fields: collect_opt(file_id, self.input_fields_definition(), |x| {
@@ -321,7 +321,7 @@ impl Convert for cst::SchemaExtension {
 
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             root_operations: self
@@ -338,7 +338,7 @@ impl Convert for cst::ScalarTypeExtension {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
         })
@@ -352,7 +352,7 @@ impl Convert for cst::ObjectTypeExtension {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
             implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
@@ -367,7 +367,7 @@ impl Convert for cst::InterfaceTypeExtension {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
             implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
@@ -381,7 +381,7 @@ impl Convert for cst::UnionTypeExtension {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             members: self
@@ -402,7 +402,7 @@ impl Convert for cst::EnumTypeExtension {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             values: collect_opt(file_id, self.enum_values_definition(), |x| {
@@ -418,7 +418,7 @@ impl Convert for cst::InputObjectTypeExtension {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             name: self.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             fields: collect_opt(file_id, self.input_fields_definition(), |x| {
@@ -538,7 +538,7 @@ impl Convert for cst::VariableDefinition {
             name: self.variable()?.name()?.convert(file_id)?,
             ty: with_location(file_id, ty.syntax(), ty.convert(file_id)?),
             default_value,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
         })
@@ -578,7 +578,7 @@ impl Convert for cst::FieldDefinition {
                 x.input_value_definitions()
             }),
             ty: self.ty()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
         })
@@ -616,7 +616,7 @@ impl Convert for cst::InputValueDefinition {
             name: self.name()?.convert(file_id)?,
             ty: with_location(file_id, ty.syntax(), ty.convert(file_id)?),
             default_value,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
         })
@@ -630,7 +630,7 @@ impl Convert for cst::EnumValueDefinition {
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             value: self.enum_value()?.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
         })
@@ -682,7 +682,7 @@ impl Convert for cst::Field {
             alias: self.alias().convert(file_id)?,
             name: self.name()?.convert(file_id)?,
             arguments: collect_opt(file_id, self.arguments(), |x| x.arguments()),
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             // Use an empty Vec for a field without sub-selections
@@ -697,7 +697,7 @@ impl Convert for cst::FragmentSpread {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             fragment_name: self.fragment_name()?.name()?.convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
         })
@@ -710,7 +710,7 @@ impl Convert for cst::InlineFragment {
     fn convert(&self, file_id: FileId) -> Option<Self::Target> {
         Some(Self::Target {
             type_condition: self.type_condition().convert(file_id)?,
-            directives: ast::Directives(collect_opt(file_id, self.directives(), |x| {
+            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
                 x.directives()
             })),
             selection_set: self.selection_set().convert(file_id)??,

--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::node::NodeLocation;
 use crate::schema::SchemaBuilder;
-use crate::validation::Diagnostics;
+use crate::validation::DiagnosticList;
 use crate::ExecutableDocument;
 use crate::Parser;
 use crate::Schema;
@@ -35,8 +35,8 @@ impl Document {
     /// the GraphQL grammar or where the parser reached a token limit or recursion limit.
     ///
     /// Does not perform any validation beyond this syntactic level.
-    pub fn check_parse_errors(&self) -> Result<(), Diagnostics> {
-        let mut errors = Diagnostics::new(None, self.sources.clone());
+    pub fn check_parse_errors(&self) -> Result<(), DiagnosticList> {
+        let mut errors = DiagnosticList::new(None, self.sources.clone());
         for (file_id, source) in self.sources.iter() {
             source.validate_parse_errors(&mut errors, *file_id)
         }
@@ -44,14 +44,14 @@ impl Document {
     }
 
     /// Validate as an executable document, as much as possible without a schema
-    pub fn validate_standalone_executable(&self) -> Result<(), Diagnostics> {
+    pub fn validate_standalone_executable(&self) -> Result<(), DiagnosticList> {
         let type_system_definitions_are_errors = true;
         let executable = crate::executable::from_ast::document_from_ast(
             None,
             self,
             type_system_definitions_are_errors,
         );
-        let mut errors = Diagnostics::new(None, self.sources.clone());
+        let mut errors = DiagnosticList::new(None, self.sources.clone());
         crate::executable::validation::validate_standalone_executable(&mut errors, &executable);
         errors.into_result()
     }
@@ -240,8 +240,8 @@ impl Definition {
         }
     }
 
-    pub fn directives(&self) -> &Directives {
-        static EMPTY: Directives = Directives(Vec::new());
+    pub fn directives(&self) -> &DirectiveList {
+        static EMPTY: DirectiveList = DirectiveList(Vec::new());
         match self {
             Self::DirectiveDefinition(_) => &EMPTY,
             Self::OperationDefinition(def) => &def.directives,
@@ -380,7 +380,7 @@ impl InputObjectTypeExtension {
     serialize_method!();
 }
 
-impl Directives {
+impl DirectiveList {
     pub fn new() -> Self {
         Self(Vec::new())
     }
@@ -412,13 +412,13 @@ impl Directives {
     serialize_method!();
 }
 
-impl std::fmt::Debug for Directives {
+impl std::fmt::Debug for DirectiveList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl std::ops::Deref for Directives {
+impl std::ops::Deref for DirectiveList {
     type Target = Vec<Node<Directive>>;
 
     fn deref(&self) -> &Self::Target {
@@ -426,13 +426,13 @@ impl std::ops::Deref for Directives {
     }
 }
 
-impl std::ops::DerefMut for Directives {
+impl std::ops::DerefMut for DirectiveList {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<'a> IntoIterator for &'a Directives {
+impl<'a> IntoIterator for &'a DirectiveList {
     type Item = &'a Node<Directive>;
 
     type IntoIter = std::slice::Iter<'a, Node<Directive>>;
@@ -442,7 +442,7 @@ impl<'a> IntoIterator for &'a Directives {
     }
 }
 
-impl<'a> IntoIterator for &'a mut Directives {
+impl<'a> IntoIterator for &'a mut DirectiveList {
     type Item = &'a mut Node<Directive>;
 
     type IntoIter = std::slice::IterMut<'a, Node<Directive>>;

--- a/crates/apollo-compiler/src/ast/mod.rs
+++ b/crates/apollo-compiler/src/ast/mod.rs
@@ -92,7 +92,7 @@ pub struct OperationDefinition {
     pub operation_type: OperationType,
     pub name: Option<Name>,
     pub variables: Vec<Node<VariableDefinition>>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub selection_set: Vec<Selection>,
 }
 
@@ -100,7 +100,7 @@ pub struct OperationDefinition {
 pub struct FragmentDefinition {
     pub name: Name,
     pub type_condition: NamedType,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub selection_set: Vec<Selection>,
 }
 
@@ -116,7 +116,7 @@ pub struct DirectiveDefinition {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SchemaDefinition {
     pub description: Option<NodeStr>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub root_operations: Vec<Node<(OperationType, NamedType)>>,
 }
 
@@ -124,7 +124,7 @@ pub struct SchemaDefinition {
 pub struct ScalarTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -132,7 +132,7 @@ pub struct ObjectTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
     pub implements_interfaces: Vec<Name>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub fields: Vec<Node<FieldDefinition>>,
 }
 
@@ -141,7 +141,7 @@ pub struct InterfaceTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
     pub implements_interfaces: Vec<Name>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub fields: Vec<Node<FieldDefinition>>,
 }
 
@@ -149,7 +149,7 @@ pub struct InterfaceTypeDefinition {
 pub struct UnionTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub members: Vec<NamedType>,
 }
 
@@ -157,7 +157,7 @@ pub struct UnionTypeDefinition {
 pub struct EnumTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub values: Vec<Node<EnumValueDefinition>>,
 }
 
@@ -165,27 +165,27 @@ pub struct EnumTypeDefinition {
 pub struct InputObjectTypeDefinition {
     pub description: Option<NodeStr>,
     pub name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub fields: Vec<Node<InputValueDefinition>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SchemaExtension {
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub root_operations: Vec<Node<(OperationType, NamedType)>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ScalarTypeExtension {
     pub name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ObjectTypeExtension {
     pub name: Name,
     pub implements_interfaces: Vec<Name>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub fields: Vec<Node<FieldDefinition>>,
 }
 
@@ -193,28 +193,28 @@ pub struct ObjectTypeExtension {
 pub struct InterfaceTypeExtension {
     pub name: Name,
     pub implements_interfaces: Vec<Name>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub fields: Vec<Node<FieldDefinition>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct UnionTypeExtension {
     pub name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub members: Vec<NamedType>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EnumTypeExtension {
     pub name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub values: Vec<Node<EnumValueDefinition>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct InputObjectTypeExtension {
     pub name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub fields: Vec<Node<InputValueDefinition>>,
 }
 
@@ -225,7 +225,7 @@ pub struct Argument {
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Default)]
-pub struct Directives(pub Vec<Node<Directive>>);
+pub struct DirectiveList(pub Vec<Node<Directive>>);
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Directive {
@@ -268,7 +268,7 @@ pub struct VariableDefinition {
     pub name: Name,
     pub ty: Node<Type>,
     pub default_value: Option<Node<Value>>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -285,7 +285,7 @@ pub struct FieldDefinition {
     pub name: Name,
     pub arguments: Vec<Node<InputValueDefinition>>,
     pub ty: Type,
-    pub directives: Directives,
+    pub directives: DirectiveList,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -294,14 +294,14 @@ pub struct InputValueDefinition {
     pub name: Name,
     pub ty: Node<Type>,
     pub default_value: Option<Node<Value>>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct EnumValueDefinition {
     pub description: Option<NodeStr>,
     pub value: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -316,20 +316,20 @@ pub struct Field {
     pub alias: Option<Name>,
     pub name: Name,
     pub arguments: Vec<Node<Argument>>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub selection_set: Vec<Selection>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct FragmentSpread {
     pub fragment_name: Name,
-    pub directives: Directives,
+    pub directives: DirectiveList,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct InlineFragment {
     pub type_condition: Option<NamedType>,
-    pub directives: Directives,
+    pub directives: DirectiveList,
     pub selection_set: Vec<Selection>,
 }
 

--- a/crates/apollo-compiler/src/ast/serialize.rs
+++ b/crates/apollo-compiler/src/ast/serialize.rs
@@ -322,7 +322,7 @@ fn serialize_object_type_like(
     state: &mut State,
     name: &str,
     implements_interfaces: &[Name],
-    directives: &Directives,
+    directives: &DirectiveList,
     fields: &[Node<FieldDefinition>],
 ) -> Result<(), fmt::Error> {
     state.write(name)?;
@@ -375,7 +375,7 @@ impl UnionTypeDefinition {
 fn serialize_union(
     state: &mut State,
     name: &str,
-    directives: &Directives,
+    directives: &DirectiveList,
     members: &[Name],
 ) -> fmt::Result {
     state.write(name)?;
@@ -537,7 +537,7 @@ impl InputObjectTypeExtension {
     }
 }
 
-impl Directives {
+impl DirectiveList {
     fn serialize_impl(&self, state: &mut State) -> fmt::Result {
         for dir in self {
             state.write(" ")?;
@@ -907,7 +907,7 @@ impl_display! {
     UnionTypeExtension
     EnumTypeExtension
     InputObjectTypeExtension
-    Directives
+    DirectiveList
     Directive
     VariableDefinition
     FieldDefinition
@@ -920,7 +920,7 @@ impl_display! {
     Value
     crate::Schema
     crate::ExecutableDocument
-    schema::Directives
+    schema::DirectiveList
     schema::ExtendedType
     schema::ScalarType
     schema::ObjectType

--- a/crates/apollo-compiler/src/executable/validation.rs
+++ b/crates/apollo-compiler/src/executable/validation.rs
@@ -2,7 +2,7 @@ use super::BuildError;
 use super::FieldSet;
 use crate::ast;
 use crate::validation::Details;
-use crate::validation::Diagnostics;
+use crate::validation::DiagnosticList;
 use crate::ExecutableDocument;
 use crate::FileId;
 use crate::InputDatabase;
@@ -11,7 +11,7 @@ use crate::ValidationDatabase;
 use std::sync::Arc;
 
 pub(crate) fn validate_executable_document(
-    errors: &mut Diagnostics,
+    errors: &mut DiagnosticList,
     schema: &Schema,
     document: &ExecutableDocument,
 ) {
@@ -21,14 +21,14 @@ pub(crate) fn validate_executable_document(
 }
 
 pub(crate) fn validate_standalone_executable(
-    errors: &mut Diagnostics,
+    errors: &mut DiagnosticList,
     document: &ExecutableDocument,
 ) {
     validate_common(errors, document);
     compiler_validation(errors, None, document);
 }
 
-pub(crate) fn validate_common(errors: &mut Diagnostics, document: &ExecutableDocument) {
+pub(crate) fn validate_common(errors: &mut DiagnosticList, document: &ExecutableDocument) {
     for (file_id, source) in document.sources.iter() {
         source.validate_parse_errors(errors, *file_id)
     }
@@ -54,7 +54,7 @@ pub(crate) fn validate_common(errors: &mut Diagnostics, document: &ExecutableDoc
     // TODO
 }
 
-fn validate_build_error(errors: &mut Diagnostics, build_error: &BuildError) {
+fn validate_build_error(errors: &mut DiagnosticList, build_error: &BuildError) {
     let location = match build_error {
         BuildError::TypeSystemDefinition { location, .. }
         | BuildError::AmbiguousAnonymousOperation { location }
@@ -72,7 +72,7 @@ fn validate_build_error(errors: &mut Diagnostics, build_error: &BuildError) {
 
 /// TODO: replace this with validation based on `ExecutableDocument` without a database
 fn compiler_validation(
-    errors: &mut Diagnostics,
+    errors: &mut DiagnosticList,
     schema: Option<&Schema>,
     document: &ExecutableDocument,
 ) {
@@ -116,7 +116,11 @@ fn compiler_validation(
     }
 }
 
-pub(crate) fn validate_field_set(errors: &mut Diagnostics, schema: &Schema, field_set: &FieldSet) {
+pub(crate) fn validate_field_set(
+    errors: &mut DiagnosticList,
+    schema: &Schema,
+    field_set: &FieldSet,
+) {
     for (file_id, source) in &*field_set.sources {
         source.validate_parse_errors(errors, *file_id)
     }

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -22,7 +22,7 @@ pub use self::node::{Node, NodeLocation};
 pub use self::node_str::NodeStr;
 pub use self::parser::{parse_mixed, Parser, SourceFile, SourceMap};
 pub use self::schema::Schema;
-pub use self::validation::{Diagnostic, Diagnostics, GraphQLError, GraphQLLocation};
+pub use self::validation::{Diagnostic, DiagnosticList, GraphQLError, GraphQLLocation};
 
 pub(crate) struct ApolloCompiler {
     pub db: RootDatabase,

--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -3,7 +3,7 @@ use crate::ast::Document;
 use crate::executable;
 use crate::schema::SchemaBuilder;
 use crate::validation::Details;
-use crate::validation::Diagnostics;
+use crate::validation::DiagnosticList;
 use crate::ExecutableDocument;
 use crate::FileId;
 use crate::NodeLocation;
@@ -299,7 +299,7 @@ impl SourceFile {
         Some((line, column))
     }
 
-    pub(crate) fn validate_parse_errors(&self, errors: &mut Diagnostics, file_id: FileId) {
+    pub(crate) fn validate_parse_errors(&self, errors: &mut DiagnosticList, file_id: FileId) {
         for err in &self.parse_errors {
             // Silently skip parse errors at index beyond 4 GiB.
             // Rowan in apollo-parser might complain about files that large

--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -33,7 +33,7 @@ impl SchemaBuilder {
                 build_errors: Vec::new(),
                 schema_definition: Node::new(SchemaDefinition {
                     description: None,
-                    directives: Directives::default(),
+                    directives: DirectiveList::default(),
                     query: None,
                     mutation: None,
                     subscription: None,

--- a/crates/apollo-compiler/src/schema/serialize.rs
+++ b/crates/apollo-compiler/src/schema/serialize.rs
@@ -91,7 +91,7 @@ impl Node<SchemaDefinition> {
             Some(ast::Definition::SchemaDefinition(self.same_location(
                 ast::SchemaDefinition {
                     description: self.description.clone(),
-                    directives: ast::Directives(components(&self.directives, None)),
+                    directives: ast::DirectiveList(components(&self.directives, None)),
                     root_operations: root_ops(None),
                 },
             )))
@@ -99,7 +99,7 @@ impl Node<SchemaDefinition> {
         .into_iter()
         .chain(extensions.into_iter().map(move |ext| {
             ast::Definition::SchemaExtension(ext.same_location(ast::SchemaExtension {
-                directives: ast::Directives(components(&self.directives, Some(ext))),
+                directives: ast::DirectiveList(components(&self.directives, Some(ext))),
                 root_operations: root_ops(Some(ext)),
             }))
         }))
@@ -137,13 +137,13 @@ impl ScalarType {
         let def = ast::ScalarTypeDefinition {
             description: self.description.clone(),
             name: self.name.clone(),
-            directives: ast::Directives(components(&self.directives, None)),
+            directives: ast::DirectiveList(components(&self.directives, None)),
         };
         std::iter::once(Node::new_opt_location(def, location).into()).chain(
             self.extensions().into_iter().map(move |ext| {
                 ast::Definition::ScalarTypeExtension(ext.same_location(ast::ScalarTypeExtension {
                     name: self.name.clone(),
-                    directives: ast::Directives(components(&self.directives, Some(ext))),
+                    directives: ast::DirectiveList(components(&self.directives, Some(ext))),
                 }))
             }),
         )
@@ -162,7 +162,7 @@ impl ObjectType {
             description: self.description.clone(),
             name: self.name.clone(),
             implements_interfaces: names(&self.implements_interfaces, None),
-            directives: ast::Directives(components(&self.directives, None)),
+            directives: ast::DirectiveList(components(&self.directives, None)),
             fields: components(self.fields.values(), None),
         };
         std::iter::once(Node::new_opt_location(def, location).into()).chain(
@@ -170,7 +170,7 @@ impl ObjectType {
                 ast::Definition::ObjectTypeExtension(ext.same_location(ast::ObjectTypeExtension {
                     name: self.name.clone(),
                     implements_interfaces: names(&self.implements_interfaces, Some(ext)),
-                    directives: ast::Directives(components(&self.directives, Some(ext))),
+                    directives: ast::DirectiveList(components(&self.directives, Some(ext))),
                     fields: components(self.fields.values(), Some(ext)),
                 }))
             }),
@@ -190,7 +190,7 @@ impl InterfaceType {
             description: self.description.clone(),
             name: self.name.clone(),
             implements_interfaces: names(&self.implements_interfaces, None),
-            directives: ast::Directives(components(&self.directives, None)),
+            directives: ast::DirectiveList(components(&self.directives, None)),
             fields: components(self.fields.values(), None),
         };
         std::iter::once(Node::new_opt_location(def, location).into()).chain(
@@ -199,7 +199,7 @@ impl InterfaceType {
                     ast::InterfaceTypeExtension {
                         name: self.name.clone(),
                         implements_interfaces: names(&self.implements_interfaces, Some(ext)),
-                        directives: ast::Directives(components(&self.directives, Some(ext))),
+                        directives: ast::DirectiveList(components(&self.directives, Some(ext))),
                         fields: components(self.fields.values(), Some(ext)),
                     },
                 ))
@@ -219,14 +219,14 @@ impl UnionType {
         let def = ast::UnionTypeDefinition {
             description: self.description.clone(),
             name: self.name.clone(),
-            directives: ast::Directives(components(&self.directives, None)),
+            directives: ast::DirectiveList(components(&self.directives, None)),
             members: names(&self.members, None),
         };
         std::iter::once(Node::new_opt_location(def, location).into()).chain(
             self.extensions().into_iter().map(move |ext| {
                 ast::Definition::UnionTypeExtension(ext.same_location(ast::UnionTypeExtension {
                     name: self.name.clone(),
-                    directives: ast::Directives(components(&self.directives, Some(ext))),
+                    directives: ast::DirectiveList(components(&self.directives, Some(ext))),
                     members: names(&self.members, Some(ext)),
                 }))
             }),
@@ -245,14 +245,14 @@ impl EnumType {
         let def = ast::EnumTypeDefinition {
             description: self.description.clone(),
             name: self.name.clone(),
-            directives: ast::Directives(components(&self.directives, None)),
+            directives: ast::DirectiveList(components(&self.directives, None)),
             values: components(self.values.values(), None),
         };
         std::iter::once(Node::new_opt_location(def, location).into()).chain(
             self.extensions().into_iter().map(move |ext| {
                 ast::Definition::EnumTypeExtension(ext.same_location(ast::EnumTypeExtension {
                     name: self.name.clone(),
-                    directives: ast::Directives(components(&self.directives, Some(ext))),
+                    directives: ast::DirectiveList(components(&self.directives, Some(ext))),
                     values: components(self.values.values(), Some(ext)),
                 }))
             }),
@@ -271,7 +271,7 @@ impl InputObjectType {
         let def = ast::InputObjectTypeDefinition {
             description: self.description.clone(),
             name: self.name.clone(),
-            directives: ast::Directives(components(&self.directives, None)),
+            directives: ast::DirectiveList(components(&self.directives, None)),
             fields: components(self.fields.values(), None),
         };
         std::iter::once(Node::new_opt_location(def, location).into()).chain(
@@ -279,7 +279,7 @@ impl InputObjectType {
                 ast::Definition::InputObjectTypeExtension(ext.same_location(
                     ast::InputObjectTypeExtension {
                         name: self.name.clone(),
-                        directives: ast::Directives(components(&self.directives, Some(ext))),
+                        directives: ast::DirectiveList(components(&self.directives, Some(ext))),
                         fields: components(self.fields.values(), Some(ext)),
                     },
                 ))
@@ -313,7 +313,7 @@ fn names(names: &IndexSet<ComponentStr>, ext: Option<&ExtensionId>) -> Vec<Name>
         .collect()
 }
 
-impl Directives {
+impl DirectiveList {
     pub(crate) fn serialize_impl(&self, state: &mut State) -> fmt::Result {
         for directive in self.iter() {
             state.write(" ")?;

--- a/crates/apollo-compiler/src/schema/validation.rs
+++ b/crates/apollo-compiler/src/schema/validation.rs
@@ -1,6 +1,6 @@
 use super::BuildError;
 use crate::validation::Details;
-use crate::validation::Diagnostics;
+use crate::validation::DiagnosticList;
 use crate::FileId;
 use crate::InputDatabase;
 use crate::Schema;
@@ -8,7 +8,7 @@ use crate::ValidationDatabase;
 use std::sync::Arc;
 
 pub(crate) fn validate_schema(
-    errors: &mut Diagnostics,
+    errors: &mut DiagnosticList,
     schema: &Schema,
 ) -> Vec<crate::ApolloDiagnostic> {
     for (&file_id, source) in schema.sources.iter() {
@@ -20,7 +20,7 @@ pub(crate) fn validate_schema(
     compiler_validation(errors, schema)
 }
 
-fn validate_build_error(errors: &mut Diagnostics, build_error: &BuildError) {
+fn validate_build_error(errors: &mut DiagnosticList, build_error: &BuildError) {
     match build_error {
         BuildError::ExecutableDefinition { location, .. }
         | BuildError::SchemaDefinitionCollision { location, .. }
@@ -44,7 +44,10 @@ fn validate_build_error(errors: &mut Diagnostics, build_error: &BuildError) {
 }
 
 /// TODO: replace this with validation based on `Schema` without a database
-fn compiler_validation(errors: &mut Diagnostics, schema: &Schema) -> Vec<crate::ApolloDiagnostic> {
+fn compiler_validation(
+    errors: &mut DiagnosticList,
+    schema: &Schema,
+) -> Vec<crate::ApolloDiagnostic> {
     let mut compiler = crate::ApolloCompiler::new();
     let mut ids = Vec::new();
     for (id, source) in schema.sources.iter() {

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -31,11 +31,11 @@ use std::sync::OnceLock;
 pub(crate) use validation_db::{ValidationDatabase, ValidationStorage};
 
 /// A collection of diagnostics returned by some validation method
-pub struct Diagnostics(Box<DiagnosticsBoxed>);
+pub struct DiagnosticList(Box<DiagnosticListBoxed>);
 
 /// Box indirection to avoid large `Err` values:
 /// <https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err>
-struct DiagnosticsBoxed {
+struct DiagnosticListBoxed {
     sources: Sources,
     diagnostics_data: Vec<DiagnosticData>,
 }
@@ -315,7 +315,7 @@ impl<'a> Diagnostic<'a> {
     }
 }
 
-impl Diagnostics {
+impl DiagnosticList {
     pub fn is_empty(&self) -> bool {
         self.0.diagnostics_data.is_empty()
     }
@@ -342,7 +342,7 @@ impl Diagnostics {
     }
 
     pub(crate) fn new(schema_sources: Option<SourceMap>, self_sources: SourceMap) -> Self {
-        Self(Box::new(DiagnosticsBoxed {
+        Self(Box::new(DiagnosticListBoxed {
             sources: Sources {
                 schema_sources,
                 self_sources,
@@ -376,7 +376,7 @@ impl Diagnostics {
 /// Defaults to ANSI color codes if stderr is a terminal.
 ///
 /// Use alternate formatting to never use colors: `format!("{diagnostics:#}")`
-impl fmt::Display for Diagnostics {
+impl fmt::Display for DiagnosticList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for diagnostic in self.iter() {
             diagnostic.fmt(f)?
@@ -460,7 +460,7 @@ impl ariadne::Cache<FileId> for &'_ Sources {
     }
 }
 
-impl fmt::Debug for Diagnostics {
+impl fmt::Debug for DiagnosticList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }

--- a/crates/apollo-compiler/src/validation/validation_db.rs
+++ b/crates/apollo-compiler/src/validation/validation_db.rs
@@ -241,7 +241,7 @@ fn ast_types(db: &dyn ValidationDatabase) -> Arc<ast::TypeSystem> {
         definition: schema_definition.unwrap_or_else(|| {
             Node::new(ast::SchemaDefinition {
                 description: None,
-                directives: ast::Directives::new(),
+                directives: ast::DirectiveList::new(),
                 root_operations: {
                     let mut operations = Vec::with_capacity(3);
                     let query_name = ast::Name::new("Query");

--- a/crates/apollo-compiler/tests/snapshot_tests.rs
+++ b/crates/apollo-compiler/tests/snapshot_tests.rs
@@ -9,7 +9,7 @@
 
 use apollo_compiler::ast;
 use apollo_compiler::schema;
-use apollo_compiler::Diagnostics;
+use apollo_compiler::DiagnosticList;
 use apollo_compiler::FileId;
 use apollo_compiler::Schema;
 use expect_test::expect_file;
@@ -92,8 +92,8 @@ fn validation() {
 }
 
 fn assert_diagnostics_are_present(
-    schema_validation_errors: &Option<Diagnostics>,
-    executable_validation_errors: &Option<Diagnostics>,
+    schema_validation_errors: &Option<DiagnosticList>,
+    executable_validation_errors: &Option<DiagnosticList>,
     path: &Path,
 ) {
     assert!(
@@ -104,8 +104,8 @@ fn assert_diagnostics_are_present(
 }
 
 fn assert_diagnostics_are_absent(
-    schema_validation_errors: &Option<Diagnostics>,
-    executable_validation_errors: &Option<Diagnostics>,
+    schema_validation_errors: &Option<DiagnosticList>,
+    executable_validation_errors: &Option<DiagnosticList>,
     path: &Path,
 ) {
     if schema_validation_errors.is_some() || executable_validation_errors.is_some() {


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-rs/issues/711

The previous names were too similar to `Directive` and `Diagnostic` (singular).