### PR TITLE
Fix validation stack overflow for fragment cycles inside nested fields

### DIFF
--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -324,7 +324,9 @@ pub(crate) fn validate_fragment_cycles(
                 ast::Selection::InlineFragment(inline) => {
                     detect_fragment_cycles(named_fragments, &inline.selection_set, visited)?;
                 }
-                _ => {}
+                ast::Selection::Field(field) => {
+                    detect_fragment_cycles(named_fragments, &field.selection_set, visited)?;
+                }
             }
         }
 

--- a/crates/apollo-compiler/test_data/diagnostics/0092_recursive_fragment_spread.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0092_recursive_fragment_spread.graphql
@@ -9,7 +9,16 @@ type Query {
 # Query
 {
   human { ...fragA }
+  __schema { types { ...cycle1 } }
 }
 fragment fragA on Human { name, ...fragB }
 fragment fragB on Human { name, ...fragC }
 fragment fragC on Human { name, ...fragA }
+
+# Indirect cycle
+fragment cycle1 on __Type { kind, ...cycle2 }
+
+fragment cycle2 on __Type {
+  kind
+  ofType { ...cycle1 }
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0092_recursive_fragment_spread.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0092_recursive_fragment_spread.txt
@@ -1,12 +1,23 @@
 Error: `fragA` fragment cannot reference itself
-    ╭─[0092_recursive_fragment_spread.graphql:13:1]
+    ╭─[0092_recursive_fragment_spread.graphql:14:1]
     │
- 13 │ fragment fragA on Human { name, ...fragB }
+ 14 │ fragment fragA on Human { name, ...fragB }
     │ ───────┬──────  
     │        ╰──────── recursive fragment definition
     │ 
- 15 │ fragment fragC on Human { name, ...fragA }
+ 16 │ fragment fragC on Human { name, ...fragA }
     │                                 ────┬───  
     │                                     ╰───── refers to itself here
+────╯
+Error: `cycle1` fragment cannot reference itself
+    ╭─[0092_recursive_fragment_spread.graphql:19:1]
+    │
+ 19 │ fragment cycle1 on __Type { kind, ...cycle2 }
+    │ ───────┬───────  
+    │        ╰───────── recursive fragment definition
+    │ 
+ 23 │   ofType { ...cycle1 }
+    │            ────┬────  
+    │                ╰────── refers to itself here
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0092_recursive_fragment_spread.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0092_recursive_fragment_spread.txt
@@ -2,22 +2,28 @@ Error: `fragA` fragment cannot reference itself
     ╭─[0092_recursive_fragment_spread.graphql:14:1]
     │
  14 │ fragment fragA on Human { name, ...fragB }
-    │ ───────┬──────  
-    │        ╰──────── recursive fragment definition
-    │ 
+    │ ───────┬──────                  ────┬───  
+    │        ╰────────────────────────────────── recursive fragment definition
+    │                                     │     
+    │                                     ╰───── `fragA` references `fragB` here...
+ 15 │ fragment fragB on Human { name, ...fragC }
+    │                                 ────┬───  
+    │                                     ╰───── `fragB` references `fragC` here...
  16 │ fragment fragC on Human { name, ...fragA }
     │                                 ────┬───  
-    │                                     ╰───── refers to itself here
+    │                                     ╰───── `fragC` circularly references `fragA` here
 ────╯
 Error: `cycle1` fragment cannot reference itself
     ╭─[0092_recursive_fragment_spread.graphql:19:1]
     │
  19 │ fragment cycle1 on __Type { kind, ...cycle2 }
-    │ ───────┬───────  
-    │        ╰───────── recursive fragment definition
+    │ ───────┬───────                   ────┬────  
+    │        ╰───────────────────────────────────── recursive fragment definition
+    │                                       │      
+    │                                       ╰────── `cycle1` references `cycle2` here...
     │ 
  23 │   ofType { ...cycle1 }
     │            ────┬────  
-    │                ╰────── refers to itself here
+    │                ╰────── `cycle2` circularly references `cycle1` here
 ────╯
 

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0092_recursive_fragment_spread.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0092_recursive_fragment_spread.graphql
@@ -10,6 +10,11 @@ query {
   human {
     ...fragA
   }
+  __schema {
+    types {
+      ...cycle1
+    }
+  }
 }
 
 fragment fragA on Human {
@@ -25,4 +30,16 @@ fragment fragB on Human {
 fragment fragC on Human {
   name
   ...fragA
+}
+
+fragment cycle1 on __Type {
+  kind
+  ...cycle2
+}
+
+fragment cycle2 on __Type {
+  kind
+  ofType {
+    ...cycle1
+  }
 }


### PR DESCRIPTION
Previously fragment cycle detection only counted fragments that are
directly recursive, where the top-level selection for the fragment
included a fragment spread of itself. But spreading a fragment anywhere
inside a nested field is also problematic and prohibited by spec,
because even if the field you're spreading into is nullable, the client
can't know how deep that recursion goes, and it could be infinite.

Fixes https://github.com/apollographql/apollo-rs/issues/716
