### PR TITLE
fix(compiler): raise diagnostics when using `null` in non-nullable position

### DIFF
--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -599,7 +599,7 @@ impl Type {
     /// ```
     pub fn item_type(&self) -> &Self {
         match self {
-            Type::List(inner) | Type::NonNullList(inner) => &inner,
+            Type::List(inner) | Type::NonNullList(inner) => inner,
             ty => ty,
         }
     }

--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -587,6 +587,23 @@ impl Type {
         Type::List(Box::new(self))
     }
 
+    /// If the type is a list type or a non-null list type, return the item type.
+    ///
+    /// # Example
+    /// ```
+    /// use apollo_compiler::ty;
+    /// // Returns the inner type of the list.
+    /// assert_eq!(ty!([Foo!]).item_type(), &ty!(Foo!));
+    /// // Not a list: returns the input.
+    /// assert_eq!(ty!(Foo!).item_type(), &ty!(Foo!));
+    /// ```
+    pub fn item_type(&self) -> &Self {
+        match self {
+            Type::List(inner) | Type::NonNullList(inner) => &inner,
+            ty => ty,
+        }
+    }
+
     /// Returns the inner named type, after unwrapping any non-null or list markers.
     pub fn inner_named_type(&self) -> &NamedType {
         match self {

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -180,7 +180,7 @@ pub(crate) enum DiagnosticData {
         /// The source location where the directive that's being used was defined.
         directive_def: Option<NodeLocation>,
     },
-    #[error("{ty} cannot be represented by a {value} value")]
+    #[error("expected value of type {ty}, found {value}")]
     UnsupportedValueType {
         // input value
         value: String,

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -280,7 +280,7 @@ pub(crate) fn validate_directives<'dir>(
                         diagnostics.push(diag)
                     } else {
                         let type_diags =
-                            super::value::validate_values2(db, &input_value.ty, argument, var_defs);
+                            super::value::validate_values(db, &input_value.ty, argument, var_defs);
 
                         diagnostics.extend(type_diags);
                     }

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -54,7 +54,7 @@ pub(crate) fn validate_field(
                 {
                     diagnostics.push(diag)
                 } else {
-                    diagnostics.extend(super::value::validate_values2(
+                    diagnostics.extend(super::value::validate_values(
                         db,
                         &arg_definition.ty,
                         argument,

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -36,21 +36,18 @@ fn unsupported_type(
     ))
 }
 
-//for bigint
-/*
-*/
-pub(crate) fn validate_values2(
+pub(crate) fn validate_values(
     db: &dyn ValidationDatabase,
     ty: &Node<ast::Type>,
     argument: &Node<ast::Argument>,
     var_defs: &[Node<ast::VariableDefinition>],
 ) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = vec![];
-    value_of_correct_type2(db, ty, &argument.value, var_defs, &mut diagnostics);
+    value_of_correct_type(db, ty, &argument.value, var_defs, &mut diagnostics);
     diagnostics
 }
 
-pub(crate) fn value_of_correct_type2(
+pub(crate) fn value_of_correct_type(
     db: &dyn ValidationDatabase,
     ty: &Node<ast::Type>,
     arg_value: &Node<ast::Value>,
@@ -191,7 +188,7 @@ pub(crate) fn value_of_correct_type2(
                         if var_def.ty.is_non_null() && default_value.is_null() {
                             diagnostics.push(unsupported_type(db, default_value, &var_def.ty))
                         } else {
-                            value_of_correct_type2(
+                            value_of_correct_type(
                                 db,
                                 &var_def.ty,
                                 default_value,
@@ -241,7 +238,7 @@ pub(crate) fn value_of_correct_type2(
             | schema::ExtendedType::Enum(_)
             | schema::ExtendedType::InputObject(_) => li
                 .iter()
-                .for_each(|v| value_of_correct_type2(db, ty, v, var_defs, diagnostics)),
+                .for_each(|v| value_of_correct_type(db, ty, v, var_defs, diagnostics)),
             _ => diagnostics.push(unsupported_type(db, arg_value, ty)),
         },
         ast::Value::Object(obj) => match &type_definition {
@@ -302,7 +299,7 @@ pub(crate) fn value_of_correct_type2(
                     let used_val = obj.iter().find(|(obj_name, ..)| obj_name == input_name);
 
                     if let Some((_, v)) = used_val {
-                        value_of_correct_type2(db, ty, v, var_defs, diagnostics);
+                        value_of_correct_type(db, ty, v, var_defs, diagnostics);
                     }
                 })
             }

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -166,12 +166,7 @@ pub(crate) fn value_of_correct_type(
             _ => diagnostics.push(unsupported_type(db, arg_value, ty)),
         },
         ast::Value::Null => {
-            if ty.is_non_null()
-                || !matches!(
-                    type_definition,
-                    schema::ExtendedType::Enum(_) | schema::ExtendedType::Scalar(_)
-                )
-            {
+            if ty.is_non_null() {
                 diagnostics.push(unsupported_type(db, arg_value, ty));
             }
         }

--- a/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
@@ -1,4 +1,4 @@
-Error: String cannot be represented by a Int value
+Error: expected value of type String, found Int
     ╭─[0102_invalid_string_values.graphql:71:31]
     │
   8 │   stringArgField(stringArg: String): String
@@ -9,7 +9,7 @@ Error: String cannot be represented by a Int value
     │                               ┬  
     │                               ╰── argument declared here is of Int type
 ────╯
-Error: String cannot be represented by a Float value
+Error: expected value of type String, found Float
     ╭─[0102_invalid_string_values.graphql:77:31]
     │
   8 │   stringArgField(stringArg: String): String
@@ -20,7 +20,7 @@ Error: String cannot be represented by a Float value
     │                               ─┬─  
     │                                ╰─── argument declared here is of Float type
 ────╯
-Error: String cannot be represented by a Boolean value
+Error: expected value of type String, found Boolean
     ╭─[0102_invalid_string_values.graphql:83:31]
     │
   8 │   stringArgField(stringArg: String): String
@@ -31,7 +31,7 @@ Error: String cannot be represented by a Boolean value
     │                               ──┬─  
     │                                 ╰─── argument declared here is of Boolean type
 ────╯
-Error: String cannot be represented by a Enum value
+Error: expected value of type String, found Enum
     ╭─[0102_invalid_string_values.graphql:89:31]
     │
   8 │   stringArgField(stringArg: String): String
@@ -42,7 +42,7 @@ Error: String cannot be represented by a Enum value
     │                               ─┬─  
     │                                ╰─── argument declared here is of Enum type
 ────╯
-Error: Int cannot be represented by a String value
+Error: expected value of type Int, found String
     ╭─[0102_invalid_string_values.graphql:95:25]
     │
   6 │   intArgField(intArg: Int): String
@@ -60,7 +60,7 @@ Error: int cannot represent non 32-bit signed integer value
      │                         ─────────────┬─────────────  
      │                                      ╰─────────────── cannot be coerced to an 32-bit integer
 ─────╯
-Error: Int cannot be represented by a Enum value
+Error: expected value of type Int, found Enum
      ╭─[0102_invalid_string_values.graphql:107:25]
      │
    6 │   intArgField(intArg: Int): String
@@ -71,7 +71,7 @@ Error: Int cannot be represented by a Enum value
      │                         ─┬─  
      │                          ╰─── argument declared here is of Enum type
 ─────╯
-Error: Int cannot be represented by a Float value
+Error: expected value of type Int, found Float
      ╭─[0102_invalid_string_values.graphql:113:25]
      │
    6 │   intArgField(intArg: Int): String
@@ -82,7 +82,7 @@ Error: Int cannot be represented by a Float value
      │                         ─┬─  
      │                          ╰─── argument declared here is of Float type
 ─────╯
-Error: Int cannot be represented by a Float value
+Error: expected value of type Int, found Float
      ╭─[0102_invalid_string_values.graphql:119:25]
      │
    6 │   intArgField(intArg: Int): String
@@ -93,7 +93,7 @@ Error: Int cannot be represented by a Float value
      │                         ──┬──  
      │                           ╰──── argument declared here is of Float type
 ─────╯
-Error: Float cannot be represented by a String value
+Error: expected value of type Float, found String
      ╭─[0102_invalid_string_values.graphql:125:29]
      │
   11 │   floatArgField(floatArg: Float): String
@@ -104,7 +104,7 @@ Error: Float cannot be represented by a String value
      │                             ───┬───  
      │                                ╰───── argument declared here is of String type
 ─────╯
-Error: Float cannot be represented by a Boolean value
+Error: expected value of type Float, found Boolean
      ╭─[0102_invalid_string_values.graphql:131:29]
      │
   11 │   floatArgField(floatArg: Float): String
@@ -115,7 +115,7 @@ Error: Float cannot be represented by a Boolean value
      │                             ──┬─  
      │                               ╰─── argument declared here is of Boolean type
 ─────╯
-Error: Float cannot be represented by a Enum value
+Error: expected value of type Float, found Enum
      ╭─[0102_invalid_string_values.graphql:137:29]
      │
   11 │   floatArgField(floatArg: Float): String
@@ -126,7 +126,7 @@ Error: Float cannot be represented by a Enum value
      │                             ─┬─  
      │                              ╰─── argument declared here is of Enum type
 ─────╯
-Error: Boolean cannot be represented by a Int value
+Error: expected value of type Boolean, found Int
      ╭─[0102_invalid_string_values.graphql:143:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
@@ -137,7 +137,7 @@ Error: Boolean cannot be represented by a Int value
      │                                 ┬  
      │                                 ╰── argument declared here is of Int type
 ─────╯
-Error: Boolean cannot be represented by a Float value
+Error: expected value of type Boolean, found Float
      ╭─[0102_invalid_string_values.graphql:149:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
@@ -148,7 +148,7 @@ Error: Boolean cannot be represented by a Float value
      │                                 ─┬─  
      │                                  ╰─── argument declared here is of Float type
 ─────╯
-Error: Boolean cannot be represented by a String value
+Error: expected value of type Boolean, found String
      ╭─[0102_invalid_string_values.graphql:155:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
@@ -159,7 +159,7 @@ Error: Boolean cannot be represented by a String value
      │                                 ───┬──  
      │                                    ╰──── argument declared here is of String type
 ─────╯
-Error: Boolean cannot be represented by a Enum value
+Error: expected value of type Boolean, found Enum
      ╭─[0102_invalid_string_values.graphql:161:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
@@ -170,7 +170,7 @@ Error: Boolean cannot be represented by a Enum value
      │                                 ──┬─  
      │                                   ╰─── argument declared here is of Enum type
 ─────╯
-Error: ID cannot be represented by a Float value
+Error: expected value of type ID, found Float
      ╭─[0102_invalid_string_values.graphql:167:23]
      │
   12 │   idArgField(idArg: ID): String
@@ -181,7 +181,7 @@ Error: ID cannot be represented by a Float value
      │                       ─┬─  
      │                        ╰─── argument declared here is of Float type
 ─────╯
-Error: ID cannot be represented by a Boolean value
+Error: expected value of type ID, found Boolean
      ╭─[0102_invalid_string_values.graphql:173:23]
      │
   12 │   idArgField(idArg: ID): String
@@ -192,7 +192,7 @@ Error: ID cannot be represented by a Boolean value
      │                       ──┬─  
      │                         ╰─── argument declared here is of Boolean type
 ─────╯
-Error: ID cannot be represented by a Enum value
+Error: expected value of type ID, found Enum
      ╭─[0102_invalid_string_values.graphql:179:23]
      │
   12 │   idArgField(idArg: ID): String
@@ -203,7 +203,7 @@ Error: ID cannot be represented by a Enum value
      │                       ────┬────  
      │                           ╰────── argument declared here is of Enum type
 ─────╯
-Error: DogCommand cannot be represented by a Int value
+Error: expected value of type DogCommand, found Int
      ╭─[0102_invalid_string_values.graphql:186:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
@@ -214,7 +214,7 @@ Error: DogCommand cannot be represented by a Int value
      │                                 ┬  
      │                                 ╰── argument declared here is of Int type
 ─────╯
-Error: DogCommand cannot be represented by a Float value
+Error: expected value of type DogCommand, found Float
      ╭─[0102_invalid_string_values.graphql:192:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
@@ -225,7 +225,7 @@ Error: DogCommand cannot be represented by a Float value
      │                                 ─┬─  
      │                                  ╰─── argument declared here is of Float type
 ─────╯
-Error: DogCommand cannot be represented by a String value
+Error: expected value of type DogCommand, found String
      ╭─[0102_invalid_string_values.graphql:198:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
@@ -236,7 +236,7 @@ Error: DogCommand cannot be represented by a String value
      │                                 ──┬──  
      │                                   ╰──── argument declared here is of String type
 ─────╯
-Error: DogCommand cannot be represented by a Boolean value
+Error: expected value of type DogCommand, found Boolean
      ╭─[0102_invalid_string_values.graphql:204:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
@@ -261,18 +261,18 @@ Error: value `sit` does not exist on `DogCommand` type
      │                                 ─┬─  
      │                                  ╰─── does not exist on `DogCommand` type
 ─────╯
-Error: [String] cannot be represented by a Int value
+Error: expected value of type String, found Int
      ╭─[0102_invalid_string_values.graphql:222:47]
      │
   13 │   stringListArgField(stringListArg: [String]): String
      │                                     ────┬───  
-     │                                         ╰───── field declared here as [String] type
+     │                                         ╰───── field declared here as String type
      │ 
  222 │     stringListArgField(stringListArg: ["one", 2])
      │                                               ┬  
      │                                               ╰── argument declared here is of Int type
 ─────╯
-Error: [String] cannot be represented by a Int value
+Error: expected value of type [String], found Int
      ╭─[0102_invalid_string_values.graphql:228:39]
      │
   13 │   stringListArgField(stringListArg: [String]): String
@@ -283,7 +283,7 @@ Error: [String] cannot be represented by a Int value
      │                                       ┬  
      │                                       ╰── argument declared here is of Int type
 ─────╯
-Error: Int! cannot be represented by a String value
+Error: expected value of type Int!, found String
      ╭─[0102_invalid_string_values.graphql:235:24]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -294,7 +294,7 @@ Error: Int! cannot be represented by a String value
      │                        ──┬──  
      │                          ╰──── argument declared here is of String type
 ─────╯
-Error: Int! cannot be represented by a String value
+Error: expected value of type Int!, found String
      ╭─[0102_invalid_string_values.graphql:235:37]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -316,7 +316,7 @@ Error: the required argument `req2` is not provided
      │     ────────────┬────────────  
      │                 ╰────────────── missing value for argument `req2`
 ─────╯
-Error: Int! cannot be represented by a String value
+Error: expected value of type Int!, found String
      ╭─[0102_invalid_string_values.graphql:241:24]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -349,6 +349,17 @@ Error: the required argument `req2` is not provided
      │     ────────────┬───────────  
      │                 ╰───────────── missing value for argument `req2`
 ─────╯
+Error: expected value of type Int!, found Null
+     ╭─[0102_invalid_string_values.graphql:247:24]
+     │
+  16 │   multipleReqs(req1: Int!, req2: Int!): String
+     │                      ──┬─  
+     │                        ╰─── field declared here as Int! type
+     │ 
+ 247 │     multipleReqs(req1: null)
+     │                        ──┬─  
+     │                          ╰─── argument declared here is of Null type
+─────╯
 Error: the required argument `requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:254:33]
      │
@@ -360,16 +371,27 @@ Error: the required argument `requiredField` is not provided
      │                                 ───────┬───────  
      │                                        ╰───────── missing value for argument `requiredField`
 ─────╯
-Error: [String] cannot be represented by a Int value
+Error: expected value of type String, found Int
      ╭─[0102_invalid_string_values.graphql:261:32]
      │
   37 │   stringListField: [String]
      │                    ────┬───  
-     │                        ╰───── field declared here as [String] type
+     │                        ╰───── field declared here as String type
      │ 
  261 │       stringListField: ["one", 2],
      │                                ┬  
      │                                ╰── argument declared here is of Int type
+─────╯
+Error: expected value of type Boolean!, found Null
+     ╭─[0102_invalid_string_values.graphql:271:7]
+     │
+  33 │   nonNullField: Boolean! = false
+     │                 ────┬───  
+     │                     ╰───── field declared here as Boolean! type
+     │ 
+ 271 │       nonNullField: null,
+     │       ─────────┬────────  
+     │                ╰────────── argument declared here is of Null type
 ─────╯
 Error: value `invalidField` does not exist on `ComplexInput` type
      ╭─[0102_invalid_string_values.graphql:280:7]
@@ -378,21 +400,21 @@ Error: value `invalidField` does not exist on `ComplexInput` type
      │       ──────────┬──────────  
      │                 ╰──────────── does not exist on `ComplexInput` type
 ─────╯
-Error: Boolean! cannot be represented by a String value
+Error: expected value of type Boolean!, found String
      ╭─[0102_invalid_string_values.graphql:287:20]
      │
  287 │   dog @include(if: "yes") {
      │                    ──┬──  
      │                      ╰──── argument declared here is of String type
 ─────╯
-Error: Boolean! cannot be represented by a Enum value
+Error: expected value of type Boolean!, found Enum
      ╭─[0102_invalid_string_values.graphql:288:20]
      │
  288 │     name @skip(if: ENUM)
      │                    ──┬─  
      │                      ╰─── argument declared here is of Enum type
 ─────╯
-Error: Int! cannot be represented by a Null value
+Error: expected value of type Int!, found Null
      ╭─[0102_invalid_string_values.graphql:294:14]
      │
  294 │   $a: Int! = null,
@@ -401,7 +423,7 @@ Error: Int! cannot be represented by a Null value
      │                │   
      │                ╰─── argument declared here is of Null type
 ─────╯
-Error: String! cannot be represented by a Null value
+Error: expected value of type String!, found Null
      ╭─[0102_invalid_string_values.graphql:295:17]
      │
  295 │   $b: String! = null,
@@ -421,7 +443,18 @@ Error: the required argument `requiredField` is not provided
      │                      ───────────────────┬───────────────────  
      │                                         ╰───────────────────── missing value for argument `requiredField`
 ─────╯
-Error: Int cannot be represented by a String value
+Error: expected value of type Boolean!, found Null
+     ╭─[0102_invalid_string_values.graphql:296:24]
+     │
+  32 │   requiredField: Boolean!
+     │                  ────┬───  
+     │                      ╰───── field declared here as Boolean! type
+     │ 
+ 296 │   $c: ComplexInput = { requiredField: null, intField: null }
+     │                        ─────────┬─────────  
+     │                                 ╰─────────── argument declared here is of Null type
+─────╯
+Error: expected value of type Int, found String
      ╭─[0102_invalid_string_values.graphql:306:13]
      │
  306 │   $a: Int = "one",
@@ -430,7 +463,7 @@ Error: Int cannot be represented by a String value
      │               │    
      │               ╰──── argument declared here is of String type
 ─────╯
-Error: String cannot be represented by a Int value
+Error: expected value of type String, found Int
      ╭─[0102_invalid_string_values.graphql:307:16]
      │
  307 │   $b: String = 4,
@@ -439,7 +472,7 @@ Error: String cannot be represented by a Int value
      │                │  
      │                ╰── argument declared here is of Int type
 ─────╯
-Error: ComplexInput cannot be represented by a String value
+Error: expected value of type ComplexInput, found String
      ╭─[0102_invalid_string_values.graphql:308:22]
      │
  308 │   $c: ComplexInput = "NotVeryComplex"
@@ -448,7 +481,7 @@ Error: ComplexInput cannot be represented by a String value
      │                              │         
      │                              ╰───────── argument declared here is of String type
 ─────╯
-Error: Boolean! cannot be represented by a Int value
+Error: expected value of type Boolean!, found Int
      ╭─[0102_invalid_string_values.graphql:318:24]
      │
   32 │   requiredField: Boolean!
@@ -459,7 +492,7 @@ Error: Boolean! cannot be represented by a Int value
      │                        ─────────┬────────  
      │                                 ╰────────── argument declared here is of Int type
 ─────╯
-Error: Int cannot be represented by a String value
+Error: expected value of type Int, found String
      ╭─[0102_invalid_string_values.graphql:318:44]
      │
   34 │   intField: Int
@@ -481,12 +514,12 @@ Error: the required argument `requiredField` is not provided
      │                      ──────┬──────  
      │                            ╰──────── missing value for argument `requiredField`
 ─────╯
-Error: [String] cannot be represented by a Int value
+Error: expected value of type String, found Int
      ╭─[0102_invalid_string_values.graphql:335:26]
      │
  335 │   $a: [String] = ["one", 2]
      │       ────┬───           ┬  
-     │           ╰───────────────── field declared here as [String] type
+     │           ╰───────────────── field declared here as String type
      │                          │  
      │                          ╰── argument declared here is of Int type
 ─────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.graphql
@@ -1,0 +1,10 @@
+type Query {
+  foo(arg: [String!]!): String!
+  bar(arg: [String!]): String!
+}
+
+{
+  a: foo(arg: [null])
+  b: foo(arg: [null, null, "hello"])
+  bar(arg: [null])
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.graphql
@@ -1,15 +1,17 @@
+scalar CustomScalar @specifiedBy(url: "https://example.com")
+
 input WithList {
   list: [String!]
 }
 
 type Query {
-  foo(arg: [String!]!): String!
+  foo(arg: [CustomScalar!]!): String!
   bar(arg: [String!]): String!
   list(arg: WithList): String!
 }
 
 {
-  a: foo(arg: [null])
+  a: foo(arg: [null, 1])
   b: foo(arg: [null, null, "hello"])
   bar(arg: [null])
   list(arg: {list: ["ok", null]})

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.graphql
@@ -1,10 +1,16 @@
+input WithList {
+  list: [String!]
+}
+
 type Query {
   foo(arg: [String!]!): String!
   bar(arg: [String!]): String!
+  list(arg: WithList): String!
 }
 
 {
   a: foo(arg: [null])
   b: foo(arg: [null, null, "hello"])
   bar(arg: [null])
+  list(arg: {list: ["ok", null]})
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
@@ -1,45 +1,56 @@
 Error: expected value of type String!, found Null
-   ╭─[0109_null_in_list_issue_738.graphql:7:16]
-   │
- 2 │   foo(arg: [String!]!): String!
-   │            ─────┬────  
-   │                 ╰────── field declared here as String! type
-   │ 
- 7 │   a: foo(arg: [null])
-   │                ──┬─  
-   │                  ╰─── argument declared here is of Null type
-───╯
+    ╭─[0109_null_in_list_issue_738.graphql:12:16]
+    │
+  6 │   foo(arg: [String!]!): String!
+    │            ─────┬────  
+    │                 ╰────── field declared here as String! type
+    │ 
+ 12 │   a: foo(arg: [null])
+    │                ──┬─  
+    │                  ╰─── argument declared here is of Null type
+────╯
 Error: expected value of type String!, found Null
-   ╭─[0109_null_in_list_issue_738.graphql:8:16]
-   │
- 2 │   foo(arg: [String!]!): String!
-   │            ─────┬────  
-   │                 ╰────── field declared here as String! type
-   │ 
- 8 │   b: foo(arg: [null, null, "hello"])
-   │                ──┬─  
-   │                  ╰─── argument declared here is of Null type
-───╯
+    ╭─[0109_null_in_list_issue_738.graphql:13:16]
+    │
+  6 │   foo(arg: [String!]!): String!
+    │            ─────┬────  
+    │                 ╰────── field declared here as String! type
+    │ 
+ 13 │   b: foo(arg: [null, null, "hello"])
+    │                ──┬─  
+    │                  ╰─── argument declared here is of Null type
+────╯
 Error: expected value of type String!, found Null
-   ╭─[0109_null_in_list_issue_738.graphql:8:22]
-   │
- 2 │   foo(arg: [String!]!): String!
-   │            ─────┬────  
-   │                 ╰────── field declared here as String! type
-   │ 
- 8 │   b: foo(arg: [null, null, "hello"])
-   │                      ──┬─  
-   │                        ╰─── argument declared here is of Null type
-───╯
+    ╭─[0109_null_in_list_issue_738.graphql:13:22]
+    │
+  6 │   foo(arg: [String!]!): String!
+    │            ─────┬────  
+    │                 ╰────── field declared here as String! type
+    │ 
+ 13 │   b: foo(arg: [null, null, "hello"])
+    │                      ──┬─  
+    │                        ╰─── argument declared here is of Null type
+────╯
 Error: expected value of type String!, found Null
-   ╭─[0109_null_in_list_issue_738.graphql:9:13]
-   │
- 3 │   bar(arg: [String!]): String!
-   │            ────┬────  
-   │                ╰────── field declared here as String! type
-   │ 
- 9 │   bar(arg: [null])
-   │             ──┬─  
-   │               ╰─── argument declared here is of Null type
-───╯
+    ╭─[0109_null_in_list_issue_738.graphql:14:13]
+    │
+  7 │   bar(arg: [String!]): String!
+    │            ────┬────  
+    │                ╰────── field declared here as String! type
+    │ 
+ 14 │   bar(arg: [null])
+    │             ──┬─  
+    │               ╰─── argument declared here is of Null type
+────╯
+Error: expected value of type String!, found Null
+    ╭─[0109_null_in_list_issue_738.graphql:15:27]
+    │
+  2 │   list: [String!]
+    │         ────┬────  
+    │             ╰────── field declared here as String! type
+    │ 
+ 15 │   list(arg: {list: ["ok", null]})
+    │                           ──┬─  
+    │                             ╰─── argument declared here is of Null type
+────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
@@ -1,0 +1,45 @@
+Error: expected value of type String!, found Null
+   ╭─[0109_null_in_list_issue_738.graphql:7:16]
+   │
+ 2 │   foo(arg: [String!]!): String!
+   │            ─────┬────  
+   │                 ╰────── field declared here as String! type
+   │ 
+ 7 │   a: foo(arg: [null])
+   │                ──┬─  
+   │                  ╰─── argument declared here is of Null type
+───╯
+Error: expected value of type String!, found Null
+   ╭─[0109_null_in_list_issue_738.graphql:8:16]
+   │
+ 2 │   foo(arg: [String!]!): String!
+   │            ─────┬────  
+   │                 ╰────── field declared here as String! type
+   │ 
+ 8 │   b: foo(arg: [null, null, "hello"])
+   │                ──┬─  
+   │                  ╰─── argument declared here is of Null type
+───╯
+Error: expected value of type String!, found Null
+   ╭─[0109_null_in_list_issue_738.graphql:8:22]
+   │
+ 2 │   foo(arg: [String!]!): String!
+   │            ─────┬────  
+   │                 ╰────── field declared here as String! type
+   │ 
+ 8 │   b: foo(arg: [null, null, "hello"])
+   │                      ──┬─  
+   │                        ╰─── argument declared here is of Null type
+───╯
+Error: expected value of type String!, found Null
+   ╭─[0109_null_in_list_issue_738.graphql:9:13]
+   │
+ 3 │   bar(arg: [String!]): String!
+   │            ────┬────  
+   │                ╰────── field declared here as String! type
+   │ 
+ 9 │   bar(arg: [null])
+   │             ──┬─  
+   │               ╰─── argument declared here is of Null type
+───╯
+

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
@@ -1,55 +1,55 @@
-Error: expected value of type String!, found Null
-    ╭─[0109_null_in_list_issue_738.graphql:12:16]
+Error: expected value of type CustomScalar!, found Null
+    ╭─[0109_null_in_list_issue_738.graphql:14:16]
     │
-  6 │   foo(arg: [String!]!): String!
-    │            ─────┬────  
-    │                 ╰────── field declared here as String! type
+  8 │   foo(arg: [CustomScalar!]!): String!
+    │            ────────┬───────  
+    │                    ╰───────── field declared here as CustomScalar! type
     │ 
- 12 │   a: foo(arg: [null])
+ 14 │   a: foo(arg: [null, 1])
     │                ──┬─  
     │                  ╰─── argument declared here is of Null type
 ────╯
-Error: expected value of type String!, found Null
-    ╭─[0109_null_in_list_issue_738.graphql:13:16]
+Error: expected value of type CustomScalar!, found Null
+    ╭─[0109_null_in_list_issue_738.graphql:15:16]
     │
-  6 │   foo(arg: [String!]!): String!
-    │            ─────┬────  
-    │                 ╰────── field declared here as String! type
+  8 │   foo(arg: [CustomScalar!]!): String!
+    │            ────────┬───────  
+    │                    ╰───────── field declared here as CustomScalar! type
     │ 
- 13 │   b: foo(arg: [null, null, "hello"])
+ 15 │   b: foo(arg: [null, null, "hello"])
     │                ──┬─  
     │                  ╰─── argument declared here is of Null type
 ────╯
-Error: expected value of type String!, found Null
-    ╭─[0109_null_in_list_issue_738.graphql:13:22]
+Error: expected value of type CustomScalar!, found Null
+    ╭─[0109_null_in_list_issue_738.graphql:15:22]
     │
-  6 │   foo(arg: [String!]!): String!
-    │            ─────┬────  
-    │                 ╰────── field declared here as String! type
+  8 │   foo(arg: [CustomScalar!]!): String!
+    │            ────────┬───────  
+    │                    ╰───────── field declared here as CustomScalar! type
     │ 
- 13 │   b: foo(arg: [null, null, "hello"])
+ 15 │   b: foo(arg: [null, null, "hello"])
     │                      ──┬─  
     │                        ╰─── argument declared here is of Null type
 ────╯
 Error: expected value of type String!, found Null
-    ╭─[0109_null_in_list_issue_738.graphql:14:13]
+    ╭─[0109_null_in_list_issue_738.graphql:16:13]
     │
-  7 │   bar(arg: [String!]): String!
+  9 │   bar(arg: [String!]): String!
     │            ────┬────  
     │                ╰────── field declared here as String! type
     │ 
- 14 │   bar(arg: [null])
+ 16 │   bar(arg: [null])
     │             ──┬─  
     │               ╰─── argument declared here is of Null type
 ────╯
 Error: expected value of type String!, found Null
-    ╭─[0109_null_in_list_issue_738.graphql:15:27]
+    ╭─[0109_null_in_list_issue_738.graphql:17:27]
     │
-  2 │   list: [String!]
+  4 │   list: [String!]
     │         ────┬────  
     │             ╰────── field declared here as String! type
     │ 
- 15 │   list(arg: {list: ["ok", null]})
+ 17 │   list(arg: {list: ["ok", null]})
     │                           ──┬─  
     │                             ╰─── argument declared here is of Null type
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.graphql
@@ -1,0 +1,27 @@
+scalar CustomScalar @specifiedBy(url: "https://example.com")
+
+input Args {
+  ok: CustomScalar # should accept a list
+  int: Int!
+  str: String!
+  bool: Boolean!
+  opt: Int
+  id: ID!
+  list: [Int]
+}
+
+type Query {
+  field(args: Args): String!
+}
+
+query {
+  field(args: {
+    ok: [1, "2", 3, []]
+    int: [1, 2, 3]
+    str: ["1"]
+    bool: [true, false]
+    opt: [1, 2, 3]
+    id: [1, "2", 3]
+    list: [1, 2, 3]
+  })
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.txt
@@ -1,0 +1,56 @@
+Error: expected value of type Int!, found List
+    ╭─[0110_list_usage_in_non_list_type.graphql:20:5]
+    │
+  5 │   int: Int!
+    │        ──┬─  
+    │          ╰─── field declared here as Int! type
+    │ 
+ 20 │     int: [1, 2, 3]
+    │     ───────┬──────  
+    │            ╰──────── argument declared here is of List type
+────╯
+Error: expected value of type String!, found List
+    ╭─[0110_list_usage_in_non_list_type.graphql:21:5]
+    │
+  6 │   str: String!
+    │        ───┬───  
+    │           ╰───── field declared here as String! type
+    │ 
+ 21 │     str: ["1"]
+    │     ─────┬────  
+    │          ╰────── argument declared here is of List type
+────╯
+Error: expected value of type Boolean!, found List
+    ╭─[0110_list_usage_in_non_list_type.graphql:22:5]
+    │
+  7 │   bool: Boolean!
+    │         ────┬───  
+    │             ╰───── field declared here as Boolean! type
+    │ 
+ 22 │     bool: [true, false]
+    │     ─────────┬─────────  
+    │              ╰─────────── argument declared here is of List type
+────╯
+Error: expected value of type Int, found List
+    ╭─[0110_list_usage_in_non_list_type.graphql:23:5]
+    │
+  8 │   opt: Int
+    │        ─┬─  
+    │         ╰─── field declared here as Int type
+    │ 
+ 23 │     opt: [1, 2, 3]
+    │     ───────┬──────  
+    │            ╰──────── argument declared here is of List type
+────╯
+Error: expected value of type ID!, found List
+    ╭─[0110_list_usage_in_non_list_type.graphql:24:5]
+    │
+  9 │   id: ID!
+    │       ─┬─  
+    │        ╰─── field declared here as ID! type
+    │ 
+ 24 │     id: [1, "2", 3]
+    │     ───────┬───────  
+    │            ╰───────── argument declared here is of List type
+────╯
+

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0109_null_in_list_issue_738.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0109_null_in_list_issue_738.graphql
@@ -1,10 +1,16 @@
+input WithList {
+  list: [String!]
+}
+
 type Query {
   foo(arg: [String!]!): String!
   bar(arg: [String!]): String!
+  list(arg: WithList): String!
 }
 
 query {
   a: foo(arg: [null])
   b: foo(arg: [null, null, "hello"])
   bar(arg: [null])
+  list(arg: {list: ["ok", null]})
 }

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0109_null_in_list_issue_738.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0109_null_in_list_issue_738.graphql
@@ -1,15 +1,17 @@
+scalar CustomScalar @specifiedBy(url: "https://example.com")
+
 input WithList {
   list: [String!]
 }
 
 type Query {
-  foo(arg: [String!]!): String!
+  foo(arg: [CustomScalar!]!): String!
   bar(arg: [String!]): String!
   list(arg: WithList): String!
 }
 
 query {
-  a: foo(arg: [null])
+  a: foo(arg: [null, 1])
   b: foo(arg: [null, null, "hello"])
   bar(arg: [null])
   list(arg: {list: ["ok", null]})

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0109_null_in_list_issue_738.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0109_null_in_list_issue_738.graphql
@@ -1,0 +1,10 @@
+type Query {
+  foo(arg: [String!]!): String!
+  bar(arg: [String!]): String!
+}
+
+query {
+  a: foo(arg: [null])
+  b: foo(arg: [null, null, "hello"])
+  bar(arg: [null])
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0110_list_usage_in_non_list_type.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0110_list_usage_in_non_list_type.graphql
@@ -1,0 +1,19 @@
+scalar CustomScalar @specifiedBy(url: "https://example.com")
+
+input Args {
+  ok: CustomScalar
+  int: Int!
+  str: String!
+  bool: Boolean!
+  opt: Int
+  id: ID!
+  list: [Int]
+}
+
+type Query {
+  field(args: Args): String!
+}
+
+query {
+  field(args: {ok: [1, "2", 3, []], int: [1, 2, 3], str: ["1"], bool: [true, false], opt: [1, 2, 3], id: [1, "2", 3], list: [1, 2, 3]})
+}

--- a/crates/apollo-compiler/tests/validation/mod.rs
+++ b/crates/apollo-compiler/tests/validation/mod.rs
@@ -1,6 +1,7 @@
 mod interface;
 mod object;
 mod operation;
+mod types;
 mod variable;
 
 use apollo_compiler::ast;

--- a/crates/apollo-compiler/tests/validation/types.rs
+++ b/crates/apollo-compiler/tests/validation/types.rs
@@ -1,0 +1,1282 @@
+//! Ported from graphql-js, 2023-11-16
+//! https://github.com/graphql/graphql-js/blob/0b7590f0a2b65e6210da2e49be0d8e6c27781af2/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+//!
+//! Note all `expect_errors` calls do not check for the kind of errors right now, while in
+//! graphql-js they do.
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+
+const GRAPHQL_JS_TEST_SCHEMA: &'static str = r#"
+  interface Mammal {
+    mother: Mammal
+    father: Mammal
+  }
+
+  interface Pet {
+    name(surname: Boolean): String
+  }
+
+  interface Canine implements Mammal {
+    name(surname: Boolean): String
+    mother: Canine
+    father: Canine
+  }
+
+  enum DogCommand {
+    SIT
+    HEEL
+    DOWN
+  }
+
+  type Dog implements Pet & Mammal & Canine {
+    name(surname: Boolean): String
+    nickname: String
+    barkVolume: Int
+    barks: Boolean
+    doesKnowCommand(dogCommand: DogCommand): Boolean
+    isHouseTrained(atOtherHomes: Boolean = true): Boolean
+    isAtLocation(x: Int, y: Int): Boolean
+    mother: Dog
+    father: Dog
+  }
+
+  type Cat implements Pet {
+    name(surname: Boolean): String
+    nickname: String
+    meows: Boolean
+    meowsVolume: Int
+    furColor: FurColor
+  }
+
+  union CatOrDog = Cat | Dog
+
+  type Human {
+    name(surname: Boolean): String
+    pets: [Pet]
+    relatives: [Human]!
+  }
+
+  enum FurColor {
+    BROWN
+    BLACK
+    TAN
+    SPOTTED
+    NO_FUR
+    UNKNOWN
+  }
+
+  input ComplexInput {
+    requiredField: Boolean!
+    nonNullField: Boolean! = false
+    intField: Int
+    stringField: String
+    booleanField: Boolean
+    stringListField: [String]
+  }
+
+  # TODO oneOf not supported in apollo-rs
+  input OneOfInput { # @oneOf
+    stringField: String
+    intField: Int
+  }
+
+  type ComplicatedArgs {
+    # TODO List
+    # TODO Coercion
+    # TODO NotNulls
+    intArgField(intArg: Int): String
+    nonNullIntArgField(nonNullIntArg: Int!): String
+    stringArgField(stringArg: String): String
+    booleanArgField(booleanArg: Boolean): String
+    enumArgField(enumArg: FurColor): String
+    floatArgField(floatArg: Float): String
+    idArgField(idArg: ID): String
+    stringListArgField(stringListArg: [String]): String
+    stringListNonNullArgField(stringListNonNullArg: [String!]): String
+    complexArgField(complexArg: ComplexInput): String
+    oneOfArgField(oneOfArg: OneOfInput): String
+    multipleReqs(req1: Int!, req2: Int!): String
+    nonNullFieldWithDefault(arg: Int! = 0): String
+    multipleOpts(opt1: Int = 0, opt2: Int = 0): String
+    multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String
+  }
+
+  type QueryRoot {
+    human(id: ID): Human
+    dog: Dog
+    cat: Cat
+    pet: Pet
+    catOrDog: CatOrDog
+    complicatedArgs: ComplicatedArgs
+  }
+
+  schema {
+    query: QueryRoot
+  }
+
+  directive @onField on FIELD
+"#;
+
+fn expect_valid(query: &'static str) {
+    let schema = Schema::parse(GRAPHQL_JS_TEST_SCHEMA, "schema.graphql");
+    schema.validate().unwrap();
+
+    let executable = ExecutableDocument::parse(&schema, query, "query.graphql");
+    executable.validate(&schema).unwrap();
+}
+
+fn expect_errors(query: &'static str) {
+    let schema = Schema::parse(GRAPHQL_JS_TEST_SCHEMA, "schema.graphql");
+    schema.validate().unwrap();
+
+    let executable = ExecutableDocument::parse(&schema, query, "query.graphql");
+    let _errors = executable
+        .validate(&schema)
+        .expect_err("should have errors");
+}
+
+mod valid_values {
+    use super::expect_valid;
+
+    #[test]
+    fn good_int_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            intArgField(intArg: 2)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn good_negative_int_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            intArgField(intArg: -2)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn good_boolean_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            booleanArgField(booleanArg: true)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn good_string_value() {
+        expect_valid(
+            r#"
+        {
+          complicatedArgs {
+            stringArgField(stringArg: "foo")
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn good_float_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            floatArgField(floatArg: 1.1)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn good_negative_float_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            floatArgField(floatArg: -1.1)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn int_into_float() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            floatArgField(floatArg: 1)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn int_into_id() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            idArgField(idArg: 1)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn string_into_id() {
+        expect_valid(
+            r#"
+        {
+          complicatedArgs {
+            idArgField(idArg: "someIdString")
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn good_enum_value() {
+        expect_valid(
+            "
+        {
+          dog {
+            doesKnowCommand(dogCommand: SIT)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn enum_with_undefined_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            enumArgField(enumArg: UNKNOWN)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn enum_with_null_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            enumArgField(enumArg: NO_FUR)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn null_into_nullable_type() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            intArgField(intArg: null)
+          }
+        }
+      ",
+        );
+
+        // TODO what is this meant to do?
+        // expect_valid(
+        //     "
+        // {
+        //   dog(a: null, b: null, c:{ requiredField: true, intField: null }) {
+        //     name
+        //   }
+        // }
+        // ",
+        // );
+    }
+}
+
+mod invalid_string_values {
+    use super::expect_errors;
+
+    #[test]
+    fn int_into_string() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            stringArgField(stringArg: 1)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn float_into_string() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            stringArgField(stringArg: 1.0)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn boolean_into_string() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            stringArgField(stringArg: true)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn unquoted_into_string() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            stringArgField(stringArg: BAR)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod invalid_int_values {
+    use super::expect_errors;
+
+    #[test]
+    fn string_into_int() {
+        expect_errors(
+            r#"
+        {
+          complicatedArgs {
+            intArgField(intArg: "3")
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn big_int_into_int() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            intArgField(intArg: 829384293849283498239482938)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn unquoted_string_into_int() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            intArgField(intArg: FOO)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn simple_float_into_int() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            intArgField(intArg: 3.0)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn float_into_int() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            intArgField(intArg: 3.333)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod invalid_float_values {
+    use super::expect_errors;
+
+    #[test]
+    fn string_into_float() {
+        expect_errors(
+            r#"
+        {
+          complicatedArgs {
+            floatArgField(floatArg: "3.333")
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn boolean_into_float() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            floatArgField(floatArg: true)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn unquoted_into_float() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            floatArgField(floatArg: FOO)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod invalid_boolean_values {
+    use super::expect_errors;
+
+    #[test]
+    fn int_into_boolean() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            booleanArgField(booleanArg: 2)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn float_into_boolean() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            booleanArgField(booleanArg: 1.0)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn string_into_boolean() {
+        expect_errors(
+            r#"
+        {
+          complicatedArgs {
+            booleanArgField(booleanArg: "true")
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn unquoted_into_boolean() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            booleanArgField(booleanArg: TRUE)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod invalid_id_values {
+    use super::expect_errors;
+
+    #[test]
+    fn float_into_id() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            idArgField(idArg: 1.0)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn boolean_into_id() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            idArgField(idArg: true)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn unquoted_into_id() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            idArgField(idArg: SOMETHING)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod invalid_enum_values {
+    use super::expect_errors;
+
+    #[test]
+    fn int_into_enum() {
+        expect_errors(
+            "
+        {
+          dog {
+            doesKnowCommand(dogCommand: 2)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn float_into_enum() {
+        expect_errors(
+            "
+        {
+          dog {
+            doesKnowCommand(dogCommand: 1.0)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn string_into_enum() {
+        expect_errors(
+            r#"
+        {
+          dog {
+            doesKnowCommand(dogCommand: "SIT")
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn boolean_into_enum() {
+        expect_errors(
+            "
+        {
+          dog {
+            doesKnowCommand(dogCommand: true)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn unknown_enum_value_into_enum() {
+        expect_errors(
+            "
+        {
+          dog {
+            doesKnowCommand(dogCommand: JUGGLE)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn different_case_enum_value_into_enum() {
+        expect_errors(
+            "
+        {
+          dog {
+            doesKnowCommand(dogCommand: sit)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod valid_list_values {
+    use super::expect_valid;
+
+    #[test]
+    fn good_list_value() {
+        expect_valid(
+            r#"
+        {
+          complicatedArgs {
+            stringListArgField(stringListArg: ["one", null, "two"])
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn empty_list_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            stringListArgField(stringListArg: [])
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn null_value() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            stringListArgField(stringListArg: null)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn single_value_into_list() {
+        expect_valid(
+            r#"
+        {
+          complicatedArgs {
+            stringListArgField(stringListArg: "one")
+          }
+        }
+      "#,
+        );
+    }
+}
+
+mod invalid_list_values {
+    use super::expect_errors;
+
+    #[test]
+    fn incorrect_item_type() {
+        expect_errors(
+            r#"
+        {
+          complicatedArgs {
+            stringListArgField(stringListArg: ["one", 2])
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn single_value_of_incorrect_type() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            stringListArgField(stringListArg: 1)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod valid_non_nullable_values {
+    use super::expect_valid;
+
+    #[test]
+    fn arg_on_optional_arg() {
+        expect_valid(
+            "
+        {
+          dog {
+            isHouseTrained(atOtherHomes: true)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn no_arg_on_optional_arg() {
+        expect_valid(
+            "
+        {
+          dog {
+            isHouseTrained
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn multiple_args() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            multipleReqs(req1: 1, req2: 2)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn multiple_args_reverse_order() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            multipleReqs(req2: 2, req1: 1)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn no_args_on_multiple_optional() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            multipleOpts
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn one_arg_on_multiple_optional() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            multipleOpts(opt1: 1)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn second_arg_on_multiple_optional() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            multipleOpts(opt2: 1)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn multiple_required_args_on_mixed_list() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            multipleOptAndReq(req1: 3, req2: 4)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn multiple_required_and_one_optional_arg_on_mixed_list() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            multipleOptAndReq(req1: 3, req2: 4, opt1: 5)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn all_required_and_optional_args_on_mixed_list() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            multipleOptAndReq(req1: 3, req2: 4, opt1: 5, opt2: 6)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod invalid_non_nullable_values {
+    use super::expect_errors;
+
+    #[test]
+    fn incorrect_value_type() {
+        expect_errors(
+            r#"
+        {
+          complicatedArgs {
+            multipleReqs(req2: "two", req1: "one")
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn incorrect_value_and_missing_argument() {
+        expect_errors(
+            r#"
+        {
+          complicatedArgs {
+            multipleReqs(req1: "one")
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn null_value() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            multipleReqs(req1: null)
+          }
+        }
+      ",
+        );
+    }
+}
+
+mod valid_input_object_values {
+    use super::expect_valid;
+
+    #[test]
+    fn optional_arg_required_field() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            complexArgField
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn partial_object_only_required() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            complexArgField(complexArg: { requiredField: true })
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn partial_object_required_boolean_false() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            complexArgField(complexArg: { requiredField: false })
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn partial_object_including_required() {
+        expect_valid(
+            "
+        {
+          complicatedArgs {
+            complexArgField(complexArg: { requiredField: true, intField: 4 })
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn full_object() {
+        expect_valid(
+            r#"
+        {
+          complicatedArgs {
+            complexArgField(complexArg: {
+              requiredField: true,
+              intField: 4,
+              stringField: "foo",
+              booleanField: false,
+              stringListField: ["one", "two"]
+            })
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn full_object_unordered() {
+        expect_valid(
+            r#"
+        {
+          complicatedArgs {
+            complexArgField(complexArg: {
+              stringListField: ["one", "two"],
+              booleanField: false,
+              requiredField: true,
+              stringField: "foo",
+              intField: 4,
+            })
+          }
+        }
+      "#,
+        );
+    }
+}
+
+mod invalid_input_object_values {
+    use super::expect_errors;
+
+    #[test]
+    fn partial_object_missing_required() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            complexArgField(complexArg: { intField: 4 })
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn partial_object_invalid_field_type() {
+        expect_errors(
+            r#"
+        {
+          complicatedArgs {
+            complexArgField(complexArg: {
+              stringListField: ["one", 2],
+              requiredField: true,
+            })
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn partial_object_null_to_non_null_field() {
+        expect_errors(
+            "
+        {
+          complicatedArgs {
+            complexArgField(complexArg: {
+              requiredField: true,
+              nonNullField: null,
+            })
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn partial_object_unknown_field() {
+        expect_errors(
+            r#"
+        {
+          complicatedArgs {
+            complexArgField(complexArg: {
+              requiredField: true,
+              invalidField: "value"
+            })
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn custom_scalar_accept_complex_literals() {
+        use apollo_compiler::ExecutableDocument;
+        use apollo_compiler::Schema;
+
+        let schema = Schema::parse(
+            "
+            scalar Any
+            type Query {
+              anyArg(arg: Any): String
+            }
+        ",
+            "schema.graphql",
+        );
+        schema.validate().unwrap();
+
+        let query = ExecutableDocument::parse(
+            &schema,
+            r#"
+            {
+              test1: anyArg(arg: 123)
+              test2: anyArg(arg: "abc")
+              test3: anyArg(arg: [123, "abc"])
+              test4: anyArg(arg: {deep: [123, "abc"]})
+            }
+        "#,
+            "query.graphql",
+        );
+
+        query.validate(&schema).unwrap();
+    }
+}
+
+mod directive_arguments {
+    use super::expect_errors;
+    use super::expect_valid;
+
+    #[test]
+    fn with_directives_of_valid_types() {
+        expect_valid(
+            "
+        {
+          dog @include(if: true) {
+            name
+          }
+          human @skip(if: false) {
+            name
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn with_directives_of_invalid_types() {
+        expect_errors(
+            r#"
+        {
+          dog @include(if: "yes") {
+            name @skip(if: ENUM)
+          }
+        }
+      "#,
+        );
+    }
+}
+
+mod variable_default_values {
+    use super::expect_errors;
+    use super::expect_valid;
+
+    #[test]
+    fn variables_with_valid_default_values() {
+        expect_valid(
+            r#"
+        query WithDefaultValues(
+          $a: Int = 1,
+          $b: String = "ok",
+          $c: ComplexInput = { requiredField: true, intField: 3 }
+          $d: Int! = 123
+        ) {
+          dog { name }
+          complicatedArgs {
+              intArgField(intArg: $a)
+              stringArgField(stringArg: $b)
+              complexArgField(complexArg: $c)
+              intArgField2: intArgField(intArg: $d)
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn variables_with_valid_default_null_values() {
+        expect_valid(
+            "
+        query WithDefaultValues(
+          $a: Int = null,
+          $b: String = null,
+          $c: ComplexInput = { requiredField: true, intField: null }
+        ) {
+          dog { name }
+          complicatedArgs {
+              intArgField(intArg: $a)
+              stringArgField(stringArg: $b)
+              complexArgField(complexArg: $c)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn variables_with_invalid_default_null_values() {
+        expect_errors(
+            "
+        query WithDefaultValues(
+          $a: Int! = null,
+          $b: String! = null,
+          $c: ComplexInput = { requiredField: null, intField: null }
+        ) {
+          dog { name }
+          complicatedArgs {
+              intArgField(intArg: $a)
+              stringArgField(stringArg: $b)
+              complexArgField(complexArg: $c)
+          }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn variables_with_invalid_default_values() {
+        expect_errors(
+            r#"
+        query InvalidDefaultValues(
+          $a: Int = "one",
+          $b: String = 4,
+          $c: ComplexInput = "NotVeryComplex"
+        ) {
+          dog { name }
+          complicatedArgs {
+              intArgField(intArg: $a)
+              stringArgField(stringArg: $b)
+              complexArgField(complexArg: $c)
+          }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn variables_with_complex_invalid_default_values() {
+        expect_errors(
+            r#"
+        query WithDefaultValues(
+          $a: ComplexInput = { requiredField: 123, intField: "abc" }
+        ) {
+          dog { name }
+          complicatedArgs { complexArgField(complexArg: $a) }
+        }
+      "#,
+        );
+    }
+
+    #[test]
+    fn complex_variables_missing_required_field() {
+        expect_errors(
+            "
+        query MissingRequiredField($a: ComplexInput = {intField: 3}) {
+          dog { name }
+          complicatedArgs { complexArgField(complexArg: $a) }
+        }
+      ",
+        );
+    }
+
+    #[test]
+    fn list_variables_with_invalid_item() {
+        expect_errors(
+            r#"
+        query InvalidItem($a: [String] = ["one", 2]) {
+          dog { name }
+          complicatedArgs { stringListArgField(stringListArg: $a) }
+        }
+      "#,
+        );
+    }
+}


### PR DESCRIPTION
Fixes #738

Includes porting over the ValuesOfCorrectType tests from graphql-js: https://github.com/graphql/graphql-js/blob/0b7590f0a2b65e6210da2e49be0d8e6c27781af2/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
We had many of those in snapshot tests, but having them 1:1 we can be a bit more confident that we are matching the behaviour.