### PR TITLE
apollo-parser@0.7.4

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 autotests = false # Most tests/*.rs files are modules of tests/main.rs
 
 [dependencies]
-apollo-parser = { path = "../apollo-parser", version = "0.7.3" }
+apollo-parser = { path = "../apollo-parser", version = "0.7.4" }
 ariadne = { version = "0.3.0", features = ["auto-color"] }
 indexmap = "2.0.0"
 rowan = "0.15.5"

--- a/crates/apollo-parser/CHANGELOG.md
+++ b/crates/apollo-parser/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 ## Documentation -->
-# [unreleased](https://crates.io/crates/apollo-parser/x.x.x) - 2023-xx-xx
+# [0.7.4](https://crates.io/crates/apollo-parser/0.7.4) - 2023-11-17
 
 ## Features
 - **`parse_type` parses a selection set with optional outer brackets - [lrlna], [pull/718] fixing [issue/715]**

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-parser"
-version = "0.7.3" # When bumping, also update README.md
+version = "0.7.4" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-parser/README.md
+++ b/crates/apollo-parser/README.md
@@ -35,7 +35,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
-apollo-parser = "0.7.3"
+apollo-parser = "0.7.4"
 ```
 
 ## Rust versions


### PR DESCRIPTION
## Features
- **`parse_type` parses a selection set with optional outer brackets - [lrlna], [pull/718] fixing [issue/715]**
  This returns a `SyntaxTree<Type>` which instead of `.document() -> cst::Document`
  has `.type() -> cst::Type`.
  This is intended to parse the string value of a [`@field(type:)` argument][fieldtype]
  used in some Apollo Federation directives.
  ```rust
  let source = r#"[[NestedList!]]!"#;

  let parser = Parser::new(source);
  let cst: SyntaxTree<cst::Type> = parser.parse_type();
  let errors = cst.errors().collect::<Vec<_>>();
  assert_eq!(errors.len(), 0);
  ```

[lrlna]: https://github.com/lrlna
[pull/718]: https://github.com/apollographql/apollo-rs/pull/718
[issue/715]: https://github.com/apollographql/apollo-rs/issues/715
[fieldtype]: https://specs.apollo.dev/join/v0.3/#@field

## Fixes

- **Input object values can be empty - [goto-bus-stop], [pull/745] fixing [issue/744]**
  `apollo-parser` version 0.7.3 introduced a regression where empty input objects failed to parse.
  This is now fixed.

  ```graphql
  { field(argument: {}) }
  ```

[goto-bus-stop]: https://github.com/goto-bus-stop
[pull/745]: https://github.com/apollographql/apollo-rs/pull/745
[issue/744]: https://github.com/apollographql/apollo-rs/issues/744