### PR TITLE
apollo-compiler@1.0.0-beta.7

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2023-mm-dd
+# [1.0.0-beta.7](https://crates.io/crates/apollo-compiler/1.0.0-beta.7) - 2023-11-17
 
 ## Features
 
@@ -44,6 +44,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [goto-bus-stop]: https://github.com/goto-bus-stop
 [pull/718]: https://github.com/apollographql/apollo-rs/pull/718
 [issue/715]: https://github.com/apollographql/apollo-rs/issues/715
+
+## Fixes
+
+- **Fix list and null type validation bugs - [goto-bus-stop], [pull/746] fixing [issue/738]**
+  Previous versions of apollo-compiler accepted `null` inside a list even if the list item type
+  was marked as required. Lists were also accepted as inputs to non-list fields. This is now
+  fixed.
+
+  ```graphql
+  input Args {
+    string: String
+    ints: [Int!]
+  }
+  type Query { example(args: Args): Int }
+  query {
+    example(args: {
+      # Used to be accepted, now raises an error
+      string: ["1"]
+      # Used to be accepted, now raises an error
+      ints: [1, 2, null, 4]
+    })
+  }
+  ```
+
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/746]: https://github.com/apollographql/apollo-rs/pull/746
+[issue/738]: https://github.com/apollographql/apollo-rs/issues/738
 
 # [1.0.0-beta.6](https://crates.io/crates/apollo-compiler/1.0.0-beta.6) - 2023-11-10
 

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.6" # When bumping, also update README.md
+version = "1.0.0-beta.7" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.6"
+apollo-compiler = "=1.0.0-beta.7"
 ```
 
 ## Rust versions


### PR DESCRIPTION
## Features

- **Helper features for `Name` and `Type` - [SimonSapin], [pull/739]:**
  * The `name!` macro also accepts an identifier: 
    `name!(Query)` and `name!("Query")` create equivalent `Name` values.
  * `InvalidNameError` now contain a public `NodeStr` for the input string that is invalid,
    and implements `Display`, `Debug`, and `Error` traits.
  * Add `TryFrom` conversion to `Name` from `NodeStr`, `&NodeStr`, `&str`, `String`, and `&String`.
  * Add a `ty!` macro to build a static `ast::Type` using GraphQL-like syntax.

[SimonSapin]: https://github.com/SimonSapin
[pull/739]: https://github.com/apollographql/apollo-rs/pull/739

- **Add parsing an `ast::Type` from a string - [lrlna] and [goto-bus-stop], [pull/718] fixing [issue/715]**
  Parses GraphQL type syntax:
  ```rust
  use apollo_compiler::ast::Type;
  let ty = Type::parse("[ListItem!]!")?;
  ```
[lrlna]: https://github.com/lrlna
[goto-bus-stop]: https://github.com/goto-bus-stop
[pull/718]: https://github.com/apollographql/apollo-rs/pull/718
[issue/715]: https://github.com/apollographql/apollo-rs/issues/715

## Fixes

- **Fix list and null type validation bugs - [goto-bus-stop], [pull/746] fixing [issue/738]**
  Previous versions of apollo-compiler accepted `null` inside a list even if the list item type
  was marked as required. Lists were also accepted as inputs to non-list fields. This is now
  fixed.

  ```graphql
  input Args {
    string: String
    ints: [Int!]
  }
  type Query { example(args: Args): Int }
  query {
    example(args: {
      # Used to be accepted, now raises an error
      string: ["1"]
      # Used to be accepted, now raises an error
      ints: [1, 2, null, 4]
    })
  }
  ```

[goto-bus-stop]: https://github.com/goto-bus-stop
[pull/746]: https://github.com/apollographql/apollo-rs/pull/746
[issue/738]: https://github.com/apollographql/apollo-rs/issues/738