### PR TITLE
feat(compiler): add schema coordinates

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -45,7 +45,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Schema coordinates are a compact, human-readable way to uniquely point to an item defined in a schema.
   - `string.parse::<SchemaCoordinate>()` parses a coordinate from a string.
   - Coordinates have a `Display` impl that writes them out with schema coordinate syntax.
-  - `schema.lookup(&coord)` looks up the item pointed to by a coordinate in a schema.
   - The `coord!()` macro creates a static coordinate at compile time from spec syntax.
 
 ## Fixes

--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -41,6 +41,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Add `NodeStr::from(Name)` - [goto-bus-stop], [pull/773]**
 - **Convenience accessors for `ast::Selection` enum - [SimonSapin], [pull/777]**
   `as_field`, `as_inline_fragment`, and `as_fragment_spread`; all returning `Option<&_>`.
+- **Add schema coordinates - [goto-bus-stop], [pull/757]:**
+  Schema coordinates are a compact, human-readable way to uniquely point to an item defined in a schema.
+  - `string.parse::<SchemaCoordinate>()` parses a coordinate from a string.
+  - Coordinates have a `Display` impl that writes them out with schema coordinate syntax.
+  - `schema.lookup(&coord)` looks up the item pointed to by a coordinate in a schema.
+  - The `coord!()` macro creates a static coordinate at compile time from spec syntax.
 
 ## Fixes
 - **Fix serializing single-line strings with leading whitespace - [goto-bus-stop], [pull/774]**

--- a/crates/apollo-compiler/src/coordinate.rs
+++ b/crates/apollo-compiler/src/coordinate.rs
@@ -162,9 +162,9 @@ impl TypeCoordinate {
     ///
     /// For object types and interfaces, the resulting coordinate points to a field. For enums, the
     /// resulting coordinate points to a value.
-    pub fn with_attribute(self, attribute: Name) -> TypeAttributeCoordinate {
+    pub fn with_attribute(&self, attribute: Name) -> TypeAttributeCoordinate {
         TypeAttributeCoordinate {
-            ty: self.ty,
+            ty: self.ty.clone(),
             attribute,
         }
     }
@@ -187,15 +187,17 @@ impl FromStr for TypeCoordinate {
 
 impl TypeAttributeCoordinate {
     /// Create a schema coordinate that points to the type this attribute is part of.
-    pub fn type_coordinate(self) -> TypeCoordinate {
-        TypeCoordinate { ty: self.ty }
+    pub fn type_coordinate(&self) -> TypeCoordinate {
+        TypeCoordinate {
+            ty: self.ty.clone(),
+        }
     }
 
     /// Assume this attribute is a field, and create a schema coordinate that points to an argument on this field.
-    pub fn with_argument(self, argument: Name) -> FieldArgumentCoordinate {
+    pub fn with_argument(&self, argument: Name) -> FieldArgumentCoordinate {
         FieldArgumentCoordinate {
-            ty: self.ty,
-            field: self.attribute,
+            ty: self.ty.clone(),
+            field: self.attribute.clone(),
             argument,
         }
     }
@@ -216,15 +218,17 @@ impl FromStr for TypeAttributeCoordinate {
 
 impl FieldArgumentCoordinate {
     /// Create a schema coordinate that points to the type this argument is defined in.
-    pub fn type_coordinate(self) -> TypeCoordinate {
-        TypeCoordinate { ty: self.ty }
+    pub fn type_coordinate(&self) -> TypeCoordinate {
+        TypeCoordinate {
+            ty: self.ty.clone(),
+        }
     }
 
     /// Create a schema coordinate that points to the field this argument is defined in.
-    pub fn field_coordinate(self) -> TypeAttributeCoordinate {
+    pub fn field_coordinate(&self) -> TypeAttributeCoordinate {
         TypeAttributeCoordinate {
-            ty: self.ty,
-            attribute: self.field,
+            ty: self.ty.clone(),
+            attribute: self.field.clone(),
         }
     }
 }
@@ -240,15 +244,19 @@ impl FromStr for FieldArgumentCoordinate {
         let Some((argument, ")")) = rest.split_once(':') else {
             return Err(SchemaCoordinateParseError::InvalidFormat);
         };
-        Ok(field.with_argument(Name::try_from(argument)?))
+        Ok(Self {
+            ty: field.ty,
+            field: field.attribute,
+            argument: Name::try_from(argument)?,
+        })
     }
 }
 
 impl DirectiveCoordinate {
     /// Create a schema coordinate that points to an argument of this directive.
-    pub fn with_argument(self, argument: Name) -> DirectiveArgumentCoordinate {
+    pub fn with_argument(&self, argument: Name) -> DirectiveArgumentCoordinate {
         DirectiveArgumentCoordinate {
-            directive: self.directive,
+            directive: self.directive.clone(),
             argument,
         }
     }
@@ -275,9 +283,9 @@ impl FromStr for DirectiveCoordinate {
 
 impl DirectiveArgumentCoordinate {
     /// Create a schema coordinate that points to the directive this argument is defined in.
-    pub fn directive_coordinate(self) -> DirectiveCoordinate {
+    pub fn directive_coordinate(&self) -> DirectiveCoordinate {
         DirectiveCoordinate {
-            directive: self.directive,
+            directive: self.directive.clone(),
         }
     }
 }

--- a/crates/apollo-compiler/src/coordinate.rs
+++ b/crates/apollo-compiler/src/coordinate.rs
@@ -1,9 +1,15 @@
+//! Parsing and printing for schema coordinates as described in [the RFC].
+//!
+//! Schema coordinates uniquely point to an item defined in a schema.
+//!
+//! [the RFC]: https://github.com/graphql/graphql-wg/blob/main/rfcs/SchemaCoordinates.md
+
 use crate::ast::InvalidNameError;
 use crate::schema::Name;
 use std::fmt;
 use std::str::FromStr;
 
-/// Create a static coordinate at compile time.
+/// Create a static schema coordinate at compile time.
 ///
 /// ```rust
 /// use apollo_compiler::coord;
@@ -138,11 +144,14 @@ pub enum SchemaCoordinate {
     DirectiveArgument(DirectiveArgumentCoordinate),
 }
 
+/// Errors that can occur while parsing a schema coordinate.
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
 pub enum SchemaCoordinateParseError {
+    /// Invalid format, eg. unexpected characters
     #[error("invalid schema coordinate")]
     InvalidFormat,
+    /// A name part contains invalid characters
     #[error(transparent)]
     InvalidName(#[from] InvalidNameError),
 }

--- a/crates/apollo-compiler/src/coordinate.rs
+++ b/crates/apollo-compiler/src/coordinate.rs
@@ -41,10 +41,11 @@ macro_rules! coord {
 ///
 /// # Example
 /// ```
+/// use apollo_compiler::name;
 /// use apollo_compiler::coordinate::TypeCoordinate;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// assert_eq!(TypeCoordinate("Type".try_into()?).to_string(), "Type");
+/// assert_eq!(TypeCoordinate(name!("Type")).to_string(), "Type");
 /// # Ok(()) }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -54,10 +55,11 @@ pub struct TypeCoordinate(pub Name);
 ///
 /// # Example
 /// ```
+/// use apollo_compiler::name;
 /// use apollo_compiler::coordinate::FieldCoordinate;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// assert_eq!(FieldCoordinate("Type".try_into()?, "field".try_into()?).to_string(), "Type.field");
+/// assert_eq!(FieldCoordinate(name!("Type"), name!("field")).to_string(), "Type.field");
 /// # Ok(()) }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -67,10 +69,11 @@ pub struct FieldCoordinate(pub Name, pub Name);
 ///
 /// # Example
 /// ```
+/// use apollo_compiler::name;
 /// use apollo_compiler::coordinate::FieldArgumentCoordinate;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// assert_eq!(FieldArgumentCoordinate("Type".try_into()?, "field".try_into()?, "argument".try_into()?).to_string(), "Type.field(argument:)");
+/// assert_eq!(FieldArgumentCoordinate(name!("Type"), name!("field"), name!("argument")).to_string(), "Type.field(argument:)");
 /// # Ok(()) }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -88,12 +91,13 @@ pub struct DirectiveArgumentCoordinate(pub Name, pub Name);
 ///
 /// # Example
 /// ```
+/// use apollo_compiler::name;
 /// use apollo_compiler::coordinate::{SchemaCoordinate, FieldArgumentCoordinate};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let coord: SchemaCoordinate = "Type.field(argument:)".parse().unwrap();
 /// assert_eq!(coord, SchemaCoordinate::FieldArgument(
-///     FieldArgumentCoordinate("Type".try_into()?, "field".try_into()?, "argument".try_into()?)
+///     FieldArgumentCoordinate(name!("Type"), name!("field"), name!("argument"))
 /// ));
 /// # Ok(()) }
 /// ```

--- a/crates/apollo-compiler/src/coordinate.rs
+++ b/crates/apollo-compiler/src/coordinate.rs
@@ -1,0 +1,282 @@
+use crate::ast::InvalidNameError;
+use crate::schema::Name;
+use std::fmt;
+use std::str::FromStr;
+
+/// Create a static coordinate at compile time.
+///
+/// ```rust
+/// use apollo_compiler::coord;
+///
+/// assert_eq!(coord!(@directive).to_string(), "@directive");
+/// assert_eq!(coord!(@directive(arg:)).to_string(), "@directive(arg:)");
+/// assert_eq!(coord!(Type).to_string(), "Type");
+/// assert_eq!(coord!(Type.field).to_string(), "Type.field");
+/// assert_eq!(coord!(Type.field(arg:)).to_string(), "Type.field(arg:)");
+/// ```
+#[macro_export]
+macro_rules! coord {
+    ( @ $name:ident ) => {
+        $crate::coordinate::DirectiveCoordinate($crate::name!($name))
+    };
+    ( @ $name:ident ( $arg:ident : ) ) => {
+        $crate::coordinate::DirectiveArgumentCoordinate($crate::name!($name), $crate::name!($arg))
+    };
+    ( $name:ident ) => {
+        $crate::coordinate::TypeCoordinate($crate::name!($name))
+    };
+    ( $name:ident . $field:ident ) => {
+        $crate::coordinate::FieldCoordinate($crate::name!($name), $crate::name!($field))
+    };
+    ( $name:ident . $field:ident ( $arg:ident : ) ) => {
+        $crate::coordinate::FieldArgumentCoordinate(
+            $crate::name!($name),
+            $crate::name!($field),
+            $crate::name!($arg),
+        )
+    };
+}
+
+/// A schema coordinate targeting a type definition: `Type`.
+///
+/// # Example
+/// ```
+/// use apollo_compiler::coordinate::TypeCoordinate;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// assert_eq!(TypeCoordinate("Type".try_into()?).to_string(), "Type");
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TypeCoordinate(pub Name);
+
+/// A schema coordinate targeting a field definition: `Type.field`.
+///
+/// # Example
+/// ```
+/// use apollo_compiler::coordinate::FieldCoordinate;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// assert_eq!(FieldCoordinate("Type".try_into()?, "field".try_into()?).to_string(), "Type.field");
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FieldCoordinate(pub Name, pub Name);
+
+/// A schema coordinate targeting a field argument definition: `Type.field(argument:)`.
+///
+/// # Example
+/// ```
+/// use apollo_compiler::coordinate::FieldArgumentCoordinate;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// assert_eq!(FieldArgumentCoordinate("Type".try_into()?, "field".try_into()?, "argument".try_into()?).to_string(), "Type.field(argument:)");
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FieldArgumentCoordinate(pub Name, pub Name, pub Name);
+
+/// A schema coordinate targeting a directive definition: `@directive`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DirectiveCoordinate(pub Name);
+
+/// A schema coordinate targeting a directive argument definition: `@directive(argument:)`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DirectiveArgumentCoordinate(pub Name, pub Name);
+
+/// Any schema coordinate.
+///
+/// # Example
+/// ```
+/// use apollo_compiler::coordinate::{SchemaCoordinate, FieldArgumentCoordinate};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let coord: SchemaCoordinate = "Type.field(argument:)".parse().unwrap();
+/// assert_eq!(coord, SchemaCoordinate::FieldArgument(
+///     FieldArgumentCoordinate("Type".try_into()?, "field".try_into()?, "argument".try_into()?)
+/// ));
+/// # Ok(()) }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SchemaCoordinate {
+    Type(TypeCoordinate),
+    Field(FieldCoordinate),
+    FieldArgument(FieldArgumentCoordinate),
+    Directive(DirectiveCoordinate),
+    DirectiveArgument(DirectiveArgumentCoordinate),
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum SchemaCoordinateParseError {
+    #[error("invalid schema coordinate")]
+    InvalidFormat,
+    #[error(transparent)]
+    InvalidName(#[from] InvalidNameError),
+}
+
+impl TypeCoordinate {
+    /// Create a schema coordinate that points to a field on this type.
+    pub fn field(self, field: Name) -> FieldCoordinate {
+        FieldCoordinate(self.0, field)
+    }
+}
+
+impl FromStr for TypeCoordinate {
+    type Err = SchemaCoordinateParseError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        Ok(Self(Name::try_from(input)?))
+    }
+}
+
+impl FieldCoordinate {
+    /// Create a schema coordinate that points to the type this field is on.
+    pub fn type_(self) -> TypeCoordinate {
+        TypeCoordinate(self.0)
+    }
+
+    /// Create a schema coordinate that points to an argument on this field.
+    pub fn argument(self, argument: Name) -> FieldArgumentCoordinate {
+        FieldArgumentCoordinate(self.0, self.1, argument)
+    }
+}
+
+impl FromStr for FieldCoordinate {
+    type Err = SchemaCoordinateParseError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let Some((type_name, field)) = input.split_once('.') else {
+            return Err(SchemaCoordinateParseError::InvalidFormat);
+        };
+        Ok(Self(Name::try_from(type_name)?, Name::try_from(field)?))
+    }
+}
+
+impl FieldArgumentCoordinate {
+    /// Create a schema coordinate that points to the type this argument is defined in.
+    pub fn type_(self) -> TypeCoordinate {
+        TypeCoordinate(self.0)
+    }
+
+    /// Create a schema coordinate that points to the field this argument is defined in.
+    pub fn field(self) -> FieldCoordinate {
+        FieldCoordinate(self.0, self.1)
+    }
+}
+
+impl FromStr for FieldArgumentCoordinate {
+    type Err = SchemaCoordinateParseError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let Some((field, rest)) = input.split_once('(') else {
+            return Err(SchemaCoordinateParseError::InvalidFormat);
+        };
+        let field = FieldCoordinate::from_str(field)?;
+
+        let Some((argument, ")")) = rest.split_once(':') else {
+            return Err(SchemaCoordinateParseError::InvalidFormat);
+        };
+        Ok(field.argument(Name::try_from(argument)?))
+    }
+}
+
+impl DirectiveCoordinate {
+    /// Create a schema coordinate that points to an argument of this directive.
+    pub fn argument(self, argument: Name) -> DirectiveArgumentCoordinate {
+        DirectiveArgumentCoordinate(self.0, argument)
+    }
+}
+
+impl FromStr for DirectiveCoordinate {
+    type Err = SchemaCoordinateParseError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Some(directive) = input.strip_prefix('@') {
+            Ok(Self(Name::try_from(directive)?))
+        } else {
+            Err(SchemaCoordinateParseError::InvalidFormat)
+        }
+    }
+}
+
+impl DirectiveArgumentCoordinate {
+    /// Create a schema coordinate that points to the directive this argument is defined in.
+    pub fn directive(self) -> DirectiveCoordinate {
+        DirectiveCoordinate(self.0)
+    }
+}
+
+impl FromStr for DirectiveArgumentCoordinate {
+    type Err = SchemaCoordinateParseError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let Some((directive, rest)) = input.split_once('(') else {
+            return Err(SchemaCoordinateParseError::InvalidFormat);
+        };
+        let directive = DirectiveCoordinate::from_str(directive)?;
+
+        let Some((argument, ")")) = rest.split_once(':') else {
+            return Err(SchemaCoordinateParseError::InvalidFormat);
+        };
+        Ok(directive.argument(Name::try_from(argument)?))
+    }
+}
+
+impl fmt::Display for TypeCoordinate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self(type_name) = self;
+        write!(f, "{type_name}")
+    }
+}
+
+impl fmt::Display for FieldCoordinate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self(type_name, field) = self;
+        write!(f, "{type_name}.{field}")
+    }
+}
+
+impl fmt::Display for FieldArgumentCoordinate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self(type_name, field, argument) = self;
+        write!(f, "{type_name}.{field}({argument}:)")
+    }
+}
+
+impl fmt::Display for DirectiveCoordinate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self(directive) = self;
+        write!(f, "@{directive}")
+    }
+}
+
+impl fmt::Display for DirectiveArgumentCoordinate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self(directive, argument) = self;
+        write!(f, "@{directive}({argument}:)")
+    }
+}
+
+impl FromStr for SchemaCoordinate {
+    type Err = SchemaCoordinateParseError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if input.starts_with('@') {
+            DirectiveArgumentCoordinate::from_str(input)
+                .map(Self::DirectiveArgument)
+                .or_else(|_| DirectiveCoordinate::from_str(input).map(Self::Directive))
+        } else {
+            FieldArgumentCoordinate::from_str(input)
+                .map(Self::FieldArgument)
+                .or_else(|_| FieldCoordinate::from_str(input).map(Self::Field))
+                .or_else(|_| TypeCoordinate::from_str(input).map(Self::Type))
+        }
+    }
+}
+
+impl fmt::Display for SchemaCoordinate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Type(inner) => inner.fmt(f),
+            Self::Field(inner) => inner.fmt(f),
+            Self::FieldArgument(inner) => inner.fmt(f),
+            Self::Directive(inner) => inner.fmt(f),
+            Self::DirectiveArgument(inner) => inner.fmt(f),
+        }
+    }
+}

--- a/crates/apollo-compiler/src/coordinate.rs
+++ b/crates/apollo-compiler/src/coordinate.rs
@@ -5,7 +5,8 @@
 //! [the RFC]: https://github.com/graphql/graphql-wg/blob/main/rfcs/SchemaCoordinates.md
 
 use crate::ast::InvalidNameError;
-use crate::schema::Name;
+use crate::ast::Name;
+use crate::schema::NamedType;
 use std::fmt;
 use std::str::FromStr;
 
@@ -65,7 +66,7 @@ macro_rules! coord {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeCoordinate {
-    pub ty: Name,
+    pub ty: NamedType,
 }
 
 /// A schema coordinate targeting a field definition or an enum value: `Type.field`, `Enum.VALUE`.
@@ -82,7 +83,7 @@ pub struct TypeCoordinate {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeAttributeCoordinate {
-    pub ty: Name,
+    pub ty: NamedType,
     pub attribute: Name,
 }
 
@@ -101,7 +102,7 @@ pub struct TypeAttributeCoordinate {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FieldArgumentCoordinate {
-    pub ty: Name,
+    pub ty: NamedType,
     pub field: Name,
     pub argument: Name,
 }
@@ -169,8 +170,8 @@ impl TypeCoordinate {
     }
 }
 
-impl From<Name> for TypeCoordinate {
-    fn from(ty: Name) -> Self {
+impl From<NamedType> for TypeCoordinate {
+    fn from(ty: NamedType) -> Self {
         Self { ty }
     }
 }
@@ -179,7 +180,7 @@ impl FromStr for TypeCoordinate {
     type Err = SchemaCoordinateParseError;
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         Ok(Self {
-            ty: Name::try_from(input)?,
+            ty: NamedType::try_from(input)?,
         })
     }
 }
@@ -207,7 +208,7 @@ impl FromStr for TypeAttributeCoordinate {
             return Err(SchemaCoordinateParseError::InvalidFormat);
         };
         Ok(Self {
-            ty: Name::try_from(type_name)?,
+            ty: NamedType::try_from(type_name)?,
             attribute: Name::try_from(field)?,
         })
     }

--- a/crates/apollo-compiler/src/coordinate.rs
+++ b/crates/apollo-compiler/src/coordinate.rs
@@ -368,3 +368,29 @@ impl fmt::Display for SchemaCoordinate {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_coordinates() {
+        SchemaCoordinate::from_str("Type\\.field(arg:)").expect_err("invalid character");
+        SchemaCoordinate::from_str("@directi^^ve").expect_err("invalid character");
+        SchemaCoordinate::from_str("@directi@ve").expect_err("invalid character");
+        SchemaCoordinate::from_str("@  spaces  ").expect_err("invalid character");
+
+        SchemaCoordinate::from_str("@(:)").expect_err("directive argument syntax without names");
+        SchemaCoordinate::from_str("@dir(:)")
+            .expect_err("directive argument syntax without argument name");
+        SchemaCoordinate::from_str("@(arg:)")
+            .expect_err("directive argument syntax without directive name");
+
+        SchemaCoordinate::from_str("Type.")
+            .expect_err("type attribute syntax without attribute name");
+        SchemaCoordinate::from_str(".field").expect_err("type attribute syntax without type name");
+        SchemaCoordinate::from_str("Type.field(:)")
+            .expect_err("field argument syntax without field name");
+        SchemaCoordinate::from_str("Type.field(arg)").expect_err("field argument syntax without :");
+    }
+}

--- a/crates/apollo-compiler/src/coordinate.rs
+++ b/crates/apollo-compiler/src/coordinate.rs
@@ -6,15 +6,7 @@
 
 use crate::ast::InvalidNameError;
 use crate::ast::Name;
-use crate::schema::Component;
-use crate::schema::DirectiveDefinition;
-use crate::schema::EnumValueDefinition;
-use crate::schema::ExtendedType;
-use crate::schema::FieldDefinition;
-use crate::schema::InputValueDefinition;
 use crate::schema::NamedType;
-use crate::schema::Schema;
-use crate::Node;
 use std::fmt;
 use std::str::FromStr;
 
@@ -61,21 +53,6 @@ macro_rules! coord {
             argument: $crate::name!($arg),
         }
     };
-}
-
-mod sealed {
-    pub trait Sealed {}
-}
-
-/// Provides [`schema.lookup(&coord)`][Schema::lookup] for any schema coordinate.
-pub trait SchemaLookup: sealed::Sealed {
-    type Output<'schema>;
-
-    /// Look up this coordinate in a schema.
-    fn lookup<'coord, 'schema>(
-        &'coord self,
-        schema: &'schema Schema,
-    ) -> Result<Self::Output<'schema>, SchemaLookupError<'coord, 'schema>>;
 }
 
 /// A schema coordinate targeting a type definition: `Type`.
@@ -180,43 +157,6 @@ pub enum SchemaCoordinateParseError {
     InvalidName(#[from] InvalidNameError),
 }
 
-/// Errors that can occur while looking up a schema coordinate.
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum SchemaLookupError<'coord, 'schema> {
-    #[error("type `{0}` does not exist")]
-    MissingType(&'coord NamedType),
-    #[error("type does not have attribute `{0}`")]
-    MissingAttribute(&'coord Name),
-    #[error("type attribute `{0}` is not a field and can not have arguments")]
-    InvalidArgumentAttribute(&'coord Name),
-    #[error("field or directive does not have argument `{0}`")]
-    MissingArgument(&'coord Name),
-    #[error("type does not have attributes")]
-    InvalidType(&'schema ExtendedType),
-}
-
-/// Possible types selected by a type attribute coordinate, of the form `Type.field`.
-#[derive(Debug)]
-// Should this be non-exhaustive? Allows for future extension should unions ever be added.
-#[non_exhaustive]
-pub enum TypeAttributeLookup<'schema> {
-    Field(&'schema Component<FieldDefinition>),
-    InputField(&'schema Component<InputValueDefinition>),
-    EnumValue(&'schema Component<EnumValueDefinition>),
-}
-
-/// Possible types selected by a schema coordinate.
-#[non_exhaustive]
-pub enum SchemaCoordinateLookup<'schema> {
-    Type(&'schema ExtendedType),
-    Directive(&'schema Node<DirectiveDefinition>),
-    Field(&'schema Component<FieldDefinition>),
-    InputField(&'schema Component<InputValueDefinition>),
-    EnumValue(&'schema Component<EnumValueDefinition>),
-    Argument(&'schema Node<InputValueDefinition>),
-}
-
 impl TypeCoordinate {
     /// Create a schema coordinate that points to an attribute on this type.
     ///
@@ -227,29 +167,6 @@ impl TypeCoordinate {
             ty: self.ty.clone(),
             attribute,
         }
-    }
-
-    fn lookup_ref<'coord, 'schema>(
-        ty: &'coord NamedType,
-        schema: &'schema Schema,
-    ) -> Result<&'schema ExtendedType, SchemaLookupError<'coord, 'schema>> {
-        schema
-            .types
-            .get(ty)
-            .ok_or(SchemaLookupError::MissingType(ty))
-    }
-}
-
-impl sealed::Sealed for TypeCoordinate {}
-impl SchemaLookup for TypeCoordinate {
-    type Output<'schema> = &'schema ExtendedType;
-
-    /// Look up this type coordinate in a schema.
-    fn lookup<'coord, 'schema>(
-        &'coord self,
-        schema: &'schema Schema,
-    ) -> Result<Self::Output<'schema>, SchemaLookupError<'coord, 'schema>> {
-        Self::lookup_ref(&self.ty, schema)
     }
 }
 
@@ -284,52 +201,6 @@ impl TypeAttributeCoordinate {
             argument,
         }
     }
-
-    fn lookup_ref<'coord, 'schema>(
-        ty: &'coord NamedType,
-        attribute: &'coord Name,
-        schema: &'schema Schema,
-    ) -> Result<TypeAttributeLookup<'schema>, SchemaLookupError<'coord, 'schema>> {
-        let ty = TypeCoordinate::lookup_ref(ty, schema)?;
-        match ty {
-            ExtendedType::Enum(enum_) => enum_
-                .values
-                .get(attribute)
-                .ok_or(SchemaLookupError::MissingAttribute(attribute))
-                .map(TypeAttributeLookup::EnumValue),
-            ExtendedType::InputObject(input_object) => input_object
-                .fields
-                .get(attribute)
-                .ok_or(SchemaLookupError::MissingAttribute(attribute))
-                .map(TypeAttributeLookup::InputField),
-            ExtendedType::Object(object) => object
-                .fields
-                .get(attribute)
-                .ok_or(SchemaLookupError::MissingAttribute(attribute))
-                .map(TypeAttributeLookup::Field),
-            ExtendedType::Interface(interface) => interface
-                .fields
-                .get(attribute)
-                .ok_or(SchemaLookupError::MissingAttribute(attribute))
-                .map(TypeAttributeLookup::Field),
-            ExtendedType::Union(_) | ExtendedType::Scalar(_) => {
-                Err(SchemaLookupError::InvalidType(ty))
-            }
-        }
-    }
-}
-
-impl sealed::Sealed for TypeAttributeCoordinate {}
-impl SchemaLookup for TypeAttributeCoordinate {
-    type Output<'schema> = TypeAttributeLookup<'schema>;
-
-    /// Look up this type attribute in a schema.
-    fn lookup<'coord, 'schema>(
-        &'coord self,
-        schema: &'schema Schema,
-    ) -> Result<Self::Output<'schema>, SchemaLookupError<'coord, 'schema>> {
-        Self::lookup_ref(&self.ty, &self.attribute, schema)
-    }
 }
 
 impl FromStr for TypeAttributeCoordinate {
@@ -360,34 +231,6 @@ impl FieldArgumentCoordinate {
             attribute: self.field.clone(),
         }
     }
-
-    fn lookup_ref<'coord, 'schema>(
-        ty: &'coord NamedType,
-        field: &'coord Name,
-        argument: &'coord Name,
-        schema: &'schema Schema,
-    ) -> Result<&'schema Node<InputValueDefinition>, SchemaLookupError<'coord, 'schema>> {
-        match TypeAttributeCoordinate::lookup_ref(ty, field, schema)? {
-            TypeAttributeLookup::Field(field) => field
-                .arguments
-                .iter()
-                .find(|arg| arg.name == *argument)
-                .ok_or(SchemaLookupError::MissingArgument(argument)),
-            _ => Err(SchemaLookupError::InvalidArgumentAttribute(field)),
-        }
-    }
-}
-
-impl sealed::Sealed for FieldArgumentCoordinate {}
-impl SchemaLookup for FieldArgumentCoordinate {
-    type Output<'schema> = &'schema Node<InputValueDefinition>;
-
-    fn lookup<'coord, 'schema>(
-        &'coord self,
-        schema: &'schema Schema,
-    ) -> Result<Self::Output<'schema>, SchemaLookupError<'coord, 'schema>> {
-        Self::lookup_ref(&self.ty, &self.field, &self.argument, schema)
-    }
 }
 
 impl FromStr for FieldArgumentCoordinate {
@@ -417,29 +260,6 @@ impl DirectiveCoordinate {
             argument,
         }
     }
-
-    fn lookup_ref<'coord, 'schema>(
-        directive: &'coord Name,
-        schema: &'schema Schema,
-    ) -> Result<&'schema Node<DirectiveDefinition>, SchemaLookupError<'coord, 'schema>> {
-        schema
-            .directive_definitions
-            .get(directive)
-            .ok_or(SchemaLookupError::MissingType(directive))
-    }
-}
-
-impl sealed::Sealed for DirectiveCoordinate {}
-impl SchemaLookup for DirectiveCoordinate {
-    type Output<'schema> = &'schema Node<DirectiveDefinition>;
-
-    /// Look up this type coordinate in a schema.
-    fn lookup<'coord, 'schema>(
-        &'coord self,
-        schema: &'schema Schema,
-    ) -> Result<Self::Output<'schema>, SchemaLookupError<'coord, 'schema>> {
-        Self::lookup_ref(&self.directive, schema)
-    }
 }
 
 impl From<Name> for DirectiveCoordinate {
@@ -468,31 +288,6 @@ impl DirectiveArgumentCoordinate {
             directive: self.directive.clone(),
         }
     }
-
-    fn lookup_ref<'coord, 'schema>(
-        directive: &'coord Name,
-        argument: &'coord Name,
-        schema: &'schema Schema,
-    ) -> Result<&'schema Node<InputValueDefinition>, SchemaLookupError<'coord, 'schema>> {
-        DirectiveCoordinate::lookup_ref(directive, schema)?
-            .arguments
-            .iter()
-            .find(|arg| arg.name == *argument)
-            .ok_or(SchemaLookupError::MissingArgument(argument))
-    }
-}
-
-impl sealed::Sealed for DirectiveArgumentCoordinate {}
-impl SchemaLookup for DirectiveArgumentCoordinate {
-    type Output<'schema> = &'schema Node<InputValueDefinition>;
-
-    /// Look up this argument coordinate in a schema.
-    fn lookup<'coord, 'schema>(
-        &'coord self,
-        schema: &'schema Schema,
-    ) -> Result<Self::Output<'schema>, SchemaLookupError<'coord, 'schema>> {
-        Self::lookup_ref(&self.directive, &self.argument, schema)
-    }
 }
 
 impl FromStr for DirectiveArgumentCoordinate {
@@ -510,77 +305,6 @@ impl FromStr for DirectiveArgumentCoordinate {
             directive: directive.directive,
             argument: Name::try_from(argument)?,
         })
-    }
-}
-
-impl<'schema> From<&'schema ExtendedType> for SchemaCoordinateLookup<'schema> {
-    fn from(inner: &'schema ExtendedType) -> Self {
-        Self::Type(inner)
-    }
-}
-
-impl<'schema> From<&'schema Node<DirectiveDefinition>> for SchemaCoordinateLookup<'schema> {
-    fn from(inner: &'schema Node<DirectiveDefinition>) -> Self {
-        Self::Directive(inner)
-    }
-}
-
-impl<'schema> From<&'schema Component<FieldDefinition>> for SchemaCoordinateLookup<'schema> {
-    fn from(inner: &'schema Component<FieldDefinition>) -> Self {
-        Self::Field(inner)
-    }
-}
-
-impl<'schema> From<&'schema Component<InputValueDefinition>> for SchemaCoordinateLookup<'schema> {
-    fn from(inner: &'schema Component<InputValueDefinition>) -> Self {
-        Self::InputField(inner)
-    }
-}
-
-impl<'schema> From<&'schema Component<EnumValueDefinition>> for SchemaCoordinateLookup<'schema> {
-    fn from(inner: &'schema Component<EnumValueDefinition>) -> Self {
-        Self::EnumValue(inner)
-    }
-}
-
-impl<'schema> From<TypeAttributeLookup<'schema>> for SchemaCoordinateLookup<'schema> {
-    fn from(attr: TypeAttributeLookup<'schema>) -> Self {
-        match attr {
-            TypeAttributeLookup::Field(field) => SchemaCoordinateLookup::Field(field),
-            TypeAttributeLookup::InputField(field) => SchemaCoordinateLookup::InputField(field),
-            TypeAttributeLookup::EnumValue(field) => SchemaCoordinateLookup::EnumValue(field),
-        }
-    }
-}
-
-impl<'schema> From<&'schema Node<InputValueDefinition>> for SchemaCoordinateLookup<'schema> {
-    fn from(inner: &'schema Node<InputValueDefinition>) -> Self {
-        Self::Argument(inner)
-    }
-}
-
-impl sealed::Sealed for SchemaCoordinate {}
-impl SchemaLookup for SchemaCoordinate {
-    type Output<'schema> = SchemaCoordinateLookup<'schema>;
-
-    /// Look up this type coordinate in a schema.
-    fn lookup<'coord, 'schema>(
-        &'coord self,
-        schema: &'schema Schema,
-    ) -> Result<Self::Output<'schema>, SchemaLookupError<'coord, 'schema>> {
-        match self {
-            SchemaCoordinate::Type(coordinate) => coordinate.lookup(schema).map(Into::into),
-            SchemaCoordinate::TypeAttribute(coordinate) => {
-                coordinate.lookup(schema).map(Into::into)
-            }
-            SchemaCoordinate::FieldArgument(coordinate) => {
-                coordinate.lookup(schema).map(Into::into)
-            }
-            SchemaCoordinate::Directive(coordinate) => coordinate.lookup(schema).map(Into::into),
-            SchemaCoordinate::DirectiveArgument(coordinate) => {
-                coordinate.lookup(schema).map(Into::into)
-            }
-        }
     }
 }
 

--- a/crates/apollo-compiler/src/coordinate.rs
+++ b/crates/apollo-compiler/src/coordinate.rs
@@ -324,6 +324,36 @@ impl FromStr for SchemaCoordinate {
     }
 }
 
+impl From<TypeCoordinate> for SchemaCoordinate {
+    fn from(inner: TypeCoordinate) -> Self {
+        Self::Type(inner)
+    }
+}
+
+impl From<TypeAttributeCoordinate> for SchemaCoordinate {
+    fn from(inner: TypeAttributeCoordinate) -> Self {
+        Self::TypeAttribute(inner)
+    }
+}
+
+impl From<FieldArgumentCoordinate> for SchemaCoordinate {
+    fn from(inner: FieldArgumentCoordinate) -> Self {
+        Self::FieldArgument(inner)
+    }
+}
+
+impl From<DirectiveCoordinate> for SchemaCoordinate {
+    fn from(inner: DirectiveCoordinate) -> Self {
+        Self::Directive(inner)
+    }
+}
+
+impl From<DirectiveArgumentCoordinate> for SchemaCoordinate {
+    fn from(inner: DirectiveArgumentCoordinate) -> Self {
+        Self::DirectiveArgument(inner)
+    }
+}
+
 impl fmt::Display for TypeCoordinate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { ty } = self;

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 mod macros;
 pub mod ast;
+pub mod coordinate;
 mod database;
 pub mod diagnostic;
 pub mod executable;

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -1,8 +1,6 @@
 //! High-level representation of a GraphQL schema
 
 use crate::ast;
-use crate::coordinate::SchemaLookup;
-use crate::coordinate::SchemaLookupError;
 use crate::validation::FileId;
 use crate::validation::NodeLocation;
 use crate::Node;
@@ -345,22 +343,6 @@ impl Schema {
         let mut errors = DiagnosticList::new(self.sources.clone());
         validation::validate_schema(&mut errors, &self);
         errors.into_valid_result(self)
-    }
-
-    /// Returns the node targeted by the given coordinate.
-    ///
-    /// ```rust
-    /// use apollo_compiler::Schema;
-    /// use apollo_compiler::coord;
-    ///
-    /// let schema = Schema::new();
-    /// let enum_value = schema.lookup(&coord!(__TypeKind.OBJECT)).unwrap();
-    /// ```
-    pub fn lookup<'coord, 'schema, T: SchemaLookup>(
-        &'schema self,
-        coordinate: &'coord T,
-    ) -> Result<T::Output<'schema>, SchemaLookupError<'coord, 'schema>> {
-        coordinate.lookup(self)
     }
 
     /// Returns the type with the given name, if it is a scalar type

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -1,6 +1,8 @@
 //! High-level representation of a GraphQL schema
 
 use crate::ast;
+use crate::coordinate::SchemaLookup;
+use crate::coordinate::SchemaLookupError;
 use crate::validation::FileId;
 use crate::validation::NodeLocation;
 use crate::Node;
@@ -343,6 +345,22 @@ impl Schema {
         let mut errors = DiagnosticList::new(self.sources.clone());
         validation::validate_schema(&mut errors, &self);
         errors.into_valid_result(self)
+    }
+
+    /// Returns the node targeted by the given coordinate.
+    ///
+    /// ```rust
+    /// use apollo_compiler::Schema;
+    /// use apollo_compiler::coord;
+    ///
+    /// let schema = Schema::new();
+    /// let enum_value = schema.lookup(&coord!(__TypeKind.OBJECT)).unwrap();
+    /// ```
+    pub fn lookup<'coord, 'schema, T: SchemaLookup>(
+        &'schema self,
+        coordinate: &'coord T,
+    ) -> Result<T::Output<'schema>, SchemaLookupError<'coord, 'schema>> {
+        coordinate.lookup(self)
     }
 
     /// Returns the type with the given name, if it is a scalar type

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -1,3 +1,5 @@
+use crate::coordinate::DirectiveArgumentCoordinate;
+use crate::coordinate::DirectiveCoordinate;
 use crate::validation::diagnostics::{DiagnosticData, ValidationError};
 use crate::validation::{NodeLocation, RecursionGuard, RecursionStack};
 use crate::{ast, schema, Node, ValidationDatabase};
@@ -270,7 +272,10 @@ pub(crate) fn validate_directives<'dir>(
                         argument.location(),
                         DiagnosticData::UndefinedArgument {
                             name: argument.name.clone(),
-                            coordinate: format!("@{}", dir.name),
+                            coordinate: DirectiveCoordinate {
+                                directive: dir.name.clone(),
+                            }
+                            .into(),
                             definition_location: loc,
                         },
                     ));
@@ -294,10 +299,11 @@ pub(crate) fn validate_directives<'dir>(
                         dir.location(),
                         DiagnosticData::RequiredArgument {
                             name: arg_def.name.clone(),
-                            coordinate: format!(
-                                "@{}({}:)",
-                                directive_definition.name, arg_def.name
-                            ),
+                            coordinate: DirectiveArgumentCoordinate {
+                                directive: directive_definition.name.clone(),
+                                argument: arg_def.name.clone(),
+                            }
+                            .into(),
                             definition_location: arg_def.location(),
                         },
                     ));

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -1,3 +1,4 @@
+use crate::coordinate::{FieldArgumentCoordinate, TypeAttributeCoordinate};
 use crate::validation::diagnostics::{DiagnosticData, ValidationError};
 use crate::validation::{FileId, ValidationDatabase};
 use crate::{ast, schema, Node};
@@ -63,7 +64,11 @@ pub(crate) fn validate_field(
                     argument.location(),
                     DiagnosticData::UndefinedArgument {
                         name: argument.name.clone(),
-                        coordinate: format!("{}.{}", against_type, field.name),
+                        coordinate: TypeAttributeCoordinate {
+                            ty: against_type.clone(),
+                            attribute: field.name.clone(),
+                        }
+                        .into(),
                         definition_location: loc,
                     },
                 ));
@@ -87,10 +92,12 @@ pub(crate) fn validate_field(
                     field.location(),
                     DiagnosticData::RequiredArgument {
                         name: arg_definition.name.clone(),
-                        coordinate: format!(
-                            "{}.{}({}:)",
-                            against_type, field.name, arg_definition.name
-                        ),
+                        coordinate: FieldArgumentCoordinate {
+                            ty: against_type.clone(),
+                            field: field.name.clone(),
+                            argument: arg_definition.name.clone(),
+                        }
+                        .into(),
                         definition_location: arg_definition.location(),
                     },
                 ));
@@ -200,7 +207,10 @@ pub(crate) fn validate_leaf_field_selection(
         Err(ValidationError::new(
             field.location(),
             DiagnosticData::MissingSubselection {
-                coordinate: format!("{tname}.{fname}"),
+                coordinate: TypeAttributeCoordinate {
+                    ty: tname.clone(),
+                    attribute: fname.clone(),
+                },
                 describe_type: type_def.describe(),
             },
         ))

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -1,9 +1,9 @@
-use crate::{
-    ast, schema,
-    validation::diagnostics::{DiagnosticData, ValidationError},
-    validation::ValidationDatabase,
-    Node,
-};
+use crate::ast;
+use crate::coordinate::TypeAttributeCoordinate;
+use crate::schema;
+use crate::validation::diagnostics::{DiagnosticData, ValidationError};
+use crate::validation::ValidationDatabase;
+use crate::Node;
 
 fn unsupported_type(value: &Node<ast::Value>, declared_type: &Node<ast::Type>) -> ValidationError {
     ValidationError::new(
@@ -232,9 +232,12 @@ pub(crate) fn value_of_correct_type(
                     if (ty.is_non_null() && f.default_value.is_none()) && (is_missing || is_null) {
                         diagnostics.push(ValidationError::new(
                             arg_value.location(),
-                            DiagnosticData::RequiredArgument {
+                            DiagnosticData::RequiredField {
                                 name: input_name.clone(),
-                                coordinate: format!("{}.{}", input_obj.name, input_name),
+                                coordinate: TypeAttributeCoordinate {
+                                    ty: input_obj.name.clone(),
+                                    attribute: input_name.clone(),
+                                },
                                 definition_location: f.location(),
                             },
                         ));

--- a/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
@@ -372,16 +372,16 @@ Error: expected value of type Int!, found null
      │                        ──┬─  
      │                          ╰─── provided value is null
 ─────╯
-Error: the required argument `ComplexInput.requiredField` is not provided
+Error: the required field `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:254:33]
      │
   32 │   requiredField: Boolean!
      │   ───────────┬───────────  
-     │              ╰───────────── argument defined here
+     │              ╰───────────── field defined here
      │ 
  254 │     complexArgField(complexArg: { intField: 4 })
      │                                 ───────┬───────  
-     │                                        ╰───────── missing value for argument `requiredField`
+     │                                        ╰───────── missing value for field `requiredField`
 ─────╯
 Error: expected value of type String, found an integer
      ╭─[0102_invalid_string_values.graphql:261:32]
@@ -462,16 +462,16 @@ Error: expected value of type String!, found null
      │                   │   
      │                   ╰─── provided value is null
 ─────╯
-Error: the required argument `ComplexInput.requiredField` is not provided
+Error: the required field `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:296:22]
      │
   32 │   requiredField: Boolean!
      │   ───────────┬───────────  
-     │              ╰───────────── argument defined here
+     │              ╰───────────── field defined here
      │ 
  296 │   $c: ComplexInput = { requiredField: null, intField: null }
      │                      ───────────────────┬───────────────────  
-     │                                         ╰───────────────────── missing value for argument `requiredField`
+     │                                         ╰───────────────────── missing value for field `requiredField`
 ─────╯
 Error: expected value of type Boolean!, found null
      ╭─[0102_invalid_string_values.graphql:296:24]
@@ -533,16 +533,16 @@ Error: expected value of type Int, found a string
      │                                            ───────┬───────  
      │                                                   ╰───────── provided value is a string
 ─────╯
-Error: the required argument `ComplexInput.requiredField` is not provided
+Error: the required field `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:326:22]
      │
   32 │   requiredField: Boolean!
      │   ───────────┬───────────  
-     │              ╰───────────── argument defined here
+     │              ╰───────────── field defined here
      │ 
  326 │   $a: ComplexInput = {intField: 3}
      │                      ──────┬──────  
-     │                            ╰──────── missing value for argument `requiredField`
+     │                            ╰──────── missing value for field `requiredField`
 ─────╯
 Error: expected value of type String, found an integer
      ╭─[0102_invalid_string_values.graphql:335:26]

--- a/crates/apollo-compiler/tests/validation/types.rs
+++ b/crates/apollo-compiler/tests/validation/types.rs
@@ -1556,18 +1556,18 @@ mod invalid_input_object_values {
         }
       ",
             expect![[r#"
-                Error: the required argument `ComplexInput.requiredField` is not provided
+                Error: the required field `ComplexInput.requiredField` is not provided
                     ╭─[query.graphql:3:33]
                     │
                   3 │     complexArgField(complexArg: { intField: 4 })
                     │                                 ───────┬───────  
-                    │                                        ╰───────── missing value for argument `requiredField`
+                    │                                        ╰───────── missing value for field `requiredField`
                     │
                     ├─[schema.graphql:60:3]
                     │
                  60 │   requiredField: Boolean!
                     │   ───────────┬───────────  
-                    │              ╰───────────── argument defined here
+                    │              ╰───────────── field defined here
                 ────╯
             "#]],
         );
@@ -1846,18 +1846,18 @@ mod variable_default_values {
                    │                   │   
                    │                   ╰─── provided value is null
                 ───╯
-                Error: the required argument `ComplexInput.requiredField` is not provided
+                Error: the required field `ComplexInput.requiredField` is not provided
                     ╭─[query.graphql:4:22]
                     │
                   4 │   $c: ComplexInput = { requiredField: null, intField: null }
                     │                      ───────────────────┬───────────────────  
-                    │                                         ╰───────────────────── missing value for argument `requiredField`
+                    │                                         ╰───────────────────── missing value for field `requiredField`
                     │
                     ├─[schema.graphql:60:3]
                     │
                  60 │   requiredField: Boolean!
                     │   ───────────┬───────────  
-                    │              ╰───────────── argument defined here
+                    │              ╰───────────── field defined here
                 ────╯
                 Error: expected value of type Boolean!, found null
                     ╭─[query.graphql:4:24]
@@ -1977,18 +1977,18 @@ mod variable_default_values {
         }
       ",
             expect![[r#"
-                Error: the required argument `ComplexInput.requiredField` is not provided
+                Error: the required field `ComplexInput.requiredField` is not provided
                     ╭─[query.graphql:1:47]
                     │
                   1 │ query MissingRequiredField($a: ComplexInput = {intField: 3}) {
                     │                                               ──────┬──────  
-                    │                                                     ╰──────── missing value for argument `requiredField`
+                    │                                                     ╰──────── missing value for field `requiredField`
                     │
                     ├─[schema.graphql:60:3]
                     │
                  60 │   requiredField: Boolean!
                     │   ───────────┬───────────  
-                    │              ╰───────────── argument defined here
+                    │              ╰───────────── field defined here
                 ────╯
             "#]],
         );

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -46,3 +46,9 @@ name = "strings"
 path = "fuzz_targets/strings.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "coordinate"
+path = "fuzz_targets/coordinate.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/coordinate.rs
+++ b/fuzz/fuzz_targets/coordinate.rs
@@ -1,0 +1,20 @@
+#![no_main]
+use apollo_compiler::coordinate::SchemaCoordinate;
+use libfuzzer_sys::arbitrary::Arbitrary;
+use libfuzzer_sys::arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+use log::debug;
+
+fuzz_target!(|data: &[u8]| {
+    let s = String::arbitrary(&mut Unstructured::new(data)).unwrap();
+
+    let coord = s.parse::<SchemaCoordinate>();
+    if let Ok(coord) = &coord {
+        assert_eq!(
+            &coord.to_string().parse::<SchemaCoordinate>().unwrap(),
+            coord
+        );
+    }
+
+    debug!("{:?}", coord);
+});

--- a/fuzz/fuzz_targets/coordinate.rs
+++ b/fuzz/fuzz_targets/coordinate.rs
@@ -1,14 +1,10 @@
 #![no_main]
 use apollo_compiler::coordinate::SchemaCoordinate;
-use libfuzzer_sys::arbitrary::Arbitrary;
-use libfuzzer_sys::arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
 use log::debug;
 
-fuzz_target!(|data: &[u8]| {
-    let s = String::arbitrary(&mut Unstructured::new(data)).unwrap();
-
-    let coord = s.parse::<SchemaCoordinate>();
+fuzz_target!(|data: &str| {
+    let coord = data.parse::<SchemaCoordinate>();
     if let Ok(coord) = &coord {
         assert_eq!(
             &coord.to_string().parse::<SchemaCoordinate>().unwrap(),

--- a/fuzz/fuzz_targets/strings.rs
+++ b/fuzz/fuzz_targets/strings.rs
@@ -1,19 +1,12 @@
 #![no_main]
 use apollo_compiler::{name, Schema};
-use libfuzzer_sys::{
-    arbitrary::{Arbitrary, Unstructured},
-    fuzz_target,
-};
+use libfuzzer_sys::fuzz_target;
 use log::debug;
 
-fuzz_target!(|data: &[u8]| {
-    let _ = env_logger::try_init();
-
-    let mut u = Unstructured::new(data);
-    let string = String::arbitrary(&mut u).unwrap();
+fuzz_target!(|data: &str| {
     let mut input = Schema::new();
     let def = input.schema_definition.make_mut();
-    def.description = Some(string.into());
+    def.description = Some(data.into());
     // We can refer to a type that doesn't exist as we won't run validation
     def.query = Some(name!("Dangling").into());
     let doc_generated = input.to_string();


### PR DESCRIPTION
Implements parsing and printing for the [Schema Coordinates RFC](https://github.com/graphql/graphql-wg/blob/main/rfcs/SchemaCoordinates.md).

Here, `SchemaCoordinate` is an enum of all the different kinds of coordinates. Each kind of coordinate is also its own type.

```rust
use apollo_compiler::name;
use apollo_compiler::coordinate::{SchemaCoordinate, FieldArgumentCoordinate};

let coord: SchemaCoordinate = "Type.field(argument:)".parse().unwrap();
assert_eq!(coord, SchemaCoordinate::FieldArgument(
    FieldArgumentCoordinate {
        ty: name!("Type"),
        field: name!("field"),
        argument: name!("argument"),
    },
));
```

```rust
use apollo_compiler::coord;

assert_eq!(coord!(@directive).to_string(), "@directive");
assert_eq!(coord!(@directive(arg:)).to_string(), "@directive(arg:)");
assert_eq!(coord!(Type).to_string(), "Type");
assert_eq!(coord!(Type.field).to_string(), "Type.field");
assert_eq!(coord!(Type.field(arg:)).to_string(), "Type.field(arg:)");
```

The goal of this API is:
 - easily tracking the current coordinate while walking a tree (eg with the `.argument()` method). Each kind of coordinate having its own `impl` is handy for this
 - look up a typed coordinate in the schema
   - not yet implemented but imagine an `fn lookup(&Schema, FieldArgumentCoordinate) -> Option<Node<InputValueDefinition>>`, so the return value can be typed. I'm not 100% convinced of how important this is as you may often have just a `SchemaCoordinate`, which can return multiple types.
   - Backed out for now, we can do it later, typed lookup is certainly possible.
 - Printing for use in error messages (https://github.com/apollographql/apollo-rs/issues/691)

Some other options:
 - `TypeCoordinate` could just be an alias of `NamedType` 🤪 
 - Just have a `SchemaCoordinate` enum without all the specific types--I like this less for how it's used in validation (different types with simple methods for pushing/popping are ideal)
 - A more flat text representation, so not having 3 separate refcounted strings like here. Just representing a schema coordinate as its source text is actually fairly efficient (like literally storing the string `Type.field(arg:)`). A schema coordinate could then be pointer-sized, here it's 3 pointers + a discriminant. A downside is that you need to allocate when you append a field or argument or something.