### PR TITLE
fix(compiler): use correct type for subselections in field merging validation, fixes #755

### DIFF
--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -176,15 +176,25 @@ pub(crate) fn same_response_shape(
         }
         // 6. Assert: typeA and typeB are both composite types.
         (def_a, def_b) if is_composite(def_a) && is_composite(def_b) => {
+            let Ok(subfield_a_type) = schema.type_field(field_a.against_type, &field_a.field.name)
+            else {
+                // Missing field: error raised elsewhere, we can't check if the type is correct
+                return Ok(());
+            };
+            let Ok(subfield_b_type) = schema.type_field(field_b.against_type, &field_b.field.name)
+            else {
+                // Missing field: error raised elsewhere, we can't check if the type is correct
+                return Ok(());
+            };
             let named_fragments = db.ast_named_fragments(file_id);
             let mut merged_set = operation_fields(
                 &named_fragments,
-                field_a.against_type,
+                &subfield_a_type.name,
                 &field_a.field.selection_set,
             );
             merged_set.extend(operation_fields(
                 &named_fragments,
-                field_b.against_type,
+                &subfield_b_type.name,
                 &field_b.field.selection_set,
             ));
             let grouped_by_name = group_fields_by_name(merged_set);

--- a/crates/apollo-compiler/test_data/ok/0039_field_merging_issue_755.graphql
+++ b/crates/apollo-compiler/test_data/ok/0039_field_merging_issue_755.graphql
@@ -1,0 +1,37 @@
+# Different fragments selecting the same name from different types
+# into different subselections -- all valid, unless apollo-rs
+# propagates type conditions incorrectly :)
+
+type Subselection {
+  createdAt: Int!
+}
+
+type Issue {
+  createdAt: Int
+  subselection: [Subselection!]
+}
+
+type Query {
+  issue755: Issue
+}
+
+fragment topLevelFragment on Issue {
+  subselection {
+    createdAt
+    ...subselectionFragment
+  }
+  ...collidingTopLevelFragment
+}
+fragment collidingTopLevelFragment on Issue {
+  subselection {
+    createdAt
+  }
+}
+fragment subselectionFragment on Subselection {
+  createdAt
+}
+query  {
+  issue755 {
+    ...topLevelFragment
+  }
+}

--- a/crates/apollo-compiler/test_data/ok/0039_field_merging_issue_755.txt
+++ b/crates/apollo-compiler/test_data/ok/0039_field_merging_issue_755.txt
@@ -1,0 +1,331 @@
+Schema {
+    sources: {
+        -1: SourceFile {
+            path: "built_in.graphql",
+            source_text: include_str!("built_in.graphql"),
+        },
+        38: SourceFile {
+            path: "0039_field_merging_issue_755.graphql",
+            source_text: "# Different fragments selecting the same name from different types\n# into different subselections -- all valid, unless apollo-rs\n# propagates type conditions incorrectly :)\n\ntype Subselection {\n  createdAt: Int!\n}\n\ntype Issue {\n  createdAt: Int\n  subselection: [Subselection!]\n}\n\ntype Query {\n  issue755: Issue\n}\n\nfragment topLevelFragment on Issue {\n  subselection {\n    createdAt\n    ...subselectionFragment\n  }\n  ...collidingTopLevelFragment\n}\nfragment collidingTopLevelFragment on Issue {\n  subselection {\n    createdAt\n  }\n}\nfragment subselectionFragment on Subselection {\n  createdAt\n}\nquery  {\n  issue755 {\n    ...topLevelFragment\n  }\n}\n",
+        },
+    },
+    schema_definition: SchemaDefinition {
+        description: None,
+        directives: [],
+        query: Some(
+            ComponentName {
+                origin: Definition,
+                name: "Query",
+            },
+        ),
+        mutation: None,
+        subscription: None,
+    },
+    directive_definitions: {
+        "skip": built_in_directive!("skip"),
+        "include": built_in_directive!("include"),
+        "deprecated": built_in_directive!("deprecated"),
+        "specifiedBy": built_in_directive!("specifiedBy"),
+    },
+    types: {
+        "__Schema": built_in_type!("__Schema"),
+        "__Type": built_in_type!("__Type"),
+        "__TypeKind": built_in_type!("__TypeKind"),
+        "__Field": built_in_type!("__Field"),
+        "__InputValue": built_in_type!("__InputValue"),
+        "__EnumValue": built_in_type!("__EnumValue"),
+        "__Directive": built_in_type!("__Directive"),
+        "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
+        "Int": built_in_type!("Int"),
+        "Float": built_in_type!("Float"),
+        "String": built_in_type!("String"),
+        "Boolean": built_in_type!("Boolean"),
+        "ID": built_in_type!("ID"),
+        "Subselection": Object(
+            174..213 @38 ObjectType {
+                description: None,
+                name: "Subselection",
+                implements_interfaces: {},
+                directives: [],
+                fields: {
+                    "createdAt": Component {
+                        origin: Definition,
+                        node: 196..211 @38 FieldDefinition {
+                            description: None,
+                            name: "createdAt",
+                            arguments: [],
+                            ty: NonNullNamed(
+                                "Int",
+                            ),
+                            directives: [],
+                        },
+                    },
+                },
+            },
+        ),
+        "Issue": Object(
+            215..278 @38 ObjectType {
+                description: None,
+                name: "Issue",
+                implements_interfaces: {},
+                directives: [],
+                fields: {
+                    "createdAt": Component {
+                        origin: Definition,
+                        node: 230..244 @38 FieldDefinition {
+                            description: None,
+                            name: "createdAt",
+                            arguments: [],
+                            ty: Named(
+                                "Int",
+                            ),
+                            directives: [],
+                        },
+                    },
+                    "subselection": Component {
+                        origin: Definition,
+                        node: 247..276 @38 FieldDefinition {
+                            description: None,
+                            name: "subselection",
+                            arguments: [],
+                            ty: List(
+                                NonNullNamed(
+                                    "Subselection",
+                                ),
+                            ),
+                            directives: [],
+                        },
+                    },
+                },
+            },
+        ),
+        "Query": Object(
+            280..312 @38 ObjectType {
+                description: None,
+                name: "Query",
+                implements_interfaces: {},
+                directives: [],
+                fields: {
+                    "issue755": Component {
+                        origin: Definition,
+                        node: 295..310 @38 FieldDefinition {
+                            description: None,
+                            name: "issue755",
+                            arguments: [],
+                            ty: Named(
+                                "Issue",
+                            ),
+                            directives: [],
+                        },
+                    },
+                },
+            },
+        ),
+    },
+}
+ExecutableDocument {
+    sources: {
+        -1: SourceFile {
+            path: "built_in.graphql",
+            source_text: include_str!("built_in.graphql"),
+        },
+        38: SourceFile {
+            path: "0039_field_merging_issue_755.graphql",
+            source_text: "# Different fragments selecting the same name from different types\n# into different subselections -- all valid, unless apollo-rs\n# propagates type conditions incorrectly :)\n\ntype Subselection {\n  createdAt: Int!\n}\n\ntype Issue {\n  createdAt: Int\n  subselection: [Subselection!]\n}\n\ntype Query {\n  issue755: Issue\n}\n\nfragment topLevelFragment on Issue {\n  subselection {\n    createdAt\n    ...subselectionFragment\n  }\n  ...collidingTopLevelFragment\n}\nfragment collidingTopLevelFragment on Issue {\n  subselection {\n    createdAt\n  }\n}\nfragment subselectionFragment on Subselection {\n  createdAt\n}\nquery  {\n  issue755 {\n    ...topLevelFragment\n  }\n}\n",
+        },
+    },
+    anonymous_operation: Some(
+        592..643 @38 Operation {
+            operation_type: Query,
+            name: None,
+            variables: [],
+            directives: [],
+            selection_set: SelectionSet {
+                ty: "Query",
+                selections: [
+                    Field(
+                        603..641 @38 Field {
+                            definition: 295..310 @38 FieldDefinition {
+                                description: None,
+                                name: "issue755",
+                                arguments: [],
+                                ty: Named(
+                                    "Issue",
+                                ),
+                                directives: [],
+                            },
+                            alias: None,
+                            name: "issue755",
+                            arguments: [],
+                            directives: [],
+                            selection_set: SelectionSet {
+                                ty: "Issue",
+                                selections: [
+                                    FragmentSpread(
+                                        618..637 @38 FragmentSpread {
+                                            fragment_name: "topLevelFragment",
+                                            directives: [],
+                                        },
+                                    ),
+                                ],
+                            },
+                        },
+                    ),
+                ],
+            },
+        },
+    ),
+    named_operations: {},
+    fragments: {
+        "topLevelFragment": 314..446 @38 Fragment {
+            name: "topLevelFragment",
+            directives: [],
+            selection_set: SelectionSet {
+                ty: "Issue",
+                selections: [
+                    Field(
+                        353..413 @38 Field {
+                            definition: 247..276 @38 FieldDefinition {
+                                description: None,
+                                name: "subselection",
+                                arguments: [],
+                                ty: List(
+                                    NonNullNamed(
+                                        "Subselection",
+                                    ),
+                                ),
+                                directives: [],
+                            },
+                            alias: None,
+                            name: "subselection",
+                            arguments: [],
+                            directives: [],
+                            selection_set: SelectionSet {
+                                ty: "Subselection",
+                                selections: [
+                                    Field(
+                                        372..381 @38 Field {
+                                            definition: 196..211 @38 FieldDefinition {
+                                                description: None,
+                                                name: "createdAt",
+                                                arguments: [],
+                                                ty: NonNullNamed(
+                                                    "Int",
+                                                ),
+                                                directives: [],
+                                            },
+                                            alias: None,
+                                            name: "createdAt",
+                                            arguments: [],
+                                            directives: [],
+                                            selection_set: SelectionSet {
+                                                ty: "Int",
+                                                selections: [],
+                                            },
+                                        },
+                                    ),
+                                    FragmentSpread(
+                                        386..409 @38 FragmentSpread {
+                                            fragment_name: "subselectionFragment",
+                                            directives: [],
+                                        },
+                                    ),
+                                ],
+                            },
+                        },
+                    ),
+                    FragmentSpread(
+                        416..444 @38 FragmentSpread {
+                            fragment_name: "collidingTopLevelFragment",
+                            directives: [],
+                        },
+                    ),
+                ],
+            },
+        },
+        "collidingTopLevelFragment": 447..529 @38 Fragment {
+            name: "collidingTopLevelFragment",
+            directives: [],
+            selection_set: SelectionSet {
+                ty: "Issue",
+                selections: [
+                    Field(
+                        495..527 @38 Field {
+                            definition: 247..276 @38 FieldDefinition {
+                                description: None,
+                                name: "subselection",
+                                arguments: [],
+                                ty: List(
+                                    NonNullNamed(
+                                        "Subselection",
+                                    ),
+                                ),
+                                directives: [],
+                            },
+                            alias: None,
+                            name: "subselection",
+                            arguments: [],
+                            directives: [],
+                            selection_set: SelectionSet {
+                                ty: "Subselection",
+                                selections: [
+                                    Field(
+                                        514..523 @38 Field {
+                                            definition: 196..211 @38 FieldDefinition {
+                                                description: None,
+                                                name: "createdAt",
+                                                arguments: [],
+                                                ty: NonNullNamed(
+                                                    "Int",
+                                                ),
+                                                directives: [],
+                                            },
+                                            alias: None,
+                                            name: "createdAt",
+                                            arguments: [],
+                                            directives: [],
+                                            selection_set: SelectionSet {
+                                                ty: "Int",
+                                                selections: [],
+                                            },
+                                        },
+                                    ),
+                                ],
+                            },
+                        },
+                    ),
+                ],
+            },
+        },
+        "subselectionFragment": 530..591 @38 Fragment {
+            name: "subselectionFragment",
+            directives: [],
+            selection_set: SelectionSet {
+                ty: "Subselection",
+                selections: [
+                    Field(
+                        580..589 @38 Field {
+                            definition: 196..211 @38 FieldDefinition {
+                                description: None,
+                                name: "createdAt",
+                                arguments: [],
+                                ty: NonNullNamed(
+                                    "Int",
+                                ),
+                                directives: [],
+                            },
+                            alias: None,
+                            name: "createdAt",
+                            arguments: [],
+                            directives: [],
+                            selection_set: SelectionSet {
+                                ty: "Int",
+                                selections: [],
+                            },
+                        },
+                    ),
+                ],
+            },
+        },
+    },
+}

--- a/crates/apollo-compiler/test_data/serializer/ok/0039_field_merging_issue_755.graphql
+++ b/crates/apollo-compiler/test_data/serializer/ok/0039_field_merging_issue_755.graphql
@@ -1,0 +1,36 @@
+type Subselection {
+  createdAt: Int!
+}
+
+type Issue {
+  createdAt: Int
+  subselection: [Subselection!]
+}
+
+type Query {
+  issue755: Issue
+}
+
+fragment topLevelFragment on Issue {
+  subselection {
+    createdAt
+    ...subselectionFragment
+  }
+  ...collidingTopLevelFragment
+}
+
+fragment collidingTopLevelFragment on Issue {
+  subselection {
+    createdAt
+  }
+}
+
+fragment subselectionFragment on Subselection {
+  createdAt
+}
+
+query {
+  issue755 {
+    ...topLevelFragment
+  }
+}


### PR DESCRIPTION
In #755, having a top-level selection fragment spread and a fragment spread in a subselection validates the subselection spread against the top-level selection's type instead of the subselection's type. This change fixes the type used for the subselection.

We look up the field definition twice here with `.type_field`, also at the start of the recursion into `same_response_shape()`. I'll see if I can refactor it easily. But not super important compared to the issue it fixes :)

