### PR TITLE
apollo-compiler@1.0.0-beta.8

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2023-mm-dd
+# [1.0.0-beta.8](https://crates.io/crates/apollo-compiler/1.0.0-beta.8) - 2023-11-30
 
 ## BREAKING
 
@@ -137,13 +137,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   schema { query: MyQuery }
   ```
 
-[SimonSapin]: https://github.com/SimonSapin
-[issue/709]: https://github.com/apollographql/apollo-rs/issues/709
-[issue/751]: https://github.com/apollographql/apollo-rs/issues/751
-[pull/724]: https://github.com/apollographql/apollo-rs/pull/724
-[pull/752]: https://github.com/apollographql/apollo-rs/pull/752
-[pull/760]: https://github.com/apollographql/apollo-rs/pull/760
-
 ## Fixes
 
 - **Limit recursion in validation - [goto-bus-stop], [pull/748] fixing [issue/742]**
@@ -154,9 +147,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   The limit for input objects and directives is set at 32. For fragments, the limit is set at 100.
   Based on our datasets, real-world documents don't come anywhere close to this.
 
+[SimonSapin]: https://github.com/SimonSapin
 [goto-bus-stop]: https://github.com/goto-bus-stop
+[issue/709]: https://github.com/apollographql/apollo-rs/issues/709
 [issue/742]: https://github.com/apollographql/apollo-rs/issues/742
+[issue/751]: https://github.com/apollographql/apollo-rs/issues/751
+[pull/724]: https://github.com/apollographql/apollo-rs/pull/724
 [pull/748]: https://github.com/apollographql/apollo-rs/pull/748
+[pull/752]: https://github.com/apollographql/apollo-rs/pull/752
+[pull/760]: https://github.com/apollographql/apollo-rs/pull/760
 
 # [1.0.0-beta.7](https://crates.io/crates/apollo-compiler/1.0.0-beta.7) - 2023-11-17
 

--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -139,7 +139,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Fixes
 
-- **Limit recursion in validation - [goto-bus-stop], [pull/748] fixing [issue/742]**
+- **Limit recursion in validation - [goto-bus-stop], [pull/748] fixing [issue/742]:**
   Validation now bails out of very long chains of definitions that refer to each other,
   even if they don't strictly form a cycle. These could previously cause extremely long validation
   times or stack overflows.

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.7" # When bumping, also update README.md
+version = "1.0.0-beta.8" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.7"
+apollo-compiler = "=1.0.0-beta.8"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.7" }
+apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.8" }
 apollo-parser = { path = "../apollo-parser", version = "0.7.0" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 indexmap = "2.0.0"


### PR DESCRIPTION

## BREAKING

- **API refactor to make it harder to ignore errors - [SimonSapin], 
  [pull/752] fixing [issue/709]:**
  - `ast::Document`, `Schema`, and `ExecutableDocument` not longer contain potential errors
    that users need to check separately.
  - Instead, various constructors and methods now return a `Result`,
    with the `Err` case containing both both errors and a maybe-incomplete value.
  - Change `validate` methods of `Schema` and `ExecutableDocument` to take ownership of `self`.
    On success they return the schema or document (unmodified) wrapped in a `Valid<_>` marker type,
    which is **immutable**.
  - Change `ExecutableDocument` to require a `&Valid<Schema>` instead of `&Schema`,
    forcing callers to either run validation or opt out explicitly with `Valid::assume_valid`.
  - Make `parse_mixed` and `to_mixed` validate both the schema and document.
    Rename them with a `_validate` suffix.
  - Corresponding changes to all of the above in `Parser` method signatures
  - Remove `ast::Document::check_parse_errors`:
    parse errors are now encoded in the return value of `parse`.
  - Remove `ast::Document::to_schema_builder`. Use `SchemaBuilder::add_ast` instead.
  - Move items from the crate top-level to `apollo_compiler::validation`:
    * `Diagnostic`
    * `DiagnosticList`
    * `FileId`
    * `NodeLocation`
  - Move items from the crate top-level to `apollo_compiler::execution`:
    * `GraphQLError`
    * `GraphQLLocation`
  - Remove warning-level and advice-level diagnostics. See [issue/751].

  Highlight of signature changes:

  ```diff
  +struct Valid<T>(T); // Implements `Deref` and `AsRef` but not `DerefMut` or `AsMut`
  +
  +struct WithErrors<T> {
  +    partial: T, // Errors may cause components to be missing
  +    errors: DiagnosticList,
  +}

  -pub fn parse_mixed(…) -> (Schema, ExecutableDocument)
  +pub fn parse_mixed_validate(…)
  +    -> Result<(Valid<Schema>, Valid<ExecutableDocument>), DiagnosticList>

   impl ast::Document {
  -    pub fn parse(…) -> Self
  +    pub fn parse(…) -> Result<Self, WithErrors<Self>>

  -    pub fn to_schema(&self) -> Schema
  +    pub fn to_schema(&self) -> Result<Schema, WithErrors<Schema>>

  -    pub fn to_executable(&self) -> ExecutableDocument
  +    pub fn to_executable(&self) -> Result<ExecutableDocument, WithErrors<ExecutableDocument>>

  -    pub fn to_mixed(&self) -> (Schema, ExecutableDocument)
  +    pub fn to_mixed_validate(
  +        &self,
  +    ) -> Result<(Valid<Schema>, Valid<ExecutableDocument>), DiagnosticList>
   }

   impl Schema {
  -    pub fn parse(…) -> Self
  -    pub fn validate(&self) -> Result<DiagnosticList, DiagnosticList>

  +    pub fn parse_and_validate(…) -> Result<Valid<Self>, WithErrors<Self>>
  +    pub fn parse(…) -> Result<Self, WithErrors<Self>>
  +    pub fn validate(self) -> Result<Valid<Self>, WithErrors<Self>>
   }

   impl SchemaBuilder {
  -    pub fn build(self) -> Schema
  +    pub fn build(self) -> Result<Schema, WithErrors<Schema>>
   }

   impl ExecutableDocument {
  -    pub fn parse(schema: &Schema, …) -> Self
  -    pub fn validate(&self, schema: &Schema) -> Result<(), DiagnosticList>

  +    pub fn parse_and_validate(schema: &Valid<Schema>, …) -> Result<Valid<Self>, WithErrors<Self>>
  +    pub fn parse(schema: &Valid<Schema>, …) -> Result<Self, WithErrors<Self>>
  +    pub fn validate(self, schema: &Valid<Schema>) -> Result<Valid<Self>, WithErrors<Self>>
   }
  ```

## Features

- **Add `parse_and_validate` constructors for `Schema` and `ExecutableDocument` - [SimonSapin],
  [pull/752]:**
  when mutating isn’t needed after parsing,
  this returns an immutable `Valid<_>` value in one step.

- **Implement serde `Serialize` and `Deserialize` for some AST types - [SimonSapin], [pull/760]:**
  * `Node`
  * `NodeStr`
  * `Name`
  * `IntValue`
  * `FloatValue`
  * `Value`
  * `Type`
  Source locations are not preserved through serialization.

- **Add `ast::Definition::as_*() -> Option<&_>` methods for each variant - [SimonSapin], [pull/760]**

- **Serialize (to GraphQL) multi-line strings as block strings - [SimonSapin], [pull/724]:**
  Example before:
  ```graphql
  "Example\n\nDescription description description"
  schema { query: MyQuery }
  ```
  After:
  ```graphql
  """
  Example
  
  Description description description
  """
  schema { query: MyQuery }
  ```

## Fixes

- **Limit recursion in validation - [goto-bus-stop], [pull/748] fixing [issue/742]**
  Validation now bails out of very long chains of definitions that refer to each other,
  even if they don't strictly form a cycle. These could previously cause extremely long validation
  times or stack overflows.

  The limit for input objects and directives is set at 32. For fragments, the limit is set at 100.
  Based on our datasets, real-world documents don't come anywhere close to this.

[SimonSapin]: https://github.com/SimonSapin
[goto-bus-stop]: https://github.com/goto-bus-stop
[issue/709]: https://github.com/apollographql/apollo-rs/issues/709
[issue/742]: https://github.com/apollographql/apollo-rs/issues/742
[issue/751]: https://github.com/apollographql/apollo-rs/issues/751
[pull/724]: https://github.com/apollographql/apollo-rs/pull/724
[pull/748]: https://github.com/apollographql/apollo-rs/pull/748
[pull/752]: https://github.com/apollographql/apollo-rs/pull/752
[pull/760]: https://github.com/apollographql/apollo-rs/pull/760
