### PR TITLE
feat(compiler): add impl From<Name> for NodeStr

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [x.x.x] (unreleased) - 2023-xx-xx
+
+## Features
+- **Add `NodeStr::from(Name)` - [goto-bus-stop], [pull/FIXME]**
+
+[goto-bus-stop]: https://github.com/goto-bus-stop]
+[pull/FIXME]: https://github.com/apollographql/apollo-rs/pull/FIXME
+
 # [1.0.0-beta.10](https://crates.io/crates/apollo-compiler/1.0.0-beta.10) - 2023-12-04
 
 ## Features

--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -1666,6 +1666,12 @@ impl serde::Serialize for Name {
     }
 }
 
+impl From<Name> for NodeStr {
+    fn from(name: Name) -> Self {
+        name.0
+    }
+}
+
 impl TryFrom<NodeStr> for Name {
     type Error = InvalidNameError;
 


### PR DESCRIPTION
Federation converts back and forth between `Value::String(name)` and `Name` representations in some of its directives. Going from a `Value::String()` to a `Name` is easy, you just do `Name::new()`. Going the other direction requires a copy or a turbofish dance with `Name::as_ref()`. With this patch you can do `Value::String(name.into())`.