### PR TITLE
chore(compiler): port compiler validation errors to new diagnostics API

### DIFF
--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -991,17 +991,17 @@ impl Value {
         }
     }
 
-    pub fn kind(&self) -> &'static str {
+    pub(crate) fn describe(&self) -> &'static str {
         match self {
-            Value::Null => "Null",
-            Value::Enum(_) => "Enum",
-            Value::Variable(_) => "Variable",
-            Value::String(_) => "String",
-            Value::Float(_) => "Float",
-            Value::Int(_) => "Int",
-            Value::Boolean(_) => "Boolean",
-            Value::List(_) => "List",
-            Value::Object(_) => "Object",
+            Value::Null => "null",
+            Value::Enum(_) => "an enum",
+            Value::Variable(_) => "a variable",
+            Value::String(_) => "a string",
+            Value::Float(_) => "a float",
+            Value::Int(_) => "an integer",
+            Value::Boolean(_) => "a boolean",
+            Value::List(_) => "a list",
+            Value::Object(_) => "an input object",
         }
     }
 

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -1,6 +1,11 @@
+use crate::ast;
 use crate::ast::DirectiveLocation;
+use crate::ast::Name;
+use crate::ast::Type;
+use crate::ast::Value;
 use crate::diagnostic::CliReport;
-use crate::validation::NodeLocation;
+use crate::diagnostic::NodeLocation;
+use crate::Node;
 use std::fmt;
 use thiserror::Error;
 
@@ -21,8 +26,6 @@ impl Label {
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub(crate) struct ApolloDiagnostic {
     pub location: Option<NodeLocation>,
-    pub labels: Vec<Label>,
-    pub help: Option<String>,
     pub data: Box<DiagnosticData>,
 }
 
@@ -30,29 +33,8 @@ impl ApolloDiagnostic {
     pub fn new<DB: ?Sized>(_db: &DB, location: Option<NodeLocation>, data: DiagnosticData) -> Self {
         Self {
             location,
-            labels: vec![],
-            help: None,
             data: Box::new(data),
         }
-    }
-
-    pub fn help(self, help: impl Into<String>) -> Self {
-        Self {
-            help: Some(help.into()),
-            ..self
-        }
-    }
-
-    pub fn labels(self, labels: impl Into<Vec<Label>>) -> Self {
-        Self {
-            labels: labels.into(),
-            ..self
-        }
-    }
-
-    pub fn label(mut self, label: Label) -> Self {
-        self.labels.push(label);
-        self
     }
 }
 
@@ -66,14 +48,13 @@ impl fmt::Display for ApolloDiagnostic {
 #[derive(Debug, Error, Clone, Hash, PartialEq, Eq)]
 #[non_exhaustive]
 pub(crate) enum DiagnosticData {
-    #[error("the {ty} `{name}` is defined multiple times in the document")]
-    UniqueDefinition {
-        ty: &'static str,
+    #[error("the variable `${name}` is declared multiple times")]
+    UniqueVariable {
         name: String,
         original_definition: Option<NodeLocation>,
         redefined_definition: Option<NodeLocation>,
     },
-    #[error("the argument `{name}` is defined multiple times")]
+    #[error("the argument `{name}` is provided multiple times")]
     UniqueArgument {
         name: String,
         original_definition: Option<NodeLocation>,
@@ -82,29 +63,28 @@ pub(crate) enum DiagnosticData {
     #[error("the value `{name}` is defined multiple times")]
     UniqueInputValue {
         name: String,
-        original_value: Option<NodeLocation>,
-        redefined_value: Option<NodeLocation>,
+        original_definition: Option<NodeLocation>,
+        redefined_definition: Option<NodeLocation>,
     },
     #[error("subscription operations can only have one root field")]
-    SingleRootField {
-        // TODO(goto-bus-stop) if we keep this it should be a vec of the field names or nodes i think.
-        // Else just remove as the labeling is done separately.
-        fields: usize,
-        subscription: Option<NodeLocation>,
+    SingleRootField { fields: Vec<Name> },
+    #[error("the argument `{name}` is not supported by `{coordinate}`")]
+    UndefinedArgument {
+        name: Name,
+        coordinate: String,
+        definition_location: Option<NodeLocation>,
     },
-    #[error("the argument `{name}` is not supported")]
-    UndefinedArgument { name: String },
     #[error("cannot find type `{name}` in this document")]
     UndefinedDefinition {
         /// Name of the type not in scope
         name: String,
     },
-    #[error("cannot find directive `{name}` in this document")]
+    #[error("cannot find directive `@{name}` in this document")]
     UndefinedDirective {
         /// Name of the missing directive
         name: String,
     },
-    #[error("variable `{name}` is not defined")]
+    #[error("variable `${name}` is not defined")]
     UndefinedVariable {
         /// Name of the variable not in scope
         name: String,
@@ -114,40 +94,58 @@ pub(crate) enum DiagnosticData {
         /// Name of the fragment not in scope
         name: String,
     },
-    #[error("value `{value}` does not exist on `{definition}` type")]
-    UndefinedValue {
-        /// Value of the enum that doesn't exist
+    #[error("value `{value}` does not exist on `{definition}`")]
+    UndefinedEnumValue {
+        /// Value of the enum value that doesn't exist
         value: String,
-        /// type definition
+        /// Name of the enum
         definition: String,
+        definition_location: Option<NodeLocation>,
     },
-    #[error("`{name}` directive definition cannot reference itself")]
-    RecursiveDirectiveDefinition { name: String },
-    #[error("interface {name} cannot implement itself")]
-    RecursiveInterfaceDefinition { name: String },
-    #[error("`{name}` input object cannot reference itself")]
-    RecursiveInputObjectDefinition { name: String },
-    #[error("`{name}` fragment cannot reference itself")]
-    RecursiveFragmentDefinition { name: String },
-    #[error("`{name}` contains too much nesting")]
-    DeeplyNestedType { name: String },
-    #[error("type does not satisfy interface `{interface}`: missing field `{field}`")]
-    MissingInterfaceField { interface: String, field: String },
-    #[error("the required argument `{name}` is not provided")]
-    RequiredArgument { name: String },
+    #[error("field `{value}` does not exist on `{definition}`")]
+    UndefinedInputValue {
+        /// Value of the input object field that doesn't exist
+        value: String,
+        /// Name of the input object type
+        definition: String,
+        definition_location: Option<NodeLocation>,
+    },
+    #[error("type `{name}` does not satisfy interface `{interface}`: missing field `{field}`")]
+    MissingInterfaceField {
+        name: String,
+        /// Location of the `implements XYZ` of the interface
+        implements_location: Option<NodeLocation>,
+        interface: String,
+        field: String,
+        /// Location of the definition of the field in the interface
+        field_location: Option<NodeLocation>,
+    },
+    #[error("the required argument `{coordinate}` is not provided")]
+    RequiredArgument {
+        name: String,
+        coordinate: String,
+        definition_location: Option<NodeLocation>,
+    },
     #[error(
         "Transitively implemented interfaces must also be defined on an implementing interface or object"
     )]
     TransitiveImplementedInterfaces {
-        // interface that should be defined
+        /// Name of the interface definition
+        interface: String,
+        /// Super interface that declares the implementation
+        via_interface: String,
+        /// Source location where the super interface declares the implementation
+        transitive_interface_location: Option<NodeLocation>,
+        /// Interface that should be implemented
         missing_interface: String,
     },
     #[error("`{name}` field must return an output type")]
     OutputType {
-        // field name
+        /// Field name.
         name: String,
-        // field type
+        /// The kind of type that the field is declared with.
         ty: &'static str,
+        type_location: Option<NodeLocation>,
     },
     #[error("`{name}` field must be of an input type")]
     InputType {
@@ -155,33 +153,53 @@ pub(crate) enum DiagnosticData {
         name: String,
         /// The kind of type that the field is declared with.
         ty: &'static str,
+        type_location: Option<NodeLocation>,
+    },
+    #[error("`${name}` variable must be of an input type")]
+    VariableInputType {
+        /// Variable name.
+        name: String,
+        /// The kind of type that the variable is declared with.
+        ty: &'static str,
+        type_location: Option<NodeLocation>,
     },
     #[error("missing query root operation type in schema definition")]
     QueryRootOperationType,
-    #[error("unused variable: `{name}`")]
+    #[error("unused variable: `${name}`")]
     UnusedVariable { name: String },
     #[error("`{name}` field must return an object type")]
-    ObjectType {
-        // union member
+    RootOperationObjectType {
+        /// Name of the root operation type
         name: String,
-        // actual type
+        /// Category of the type
         ty: &'static str,
     },
-    #[error("{name} directive is not supported for {dir_loc} location")]
-    UnsupportedLocation {
-        /// current directive definition
+    #[error("union member `{name}` must be an object type")]
+    UnionMemberObjectType {
+        /// Name of the type in the union
         name: String,
-        /// current location where the directive is used
-        dir_loc: DirectiveLocation,
+        /// Category of the type
+        ty: &'static str,
+    },
+    #[error("{name} directive is not supported for {location} location")]
+    UnsupportedLocation {
+        /// Name of the directive
+        name: String,
+        /// The location where the directive is attempted to be used
+        location: DirectiveLocation,
+        /// Locations that *are* valid for this directive
+        valid_locations: Vec<DirectiveLocation>,
         /// The source location where the directive that's being used was defined.
-        directive_def: Option<NodeLocation>,
+        definition_location: Option<NodeLocation>,
     },
     #[error("expected value of type {ty}, found {value}")]
     UnsupportedValueType {
-        // input value
+        /// The kind of value provided. Not a concrete type, but a category like "string", "list",
+        /// "input object".
         value: String,
-        // defined type
+        /// Expected concrete type
         ty: String,
+        definition_location: Option<NodeLocation>,
     },
     #[error("int cannot represent non 32-bit signed integer value")]
     IntCoercionError {
@@ -197,8 +215,7 @@ pub(crate) enum DiagnosticData {
     UniqueDirective {
         /// Name of the non-unique directive.
         name: String,
-        original_call: Option<NodeLocation>,
-        conflicting_call: Option<NodeLocation>,
+        original_application: Option<NodeLocation>,
     },
     #[error("subscription operations can not have an introspection field as a root field")]
     IntrospectionField {
@@ -206,25 +223,70 @@ pub(crate) enum DiagnosticData {
         field: String,
     },
     #[error("interface, union and object types must have a subselection set")]
-    MissingSubselection,
+    MissingSubselection {
+        coordinate: String,
+        ty: &'static str,
+    },
     #[error("operation must not select different types using the same field name `{field}`")]
-    ConflictingField {
+    ConflictingFieldType {
         /// Name of the non-unique field.
         field: String,
         original_selection: Option<NodeLocation>,
+        original_type: Type,
         redefined_selection: Option<NodeLocation>,
+        redefined_type: Type,
     },
-    #[error("fragments can not be declared on primitive types")]
+    #[error(
+        "operation must not provide conflicting field arguments for the same field name `{field}`"
+    )]
+    ConflictingFieldArgument {
+        /// Name of the non-unique field.
+        field: String,
+        argument: String,
+        original_selection: Option<NodeLocation>,
+        original_value: Option<Value>,
+        redefined_selection: Option<NodeLocation>,
+        redefined_value: Option<Value>,
+    },
+    #[error("operation must not select different fields to the same alias `{field}`")]
+    ConflictingFieldName {
+        /// Name of the non-unique field.
+        field: String,
+        original_selection: Option<NodeLocation>,
+        original_name: String,
+        redefined_selection: Option<NodeLocation>,
+        redefined_name: String,
+    },
+    #[error(
+        "{} must have a composite type in its type condition",
+        .name.as_ref().map_or_else(
+            || "inline fragment".to_string(),
+            |name| format!("fragment `{name}`"),
+        ),
+    )]
     InvalidFragmentTarget {
+        /// Name of the fragment, None if an inline fragment.
+        name: Option<Name>,
         /// Name of the type on which the fragment is declared
         ty: String,
     },
-    #[error("fragment cannot be applied to this type")]
+    #[error(
+        "{} with type condition `{type_condition}` cannot be applied to `{type_name}`",
+        .name.as_ref().map_or_else(
+            || "inline fragment".to_string(),
+            |name| format!("fragment `{name}`"),
+        ),
+    )]
     InvalidFragmentSpread {
         /// Fragment name or None if it's an inline fragment
         name: Option<String>,
         /// Type name the fragment is being applied to
         type_name: String,
+        type_condition: String,
+        /// Source location where the fragment is defined
+        fragment_location: Option<NodeLocation>,
+        /// Source location of the type the fragment is being applied to.
+        type_location: Option<NodeLocation>,
     },
     #[error("fragment `{name}` must be used in an operation")]
     UnusedFragment {
@@ -232,14 +294,39 @@ pub(crate) enum DiagnosticData {
         name: String,
     },
     #[error(
-        "variable `{var_name}` cannot be used for argument `{arg_name}` as their types mismatch"
+        "variable `${variable}` of type `{variable_type}` cannot be used for argument `{argument}` of type `{argument_type}`"
     )]
     DisallowedVariableUsage {
         /// Name of the variable being used in an argument
-        var_name: String,
+        variable: String,
+        variable_type: Type,
+        variable_location: Option<NodeLocation>,
         /// Name of the argument where variable is used
-        arg_name: String,
+        argument: String,
+        argument_type: Type,
+        argument_location: Option<NodeLocation>,
     },
+    #[error("`{name}` directive definition cannot reference itself")]
+    RecursiveDirectiveDefinition {
+        name: String,
+        trace: Vec<Node<ast::Directive>>,
+    },
+    #[error("interface {name} cannot implement itself")]
+    RecursiveInterfaceDefinition { name: String },
+    #[error("`{name}` input object cannot reference itself")]
+    RecursiveInputObjectDefinition {
+        name: String,
+        trace: Vec<Node<ast::InputValueDefinition>>,
+    },
+    #[error("`{name}` fragment cannot reference itself")]
+    RecursiveFragmentDefinition {
+        /// Source location of just the "fragment FragName" part.
+        head_location: Option<NodeLocation>,
+        name: String,
+        trace: Vec<Node<ast::FragmentSpread>>,
+    },
+    #[error("`{name}` contains too much nesting")]
+    DeeplyNestedType { name: String, ty: &'static str },
     #[error("too much recursion")]
     RecursionError {},
 }
@@ -247,11 +334,501 @@ pub(crate) enum DiagnosticData {
 impl ApolloDiagnostic {
     pub(crate) fn report(&self, report: &mut CliReport) {
         report.with_message(&self.data);
-        for label in &self.labels {
-            report.with_label_opt(label.location, &label.text);
+
+        match &*self.data {
+            DiagnosticData::UniqueVariable {
+                name,
+                original_definition,
+                redefined_definition,
+            } => {
+                report.with_label_opt(
+                    *original_definition,
+                    format_args!("previous definition of `${name}` here"),
+                );
+                report.with_label_opt(
+                    *redefined_definition,
+                    format_args!("`${name}` defined again here"),
+                );
+            }
+            DiagnosticData::UniqueArgument {
+                name,
+                original_definition,
+                redefined_definition,
+            } => {
+                report.with_label_opt(
+                    *original_definition,
+                    format_args!("previously provided `{name}` here"),
+                );
+                report.with_label_opt(
+                    *redefined_definition,
+                    format_args!("`{name}` provided again here"),
+                );
+                report.with_help(format_args!(
+                    "`{name}` argument must only be provided once."
+                ));
+            }
+            DiagnosticData::UniqueInputValue {
+                name,
+                original_definition,
+                redefined_definition,
+            } => {
+                report.with_label_opt(
+                    *original_definition,
+                    format_args!("previous definition of `{name}` here"),
+                );
+                report.with_label_opt(
+                    *redefined_definition,
+                    format_args!("`{name}` defined again here"),
+                );
+                report.with_help(format_args!(
+                    "`{name}` must only be defined once in this argument list or input object definition."
+                ));
+            }
+            DiagnosticData::SingleRootField { fields } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("subscription with {} root fields", fields.len()),
+                );
+                report.with_help(format_args!(
+                    "There are {} root fields: {}. This is not allowed.",
+                    fields.len(),
+                    CommaSeparated(fields)
+                ));
+            }
+            DiagnosticData::UndefinedArgument {
+                coordinate,
+                definition_location,
+                ..
+            } => {
+                report.with_label_opt(self.location, "argument by this name not found");
+                report.with_label_opt(
+                    *definition_location,
+                    format_args!("{coordinate} defined here"),
+                );
+            }
+            DiagnosticData::RequiredArgument {
+                name,
+                coordinate: _,
+                definition_location,
+            } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("missing value for argument `{name}`"),
+                );
+                report.with_label_opt(*definition_location, "argument defined here");
+            }
+            DiagnosticData::UndefinedDefinition { .. } => {
+                report.with_label_opt(self.location, "not found in this scope");
+            }
+            DiagnosticData::UndefinedDirective { .. } => {
+                report.with_label_opt(self.location, "directive not defined");
+            }
+            DiagnosticData::UndefinedVariable { .. } => {
+                report.with_label_opt(self.location, "not found in this scope");
+            }
+            DiagnosticData::UndefinedFragment { name } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("fragment `{name}` is not defined"),
+                );
+            }
+            DiagnosticData::UndefinedEnumValue {
+                value: _,
+                definition,
+                definition_location,
+            } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("value does not exist on `{definition}` enum"),
+                );
+                report.with_label_opt(*definition_location, "enum defined here");
+            }
+            DiagnosticData::UndefinedInputValue {
+                value: _,
+                definition,
+                definition_location,
+            } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("value does not exist on `{definition}` input object"),
+                );
+                report.with_label_opt(*definition_location, "input object defined here");
+            }
+            DiagnosticData::RecursiveDirectiveDefinition { name, trace } => {
+                report.with_label_opt(self.location, "recursive directive definition");
+                label_recursive_trace(report, trace, name, |directive| &directive.name);
+            }
+            DiagnosticData::RecursiveInterfaceDefinition { name } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("interface {name} cannot implement itself"),
+                );
+            }
+            DiagnosticData::RecursiveInputObjectDefinition { name, trace } => {
+                report.with_label_opt(self.location, "cyclical input object definition");
+                label_recursive_trace(report, trace, name, |reference| &reference.name);
+            }
+            DiagnosticData::RecursiveFragmentDefinition {
+                head_location,
+                name,
+                trace,
+            } => {
+                report.with_label_opt(
+                    head_location.or(self.location),
+                    "recursive fragment definition",
+                );
+                label_recursive_trace(report, trace, name, |reference| &reference.fragment_name);
+            }
+            DiagnosticData::DeeplyNestedType { ty, .. } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("references a very long chain of {ty}s in its definition"),
+                );
+            }
+            DiagnosticData::MissingInterfaceField {
+                name: _,
+                implements_location,
+                interface,
+                field,
+                field_location,
+            } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("add `{field}` field to this type"),
+                );
+                report.with_label_opt(
+                    *implements_location,
+                    format_args!("implementation of interface {interface} declared here"),
+                );
+                report.with_label_opt(
+                    *field_location,
+                    format_args!("`{interface}.{field}` originally defined here"),
+                );
+                report.with_help(
+                    "An object or interface must declare all fields required by the interfaces it implements",
+                )
+            }
+            DiagnosticData::TransitiveImplementedInterfaces {
+                interface,
+                via_interface,
+                transitive_interface_location,
+                missing_interface,
+            } => {
+                report.with_label_opt(
+                    *transitive_interface_location,
+                    format!(
+                        "implementation of {missing_interface} declared by {via_interface} here"
+                    ),
+                );
+                report.with_label_opt(
+                    self.location,
+                    format_args!("{missing_interface} must also be implemented here"),
+                );
+            }
+            DiagnosticData::UnusedVariable { .. } => {
+                report.with_label_opt(self.location, "variable is never used");
+            }
+            DiagnosticData::UnusedFragment { name } => {
+                report.with_label_opt(self.location, format_args!("`{name}` is defined here"));
+                report.with_help(format_args!(
+                    "fragment `{name}` must be used in an operation"
+                ));
+            }
+            DiagnosticData::RootOperationObjectType { name: _, ty } => {
+                let particle = particle_for(ty);
+                report.with_label_opt(self.location, format_args!("this is {particle} {ty}"));
+                report.with_help("Root operation type must be an object type.");
+            }
+            DiagnosticData::UnionMemberObjectType { name: _, ty } => {
+                let particle = particle_for(ty);
+                report.with_label_opt(self.location, format_args!("this is {particle} {ty}"));
+                report.with_help("Union members must be object types.");
+            }
+            DiagnosticData::OutputType {
+                name,
+                ty,
+                type_location,
+            } => {
+                let particle = particle_for(ty);
+                report.with_label_opt(
+                    type_location.or(self.location),
+                    format_args!("this is {particle} {ty}"),
+                );
+                report.with_help(format!("Scalars, Objects, Interfaces, Unions and Enums are output types. Change `{name}` field to return one of these output types."));
+            }
+            DiagnosticData::InputType {
+                name,
+                ty,
+                type_location,
+            } => {
+                let particle = particle_for(ty);
+                report.with_label_opt(
+                    type_location.or(self.location),
+                    format_args!("this is {particle} {ty}"),
+                );
+                report.with_help(format!("Scalars, Enums, and Input Objects are input types. Change `{name}` field to take one of these input types."));
+            }
+            DiagnosticData::VariableInputType {
+                name: _,
+                ty,
+                type_location,
+            } => {
+                let particle = particle_for(ty);
+                report.with_label_opt(
+                    type_location.or(self.location),
+                    format_args!("this is {particle} {ty}"),
+                );
+                report.with_help("objects, unions, and interfaces cannot be used because variables can only be of input type");
+            }
+            DiagnosticData::QueryRootOperationType => {
+                report.with_label_opt(
+                    self.location,
+                    "`query` root operation type must be defined here",
+                );
+            }
+            DiagnosticData::UnsupportedLocation {
+                name: _,
+                location,
+                valid_locations,
+                definition_location,
+            } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("directive cannot be used on {location}"),
+                );
+                report.with_label_opt(*definition_location, "directive defined here");
+                report.with_help(format!(
+                    "the directive must be used in a location that the service has declared support for: {}",
+                    CommaSeparated(valid_locations),
+                ));
+            }
+            DiagnosticData::UnsupportedValueType {
+                value,
+                ty,
+                definition_location,
+            } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("provided value is of {value} type"),
+                );
+                report.with_label_opt(
+                    *definition_location,
+                    format_args!("expected type declared here as {ty}"),
+                );
+            }
+            DiagnosticData::IntCoercionError { .. } => {
+                report.with_label_opt(self.location, "cannot be coerced to a 32-bit integer");
+            }
+            DiagnosticData::FloatCoercionError { .. } => {
+                report.with_label_opt(self.location, "cannot be coerced to a finite 64-bit float");
+            }
+            DiagnosticData::UniqueDirective {
+                name,
+                original_application,
+            } => {
+                report.with_label_opt(
+                    *original_application,
+                    format_args!("directive `@{name}` first called here"),
+                );
+                report.with_label_opt(
+                    self.location,
+                    format_args!("directive `@{name}` called again here"),
+                );
+            }
+            DiagnosticData::IntrospectionField { field } => {
+                report.with_label_opt(
+                    self.location,
+                    format_args!("{field} is an introspection field"),
+                );
+            }
+            DiagnosticData::MissingSubselection { coordinate, ty } => {
+                let particle = particle_for(ty);
+                report.with_label_opt(
+                    self.location,
+                    format_args!("{coordinate} is {particle} {ty} type and must select fields"),
+                );
+            }
+            DiagnosticData::ConflictingFieldType {
+                field,
+                original_selection,
+                original_type,
+                redefined_selection,
+                redefined_type,
+            } => {
+                report.with_label_opt(
+                    *original_selection,
+                    format_args!("`{field}` has type `{original_type}` here"),
+                );
+                report.with_label_opt(
+                    *redefined_selection,
+                    format_args!("but the same field name has type `{redefined_type}` here"),
+                );
+            }
+            DiagnosticData::ConflictingFieldArgument {
+                field,
+                argument,
+                original_selection,
+                original_value,
+                redefined_selection,
+                redefined_value,
+            } => {
+                match (original_value, redefined_value) {
+                    (Some(_), Some(_)) => {
+                        report.with_label_opt(
+                            *original_selection,
+                            format_args!("field `{field}` provides one argument value here"),
+                        );
+                        report.with_label_opt(*redefined_selection, "but a different value here");
+                    }
+                    (Some(_), None) => {
+                        report.with_label_opt(
+                            *original_selection,
+                            format!("field `{field}` is selected with argument `{argument}` here",),
+                        );
+                        report.with_label_opt(
+                            *redefined_selection,
+                            format!("but argument `{argument}` is not provided here"),
+                        );
+                    }
+                    (None, Some(_)) => {
+                        report.with_label_opt(
+                            *redefined_selection,
+                            format!("field `{field}` is selected with argument `{argument}` here",),
+                        );
+                        report.with_label_opt(
+                            *original_selection,
+                            format!("but argument `{argument}` is not provided here"),
+                        );
+                    }
+                    (None, None) => unreachable!(),
+                }
+                report.with_help("Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.");
+            }
+            DiagnosticData::ConflictingFieldName {
+                field,
+                original_selection,
+                original_name,
+                redefined_selection,
+                redefined_name,
+            } => {
+                report.with_label_opt(
+                    *original_selection,
+                    format_args!("field `{field}` is selected from field `{original_name}` here"),
+                );
+                report.with_label_opt(
+                    *redefined_selection,
+                    format_args!("but the same field `{field}` is also selected from field `{redefined_name}` here"),
+                );
+            }
+            DiagnosticData::InvalidFragmentTarget { name: _, ty } => {
+                report.with_label_opt(
+                    self.location,
+                    format!("fragment declares unsupported type condition `{ty}`"),
+                );
+                report.with_help("fragments cannot be defined on enums, scalars and input objects");
+            }
+            DiagnosticData::InvalidFragmentSpread {
+                name,
+                type_name: _,
+                type_condition,
+                fragment_location,
+                type_location,
+            } => {
+                if let Some(name) = name {
+                    report.with_label_opt(
+                        self.location,
+                        format_args!("fragment `{name}` cannot be applied"),
+                    );
+                    // Only for named fragments: for inline fragments the type condition is right
+                    // there
+                    report.with_label_opt(
+                        *fragment_location,
+                        format_args!(
+                            "fragment declared with type condition `{type_condition}` here"
+                        ),
+                    );
+                } else {
+                    report.with_label_opt(self.location, "inline fragment cannot be applied");
+                }
+                report.with_label_opt(
+                    *type_location,
+                    format!("type condition `{type_condition}` is not assignable to this type"),
+                );
+            }
+            DiagnosticData::DisallowedVariableUsage {
+                variable,
+                variable_type,
+                variable_location,
+                ..
+            } => {
+                report.with_label_opt(
+                    *variable_location,
+                    format_args!(
+                        "variable `${variable}` of type `{variable_type}` is declared here"
+                    ),
+                );
+                report.with_label_opt(
+                    self.location,
+                    format_args!("variable `${variable}` used here"),
+                );
+            }
+            DiagnosticData::RecursionError {} => {}
         }
-        if let Some(help) = &self.help {
-            report.with_help(help);
+    }
+}
+
+/// Get the appropriate particle "a" or "an" for a type category string like "enum" or "interface".
+fn particle_for(thing: &str) -> &'static str {
+    match thing {
+        "enum" => "an",
+        "input object" => "an",
+        "interface" => "an",
+        "object" => "an",
+        "scalar" => "a",
+        "union" => "a",
+        _ => "a(n)",
+    }
+}
+
+fn label_recursive_trace<T>(
+    report: &mut CliReport,
+    trace: &[Node<T>],
+    original_name: &str,
+    get_name: impl Fn(&T) -> &str,
+) {
+    if let Some((cyclical_application, path)) = trace.split_first() {
+        let mut prev_name = original_name;
+        for node in path.iter().rev() {
+            let name = get_name(node);
+            report.with_label_opt(
+                node.location(),
+                format!("`{prev_name}` references `{name}` here..."),
+            );
+            prev_name = name;
         }
+
+        report.with_label_opt(
+            cyclical_application.location(),
+            format!("`{prev_name}` circularly references `{original_name}` here"),
+        );
+    }
+}
+
+struct CommaSeparated<'a, It>(&'a It);
+impl<'a, T, It> fmt::Display for CommaSeparated<'a, It>
+where
+    T: fmt::Display,
+    &'a It: IntoIterator<Item = T>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut it = self.0.into_iter();
+        if let Some(element) = it.next() {
+            element.fmt(f)?;
+        }
+        for element in it {
+            f.write_str(", ")?;
+            element.fmt(f)?;
+        }
+        Ok(())
     }
 }

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -495,7 +495,7 @@ impl ApolloDiagnostic {
                 )
             }
             DiagnosticData::TransitiveImplementedInterfaces {
-                interface,
+                interface: _,
                 via_interface,
                 transitive_interface_location,
                 missing_interface,

--- a/crates/apollo-compiler/src/diagnostics.rs
+++ b/crates/apollo-compiler/src/diagnostics.rs
@@ -9,20 +9,6 @@ use crate::Node;
 use std::fmt;
 use thiserror::Error;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub(crate) struct Label {
-    pub location: Option<NodeLocation>,
-    pub text: String,
-}
-impl Label {
-    pub fn new(location: Option<NodeLocation>, text: impl Into<String>) -> Self {
-        Self {
-            location,
-            text: text.into(),
-        }
-    }
-}
-
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub(crate) struct ApolloDiagnostic {
     pub location: Option<NodeLocation>,
@@ -30,7 +16,7 @@ pub(crate) struct ApolloDiagnostic {
 }
 
 impl ApolloDiagnostic {
-    pub fn new<DB: ?Sized>(_db: &DB, location: Option<NodeLocation>, data: DiagnosticData) -> Self {
+    pub fn new(location: Option<NodeLocation>, data: DiagnosticData) -> Self {
         Self {
             location,
             data: Box::new(data),

--- a/crates/apollo-compiler/src/lib.rs
+++ b/crates/apollo-compiler/src/lib.rs
@@ -5,7 +5,6 @@ mod macros;
 pub mod ast;
 mod database;
 pub mod diagnostic;
-mod diagnostics;
 pub mod executable;
 pub mod execution;
 mod node;
@@ -15,7 +14,6 @@ pub mod schema;
 pub mod validation;
 
 use crate::database::{InputDatabase, ReprDatabase, RootDatabase, Source};
-use crate::diagnostics::ApolloDiagnostic;
 use crate::validation::ValidationDatabase;
 
 pub use self::executable::ExecutableDocument;

--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -36,6 +36,7 @@ pub struct SourceFile {
 
 pub type SourceMap = Arc<IndexMap<FileId, Arc<SourceFile>>>;
 
+/// Translate byte offsets to ariadne's char offsets.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MappedSource {
     ariadne: ariadne::Source,

--- a/crates/apollo-compiler/src/validation/argument.rs
+++ b/crates/apollo-compiler/src/validation/argument.rs
@@ -15,28 +15,15 @@ pub(crate) fn validate_arguments(
         let name = &argument.name;
         if let Some(&original_definition) = seen.get(name) {
             let redefined_definition = argument.location();
-            diagnostics.push(
-                ApolloDiagnostic::new(
-                    db,
+            diagnostics.push(ApolloDiagnostic::new(
+                db,
+                redefined_definition,
+                DiagnosticData::UniqueArgument {
+                    name: name.to_string(),
+                    original_definition,
                     redefined_definition,
-                    DiagnosticData::UniqueArgument {
-                        name: name.to_string(),
-                        original_definition,
-                        redefined_definition,
-                    },
-                )
-                .labels([
-                    Label::new(
-                        original_definition,
-                        format!("previously provided `{name}` here"),
-                    ),
-                    Label::new(
-                        redefined_definition,
-                        format!("`{name}` provided again here"),
-                    ),
-                ])
-                .help(format!("`{name}` argument must only be provided once.")),
-            );
+                },
+            ));
         } else {
             seen.insert(name, argument.location());
         }

--- a/crates/apollo-compiler/src/validation/argument.rs
+++ b/crates/apollo-compiler/src/validation/argument.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData, Label};
+use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
 use crate::validation::{NodeLocation, ValidationDatabase};
 use crate::{ast, Node};
 
@@ -16,7 +16,6 @@ pub(crate) fn validate_arguments(
         if let Some(&original_definition) = seen.get(name) {
             let redefined_definition = argument.location();
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 redefined_definition,
                 DiagnosticData::UniqueArgument {
                     name: name.to_string(),

--- a/crates/apollo-compiler/src/validation/argument.rs
+++ b/crates/apollo-compiler/src/validation/argument.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
+use crate::validation::diagnostics::{DiagnosticData, ValidationError};
 use crate::validation::NodeLocation;
 use crate::{ast, Node};
 
-pub(crate) fn validate_arguments(arguments: &[Node<ast::Argument>]) -> Vec<ApolloDiagnostic> {
+pub(crate) fn validate_arguments(arguments: &[Node<ast::Argument>]) -> Vec<ValidationError> {
     let mut diagnostics = Vec::new();
     let mut seen = HashMap::<_, Option<NodeLocation>>::new();
 
@@ -12,7 +12,7 @@ pub(crate) fn validate_arguments(arguments: &[Node<ast::Argument>]) -> Vec<Apoll
         let name = &argument.name;
         if let Some(&original_definition) = seen.get(name) {
             let redefined_definition = argument.location();
-            diagnostics.push(ApolloDiagnostic::new(
+            diagnostics.push(ValidationError::new(
                 redefined_definition,
                 DiagnosticData::UniqueArgument {
                     name: name.to_string(),

--- a/crates/apollo-compiler/src/validation/argument.rs
+++ b/crates/apollo-compiler/src/validation/argument.rs
@@ -1,13 +1,10 @@
 use std::collections::HashMap;
 
 use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
-use crate::validation::{NodeLocation, ValidationDatabase};
+use crate::validation::NodeLocation;
 use crate::{ast, Node};
 
-pub(crate) fn validate_arguments(
-    db: &dyn ValidationDatabase,
-    arguments: &[Node<ast::Argument>],
-) -> Vec<ApolloDiagnostic> {
+pub(crate) fn validate_arguments(arguments: &[Node<ast::Argument>]) -> Vec<ApolloDiagnostic> {
     let mut diagnostics = Vec::new();
     let mut seen = HashMap::<_, Option<NodeLocation>>::new();
 

--- a/crates/apollo-compiler/src/validation/argument.rs
+++ b/crates/apollo-compiler/src/validation/argument.rs
@@ -15,7 +15,7 @@ pub(crate) fn validate_arguments(arguments: &[Node<ast::Argument>]) -> Vec<Valid
             diagnostics.push(ValidationError::new(
                 redefined_definition,
                 DiagnosticData::UniqueArgument {
-                    name: name.to_string(),
+                    name: name.clone(),
                     original_definition,
                     redefined_definition,
                 },

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -113,7 +113,7 @@ pub(crate) enum DiagnosticData {
         definition_location: Option<NodeLocation>,
     },
     #[error(
-        "Transitively implemented interfaces must also be defined on an implementing interface or object"
+        "interface `{interface}` declares that it implements `{via_interface}`, but to do so it must also implement `{missing_interface}`"
     )]
     TransitiveImplementedInterfaces {
         /// Name of the interface definition

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -326,8 +326,6 @@ pub(crate) enum DiagnosticData {
 
 impl ValidationError {
     pub(crate) fn report(&self, report: &mut CliReport) {
-        report.with_message(&self.data);
-
         match &*self.data {
             DiagnosticData::UniqueVariable {
                 name,

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -54,7 +54,7 @@ pub(crate) enum DiagnosticData {
     },
     #[error(
         "{} can only have one root field",
-        subscription_name_or_anonymous(&name),
+        subscription_name_or_anonymous(name)
     )]
     SingleRootField {
         name: Option<Name>,
@@ -210,7 +210,7 @@ pub(crate) enum DiagnosticData {
     },
     #[error(
         "{} can not have an introspection field as a root field",
-        subscription_name_or_anonymous(&name),
+        subscription_name_or_anonymous(name)
     )]
     IntrospectionField {
         /// Name of the operation
@@ -255,7 +255,7 @@ pub(crate) enum DiagnosticData {
     },
     #[error(
         "{} must have a composite type in its type condition",
-        fragment_name_or_inline(&name),
+        fragment_name_or_inline(name)
     )]
     InvalidFragmentTarget {
         /// Name of the fragment, None if an inline fragment.
@@ -265,7 +265,7 @@ pub(crate) enum DiagnosticData {
     },
     #[error(
         "{} with type condition `{type_condition}` cannot be applied to `{type_name}`",
-        fragment_name_or_inline(&name),
+        fragment_name_or_inline(name)
     )]
     InvalidFragmentSpread {
         /// Fragment name or None if it's an inline fragment
@@ -821,7 +821,7 @@ struct NameOrAnon<'a, T> {
     if_some_prefix: &'a str,
     if_none: &'a str,
 }
-impl<'a, T> fmt::Display for NameOrAnon<'a, T>
+impl<T> fmt::Display for NameOrAnon<'_, T>
 where
     T: fmt::Display,
 {
@@ -833,14 +833,14 @@ where
     }
 }
 
-fn fragment_name_or_inline<'a, T>(name: &'a Option<T>) -> NameOrAnon<'a, T> {
+fn fragment_name_or_inline<T>(name: &'_ Option<T>) -> NameOrAnon<'_, T> {
     NameOrAnon {
         name: name.as_ref(),
         if_some_prefix: "fragment",
         if_none: "inline fragment",
     }
 }
-fn subscription_name_or_anonymous<'a, T>(name: &'a Option<T>) -> NameOrAnon<'a, T> {
+fn subscription_name_or_anonymous<T>(name: &'_ Option<T>) -> NameOrAnon<'_, T> {
     NameOrAnon {
         name: name.as_ref(),
         if_some_prefix: "subscription",

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -12,15 +12,12 @@ use thiserror::Error;
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub(crate) struct ValidationError {
     pub location: Option<NodeLocation>,
-    pub data: Box<DiagnosticData>,
+    pub data: DiagnosticData,
 }
 
 impl ValidationError {
     pub fn new(location: Option<NodeLocation>, data: DiagnosticData) -> Self {
-        Self {
-            location,
-            data: Box::new(data),
-        }
+        Self { location, data }
     }
 }
 
@@ -326,7 +323,7 @@ pub(crate) enum DiagnosticData {
 
 impl ValidationError {
     pub(crate) fn report(&self, report: &mut CliReport) {
-        match &*self.data {
+        match &self.data {
             DiagnosticData::UniqueVariable {
                 name,
                 original_definition,

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -36,19 +36,19 @@ impl fmt::Display for ValidationError {
 pub(crate) enum DiagnosticData {
     #[error("the variable `${name}` is declared multiple times")]
     UniqueVariable {
-        name: String,
+        name: Name,
         original_definition: Option<NodeLocation>,
         redefined_definition: Option<NodeLocation>,
     },
     #[error("the argument `{name}` is provided multiple times")]
     UniqueArgument {
-        name: String,
+        name: Name,
         original_definition: Option<NodeLocation>,
         redefined_definition: Option<NodeLocation>,
     },
     #[error("the value `{name}` is defined multiple times")]
     UniqueInputValue {
-        name: String,
+        name: Name,
         original_definition: Option<NodeLocation>,
         redefined_definition: Option<NodeLocation>,
     },
@@ -63,52 +63,52 @@ pub(crate) enum DiagnosticData {
     #[error("cannot find type `{name}` in this document")]
     UndefinedDefinition {
         /// Name of the type not in scope
-        name: String,
+        name: Name,
     },
     #[error("cannot find directive `@{name}` in this document")]
     UndefinedDirective {
         /// Name of the missing directive
-        name: String,
+        name: Name,
     },
     #[error("variable `${name}` is not defined")]
     UndefinedVariable {
         /// Name of the variable not in scope
-        name: String,
+        name: Name,
     },
     #[error("cannot find fragment `{name}` in this document")]
     UndefinedFragment {
         /// Name of the fragment not in scope
-        name: String,
+        name: Name,
     },
     #[error("value `{value}` does not exist on `{definition}`")]
     UndefinedEnumValue {
         /// Value of the enum value that doesn't exist
-        value: String,
+        value: Name,
         /// Name of the enum
-        definition: String,
+        definition: Name,
         definition_location: Option<NodeLocation>,
     },
     #[error("field `{value}` does not exist on `{definition}`")]
     UndefinedInputValue {
         /// Value of the input object field that doesn't exist
-        value: String,
+        value: Name,
         /// Name of the input object type
-        definition: String,
+        definition: Name,
         definition_location: Option<NodeLocation>,
     },
     #[error("type `{name}` does not satisfy interface `{interface}`: missing field `{field}`")]
     MissingInterfaceField {
-        name: String,
+        name: Name,
         /// Location of the `implements XYZ` of the interface
         implements_location: Option<NodeLocation>,
-        interface: String,
-        field: String,
+        interface: Name,
+        field: Name,
         /// Location of the definition of the field in the interface
         field_location: Option<NodeLocation>,
     },
     #[error("the required argument `{coordinate}` is not provided")]
     RequiredArgument {
-        name: String,
+        name: Name,
         coordinate: String,
         definition_location: Option<NodeLocation>,
     },
@@ -117,18 +117,18 @@ pub(crate) enum DiagnosticData {
     )]
     TransitiveImplementedInterfaces {
         /// Name of the interface definition
-        interface: String,
+        interface: Name,
         /// Super interface that declares the implementation
-        via_interface: String,
+        via_interface: Name,
         /// Source location where the super interface declares the implementation
         transitive_interface_location: Option<NodeLocation>,
         /// Interface that should be implemented
-        missing_interface: String,
+        missing_interface: Name,
     },
     #[error("`{name}` field must return an output type")]
     OutputType {
         /// Field name.
-        name: String,
+        name: Name,
         /// The kind of type that the field is declared with.
         describe_type: &'static str,
         type_location: Option<NodeLocation>,
@@ -136,7 +136,7 @@ pub(crate) enum DiagnosticData {
     #[error("`{name}` field must be of an input type")]
     InputType {
         /// Field name.
-        name: String,
+        name: Name,
         /// The kind of type that the field is declared with.
         describe_type: &'static str,
         type_location: Option<NodeLocation>,
@@ -144,7 +144,7 @@ pub(crate) enum DiagnosticData {
     #[error("`${name}` variable must be of an input type")]
     VariableInputType {
         /// Variable name.
-        name: String,
+        name: Name,
         /// The kind of type that the variable is declared with.
         describe_type: &'static str,
         type_location: Option<NodeLocation>,
@@ -152,25 +152,25 @@ pub(crate) enum DiagnosticData {
     #[error("missing query root operation type in schema definition")]
     QueryRootOperationType,
     #[error("unused variable: `${name}`")]
-    UnusedVariable { name: String },
+    UnusedVariable { name: Name },
     #[error("`{name}` field must return an object type")]
     RootOperationObjectType {
         /// Name of the root operation type
-        name: String,
+        name: Name,
         /// Category of the type
         describe_type: &'static str,
     },
     #[error("union member `{name}` must be an object type")]
     UnionMemberObjectType {
         /// Name of the type in the union
-        name: String,
+        name: Name,
         /// Category of the type
         describe_type: &'static str,
     },
     #[error("{name} directive is not supported for {location} location")]
     UnsupportedLocation {
         /// Name of the directive
-        name: String,
+        name: Name,
         /// The location where the directive is attempted to be used
         location: DirectiveLocation,
         /// Locations that *are* valid for this directive
@@ -199,13 +199,13 @@ pub(crate) enum DiagnosticData {
     #[error("non-repeatable directive {name} can only be used once per location")]
     UniqueDirective {
         /// Name of the non-unique directive.
-        name: String,
+        name: Name,
         original_application: Option<NodeLocation>,
     },
     #[error("subscription operations can not have an introspection field as a root field")]
     IntrospectionField {
         /// Name of the field
-        field: String,
+        field: Name,
     },
     #[error("interface, union and object types must have a subselection set")]
     MissingSubselection {
@@ -215,7 +215,7 @@ pub(crate) enum DiagnosticData {
     #[error("operation must not select different types using the same field name `{field}`")]
     ConflictingFieldType {
         /// Name of the non-unique field.
-        field: String,
+        field: Name,
         original_selection: Option<NodeLocation>,
         original_type: Type,
         redefined_selection: Option<NodeLocation>,
@@ -226,8 +226,8 @@ pub(crate) enum DiagnosticData {
     )]
     ConflictingFieldArgument {
         /// Name of the non-unique field.
-        field: String,
-        argument: String,
+        field: Name,
+        argument: Name,
         original_selection: Option<NodeLocation>,
         original_value: Option<Value>,
         redefined_selection: Option<NodeLocation>,
@@ -236,11 +236,11 @@ pub(crate) enum DiagnosticData {
     #[error("operation must not select different fields to the same alias `{field}`")]
     ConflictingFieldName {
         /// Name of the non-unique field.
-        field: String,
+        field: Name,
         original_selection: Option<NodeLocation>,
-        original_name: String,
+        original_name: Name,
         redefined_selection: Option<NodeLocation>,
-        redefined_name: String,
+        redefined_name: Name,
     },
     #[error(
         "{} must have a composite type in its type condition",
@@ -253,7 +253,7 @@ pub(crate) enum DiagnosticData {
         /// Name of the fragment, None if an inline fragment.
         name: Option<Name>,
         /// Name of the type on which the fragment is declared
-        ty: String,
+        ty: Name,
     },
     #[error(
         "{} with type condition `{type_condition}` cannot be applied to `{type_name}`",
@@ -264,10 +264,10 @@ pub(crate) enum DiagnosticData {
     )]
     InvalidFragmentSpread {
         /// Fragment name or None if it's an inline fragment
-        name: Option<String>,
+        name: Option<Name>,
         /// Type name the fragment is being applied to
-        type_name: String,
-        type_condition: String,
+        type_name: Name,
+        type_condition: Name,
         /// Source location where the fragment is defined
         fragment_location: Option<NodeLocation>,
         /// Source location of the type the fragment is being applied to.
@@ -276,43 +276,43 @@ pub(crate) enum DiagnosticData {
     #[error("fragment `{name}` must be used in an operation")]
     UnusedFragment {
         /// Name of the fragment
-        name: String,
+        name: Name,
     },
     #[error(
         "variable `${variable}` of type `{variable_type}` cannot be used for argument `{argument}` of type `{argument_type}`"
     )]
     DisallowedVariableUsage {
         /// Name of the variable being used in an argument
-        variable: String,
+        variable: Name,
         variable_type: Type,
         variable_location: Option<NodeLocation>,
         /// Name of the argument where variable is used
-        argument: String,
+        argument: Name,
         argument_type: Type,
         argument_location: Option<NodeLocation>,
     },
     #[error("`{name}` directive definition cannot reference itself")]
     RecursiveDirectiveDefinition {
-        name: String,
+        name: Name,
         trace: Vec<Node<ast::Directive>>,
     },
     #[error("interface {name} cannot implement itself")]
-    RecursiveInterfaceDefinition { name: String },
+    RecursiveInterfaceDefinition { name: Name },
     #[error("`{name}` input object cannot reference itself")]
     RecursiveInputObjectDefinition {
-        name: String,
+        name: Name,
         trace: Vec<Node<ast::InputValueDefinition>>,
     },
     #[error("`{name}` fragment cannot reference itself")]
     RecursiveFragmentDefinition {
         /// Source location of just the "fragment FragName" part.
         head_location: Option<NodeLocation>,
-        name: String,
+        name: Name,
         trace: Vec<Node<ast::FragmentSpread>>,
     },
     #[error("`{name}` contains too much nesting")]
     DeeplyNestedType {
-        name: String,
+        name: Name,
         describe_type: &'static str,
     },
     #[error("too much recursion")]

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -10,12 +10,12 @@ use std::fmt;
 use thiserror::Error;
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
-pub(crate) struct ApolloDiagnostic {
+pub(crate) struct ValidationError {
     pub location: Option<NodeLocation>,
     pub data: Box<DiagnosticData>,
 }
 
-impl ApolloDiagnostic {
+impl ValidationError {
     pub fn new(location: Option<NodeLocation>, data: DiagnosticData) -> Self {
         Self {
             location,
@@ -24,7 +24,7 @@ impl ApolloDiagnostic {
     }
 }
 
-impl fmt::Display for ApolloDiagnostic {
+impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.data.fmt(f)
     }
@@ -317,7 +317,7 @@ pub(crate) enum DiagnosticData {
     RecursionError {},
 }
 
-impl ApolloDiagnostic {
+impl ValidationError {
     pub(crate) fn report(&self, report: &mut CliReport) {
         report.with_message(&self.data);
 

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData, Label};
+use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
 use crate::validation::{NodeLocation, RecursionGuard, RecursionStack};
 use crate::{ast, schema, Node, ValidationDatabase};
 use std::collections::{HashMap, HashSet};
@@ -152,7 +152,6 @@ pub(crate) fn validate_directive_definition(
         Ok(_) => {}
         Err(CycleError::Recursed(trace)) => {
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 head_location,
                 DiagnosticData::RecursiveDirectiveDefinition {
                     name: def.name.to_string(),
@@ -161,7 +160,6 @@ pub(crate) fn validate_directive_definition(
             ));
         }
         Err(CycleError::Limit(_)) => diagnostics.push(ApolloDiagnostic::new(
-            db,
             head_location,
             DiagnosticData::DeeplyNestedType {
                 name: def.name.to_string(),
@@ -215,7 +213,6 @@ pub(crate) fn validate_directives<'dir>(
 
             if !is_repeatable {
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     loc,
                     DiagnosticData::UniqueDirective {
                         name: name.to_string(),
@@ -233,7 +230,6 @@ pub(crate) fn validate_directives<'dir>(
                 HashSet::from_iter(directive_definition.locations.iter().cloned());
             if !allowed_loc.contains(&dir_loc) {
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     loc,
                     DiagnosticData::UnsupportedLocation {
                         name: name.to_string(),
@@ -272,7 +268,6 @@ pub(crate) fn validate_directives<'dir>(
                     }
                 } else {
                     diagnostics.push(ApolloDiagnostic::new(
-                        db,
                         argument.location(),
                         DiagnosticData::UndefinedArgument {
                             name: argument.name.clone(),
@@ -297,7 +292,6 @@ pub(crate) fn validate_directives<'dir>(
 
                 if arg_def.is_required() && is_null && arg_def.default_value.is_none() {
                     diagnostics.push(ApolloDiagnostic::new(
-                        db,
                         dir.location(),
                         DiagnosticData::RequiredArgument {
                             name: arg_def.name.to_string(),
@@ -312,7 +306,6 @@ pub(crate) fn validate_directives<'dir>(
             }
         } else {
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 loc,
                 DiagnosticData::UndefinedDirective {
                     name: name.to_string(),

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -199,7 +199,7 @@ pub(crate) fn validate_directives<'dir>(
 
     let schema = db.schema();
     for dir in dirs {
-        diagnostics.extend(super::argument::validate_arguments(db, &dir.arguments));
+        diagnostics.extend(super::argument::validate_arguments(&dir.arguments));
 
         let name = &dir.name;
         let loc = dir.location();
@@ -252,7 +252,6 @@ pub(crate) fn validate_directives<'dir>(
                     // TODO(@goto-bus-stop) do we really need value validation and variable
                     // validation separately?
                     if let Some(diag) = super::variable::validate_variable_usage(
-                        db,
                         input_value.clone(),
                         var_defs,
                         argument,

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -163,7 +163,7 @@ pub(crate) fn validate_directive_definition(
             head_location,
             DiagnosticData::DeeplyNestedType {
                 name: def.name.to_string(),
-                ty: "directive",
+                describe_type: "directive",
             },
         )),
     }

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -154,7 +154,7 @@ pub(crate) fn validate_directive_definition(
             diagnostics.push(ValidationError::new(
                 head_location,
                 DiagnosticData::RecursiveDirectiveDefinition {
-                    name: def.name.to_string(),
+                    name: def.name.clone(),
                     trace,
                 },
             ));
@@ -162,7 +162,7 @@ pub(crate) fn validate_directive_definition(
         Err(CycleError::Limit(_)) => diagnostics.push(ValidationError::new(
             head_location,
             DiagnosticData::DeeplyNestedType {
-                name: def.name.to_string(),
+                name: def.name.clone(),
                 describe_type: "directive",
             },
         )),
@@ -215,7 +215,7 @@ pub(crate) fn validate_directives<'dir>(
                 diagnostics.push(ValidationError::new(
                     loc,
                     DiagnosticData::UniqueDirective {
-                        name: name.to_string(),
+                        name: name.clone(),
                         original_application: original_loc,
                     },
                 ));
@@ -232,7 +232,7 @@ pub(crate) fn validate_directives<'dir>(
                 diagnostics.push(ValidationError::new(
                     loc,
                     DiagnosticData::UnsupportedLocation {
-                        name: name.to_string(),
+                        name: name.clone(),
                         location: dir_loc,
                         valid_locations: directive_definition.locations.clone(),
                         definition_location: directive_definition.location(),
@@ -293,7 +293,7 @@ pub(crate) fn validate_directives<'dir>(
                     diagnostics.push(ValidationError::new(
                         dir.location(),
                         DiagnosticData::RequiredArgument {
-                            name: arg_def.name.to_string(),
+                            name: arg_def.name.clone(),
                             coordinate: format!(
                                 "@{}({}:)",
                                 directive_definition.name, arg_def.name
@@ -306,9 +306,7 @@ pub(crate) fn validate_directives<'dir>(
         } else {
             diagnostics.push(ValidationError::new(
                 loc,
-                DiagnosticData::UndefinedDirective {
-                    name: name.to_string(),
-                },
+                DiagnosticData::UndefinedDirective { name: name.clone() },
             ))
         }
     }

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -1,6 +1,7 @@
-use crate::{ast, diagnostics::ApolloDiagnostic, Node, ValidationDatabase};
+use crate::validation::diagnostics::ValidationError;
+use crate::{ast, Node, ValidationDatabase};
 
-pub(crate) fn validate_enum_definitions(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
+pub(crate) fn validate_enum_definitions(db: &dyn ValidationDatabase) -> Vec<ValidationError> {
     let mut diagnostics = Vec::new();
 
     for enum_ in db.ast_types().enums.values() {
@@ -13,7 +14,7 @@ pub(crate) fn validate_enum_definitions(db: &dyn ValidationDatabase) -> Vec<Apol
 pub(crate) fn validate_enum_definition(
     db: &dyn ValidationDatabase,
     enum_def: ast::TypeWithExtensions<ast::EnumTypeDefinition>,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = super::directive::validate_directives(
         db,
         enum_def.directives(),
@@ -32,7 +33,7 @@ pub(crate) fn validate_enum_definition(
 pub(crate) fn validate_enum_value(
     db: &dyn ValidationDatabase,
     enum_val: &Node<ast::EnumValueDefinition>,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     super::directive::validate_directives(
         db,
         enum_val.directives.iter(),

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -58,20 +58,17 @@ pub(crate) fn validate_field(
                     ));
                 }
             } else {
-                let mut labels = vec![Label::new(argument.location(), "argument name not found")];
                 let loc = field_definition.location();
-                labels.push(Label::new(loc, "field declared here"));
 
-                diagnostics.push(
-                    ApolloDiagnostic::new(
-                        db,
-                        argument.location(),
-                        DiagnosticData::UndefinedArgument {
-                            name: argument.name.to_string(),
-                        },
-                    )
-                    .labels(labels),
-                );
+                diagnostics.push(ApolloDiagnostic::new(
+                    db,
+                    argument.location(),
+                    DiagnosticData::UndefinedArgument {
+                        name: argument.name.clone(),
+                        coordinate: format!("{}.{}", against_type, field.name),
+                        definition_location: loc,
+                    },
+                ));
             }
         }
 
@@ -88,21 +85,18 @@ pub(crate) fn validate_field(
             };
 
             if arg_definition.is_required() && is_null && arg_definition.default_value.is_none() {
-                let mut diagnostic = ApolloDiagnostic::new(
+                diagnostics.push(ApolloDiagnostic::new(
                     db,
                     field.location(),
                     DiagnosticData::RequiredArgument {
                         name: arg_definition.name.to_string(),
+                        coordinate: format!(
+                            "{}.{}({}:)",
+                            against_type, field.name, arg_definition.name
+                        ),
+                        definition_location: arg_definition.location(),
                     },
-                );
-                diagnostic = diagnostic.label(Label::new(
-                    field.location(),
-                    format!("missing value for argument `{}`", arg_definition.name),
                 ));
-                let loc = arg_definition.location();
-                diagnostic = diagnostic.label(Label::new(loc, "argument defined here"));
-
-                diagnostics.push(diagnostic);
             }
         }
 
@@ -155,38 +149,36 @@ pub(crate) fn validate_field_definitions(
 
         // Field types in Object Types must be of output type
         let loc = field.location();
+        let type_location = field.ty.inner_named_type().location();
         if let Some(field_ty) = schema.types.get(field.ty.inner_named_type()) {
             if !field_ty.is_output_type() {
                 // Output types are unreachable
-                let (particle, kind) = match field_ty {
+                let kind = match field_ty {
                     schema::ExtendedType::Scalar(_) => unreachable!(),
                     schema::ExtendedType::Union(_) => unreachable!(),
                     schema::ExtendedType::Enum(_) => unreachable!(),
                     schema::ExtendedType::Interface(_) => unreachable!(),
-                    schema::ExtendedType::InputObject(_) => ("an", "input object"),
+                    schema::ExtendedType::InputObject(_) => "input object",
                     schema::ExtendedType::Object(_) => unreachable!(),
                 };
-                diagnostics.push(
-                    ApolloDiagnostic::new(db, loc, DiagnosticData::OutputType {
+                diagnostics.push(ApolloDiagnostic::new(
+                    db,
+                    loc,
+                    DiagnosticData::OutputType {
                         name: field.name.to_string(),
                         ty: kind,
-                    })
-                        .label(Label::new(loc, format!("this is {particle} {kind}")))
-                        .help(format!("Scalars, Objects, Interfaces, Unions and Enums are output types. Change `{}` field to return one of these output types.", field.name)),
-                );
+                        type_location,
+                    },
+                ));
             }
         } else {
-            let field_ty_loc = field.ty.inner_named_type().location();
-            diagnostics.push(
-                ApolloDiagnostic::new(
-                    db,
-                    field_ty_loc,
-                    DiagnosticData::UndefinedDefinition {
-                        name: field.ty.inner_named_type().to_string(),
-                    },
-                )
-                .label(Label::new(field_ty_loc, "not found in this scope")),
-            );
+            diagnostics.push(ApolloDiagnostic::new(
+                db,
+                type_location,
+                DiagnosticData::UndefinedDefinition {
+                    name: field.ty.inner_named_type().to_string(),
+                },
+            ));
         }
     }
 
@@ -206,31 +198,26 @@ pub(crate) fn validate_leaf_field_selection(
 
     let type_def = match schema.types.get(tname) {
         Some(type_def) => type_def,
+        // If we don't have the type we can't check if it requires a subselection.
         None => return Ok(()),
     };
 
-    let (label, diagnostic_data) = if is_leaf {
-        let label = match type_def {
-            schema::ExtendedType::Object(_) => {
-                format!("field `{fname}` type `{tname}` is an object and must select fields")
-            }
-            schema::ExtendedType::Interface(_) => {
-                format!("field `{fname}` type `{tname}` is an interface and must select fields")
-            }
-            schema::ExtendedType::Union(_) => {
-                format!("field `{fname}` type `{tname}` is an union and must select fields")
-            }
+    if is_leaf {
+        let kind = match type_def {
+            schema::ExtendedType::Object(_) => "object",
+            schema::ExtendedType::Interface(_) => "interface",
+            schema::ExtendedType::Union(_) => "union",
             _ => return Ok(()),
         };
-        (label, DiagnosticData::MissingSubselection)
+        Err(ApolloDiagnostic::new(
+            db,
+            field.location(),
+            DiagnosticData::MissingSubselection {
+                coordinate: format!("{tname}.{fname}"),
+                ty: kind,
+            },
+        ))
     } else {
-        return Ok(());
-    };
-
-    Err(ApolloDiagnostic::new(db, field.location(), diagnostic_data)
-        .label(Label::new(field.location(), label))
-        .label(Label::new(
-            type_def.location(),
-            format!("`{tname}` declared here"),
-        )))
+        Ok(())
+    }
 }

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData, Label};
+use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
 use crate::validation::{FileId, ValidationDatabase};
 use crate::{ast, schema, Node};
 
@@ -61,7 +61,6 @@ pub(crate) fn validate_field(
                 let loc = field_definition.location();
 
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     argument.location(),
                     DiagnosticData::UndefinedArgument {
                         name: argument.name.clone(),
@@ -86,7 +85,6 @@ pub(crate) fn validate_field(
 
             if arg_definition.is_required() && is_null && arg_definition.default_value.is_none() {
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     field.location(),
                     DiagnosticData::RequiredArgument {
                         name: arg_definition.name.to_string(),
@@ -162,7 +160,6 @@ pub(crate) fn validate_field_definitions(
                     schema::ExtendedType::Object(_) => unreachable!(),
                 };
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     loc,
                     DiagnosticData::OutputType {
                         name: field.name.to_string(),
@@ -173,7 +170,6 @@ pub(crate) fn validate_field_definitions(
             }
         } else {
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 type_location,
                 DiagnosticData::UndefinedDefinition {
                     name: field.ty.inner_named_type().to_string(),
@@ -210,7 +206,6 @@ pub(crate) fn validate_leaf_field_selection(
             _ => return Ok(()),
         };
         Err(ApolloDiagnostic::new(
-            db,
             field.location(),
             DiagnosticData::MissingSubselection {
                 coordinate: format!("{tname}.{fname}"),

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -21,7 +21,7 @@ pub(crate) fn validate_field(
         context.variables,
     );
 
-    diagnostics.extend(super::argument::validate_arguments(db, &field.arguments));
+    diagnostics.extend(super::argument::validate_arguments(&field.arguments));
 
     // Return early if we don't know the type--this can happen if we are nested deeply
     // inside a selection set that has a wrong field, or if we are validating a standalone
@@ -41,7 +41,6 @@ pub(crate) fn validate_field(
                 .cloned();
             if let Some(arg_definition) = arg_definition {
                 if let Some(diag) = super::variable::validate_variable_usage(
-                    db,
                     arg_definition.clone(),
                     context.variables,
                     argument,

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -86,7 +86,7 @@ pub(crate) fn validate_field(
                 diagnostics.push(ValidationError::new(
                     field.location(),
                     DiagnosticData::RequiredArgument {
-                        name: arg_definition.name.to_string(),
+                        name: arg_definition.name.clone(),
                         coordinate: format!(
                             "{}.{}({}:)",
                             against_type, field.name, arg_definition.name
@@ -153,7 +153,7 @@ pub(crate) fn validate_field_definitions(
                 diagnostics.push(ValidationError::new(
                     loc,
                     DiagnosticData::OutputType {
-                        name: field.name.to_string(),
+                        name: field.name.clone(),
                         describe_type: field_ty.describe(),
                         type_location,
                     },
@@ -163,7 +163,7 @@ pub(crate) fn validate_field_definitions(
             diagnostics.push(ValidationError::new(
                 type_location,
                 DiagnosticData::UndefinedDefinition {
-                    name: field.ty.inner_named_type().to_string(),
+                    name: field.ty.inner_named_type().clone(),
                 },
             ));
         }

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData, Label};
+use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
 use crate::schema;
 use crate::schema::Implementers;
 use crate::validation::operation::OperationValidationConfig;
@@ -77,7 +77,6 @@ fn validate_fragment_spread_type(
                 let fragment_definition = named_fragments.get(&spread.fragment_name).unwrap();
 
                 ApolloDiagnostic::new(
-                    db,
                     spread.location(),
                     DiagnosticData::InvalidFragmentSpread {
                         name: Some(spread.fragment_name.to_string()),
@@ -89,7 +88,6 @@ fn validate_fragment_spread_type(
                 )
             }
             ast::Selection::InlineFragment(inline) => ApolloDiagnostic::new(
-                db,
                 inline.location(),
                 DiagnosticData::InvalidFragmentSpread {
                     name: None,
@@ -197,7 +195,6 @@ pub(crate) fn validate_fragment_spread(
         }
         None => {
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 spread.location(),
                 DiagnosticData::UndefinedFragment {
                     name: spread.fragment_name.to_string(),
@@ -321,7 +318,6 @@ pub(crate) fn validate_fragment_cycles(
             let head_location = NodeLocation::recompose(def.location(), def.name.location());
 
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 def.location(),
                 DiagnosticData::RecursiveFragmentDefinition {
                     head_location,
@@ -334,7 +330,6 @@ pub(crate) fn validate_fragment_cycles(
             let head_location = NodeLocation::recompose(def.location(), def.name.location());
 
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 head_location,
                 DiagnosticData::DeeplyNestedType {
                     name: def.name.to_string(),
@@ -371,7 +366,6 @@ pub(crate) fn validate_fragment_type_condition(
 
     if !is_composite {
         diagnostics.push(ApolloDiagnostic::new(
-            db,
             fragment_location,
             DiagnosticData::InvalidFragmentTarget {
                 name: fragment_name,
@@ -417,7 +411,6 @@ pub(crate) fn validate_fragment_used(
     // Returns Unused Fragment error.
     if !is_used {
         diagnostics.push(ApolloDiagnostic::new(
-            db,
             fragment.location(),
             DiagnosticData::UnusedFragment {
                 name: fragment_name.to_string(),

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -79,9 +79,9 @@ fn validate_fragment_spread_type(
                 ValidationError::new(
                     spread.location(),
                     DiagnosticData::InvalidFragmentSpread {
-                        name: Some(spread.fragment_name.to_string()),
-                        type_name: against_type.to_string(),
-                        type_condition: type_condition.to_string(),
+                        name: Some(spread.fragment_name.clone()),
+                        type_name: against_type.clone(),
+                        type_condition: type_condition.clone(),
                         fragment_location: fragment_definition.location(),
                         type_location: against_type_definition.location(),
                     },
@@ -91,8 +91,8 @@ fn validate_fragment_spread_type(
                 inline.location(),
                 DiagnosticData::InvalidFragmentSpread {
                     name: None,
-                    type_name: against_type.to_string(),
-                    type_condition: type_condition.to_string(),
+                    type_name: against_type.clone(),
+                    type_condition: type_condition.clone(),
                     fragment_location: inline.location(),
                     type_location: against_type_definition.location(),
                 },
@@ -197,7 +197,7 @@ pub(crate) fn validate_fragment_spread(
             diagnostics.push(ValidationError::new(
                 spread.location(),
                 DiagnosticData::UndefinedFragment {
-                    name: spread.fragment_name.to_string(),
+                    name: spread.fragment_name.clone(),
                 },
             ));
         }
@@ -321,7 +321,7 @@ pub(crate) fn validate_fragment_cycles(
                 def.location(),
                 DiagnosticData::RecursiveFragmentDefinition {
                     head_location,
-                    name: def.name.to_string(),
+                    name: def.name.clone(),
                     trace,
                 },
             ));
@@ -332,7 +332,7 @@ pub(crate) fn validate_fragment_cycles(
             diagnostics.push(ValidationError::new(
                 head_location,
                 DiagnosticData::DeeplyNestedType {
-                    name: def.name.to_string(),
+                    name: def.name.clone(),
                     describe_type: "fragment",
                 },
             ));
@@ -369,7 +369,7 @@ pub(crate) fn validate_fragment_type_condition(
             fragment_location,
             DiagnosticData::InvalidFragmentTarget {
                 name: fragment_name,
-                ty: type_cond.to_string(),
+                ty: type_cond.clone(),
             },
         ));
     }
@@ -413,7 +413,7 @@ pub(crate) fn validate_fragment_used(
         diagnostics.push(ValidationError::new(
             fragment.location(),
             DiagnosticData::UnusedFragment {
-                name: fragment_name.to_string(),
+                name: fragment_name.clone(),
             },
         ))
     }

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -333,7 +333,7 @@ pub(crate) fn validate_fragment_cycles(
                 head_location,
                 DiagnosticData::DeeplyNestedType {
                     name: def.name.to_string(),
-                    ty: "fragment",
+                    describe_type: "fragment",
                 },
             ));
         }

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast,
-    diagnostics::{ApolloDiagnostic, DiagnosticData, Label},
+    diagnostics::{ApolloDiagnostic, DiagnosticData},
     schema,
     validation::{CycleError, RecursionGuard, RecursionStack},
     Node, ValidationDatabase,
@@ -89,7 +89,6 @@ pub(crate) fn validate_input_object_definition(
     match FindRecursiveInputValue::check(db, &input_object) {
         Ok(_) => {}
         Err(CycleError::Recursed(trace)) => diagnostics.push(ApolloDiagnostic::new(
-            db,
             input_object.definition.location(),
             DiagnosticData::RecursiveInputObjectDefinition {
                 name: input_object.definition.name.to_string(),
@@ -98,7 +97,6 @@ pub(crate) fn validate_input_object_definition(
         )),
         Err(CycleError::Limit(_)) => {
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 input_object.definition.location(),
                 DiagnosticData::DeeplyNestedType {
                     name: input_object.definition.name.to_string(),
@@ -136,7 +134,6 @@ pub(crate) fn validate_argument_definitions(
                 (prev_value.location(), input_value.location());
 
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 original_definition,
                 DiagnosticData::UniqueInputValue {
                     name: name.to_string(),
@@ -181,7 +178,6 @@ pub(crate) fn validate_input_value_definitions(
                     schema::ExtendedType::InputObject(_) => unreachable!(),
                 };
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     loc,
                     DiagnosticData::InputType {
                         name: input_value.name.to_string(),
@@ -194,7 +190,6 @@ pub(crate) fn validate_input_value_definitions(
             let named_type = input_value.ty.inner_named_type();
             let loc = named_type.location();
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 loc,
                 DiagnosticData::UndefinedDefinition {
                     name: named_type.to_string(),

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -89,7 +89,7 @@ pub(crate) fn validate_input_object_definition(
         Err(CycleError::Recursed(trace)) => diagnostics.push(ValidationError::new(
             input_object.definition.location(),
             DiagnosticData::RecursiveInputObjectDefinition {
-                name: input_object.definition.name.to_string(),
+                name: input_object.definition.name.clone(),
                 trace,
             },
         )),
@@ -97,7 +97,7 @@ pub(crate) fn validate_input_object_definition(
             diagnostics.push(ValidationError::new(
                 input_object.definition.location(),
                 DiagnosticData::DeeplyNestedType {
-                    name: input_object.definition.name.to_string(),
+                    name: input_object.definition.name.clone(),
                     describe_type: "input object",
                 },
             ));
@@ -134,7 +134,7 @@ pub(crate) fn validate_argument_definitions(
             diagnostics.push(ValidationError::new(
                 original_definition,
                 DiagnosticData::UniqueInputValue {
-                    name: name.to_string(),
+                    name: name.clone(),
                     original_definition,
                     redefined_definition,
                 },
@@ -170,7 +170,7 @@ pub(crate) fn validate_input_value_definitions(
                 diagnostics.push(ValidationError::new(
                     loc,
                     DiagnosticData::InputType {
-                        name: input_value.name.to_string(),
+                        name: input_value.name.clone(),
                         describe_type: field_ty.describe(),
                         type_location: input_value.ty.location(),
                     },
@@ -182,7 +182,7 @@ pub(crate) fn validate_input_value_definitions(
             diagnostics.push(ValidationError::new(
                 loc,
                 DiagnosticData::UndefinedDefinition {
-                    name: named_type.to_string(),
+                    name: named_type.clone(),
                 },
             ));
         }

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -1,5 +1,4 @@
 use crate::ast;
-use crate::schema;
 use crate::validation::diagnostics::{DiagnosticData, ValidationError};
 use crate::validation::{CycleError, RecursionGuard, RecursionStack};
 use crate::Node;
@@ -99,7 +98,7 @@ pub(crate) fn validate_input_object_definition(
                 input_object.definition.location(),
                 DiagnosticData::DeeplyNestedType {
                     name: input_object.definition.name.to_string(),
-                    ty: "input object",
+                    describe_type: "input object",
                 },
             ));
         }
@@ -168,19 +167,11 @@ pub(crate) fn validate_input_value_definitions(
         let loc = input_value.location();
         if let Some(field_ty) = schema.types.get(input_value.ty.inner_named_type()) {
             if !field_ty.is_input_type() {
-                let kind = match field_ty {
-                    schema::ExtendedType::Scalar(_) => unreachable!(),
-                    schema::ExtendedType::Object(_) => "object",
-                    schema::ExtendedType::Interface(_) => "interface",
-                    schema::ExtendedType::Union(_) => "union",
-                    schema::ExtendedType::Enum(_) => unreachable!(),
-                    schema::ExtendedType::InputObject(_) => unreachable!(),
-                };
                 diagnostics.push(ValidationError::new(
                     loc,
                     DiagnosticData::InputType {
                         name: input_value.name.to_string(),
-                        ty: kind,
+                        describe_type: field_ty.describe(),
                         type_location: input_value.ty.location(),
                     },
                 ));

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast,
-    diagnostics::{ApolloDiagnostic, DiagnosticData, Label},
+    diagnostics::{ApolloDiagnostic, DiagnosticData},
     schema, ValidationDatabase,
 };
 use std::collections::HashSet;
@@ -49,7 +49,6 @@ pub(crate) fn validate_interface_definition(
     for implements_interface in interface.implements_interfaces() {
         if *implements_interface == interface.definition.name {
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 implements_interface.location(),
                 DiagnosticData::RecursiveInterfaceDefinition {
                     name: implements_interface.to_string(),
@@ -86,7 +85,6 @@ pub(crate) fn validate_interface_definition(
                     continue;
                 }
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     interface.definition.location(),
                     DiagnosticData::MissingInterfaceField {
                         name: interface.definition.name.to_string(),
@@ -132,7 +130,6 @@ pub(crate) fn validate_implements_interfaces(
         // interface_name.loc should always be Some
         let loc = interface_name.location();
         diagnostics.push(ApolloDiagnostic::new(
-            db,
             loc,
             DiagnosticData::UndefinedDefinition {
                 name: interface_name.to_string(),
@@ -161,7 +158,6 @@ pub(crate) fn validate_implements_interfaces(
         //     .location();
         let transitive_loc = transitive_interface.location();
         diagnostics.push(ApolloDiagnostic::new(
-            db,
             definition_loc,
             DiagnosticData::TransitiveImplementedInterfaces {
                 interface: implementor.name().unwrap().to_string(),

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -51,7 +51,7 @@ pub(crate) fn validate_interface_definition(
             diagnostics.push(ValidationError::new(
                 implements_interface.location(),
                 DiagnosticData::RecursiveInterfaceDefinition {
-                    name: implements_interface.to_string(),
+                    name: implements_interface.clone(),
                 },
             ));
         }
@@ -87,10 +87,10 @@ pub(crate) fn validate_interface_definition(
                 diagnostics.push(ValidationError::new(
                     interface.definition.location(),
                     DiagnosticData::MissingInterfaceField {
-                        name: interface.definition.name.to_string(),
+                        name: interface.definition.name.clone(),
                         implements_location: implements_interface.location(),
-                        interface: implements_interface.to_string(),
-                        field: super_field.name.to_string(),
+                        interface: implements_interface.clone(),
+                        field: super_field.name.clone(),
                         field_location: super_field.location(),
                     },
                 ));
@@ -132,7 +132,7 @@ pub(crate) fn validate_implements_interfaces(
         diagnostics.push(ValidationError::new(
             loc,
             DiagnosticData::UndefinedDefinition {
-                name: interface_name.to_string(),
+                name: interface_name.clone(),
             },
         ));
     }
@@ -160,9 +160,9 @@ pub(crate) fn validate_implements_interfaces(
         diagnostics.push(ValidationError::new(
             definition_loc,
             DiagnosticData::TransitiveImplementedInterfaces {
-                interface: implementor.name().unwrap().to_string(),
-                via_interface: via_interface.to_string(),
-                missing_interface: transitive_interface.to_string(),
+                interface: implementor.name().unwrap().clone(),
+                via_interface: via_interface.clone(),
+                missing_interface: transitive_interface.clone(),
                 transitive_interface_location: transitive_loc,
             },
         ));

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -204,7 +204,7 @@ pub(crate) enum Details {
     #[error("{0}")]
     ExecutableBuildError(ExecutableBuildError),
     // TODO: Merge ValidationError into this enum
-    #[error("compiler error: {0}")]
+    #[error(transparent)]
     CompilerDiagnostic(diagnostics::ValidationError),
 }
 

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -180,13 +180,13 @@ impl SuspectedValidationBug {
 #[derive(Clone)]
 pub struct DiagnosticList {
     pub(crate) sources: SourceMap,
-    diagnostics_data: Vec<DiagnosticData>,
+    diagnostics_data: Vec<ValidationError>,
 }
 
 // TODO(@goto-bus-stop) Can/should this be non-pub?
 #[derive(thiserror::Error, Debug, Clone)]
 #[error("{details}")]
-pub struct DiagnosticData {
+pub struct ValidationError {
     location: Option<NodeLocation>,
     details: Details,
 }
@@ -205,7 +205,7 @@ pub(crate) enum Details {
     CompilerDiagnostic(crate::ApolloDiagnostic),
 }
 
-impl ToCliReport for DiagnosticData {
+impl ToCliReport for ValidationError {
     fn location(&self) -> Option<NodeLocation> {
         self.location
     }
@@ -430,7 +430,7 @@ impl DiagnosticList {
 
     pub fn iter(
         &self,
-    ) -> impl Iterator<Item = Diagnostic<'_, DiagnosticData>> + DoubleEndedIterator + ExactSizeIterator
+    ) -> impl Iterator<Item = Diagnostic<'_, ValidationError>> + DoubleEndedIterator + ExactSizeIterator
     {
         self.diagnostics_data
             .iter()
@@ -438,7 +438,7 @@ impl DiagnosticList {
     }
 
     pub(crate) fn push(&mut self, location: Option<NodeLocation>, details: impl Into<Details>) {
-        self.diagnostics_data.push(DiagnosticData {
+        self.diagnostics_data.push(ValidationError {
             location,
             details: details.into(),
         })

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast,
-    diagnostics::{ApolloDiagnostic, DiagnosticData, Label},
+    diagnostics::{ApolloDiagnostic, DiagnosticData},
     ValidationDatabase,
 };
 use std::collections::HashSet;
@@ -64,26 +64,7 @@ pub(crate) fn validate_object_type_definition(
                     continue;
                 }
 
-                let mut labels = vec![
-                    Label::new(
-                        implements_interface.location(),
-                        format!("implementation of interface {implements_interface} declared here"),
-                    ),
-                    Label::new(
-                        object.definition.location(),
-                        format!("add `{}` field to this object", interface_field.name),
-                    ),
-                ];
-                let loc = interface_field.location();
-                labels.push(Label::new(
-                    loc,
-                    format!(
-                        "`{}` was originally defined by {} here",
-                        interface_field.name, implements_interface
-                    ),
-                ));
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     object.definition.location(),
                     DiagnosticData::MissingInterfaceField {
                         name: interface.name.to_string(),

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -67,7 +67,7 @@ pub(crate) fn validate_object_type_definition(
                 diagnostics.push(ValidationError::new(
                     object.definition.location(),
                     DiagnosticData::MissingInterfaceField {
-                        name: interface.name.to_string(),
+                        name: object.definition.name.to_string(),
                         implements_location: implements_interface.location(),
                         interface: implements_interface.to_string(),
                         field: interface_field.name.to_string(),

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -86,12 +86,13 @@ pub(crate) fn validate_object_type_definition(
                     db,
                     object.definition.location(),
                     DiagnosticData::MissingInterfaceField {
+                        name: interface.name.to_string(),
+                        implements_location: implements_interface.location(),
                         interface: implements_interface.to_string(),
                         field: interface_field.name.to_string(),
+                        field_location: interface_field.location(),
                     },
-                )
-                .labels(labels)
-                .help("An object must provide all fields required by the interfaces it implements"))
+                ));
             }
         }
     }

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -1,13 +1,13 @@
 use crate::{
     ast,
-    diagnostics::{ApolloDiagnostic, DiagnosticData},
+    validation::diagnostics::{DiagnosticData, ValidationError},
     ValidationDatabase,
 };
 use std::collections::HashSet;
 
 pub(crate) fn validate_object_type_definitions(
     db: &dyn ValidationDatabase,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = vec![];
 
     let defs = &db.ast_types().objects;
@@ -21,7 +21,7 @@ pub(crate) fn validate_object_type_definitions(
 pub(crate) fn validate_object_type_definition(
     db: &dyn ValidationDatabase,
     object: ast::TypeWithExtensions<ast::ObjectTypeDefinition>,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = Vec::new();
 
     let schema = db.schema();
@@ -64,7 +64,7 @@ pub(crate) fn validate_object_type_definition(
                     continue;
                 }
 
-                diagnostics.push(ApolloDiagnostic::new(
+                diagnostics.push(ValidationError::new(
                     object.definition.location(),
                     DiagnosticData::MissingInterfaceField {
                         name: interface.name.to_string(),

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -67,10 +67,10 @@ pub(crate) fn validate_object_type_definition(
                 diagnostics.push(ValidationError::new(
                     object.definition.location(),
                     DiagnosticData::MissingInterfaceField {
-                        name: object.definition.name.to_string(),
+                        name: object.definition.name.clone(),
                         implements_location: implements_interface.location(),
-                        interface: implements_interface.to_string(),
-                        field: interface_field.name.to_string(),
+                        interface: implements_interface.clone(),
+                        field: interface_field.name.clone(),
                         field_location: interface_field.location(),
                     },
                 ));

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData, Label};
+use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
 use crate::validation::FileId;
 use crate::{ast, name, Node, ValidationDatabase};
 
@@ -38,7 +38,6 @@ pub(crate) fn validate_operation(
 
         if fields.len() > 1 {
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 operation.location(),
                 DiagnosticData::SingleRootField {
                     fields: fields
@@ -60,7 +59,6 @@ pub(crate) fn validate_operation(
             .map(|field| field.field);
         if let Some(field) = has_introspection_fields {
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 field.location(),
                 DiagnosticData::IntrospectionField {
                     field: field.name.to_string(),

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
+use crate::validation::diagnostics::{DiagnosticData, ValidationError};
 use crate::validation::FileId;
 use crate::{ast, name, Node, ValidationDatabase};
 
@@ -15,7 +15,7 @@ pub(crate) fn validate_operation(
     file_id: FileId,
     operation: Node<ast::OperationDefinition>,
     has_schema: bool,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = vec![];
 
     let config = OperationValidationConfig {
@@ -37,7 +37,7 @@ pub(crate) fn validate_operation(
         );
 
         if fields.len() > 1 {
-            diagnostics.push(ApolloDiagnostic::new(
+            diagnostics.push(ValidationError::new(
                 operation.location(),
                 DiagnosticData::SingleRootField {
                     fields: fields
@@ -58,7 +58,7 @@ pub(crate) fn validate_operation(
             })
             .map(|field| field.field);
         if let Some(field) = has_introspection_fields {
-            diagnostics.push(ApolloDiagnostic::new(
+            diagnostics.push(ValidationError::new(
                 field.location(),
                 DiagnosticData::IntrospectionField {
                     field: field.name.to_string(),
@@ -99,7 +99,7 @@ pub(crate) fn validate_operation_definitions_inner(
     db: &dyn ValidationDatabase,
     file_id: FileId,
     has_schema: bool,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = Vec::new();
     let document = db.ast(file_id);
 
@@ -120,6 +120,6 @@ pub(crate) fn validate_operation_definitions_inner(
 pub(crate) fn validate_operation_definitions(
     db: &dyn ValidationDatabase,
     file_id: FileId,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     validate_operation_definitions_inner(db, file_id, false)
 }

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -37,29 +37,16 @@ pub(crate) fn validate_operation(
         );
 
         if fields.len() > 1 {
-            diagnostics.push(
-                ApolloDiagnostic::new(
-                    db,
-                    operation.location(),
-                    DiagnosticData::SingleRootField {
-                        fields: fields.len(),
-                        subscription: (operation.location()),
-                    },
-                )
-                .label(Label::new(
-                    operation.location(),
-                    format!("subscription with {} root fields", fields.len()),
-                ))
-                .help(format!(
-                    "There are {} root fields: {}. This is not allowed.",
-                    fields.len(),
-                    fields
+            diagnostics.push(ApolloDiagnostic::new(
+                db,
+                operation.location(),
+                DiagnosticData::SingleRootField {
+                    fields: fields
                         .iter()
-                        .map(|field| field.field.name.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )),
-            );
+                        .map(|field| field.field.name.clone())
+                        .collect(),
+                },
+            ));
         }
 
         let has_introspection_fields = fields
@@ -72,19 +59,13 @@ pub(crate) fn validate_operation(
             })
             .map(|field| field.field);
         if let Some(field) = has_introspection_fields {
-            diagnostics.push(
-                ApolloDiagnostic::new(
-                    db,
-                    field.location(),
-                    DiagnosticData::IntrospectionField {
-                        field: field.name.to_string(),
-                    },
-                )
-                .label(Label::new(
-                    field.location(),
-                    format!("{} is an introspection field", field.name),
-                )),
-            );
+            diagnostics.push(ApolloDiagnostic::new(
+                db,
+                field.location(),
+                DiagnosticData::IntrospectionField {
+                    field: field.name.to_string(),
+                },
+            ));
         }
     }
 

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -40,6 +40,7 @@ pub(crate) fn validate_operation(
             diagnostics.push(ValidationError::new(
                 operation.location(),
                 DiagnosticData::SingleRootField {
+                    name: operation.name.clone(),
                     fields: fields
                         .iter()
                         .map(|field| field.field.name.clone())
@@ -61,6 +62,7 @@ pub(crate) fn validate_operation(
             diagnostics.push(ValidationError::new(
                 field.location(),
                 DiagnosticData::IntrospectionField {
+                    name: operation.name.clone(),
                     field: field.name.clone(),
                 },
             ));

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -61,7 +61,7 @@ pub(crate) fn validate_operation(
             diagnostics.push(ValidationError::new(
                 field.location(),
                 DiagnosticData::IntrospectionField {
-                    field: field.name.to_string(),
+                    field: field.name.clone(),
                 },
             ));
         }

--- a/crates/apollo-compiler/src/validation/scalar.rs
+++ b/crates/apollo-compiler/src/validation/scalar.rs
@@ -1,6 +1,6 @@
-use crate::{ast, diagnostics::ApolloDiagnostic, schema, Node, ValidationDatabase};
+use crate::{ast, schema, validation::diagnostics::ValidationError, Node, ValidationDatabase};
 
-pub(crate) fn validate_scalar_definitions(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
+pub(crate) fn validate_scalar_definitions(db: &dyn ValidationDatabase) -> Vec<ValidationError> {
     let mut diagnostics = Vec::new();
 
     let schema = db.schema();
@@ -16,7 +16,7 @@ pub(crate) fn validate_scalar_definitions(db: &dyn ValidationDatabase) -> Vec<Ap
 pub(crate) fn validate_scalar_definition(
     db: &dyn ValidationDatabase,
     scalar_def: Node<schema::ScalarType>,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = Vec::new();
 
     // All built-in scalars must be omitted for brevity.

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -1,6 +1,9 @@
-use crate::{
-    ast, schema, validation::diagnostics::DiagnosticData, Node, ValidationDatabase, ValidationError,
-};
+use crate::ast;
+use crate::schema;
+use crate::validation::diagnostics::DiagnosticData;
+use crate::validation::diagnostics::ValidationError;
+use crate::Node;
+use crate::ValidationDatabase;
 
 pub(crate) fn validate_schema_definition(
     db: &dyn ValidationDatabase,

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -1,8 +1,4 @@
-use crate::{
-    ast,
-    diagnostics::{DiagnosticData, Label},
-    schema, ApolloDiagnostic, Node, ValidationDatabase,
-};
+use crate::{ast, diagnostics::DiagnosticData, schema, ApolloDiagnostic, Node, ValidationDatabase};
 
 pub(crate) fn validate_schema_definition(
     db: &dyn ValidationDatabase,
@@ -18,7 +14,6 @@ pub(crate) fn validate_schema_definition(
     if !has_query {
         let location = schema_definition.definition.location();
         diagnostics.push(ApolloDiagnostic::new(
-            db,
             location,
             DiagnosticData::QueryRootOperationType,
         ));
@@ -66,7 +61,6 @@ pub(crate) fn validate_root_operation_definitions(
                     schema::ExtendedType::Object(_) => unreachable!(),
                 };
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     op_loc,
                     DiagnosticData::RootOperationObjectType {
                         name: name.to_string(),
@@ -77,7 +71,6 @@ pub(crate) fn validate_root_operation_definitions(
         } else {
             let op_loc = name.location();
             diagnostics.push(ApolloDiagnostic::new(
-                db,
                 op_loc,
                 DiagnosticData::UndefinedDefinition {
                     name: name.to_string(),

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -60,7 +60,7 @@ pub(crate) fn validate_root_operation_definitions(
                 diagnostics.push(ValidationError::new(
                     op_loc,
                     DiagnosticData::RootOperationObjectType {
-                        name: name.to_string(),
+                        name: name.clone(),
                         describe_type: type_def.describe(),
                     },
                 ));
@@ -69,9 +69,7 @@ pub(crate) fn validate_root_operation_definitions(
             let op_loc = name.location();
             diagnostics.push(ValidationError::new(
                 op_loc,
-                DiagnosticData::UndefinedDefinition {
-                    name: name.to_string(),
-                },
+                DiagnosticData::UndefinedDefinition { name: name.clone() },
             ));
         }
     }

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -57,19 +57,11 @@ pub(crate) fn validate_root_operation_definitions(
         if let Some(type_def) = type_def {
             if !matches!(type_def, schema::ExtendedType::Object(_)) {
                 let op_loc = name.location();
-                let kind = match type_def {
-                    schema::ExtendedType::Scalar(_) => "scalar",
-                    schema::ExtendedType::Union(_) => "union",
-                    schema::ExtendedType::Enum(_) => "enum",
-                    schema::ExtendedType::Interface(_) => "interface",
-                    schema::ExtendedType::InputObject(_) => "input object",
-                    schema::ExtendedType::Object(_) => unreachable!(),
-                };
                 diagnostics.push(ValidationError::new(
                     op_loc,
                     DiagnosticData::RootOperationObjectType {
                         name: name.to_string(),
-                        ty: kind,
+                        describe_type: type_def.describe(),
                     },
                 ));
             }

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
+use crate::validation::diagnostics::{DiagnosticData, ValidationError};
 use crate::validation::{FileId, ValidationDatabase};
 use crate::{ast, schema, Node};
 
@@ -83,7 +83,7 @@ pub(crate) fn same_response_shape(
     file_id: FileId,
     field_a: FieldAgainstType<'_>,
     field_b: FieldAgainstType<'_>,
-) -> Result<(), ApolloDiagnostic> {
+) -> Result<(), ValidationError> {
     let schema = db.schema();
     // 1. Let typeA be the return type of fieldA.
     let Ok(full_type_a) = schema.type_field(field_a.against_type, &field_a.field.name) else {
@@ -97,7 +97,7 @@ pub(crate) fn same_response_shape(
     let mut type_b = &full_type_b.ty;
 
     let mismatching_type_diagnostic = || {
-        ApolloDiagnostic::new(
+        ValidationError::new(
             field_b.field.location(),
             DiagnosticData::ConflictingFieldType {
                 field: field_a.field.response_name().to_string(),
@@ -227,7 +227,7 @@ fn group_fields_by_name(
 fn identical_arguments(
     field_a: &Node<ast::Field>,
     field_b: &Node<ast::Field>,
-) -> Result<(), ApolloDiagnostic> {
+) -> Result<(), ValidationError> {
     let args_a = &field_a.arguments;
     let args_b = &field_b.arguments;
 
@@ -237,7 +237,7 @@ fn identical_arguments(
     // Check if fieldB provides the same argument names and values as fieldA (order-independent).
     for arg in args_a {
         let Some(other_arg) = args_b.iter().find(|other_arg| other_arg.name == arg.name) else {
-            return Err(ApolloDiagnostic::new(
+            return Err(ValidationError::new(
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
                     field: field_a.name.to_string(),
@@ -251,7 +251,7 @@ fn identical_arguments(
         };
 
         if other_arg.value != arg.value {
-            return Err(ApolloDiagnostic::new(
+            return Err(ValidationError::new(
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
                     field: field_a.name.to_string(),
@@ -267,7 +267,7 @@ fn identical_arguments(
     // Check if fieldB provides any arguments that fieldA does not provide.
     for arg in args_b {
         if !args_a.iter().any(|other_arg| other_arg.name == arg.name) {
-            return Err(ApolloDiagnostic::new(
+            return Err(ValidationError::new(
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
                     field: field_a.name.to_string(),
@@ -295,7 +295,7 @@ pub(crate) fn fields_in_set_can_merge(
     named_fragments: &HashMap<ast::Name, Node<ast::FragmentDefinition>>,
     against_type: &ast::NamedType,
     selection_set: &[ast::Selection],
-) -> Result<(), Vec<ApolloDiagnostic>> {
+) -> Result<(), Vec<ValidationError>> {
     let schema = db.schema();
 
     // 1. Let `fieldsForName` be the set of selections with a given response name in set including visiting fragments and inline fragments.
@@ -323,7 +323,7 @@ pub(crate) fn fields_in_set_can_merge(
             if field_a.against_type == field_b.against_type {
                 // 2bi. fieldA and fieldB must have identical field names.
                 if field_a.field.name != field_b.field.name {
-                    diagnostics.push(ApolloDiagnostic::new(
+                    diagnostics.push(ValidationError::new(
                         field_b.field.location(),
                         DiagnosticData::ConflictingFieldName {
                             field: field_a.field.response_name().to_string(),
@@ -371,7 +371,7 @@ pub(crate) fn validate_selection_set(
     against_type: Option<&ast::NamedType>,
     selection_set: &[ast::Selection],
     context: OperationValidationConfig<'_>,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = vec![];
 
     let named_fragments = Some(db.ast_named_fragments(file_id));
@@ -404,7 +404,7 @@ pub(crate) fn validate_selections(
     against_type: Option<&ast::NamedType>,
     selection_set: &[ast::Selection],
     context: OperationValidationConfig<'_>,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = vec![];
 
     for selection in selection_set {

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -225,7 +225,6 @@ fn group_fields_by_name(
 
 /// Check if the arguments provided to two fields are the same, so the fields can be merged.
 fn identical_arguments(
-    db: &dyn ValidationDatabase,
     field_a: &Node<ast::Field>,
     field_b: &Node<ast::Field>,
 ) -> Result<(), ApolloDiagnostic> {
@@ -337,7 +336,7 @@ pub(crate) fn fields_in_set_can_merge(
                     continue;
                 }
                 // 2bii. fieldA and fieldB must have identical sets of arguments.
-                if let Err(diagnostic) = identical_arguments(db, field_a.field, field_b.field) {
+                if let Err(diagnostic) = identical_arguments(field_a.field, field_b.field) {
                     diagnostics.push(diagnostic);
                     continue;
                 }

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData, Label};
+use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
 use crate::validation::{FileId, ValidationDatabase};
 use crate::{ast, schema, Node};
 
@@ -98,7 +98,6 @@ pub(crate) fn same_response_shape(
 
     let mismatching_type_diagnostic = || {
         ApolloDiagnostic::new(
-            db,
             field_b.field.location(),
             DiagnosticData::ConflictingFieldType {
                 field: field_a.field.response_name().to_string(),
@@ -240,7 +239,6 @@ fn identical_arguments(
     for arg in args_a {
         let Some(other_arg) = args_b.iter().find(|other_arg| other_arg.name == arg.name) else {
             return Err(ApolloDiagnostic::new(
-                db,
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
                     field: field_a.name.to_string(),
@@ -255,7 +253,6 @@ fn identical_arguments(
 
         if other_arg.value != arg.value {
             return Err(ApolloDiagnostic::new(
-                db,
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
                     field: field_a.name.to_string(),
@@ -272,7 +269,6 @@ fn identical_arguments(
     for arg in args_b {
         if !args_a.iter().any(|other_arg| other_arg.name == arg.name) {
             return Err(ApolloDiagnostic::new(
-                db,
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
                     field: field_a.name.to_string(),
@@ -329,7 +325,6 @@ pub(crate) fn fields_in_set_can_merge(
                 // 2bi. fieldA and fieldB must have identical field names.
                 if field_a.field.name != field_b.field.name {
                     diagnostics.push(ApolloDiagnostic::new(
-                        db,
                         field_b.field.location(),
                         DiagnosticData::ConflictingFieldName {
                             field: field_a.field.response_name().to_string(),

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -100,7 +100,7 @@ pub(crate) fn same_response_shape(
         ValidationError::new(
             field_b.field.location(),
             DiagnosticData::ConflictingFieldType {
-                field: field_a.field.response_name().to_string(),
+                field: field_a.field.response_name().clone(),
                 original_selection: field_a.field.location(),
                 original_type: full_type_a.ty.clone(),
                 redefined_selection: field_b.field.location(),
@@ -240,8 +240,8 @@ fn identical_arguments(
             return Err(ValidationError::new(
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
-                    field: field_a.name.to_string(),
-                    argument: arg.name.to_string(),
+                    field: field_a.name.clone(),
+                    argument: arg.name.clone(),
                     original_selection: loc_a,
                     original_value: Some((*arg.value).clone()),
                     redefined_selection: loc_b,
@@ -254,8 +254,8 @@ fn identical_arguments(
             return Err(ValidationError::new(
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
-                    field: field_a.name.to_string(),
-                    argument: arg.name.to_string(),
+                    field: field_a.name.clone(),
+                    argument: arg.name.clone(),
                     original_selection: loc_a,
                     original_value: Some((*arg.value).clone()),
                     redefined_selection: loc_b,
@@ -270,8 +270,8 @@ fn identical_arguments(
             return Err(ValidationError::new(
                 loc_b,
                 DiagnosticData::ConflictingFieldArgument {
-                    field: field_a.name.to_string(),
-                    argument: arg.name.to_string(),
+                    field: field_a.name.clone(),
+                    argument: arg.name.clone(),
                     original_selection: loc_a,
                     original_value: None,
                     redefined_selection: loc_b,
@@ -326,11 +326,11 @@ pub(crate) fn fields_in_set_can_merge(
                     diagnostics.push(ValidationError::new(
                         field_b.field.location(),
                         DiagnosticData::ConflictingFieldName {
-                            field: field_a.field.response_name().to_string(),
+                            field: field_a.field.response_name().clone(),
                             original_selection: field_a.field.location(),
-                            original_name: field_a.field.name.to_string(),
+                            original_name: field_a.field.name.clone(),
                             redefined_selection: field_b.field.location(),
-                            redefined_name: field_b.field.name.to_string(),
+                            redefined_name: field_b.field.name.clone(),
                         },
                     ));
                     continue;

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -35,43 +35,33 @@ pub(crate) fn validate_union_definition(
         match schema.types.get(union_member) {
             None => {
                 // Union member must be defined.
-                diagnostics.push(
-                    ApolloDiagnostic::new(
-                        db,
-                        member_location,
-                        DiagnosticData::UndefinedDefinition {
-                            name: union_member.to_string(),
-                        },
-                    )
-                    .label(Label::new(member_location, "not found in this scope")),
-                );
+                diagnostics.push(ApolloDiagnostic::new(
+                    db,
+                    member_location,
+                    DiagnosticData::UndefinedDefinition {
+                        name: union_member.to_string(),
+                    },
+                ));
             }
             Some(schema::ExtendedType::Object(_)) => {} // good
             Some(ty) => {
                 // Union member must be of object type.
-                let (particle, kind) = match ty {
+                let kind = match ty {
                     schema::ExtendedType::Object(_) => unreachable!(),
-                    schema::ExtendedType::Scalar(_) => ("a", "scalar"),
-                    schema::ExtendedType::Interface(_) => ("an", "interface"),
-                    schema::ExtendedType::Union(_) => ("an", "union"),
-                    schema::ExtendedType::Enum(_) => ("an", "enum"),
-                    schema::ExtendedType::InputObject(_) => ("an", "input object"),
+                    schema::ExtendedType::Scalar(_) => "scalar",
+                    schema::ExtendedType::Interface(_) => "interface",
+                    schema::ExtendedType::Union(_) => "union",
+                    schema::ExtendedType::Enum(_) => "enum",
+                    schema::ExtendedType::InputObject(_) => "input object",
                 };
-                diagnostics.push(
-                    ApolloDiagnostic::new(
-                        db,
-                        member_location,
-                        DiagnosticData::ObjectType {
-                            name: union_member.to_string(),
-                            ty: kind,
-                        },
-                    )
-                    .label(Label::new(
-                        member_location,
-                        format!("This is a {particle} {kind}"),
-                    ))
-                    .help("Union members must be of base Object Type."),
-                );
+                diagnostics.push(ApolloDiagnostic::new(
+                    db,
+                    member_location,
+                    DiagnosticData::UnionMemberObjectType {
+                        name: union_member.to_string(),
+                        ty: kind,
+                    },
+                ));
             }
         }
     }

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast,
-    diagnostics::{ApolloDiagnostic, DiagnosticData, Label},
+    diagnostics::{ApolloDiagnostic, DiagnosticData},
     schema, ValidationDatabase,
 };
 
@@ -36,7 +36,6 @@ pub(crate) fn validate_union_definition(
             None => {
                 // Union member must be defined.
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     member_location,
                     DiagnosticData::UndefinedDefinition {
                         name: union_member.to_string(),
@@ -55,7 +54,6 @@ pub(crate) fn validate_union_definition(
                     schema::ExtendedType::InputObject(_) => "input object",
                 };
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     member_location,
                     DiagnosticData::UnionMemberObjectType {
                         name: union_member.to_string(),

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -1,10 +1,10 @@
 use crate::{
-    ast,
-    diagnostics::{ApolloDiagnostic, DiagnosticData},
-    schema, ValidationDatabase,
+    ast, schema,
+    validation::diagnostics::{DiagnosticData, ValidationError},
+    ValidationDatabase,
 };
 
-pub(crate) fn validate_union_definitions(db: &dyn ValidationDatabase) -> Vec<ApolloDiagnostic> {
+pub(crate) fn validate_union_definitions(db: &dyn ValidationDatabase) -> Vec<ValidationError> {
     let mut diagnostics = Vec::new();
 
     for def in db.ast_types().unions.values() {
@@ -17,7 +17,7 @@ pub(crate) fn validate_union_definitions(db: &dyn ValidationDatabase) -> Vec<Apo
 pub(crate) fn validate_union_definition(
     db: &dyn ValidationDatabase,
     union_def: ast::TypeWithExtensions<ast::UnionTypeDefinition>,
-) -> Vec<ApolloDiagnostic> {
+) -> Vec<ValidationError> {
     let mut diagnostics = super::directive::validate_directives(
         db,
         union_def.directives(),
@@ -35,7 +35,7 @@ pub(crate) fn validate_union_definition(
         match schema.types.get(union_member) {
             None => {
                 // Union member must be defined.
-                diagnostics.push(ApolloDiagnostic::new(
+                diagnostics.push(ValidationError::new(
                     member_location,
                     DiagnosticData::UndefinedDefinition {
                         name: union_member.to_string(),
@@ -53,7 +53,7 @@ pub(crate) fn validate_union_definition(
                     schema::ExtendedType::Enum(_) => "enum",
                     schema::ExtendedType::InputObject(_) => "input object",
                 };
-                diagnostics.push(ApolloDiagnostic::new(
+                diagnostics.push(ValidationError::new(
                     member_location,
                     DiagnosticData::UnionMemberObjectType {
                         name: union_member.to_string(),

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -38,7 +38,7 @@ pub(crate) fn validate_union_definition(
                 diagnostics.push(ValidationError::new(
                     member_location,
                     DiagnosticData::UndefinedDefinition {
-                        name: union_member.to_string(),
+                        name: union_member.clone(),
                     },
                 ));
             }
@@ -48,7 +48,7 @@ pub(crate) fn validate_union_definition(
                 diagnostics.push(ValidationError::new(
                     member_location,
                     DiagnosticData::UnionMemberObjectType {
-                        name: union_member.to_string(),
+                        name: union_member.clone(),
                         describe_type: ty.describe(),
                     },
                 ));

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -45,19 +45,11 @@ pub(crate) fn validate_union_definition(
             Some(schema::ExtendedType::Object(_)) => {} // good
             Some(ty) => {
                 // Union member must be of object type.
-                let kind = match ty {
-                    schema::ExtendedType::Object(_) => unreachable!(),
-                    schema::ExtendedType::Scalar(_) => "scalar",
-                    schema::ExtendedType::Interface(_) => "interface",
-                    schema::ExtendedType::Union(_) => "union",
-                    schema::ExtendedType::Enum(_) => "enum",
-                    schema::ExtendedType::InputObject(_) => "input object",
-                };
                 diagnostics.push(ValidationError::new(
                     member_location,
                     DiagnosticData::UnionMemberObjectType {
                         name: union_member.to_string(),
-                        ty: kind,
+                        describe_type: ty.describe(),
                     },
                 ));
             }

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast,
-    diagnostics::{ApolloDiagnostic, DiagnosticData, Label},
+    diagnostics::{ApolloDiagnostic, DiagnosticData},
     schema,
     validation::ValidationDatabase,
     Node,
@@ -12,7 +12,6 @@ fn unsupported_type(
     declared_type: &Node<ast::Type>,
 ) -> ApolloDiagnostic {
     ApolloDiagnostic::new(
-        db,
         value.location(),
         DiagnosticData::UnsupportedValueType {
             value: value.kind().into(),
@@ -63,7 +62,6 @@ pub(crate) fn value_of_correct_type(
                 "Int" => {
                     if int.try_to_i32().is_err() {
                         diagnostics.push(ApolloDiagnostic::new(
-                            db,
                             arg_value.location(),
                             DiagnosticData::IntCoercionError {
                                 value: int.as_str().to_owned(),
@@ -74,7 +72,6 @@ pub(crate) fn value_of_correct_type(
                 "Float" => {
                     if int.try_to_f64().is_err() {
                         diagnostics.push(ApolloDiagnostic::new(
-                            db,
                             arg_value.location(),
                             DiagnosticData::FloatCoercionError {
                                 value: int.as_str().to_owned(),
@@ -96,7 +93,6 @@ pub(crate) fn value_of_correct_type(
             schema::ExtendedType::Scalar(scalar) if scalar.name == "Float" => {
                 if float.try_to_f64().is_err() {
                     diagnostics.push(ApolloDiagnostic::new(
-                        db,
                         arg_value.location(),
                         DiagnosticData::FloatCoercionError {
                             value: float.as_str().to_owned(),
@@ -171,7 +167,6 @@ pub(crate) fn value_of_correct_type(
             schema::ExtendedType::Enum(enum_) => {
                 if !enum_.values.contains_key(value) {
                     diagnostics.push(ApolloDiagnostic::new(
-                        db,
                         value.location(),
                         DiagnosticData::UndefinedEnumValue {
                             value: value.to_string(),
@@ -219,7 +214,6 @@ pub(crate) fn value_of_correct_type(
                 // object type
                 if let Some((name, value)) = undefined_field {
                     diagnostics.push(ApolloDiagnostic::new(
-                        db,
                         value.location(),
                         DiagnosticData::UndefinedInputValue {
                             value: name.to_string(),
@@ -242,7 +236,6 @@ pub(crate) fn value_of_correct_type(
                     // raised.
                     if (ty.is_non_null() && f.default_value.is_none()) && (is_missing || is_null) {
                         diagnostics.push(ApolloDiagnostic::new(
-                            db,
                             arg_value.location(),
                             DiagnosticData::RequiredArgument {
                                 name: input_name.to_string(),

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -164,8 +164,8 @@ pub(crate) fn value_of_correct_type(
                     diagnostics.push(ValidationError::new(
                         value.location(),
                         DiagnosticData::UndefinedEnumValue {
-                            value: value.to_string(),
-                            definition: enum_.name.to_string(),
+                            value: value.clone(),
+                            definition: enum_.name.clone(),
                             definition_location: enum_.location(),
                         },
                     ));
@@ -211,8 +211,8 @@ pub(crate) fn value_of_correct_type(
                     diagnostics.push(ValidationError::new(
                         value.location(),
                         DiagnosticData::UndefinedInputValue {
-                            value: name.to_string(),
-                            definition: input_obj.name.to_string(),
+                            value: name.clone(),
+                            definition: input_obj.name.clone(),
                             definition_location: input_obj.location(),
                         },
                     ));
@@ -233,7 +233,7 @@ pub(crate) fn value_of_correct_type(
                         diagnostics.push(ValidationError::new(
                             arg_value.location(),
                             DiagnosticData::RequiredArgument {
-                                name: input_name.to_string(),
+                                name: input_name.clone(),
                                 coordinate: format!("{}.{}", input_obj.name, input_name),
                                 definition_location: f.location(),
                             },

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -9,7 +9,7 @@ fn unsupported_type(value: &Node<ast::Value>, declared_type: &Node<ast::Type>) -
     ValidationError::new(
         value.location(),
         DiagnosticData::UnsupportedValueType {
-            value: value.kind().into(),
+            describe_value_type: value.describe(),
             ty: declared_type.to_string(),
             definition_location: declared_type.location(),
         },

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -245,7 +245,6 @@ pub(crate) fn validate_unused_variables(
 }
 
 pub(crate) fn validate_variable_usage(
-    db: &dyn ValidationDatabase,
     var_usage: Node<ast::InputValueDefinition>,
     var_defs: &[Node<ast::VariableDefinition>],
     argument: &Node<ast::Argument>,

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -2,7 +2,7 @@ use crate::validation::diagnostics::{DiagnosticData, ValidationError};
 use crate::validation::{
     FileId, NodeLocation, RecursionGuard, RecursionLimitError, RecursionStack,
 };
-use crate::{ast, schema, Node, ValidationDatabase};
+use crate::{ast, Node, ValidationDatabase};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
@@ -34,19 +34,11 @@ pub(crate) fn validate_variable_definitions(
                     // OK!
                 }
                 Some(type_definition) => {
-                    let kind = match type_definition {
-                        schema::ExtendedType::Scalar(_) => "scalar",
-                        schema::ExtendedType::Object(_) => "object",
-                        schema::ExtendedType::Interface(_) => "interface",
-                        schema::ExtendedType::Union(_) => "union",
-                        schema::ExtendedType::Enum(_) => "enum",
-                        schema::ExtendedType::InputObject(_) => "input object",
-                    };
                     diagnostics.push(ValidationError::new(
                         variable.location(),
                         DiagnosticData::VariableInputType {
                             name: variable.name.to_string(),
-                            ty: kind,
+                            describe_type: type_definition.describe(),
                             type_location: ty.location(),
                         },
                     ));

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -37,7 +37,7 @@ pub(crate) fn validate_variable_definitions(
                     diagnostics.push(ValidationError::new(
                         variable.location(),
                         DiagnosticData::VariableInputType {
-                            name: variable.name.to_string(),
+                            name: variable.name.clone(),
                             describe_type: type_definition.describe(),
                             type_location: ty.location(),
                         },
@@ -46,7 +46,7 @@ pub(crate) fn validate_variable_definitions(
                 None => diagnostics.push(ValidationError::new(
                     variable.location(),
                     DiagnosticData::UndefinedDefinition {
-                        name: ty.inner_named_type().to_string(),
+                        name: ty.inner_named_type().clone(),
                     },
                 )),
             }
@@ -59,7 +59,7 @@ pub(crate) fn validate_variable_definitions(
                 diagnostics.push(ValidationError::new(
                     redefined_definition,
                     DiagnosticData::UniqueVariable {
-                        name: variable.name.to_string(),
+                        name: variable.name.clone(),
                         original_definition,
                         redefined_definition,
                     },
@@ -228,7 +228,7 @@ pub(crate) fn validate_unused_variables(
         ValidationError::new(
             loc,
             DiagnosticData::UnusedVariable {
-                name: unused_var.to_string(),
+                name: unused_var.clone(),
             },
         )
     }));
@@ -251,10 +251,10 @@ pub(crate) fn validate_variable_usage(
                 return Err(ValidationError::new(
                     argument.location(),
                     DiagnosticData::DisallowedVariableUsage {
-                        variable: var_def.name.to_string(),
+                        variable: var_def.name.clone(),
                         variable_type: (*var_def.ty).clone(),
                         variable_location: var_def.location(),
-                        argument: argument.name.to_string(),
+                        argument: argument.name.clone(),
                         argument_type: (*var_usage.ty).clone(),
                         argument_location: argument.location(),
                     },
@@ -264,7 +264,7 @@ pub(crate) fn validate_variable_usage(
             return Err(ValidationError::new(
                 argument.value.location(),
                 DiagnosticData::UndefinedVariable {
-                    name: var_name.to_string(),
+                    name: var_name.clone(),
                 },
             ));
         }

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics::{ApolloDiagnostic, DiagnosticData, Label};
+use crate::diagnostics::{ApolloDiagnostic, DiagnosticData};
 use crate::validation::{
     FileId, NodeLocation, RecursionGuard, RecursionLimitError, RecursionStack,
 };
@@ -43,7 +43,6 @@ pub(crate) fn validate_variable_definitions(
                         schema::ExtendedType::InputObject(_) => "input object",
                     };
                     diagnostics.push(ApolloDiagnostic::new(
-                        db,
                         variable.location(),
                         DiagnosticData::VariableInputType {
                             name: variable.name.to_string(),
@@ -53,7 +52,6 @@ pub(crate) fn validate_variable_definitions(
                     ));
                 }
                 None => diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     variable.location(),
                     DiagnosticData::UndefinedDefinition {
                         name: ty.inner_named_type().to_string(),
@@ -67,7 +65,6 @@ pub(crate) fn validate_variable_definitions(
                 let original_definition = original.get().location();
                 let redefined_definition = variable.location();
                 diagnostics.push(ApolloDiagnostic::new(
-                    db,
                     redefined_definition,
                     DiagnosticData::UniqueVariable {
                         name: variable.name.to_string(),
@@ -226,7 +223,6 @@ pub(crate) fn validate_unused_variables(
     );
     if walked.is_err() {
         diagnostics.push(ApolloDiagnostic::new(
-            db,
             None,
             DiagnosticData::RecursionError {},
         ));
@@ -238,7 +234,6 @@ pub(crate) fn validate_unused_variables(
     diagnostics.extend(unused_vars.map(|unused_var| {
         let loc = locations[unused_var];
         ApolloDiagnostic::new(
-            db,
             loc,
             DiagnosticData::UnusedVariable {
                 name: unused_var.to_string(),
@@ -263,7 +258,6 @@ pub(crate) fn validate_variable_usage(
             let is_allowed = is_variable_usage_allowed(var_def, &var_usage);
             if !is_allowed {
                 return Err(ApolloDiagnostic::new(
-                    db,
                     argument.location(),
                     DiagnosticData::DisallowedVariableUsage {
                         variable: var_def.name.to_string(),
@@ -277,7 +271,6 @@ pub(crate) fn validate_variable_usage(
             }
         } else {
             return Err(ApolloDiagnostic::new(
-                db,
                 argument.value.location(),
                 DiagnosticData::UndefinedVariable {
                     name: var_name.to_string(),

--- a/crates/apollo-compiler/test_data/diagnostics/0003_anonymous_and_named_operation.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0003_anonymous_and_named_operation.txt
@@ -9,7 +9,7 @@ Error: anonymous operation cannot be selected when the document contains other o
    │     
    │     Help: GraphQL requires operations to be named if the document has more than one
 ───╯
-Error: the required argument `name` is not provided
+Error: the required argument `Mutation.addPet(name:)` is not provided
     ╭─[0003_anonymous_and_named_operation.graphql:6:3]
     │
   6 │ ╭─▶   addPet {

--- a/crates/apollo-compiler/test_data/diagnostics/0005_subscription_with_multiple_root_fields_in_fragment_spreads.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0005_subscription_with_multiple_root_fields_in_fragment_spreads.txt
@@ -1,4 +1,4 @@
-Error: subscription operations can only have one root field
+Error: subscription `sub` can only have one root field
    ╭─[0005_subscription_with_multiple_root_fields_in_fragment_spreads.graphql:1:1]
    │
  1 │ ╭─▶ subscription sub {

--- a/crates/apollo-compiler/test_data/diagnostics/0006_subscription_with_multiple_root_fields_in_inline_fragments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0006_subscription_with_multiple_root_fields_in_inline_fragments.txt
@@ -1,4 +1,4 @@
-Error: subscription operations can only have one root field
+Error: subscription `sub` can only have one root field
    ╭─[0006_subscription_with_multiple_root_fields_in_inline_fragments.graphql:1:1]
    │
  1 │ ╭─▶ subscription sub {

--- a/crates/apollo-compiler/test_data/diagnostics/0007_operation_with_undefined_variables.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0007_operation_with_undefined_variables.txt
@@ -1,5 +1,5 @@
-Error: variable `undefinedVariable` is not defined
-   ╭─[0007_operation_with_undefined_variables.graphql:2:15]
+Error: variable `$undefinedVariable` is not defined
+   ╭─[0007_operation_with_undefined_variables.graphql:2:22]
    │
  2 │   topProducts(first: $undefinedVariable) {
    │                      ─────────┬────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0008_operation_with_undefined_variables_in_inline_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0008_operation_with_undefined_variables_in_inline_fragment.txt
@@ -1,5 +1,5 @@
-Error: variable `value` is not defined
-   ╭─[0008_operation_with_undefined_variables_in_inline_fragment.graphql:5:15]
+Error: variable `$value` is not defined
+   ╭─[0008_operation_with_undefined_variables_in_inline_fragment.graphql:5:25]
    │
  5 │         price(setPrice: $value)
    │                         ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0009_operation_with_undefined_variables_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0009_operation_with_undefined_variables_in_fragment.txt
@@ -1,5 +1,5 @@
-Error: variable `value` is not defined
-    ╭─[0009_operation_with_undefined_variables_in_fragment.graphql:10:11]
+Error: variable `$value` is not defined
+    ╭─[0009_operation_with_undefined_variables_in_fragment.graphql:10:21]
     │
  10 │     price(setPrice: $value)
     │                     ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0010_operation_with_unused_variable.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0010_operation_with_unused_variable.txt
@@ -1,8 +1,8 @@
-Error: unused variable: `unusedVariable`
+Error: unused variable: `$unusedVariable`
    ╭─[0010_operation_with_unused_variable.graphql:1:20]
    │
  1 │ query ExampleQuery($unusedVariable: Int) {
    │                    ───────┬───────  
-   │                           ╰───────── this variable is never used
+   │                           ╰───────── variable is never used
 ───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0025_interface_definition_with_missing_transitive_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0025_interface_definition_with_missing_transitive_fields.txt
@@ -1,9 +1,9 @@
-Error: type does not satisfy interface `Resource`: missing field `width`
+Error: type `Image` does not satisfy interface `Resource`: missing field `width`
     ╭─[0025_interface_definition_with_missing_transitive_fields.graphql:14:1]
     │
  11 │       width: Int
     │       ─────┬────  
-    │            ╰────── `width` was originally defined by Resource here
+    │            ╰────── `Resource.width` originally defined here
     │ 
  14 │ ╭─▶ interface Image implements Resource & Node {
     │ │                              ────┬───  
@@ -11,8 +11,8 @@ Error: type does not satisfy interface `Resource`: missing field `width`
     ┆ ┆   
  17 │ ├─▶ }
     │ │      
-    │ ╰────── add `width` field to this interface
+    │ ╰────── add `width` field to this type
     │     
-    │     Help: An interface must be a super-set of all interfaces it implements
+    │     Help: An object or interface must declare all fields required by the interfaces it implements
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0026_interface_definition_with_missing_implemetns_interface.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0026_interface_definition_with_missing_implemetns_interface.txt
@@ -1,4 +1,4 @@
-Error: Transitively implemented interfaces must also be defined on an implementing interface or object
+Error: interface `Image` declares that it implements `Resource`, but to do so it must also implement `Node`
     ╭─[0026_interface_definition_with_missing_implemetns_interface.graphql:15:1]
     │
   9 │     interface Resource implements Node {

--- a/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
@@ -11,12 +11,12 @@ Error: Transitively implemented interfaces must also be defined on an implementi
     │ │      
     │ ╰────── Node must also be implemented here
 ────╯
-Error: type does not satisfy interface `Resource`: missing field `width`
+Error: type `Image` does not satisfy interface `Resource`: missing field `width`
     ╭─[0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:1]
     │
  11 │       width: Int
     │       ─────┬────  
-    │            ╰────── `width` was originally defined by Resource here
+    │            ╰────── `Resource.width` originally defined here
     │ 
  14 │ ╭─▶ interface Image implements Resource & Url{
     │ │                              ────┬───  
@@ -24,9 +24,9 @@ Error: type does not satisfy interface `Resource`: missing field `width`
     ┆ ┆   
  17 │ ├─▶ }
     │ │      
-    │ ╰────── add `width` field to this interface
+    │ ╰────── add `width` field to this type
     │     
-    │     Help: An interface must be a super-set of all interfaces it implements
+    │     Help: An object or interface must declare all fields required by the interfaces it implements
 ────╯
 Error: cannot find type `Url` in this document
     ╭─[0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:39]

--- a/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
@@ -1,4 +1,4 @@
-Error: Transitively implemented interfaces must also be defined on an implementing interface or object
+Error: interface `Image` declares that it implements `Resource`, but to do so it must also implement `Node`
     ╭─[0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:1]
     │
   9 │     interface Resource implements Node {

--- a/crates/apollo-compiler/test_data/diagnostics/0034_object_type_definition_with_missing_transitive_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0034_object_type_definition_with_missing_transitive_fields.txt
@@ -1,4 +1,4 @@
-Error: type does not satisfy interface `Node`: missing field `id`
+Error: type `Node` does not satisfy interface `Node`: missing field `id`
    ╭─[0034_object_type_definition_with_missing_transitive_fields.graphql:1:1]
    │
  1 │ ╭─▶ type Query implements Node & Resource {
@@ -7,15 +7,15 @@ Error: type does not satisfy interface `Node`: missing field `id`
    ┆ ┆   
  3 │ ├─▶ }
    │ │       
-   │ ╰─────── add `id` field to this object
+   │ ╰─────── add `id` field to this type
    │ 
  6 │       id: ID!
    │       ───┬───  
-   │          ╰───── `id` was originally defined by Node here
+   │          ╰───── `Node.id` originally defined here
    │     
-   │     Help: An object must provide all fields required by the interfaces it implements
+   │     Help: An object or interface must declare all fields required by the interfaces it implements
 ───╯
-Error: type does not satisfy interface `Resource`: missing field `width`
+Error: type `Resource` does not satisfy interface `Resource`: missing field `width`
     ╭─[0034_object_type_definition_with_missing_transitive_fields.graphql:1:1]
     │
   1 │ ╭─▶ type Query implements Node & Resource {
@@ -24,12 +24,12 @@ Error: type does not satisfy interface `Resource`: missing field `width`
     ┆ ┆   
   3 │ ├─▶ }
     │ │       
-    │ ╰─────── add `width` field to this object
+    │ ╰─────── add `width` field to this type
     │ 
  10 │       width: Int
     │       ─────┬────  
-    │            ╰────── `width` was originally defined by Resource here
+    │            ╰────── `Resource.width` originally defined here
     │     
-    │     Help: An object must provide all fields required by the interfaces it implements
+    │     Help: An object or interface must declare all fields required by the interfaces it implements
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0034_object_type_definition_with_missing_transitive_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0034_object_type_definition_with_missing_transitive_fields.txt
@@ -1,4 +1,4 @@
-Error: type `Node` does not satisfy interface `Node`: missing field `id`
+Error: type `Query` does not satisfy interface `Node`: missing field `id`
    ╭─[0034_object_type_definition_with_missing_transitive_fields.graphql:1:1]
    │
  1 │ ╭─▶ type Query implements Node & Resource {
@@ -15,7 +15,7 @@ Error: type `Node` does not satisfy interface `Node`: missing field `id`
    │     
    │     Help: An object or interface must declare all fields required by the interfaces it implements
 ───╯
-Error: type `Resource` does not satisfy interface `Resource`: missing field `width`
+Error: type `Query` does not satisfy interface `Resource`: missing field `width`
     ╭─[0034_object_type_definition_with_missing_transitive_fields.graphql:1:1]
     │
   1 │ ╭─▶ type Query implements Node & Resource {

--- a/crates/apollo-compiler/test_data/diagnostics/0035_object_type_definition_with_missing_implements_interfaces_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0035_object_type_definition_with_missing_implements_interfaces_definition.txt
@@ -1,4 +1,4 @@
-Error: Transitively implemented interfaces must also be defined on an implementing interface or object
+Error: interface `Query` declares that it implements `Image`, but to do so it must also implement `Resource`
     ╭─[0035_object_type_definition_with_missing_implements_interfaces_definition.graphql:1:1]
     │
   1 │ ╭─▶ type Query implements Image {
@@ -11,7 +11,7 @@ Error: Transitively implemented interfaces must also be defined on an implementi
     │                                ────┬───  
     │                                    ╰───── implementation of Resource declared by Image here
 ────╯
-Error: Transitively implemented interfaces must also be defined on an implementing interface or object
+Error: interface `Image` declares that it implements `Resource`, but to do so it must also implement `Node`
     ╭─[0035_object_type_definition_with_missing_implements_interfaces_definition.graphql:19:1]
     │
  13 │     interface Resource implements Node {

--- a/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
@@ -9,8 +9,8 @@ Error: `coordinates` field must return an output type
     ╭─[0036_object_type_with_non_output_field_types.graphql:21:3]
     │
  21 │   coordinates: Point2D
-    │   ──────────┬─────────  
-    │             ╰─────────── this is an input object
+    │                ───┬───  
+    │                   ╰───── this is an input object
     │ 
     │ Help: Scalars, Objects, Interfaces, Unions and Enums are output types. Change `coordinates` field to return one of these output types.
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
@@ -10,7 +10,7 @@ Error: `coordinates` field must return an output type
     │
  21 │   coordinates: Point2D
     │                ───┬───  
-    │                   ╰───── this is an input object
+    │                   ╰───── this is an input object type
     │ 
     │ Help: Scalars, Objects, Interfaces, Unions and Enums are output types. Change `coordinates` field to return one of these output types.
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
@@ -9,8 +9,8 @@ Error: `coordinates` field must return an output type
     ╭─[0037_interface_with_non_output_fields.graphql:19:3]
     │
  19 │   coordinates: Point2D
-    │   ──────────┬─────────  
-    │             ╰─────────── this is an input object
+    │                ───┬───  
+    │                   ╰───── this is an input object
     │ 
     │ Help: Scalars, Objects, Interfaces, Unions and Enums are output types. Change `coordinates` field to return one of these output types.
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
@@ -10,7 +10,7 @@ Error: `coordinates` field must return an output type
     │
  19 │   coordinates: Point2D
     │                ───┬───  
-    │                   ╰───── this is an input object
+    │                   ╰───── this is an input object type
     │ 
     │ Help: Scalars, Objects, Interfaces, Unions and Enums are output types. Change `coordinates` field to return one of these output types.
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0044_union_member_not_of_object_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0044_union_member_not_of_object_type.txt
@@ -1,10 +1,10 @@
-Error: `Pet` field must return an object type
+Error: union member `Pet` must be an object type
     ╭─[0044_union_member_not_of_object_type.graphql:17:24]
     │
  17 │ union CatOrDog = Cat | Pet
     │                        ─┬─  
-    │                         ╰─── This is a an interface
+    │                         ╰─── this is an interface
     │ 
-    │ Help: Union members must be of base Object Type.
+    │ Help: Union members must be object types.
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0044_union_member_not_of_object_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0044_union_member_not_of_object_type.txt
@@ -3,7 +3,7 @@ Error: union member `Pet` must be an object type
     │
  17 │ union CatOrDog = Cat | Pet
     │                        ─┬─  
-    │                         ╰─── this is an interface
+    │                         ╰─── this is an interface type
     │ 
     │ Help: Union members must be object types.
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0045_operation_with_unused_variable_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0045_operation_with_unused_variable_in_fragment.txt
@@ -1,9 +1,9 @@
-Error: unused variable: `variable`
+Error: unused variable: `$variable`
    ╭─[0045_operation_with_unused_variable_in_fragment.graphql:1:20]
    │
  1 │ query ExampleQuery($variable: Int) {
    │                    ────┬────  
-   │                        ╰────── this variable is never used
+   │                        ╰────── variable is never used
 ───╯
 Error: fragment `unusedFrag` must be used in an operation
     ╭─[0045_operation_with_unused_variable_in_fragment.graphql:7:1]

--- a/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.txt
@@ -1,4 +1,4 @@
-Error: the argument `url` is defined multiple times
+Error: the argument `url` is provided multiple times
    ╭─[0046_duplicate_directive_arguments.graphql:1:75]
    │
  1 │ scalar newScalar @specifiedBy(url: "https://tools.ietf.org/html/rfc4122", url: "https://tools.ietf.org/html/rfc4125")
@@ -9,7 +9,7 @@ Error: the argument `url` is defined multiple times
    │ 
    │ Help: `url` argument must only be provided once.
 ───╯
-Error: the argument `if` is defined multiple times
+Error: the argument `if` is provided multiple times
    ╭─[0046_duplicate_directive_arguments.graphql:5:40]
    │
  5 │   response: String @example(if: false, if: true)

--- a/crates/apollo-compiler/test_data/diagnostics/0047_duplicate_field_arguments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0047_duplicate_field_arguments.txt
@@ -1,4 +1,4 @@
-Error: the argument `arg` is defined multiple times
+Error: the argument `arg` is provided multiple times
    ╭─[0047_duplicate_field_arguments.graphql:5:21]
    │
  5 │   single(arg: true, arg: false)

--- a/crates/apollo-compiler/test_data/diagnostics/0048_duplicate_field_argument_definition_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0048_duplicate_field_argument_definition_names.txt
@@ -5,9 +5,9 @@ Error: the value `arg` is defined multiple times
    │             ──────┬─────  ──────┬─────  
    │                   ╰───────────────────── previous definition of `arg` here
    │                                 │       
-   │                                 ╰─────── `arg` redefined here
+   │                                 ╰─────── `arg` defined again here
    │ 
-   │ Help: `arg` field must only be defined once in this input object definition.
+   │ Help: `arg` must only be defined once in this argument list or input object definition.
 ───╯
 Error: the value `arg` is defined multiple times
    ╭─[0048_duplicate_field_argument_definition_names.graphql:7:13]
@@ -16,8 +16,8 @@ Error: the value `arg` is defined multiple times
    │             ──────┬─────  ──────┬─────  
    │                   ╰───────────────────── previous definition of `arg` here
    │                                 │       
-   │                                 ╰─────── `arg` redefined here
+   │                                 ╰─────── `arg` defined again here
    │ 
-   │ Help: `arg` field must only be defined once in this input object definition.
+   │ Help: `arg` must only be defined once in this argument list or input object definition.
 ───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0049_duplicate_directive_argument_definition_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0049_duplicate_directive_argument_definition_names.txt
@@ -5,8 +5,8 @@ Error: the value `arg` is defined multiple times
    │                    ──────┬─────  ──────┬─────  
    │                          ╰───────────────────── previous definition of `arg` here
    │                                        │       
-   │                                        ╰─────── `arg` redefined here
+   │                                        ╰─────── `arg` defined again here
    │ 
-   │ Help: `arg` field must only be defined once in this input object definition.
+   │ Help: `arg` must only be defined once in this argument list or input object definition.
 ───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
@@ -1,208 +1,288 @@
 Error: skip directive is not supported for VARIABLE_DEFINITION location
-   ╭─[0050_directives_in_invalid_locations.graphql:1:30]
-   │
- 1 │ query queryA($status: String @skip(if: true)) @skip(if: false){
-   │                              ───────┬───────  
-   │                                     ╰───────── VARIABLE_DEFINITION is not a valid location
-   │ 
-   │ Help: the directive must be used in a location that the service has declared support for
-───╯
+     ╭─[0050_directives_in_invalid_locations.graphql:1:30]
+     │
+   1 │ query queryA($status: String @skip(if: true)) @skip(if: false){
+     │                              ───────┬───────  
+     │                                     ╰───────── directive cannot be used on VARIABLE_DEFINITION
+     │
+     ├─[built_in.graphql:96:1]
+     │
+  96 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
+     ┆ ┆   
+ 100 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+     │ │                                                    
+     │ ╰──────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
+─────╯
 Error: skip directive is not supported for QUERY location
-   ╭─[0050_directives_in_invalid_locations.graphql:1:47]
-   │
- 1 │ query queryA($status: String @skip(if: true)) @skip(if: false){
-   │                                               ────────┬───────  
-   │                                                       ╰───────── QUERY is not a valid location
-   │ 
-   │ Help: the directive must be used in a location that the service has declared support for
-───╯
+     ╭─[0050_directives_in_invalid_locations.graphql:1:47]
+     │
+   1 │ query queryA($status: String @skip(if: true)) @skip(if: false){
+     │                                               ────────┬───────  
+     │                                                       ╰───────── directive cannot be used on QUERY
+     │
+     ├─[built_in.graphql:96:1]
+     │
+  96 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
+     ┆ ┆   
+ 100 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+     │ │                                                    
+     │ ╰──────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
+─────╯
 Error: deprecated directive is not supported for FIELD location
-   ╭─[0050_directives_in_invalid_locations.graphql:3:29]
-   │
- 3 │   response(status: $status) @deprecated
-   │                             ─────┬─────  
-   │                                  ╰─────── FIELD is not a valid location
-   │ 
-   │ Help: the directive must be used in a location that the service has declared support for
-───╯
+     ╭─[0050_directives_in_invalid_locations.graphql:3:29]
+     │
+   3 │   response(status: $status) @deprecated
+     │                             ─────┬─────  
+     │                                  ╰─────── directive cannot be used on FIELD
+     │
+     ├─[built_in.graphql:108:1]
+     │
+ 108 │ ╭─▶ "Marks an element of a GraphQL schema as no longer supported."
+     ┆ ┆   
+ 117 │ ├─▶ ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+     │ │                                                                                       
+     │ ╰─────────────────────────────────────────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD_DEFINITION, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION, ENUM_VALUE
+─────╯
 Error: directiveB directive is not supported for FRAGMENT_SPREAD location
     ╭─[0050_directives_in_invalid_locations.graphql:5:20]
     │
   5 │     pets { ... pet @directiveB }
     │                    ─────┬─────  
-    │                         ╰─────── FRAGMENT_SPREAD is not a valid location
+    │                         ╰─────── directive cannot be used on FRAGMENT_SPREAD
     │ 
  89 │ directive @directiveB on ENUM
     │ ──────────────┬──────────────  
-    │               ╰──────────────── consider adding FRAGMENT_SPREAD directive location here
+    │               ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 Error: directiveB directive is not supported for FRAGMENT_DEFINITION location
     ╭─[0050_directives_in_invalid_locations.graphql:9:21]
     │
   9 │ fragment pet on Cat @directiveB {
     │                     ─────┬─────  
-    │                          ╰─────── FRAGMENT_DEFINITION is not a valid location
+    │                          ╰─────── directive cannot be used on FRAGMENT_DEFINITION
     │ 
  89 │ directive @directiveB on ENUM
     │ ──────────────┬──────────────  
-    │               ╰──────────────── consider adding FRAGMENT_DEFINITION directive location here
+    │               ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 Error: directiveA directive is not supported for INLINE_FRAGMENT location
     ╭─[0050_directives_in_invalid_locations.graphql:11:14]
     │
  11 │   ... on Pet @directiveA {
     │              ─────┬─────  
-    │                   ╰─────── INLINE_FRAGMENT is not a valid location
+    │                   ╰─────── directive cannot be used on INLINE_FRAGMENT
     │ 
  88 │ directive @directiveA on UNION
     │ ───────────────┬──────────────  
-    │                ╰──────────────── consider adding INLINE_FRAGMENT directive location here
+    │                ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: UNION
 ────╯
 Error: directiveA directive is not supported for SUBSCRIPTION location
     ╭─[0050_directives_in_invalid_locations.graphql:16:28]
     │
  16 │ subscription subscriptionA @directiveA {
     │                            ─────┬─────  
-    │                                 ╰─────── SUBSCRIPTION is not a valid location
+    │                                 ╰─────── directive cannot be used on SUBSCRIPTION
     │ 
  88 │ directive @directiveA on UNION
     │ ───────────────┬──────────────  
-    │                ╰──────────────── consider adding SUBSCRIPTION directive location here
+    │                ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: UNION
 ────╯
 Error: skip directive is not supported for MUTATION location
-    ╭─[0050_directives_in_invalid_locations.graphql:23:21]
-    │
- 23 │ mutation myMutation @skip(if: true) {
-    │                     ───────┬───────  
-    │                            ╰───────── MUTATION is not a valid location
-    │ 
-    │ Help: the directive must be used in a location that the service has declared support for
-────╯
+     ╭─[0050_directives_in_invalid_locations.graphql:23:21]
+     │
+  23 │ mutation myMutation @skip(if: true) {
+     │                     ───────┬───────  
+     │                            ╰───────── directive cannot be used on MUTATION
+     │
+     ├─[built_in.graphql:96:1]
+     │
+  96 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
+     ┆ ┆   
+ 100 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+     │ │                                                    
+     │ ╰──────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
+─────╯
 Error: skip directive is not supported for INTERFACE location
-    ╭─[0050_directives_in_invalid_locations.graphql:27:15]
-    │
- 27 │ interface Pet @skip(if: true) {
-    │               ───────┬───────  
-    │                      ╰───────── INTERFACE is not a valid location
-    │ 
-    │ Help: the directive must be used in a location that the service has declared support for
-────╯
+     ╭─[0050_directives_in_invalid_locations.graphql:27:15]
+     │
+  27 │ interface Pet @skip(if: true) {
+     │               ───────┬───────  
+     │                      ╰───────── directive cannot be used on INTERFACE
+     │
+     ├─[built_in.graphql:96:1]
+     │
+  96 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
+     ┆ ┆   
+ 100 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+     │ │                                                    
+     │ ╰──────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
+─────╯
 Error: directiveB directive is not supported for FIELD_DEFINITION location
     ╭─[0050_directives_in_invalid_locations.graphql:32:16]
     │
  32 │   name: String @directiveB
     │                ─────┬─────  
-    │                     ╰─────── FIELD_DEFINITION is not a valid location
+    │                     ╰─────── directive cannot be used on FIELD_DEFINITION
     │ 
  89 │ directive @directiveB on ENUM
     │ ──────────────┬──────────────  
-    │               ╰──────────────── consider adding FIELD_DEFINITION directive location here
+    │               ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 Error: include directive is not supported for INPUT_OBJECT location
-    ╭─[0050_directives_in_invalid_locations.graphql:43:15]
-    │
- 43 │ input Example @include(if: true) {
-    │               ─────────┬────────  
-    │                        ╰────────── INPUT_OBJECT is not a valid location
-    │ 
-    │ Help: the directive must be used in a location that the service has declared support for
-────╯
+     ╭─[0050_directives_in_invalid_locations.graphql:43:15]
+     │
+  43 │ input Example @include(if: true) {
+     │               ─────────┬────────  
+     │                        ╰────────── directive cannot be used on INPUT_OBJECT
+     │
+     ├─[built_in.graphql:102:1]
+     │
+ 102 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
+     ┆ ┆   
+ 106 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+     │ │                                                    
+     │ ╰──────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
+─────╯
 Error: include directive is not supported for INPUT_FIELD_DEFINITION location
-    ╭─[0050_directives_in_invalid_locations.graphql:44:17]
-    │
- 44 │   self: Example @include(if: true)
-    │                 ─────────┬────────  
-    │                          ╰────────── INPUT_FIELD_DEFINITION is not a valid location
-    │ 
-    │ Help: the directive must be used in a location that the service has declared support for
-────╯
+     ╭─[0050_directives_in_invalid_locations.graphql:44:17]
+     │
+  44 │   self: Example @include(if: true)
+     │                 ─────────┬────────  
+     │                          ╰────────── directive cannot be used on INPUT_FIELD_DEFINITION
+     │
+     ├─[built_in.graphql:102:1]
+     │
+ 102 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
+     ┆ ┆   
+ 106 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+     │ │                                                    
+     │ ╰──────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
+─────╯
 Error: directiveB directive is not supported for UNION location
     ╭─[0050_directives_in_invalid_locations.graphql:48:16]
     │
  48 │ union CatOrDog @directiveB = Cat | Dog
     │                ─────┬─────  
-    │                     ╰─────── UNION is not a valid location
+    │                     ╰─────── directive cannot be used on UNION
     │ 
  89 │ directive @directiveB on ENUM
     │ ──────────────┬──────────────  
-    │               ╰──────────────── consider adding UNION directive location here
+    │               ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 Error: directiveA directive is not supported for ENUM location
     ╭─[0050_directives_in_invalid_locations.graphql:55:13]
     │
  55 │ enum Status @directiveA {
     │             ─────┬─────  
-    │                  ╰─────── ENUM is not a valid location
+    │                  ╰─────── directive cannot be used on ENUM
     │ 
  88 │ directive @directiveA on UNION
     │ ───────────────┬──────────────  
-    │                ╰──────────────── consider adding ENUM directive location here
+    │                ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: UNION
 ────╯
 Error: directiveA directive is not supported for ENUM_VALUE location
     ╭─[0050_directives_in_invalid_locations.graphql:56:9]
     │
  56 │   GREEN @directiveA,
     │         ─────┬─────  
-    │              ╰─────── ENUM_VALUE is not a valid location
+    │              ╰─────── directive cannot be used on ENUM_VALUE
     │ 
  88 │ directive @directiveA on UNION
     │ ───────────────┬──────────────  
-    │                ╰──────────────── consider adding ENUM_VALUE directive location here
+    │                ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: UNION
 ────╯
 Error: deprecated directive is not supported for OBJECT location
-    ╭─[0050_directives_in_invalid_locations.graphql:61:12]
-    │
- 61 │ type Query @deprecated {
-    │            ─────┬─────  
-    │                 ╰─────── OBJECT is not a valid location
-    │ 
-    │ Help: the directive must be used in a location that the service has declared support for
-────╯
+     ╭─[0050_directives_in_invalid_locations.graphql:61:12]
+     │
+  61 │ type Query @deprecated {
+     │            ─────┬─────  
+     │                 ╰─────── directive cannot be used on OBJECT
+     │
+     ├─[built_in.graphql:108:1]
+     │
+ 108 │ ╭─▶ "Marks an element of a GraphQL schema as no longer supported."
+     ┆ ┆   
+ 117 │ ├─▶ ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+     │ │                                                                                       
+     │ ╰─────────────────────────────────────────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD_DEFINITION, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION, ENUM_VALUE
+─────╯
 Error: specifiedBy directive is not supported for ARGUMENT_DEFINITION location
-    ╭─[0050_directives_in_invalid_locations.graphql:64:27]
-    │
- 64 │   response(status: String @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")): Status
-    │                           ────────────────────────────┬───────────────────────────  
-    │                                                       ╰───────────────────────────── ARGUMENT_DEFINITION is not a valid location
-    │ 
-    │ Help: the directive must be used in a location that the service has declared support for
-────╯
+     ╭─[0050_directives_in_invalid_locations.graphql:64:27]
+     │
+  64 │   response(status: String @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")): Status
+     │                           ────────────────────────────┬───────────────────────────  
+     │                                                       ╰───────────────────────────── directive cannot be used on ARGUMENT_DEFINITION
+     │
+     ├─[built_in.graphql:119:1]
+     │
+ 119 │ ╭─▶ "Exposes a URL that specifies the behaviour of this scalar."
+     ┆ ┆   
+ 123 │ ├─▶ ) on SCALAR
+     │ │                 
+     │ ╰───────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: SCALAR
+─────╯
 Error: include directive is not supported for SCHEMA location
-    ╭─[0050_directives_in_invalid_locations.graphql:75:8]
-    │
- 75 │ schema @include(if: true) {
-    │        ─────────┬────────  
-    │                 ╰────────── SCHEMA is not a valid location
-    │ 
-    │ Help: the directive must be used in a location that the service has declared support for
-────╯
+     ╭─[0050_directives_in_invalid_locations.graphql:75:8]
+     │
+  75 │ schema @include(if: true) {
+     │        ─────────┬────────  
+     │                 ╰────────── directive cannot be used on SCHEMA
+     │
+     ├─[built_in.graphql:102:1]
+     │
+ 102 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
+     ┆ ┆   
+ 106 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+     │ │                                                    
+     │ ╰──────────────────────────────────────────────────── directive defined here
+     │     
+     │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
+─────╯
 Error: directiveB directive is not supported for SCALAR location
     ╭─[0050_directives_in_invalid_locations.graphql:86:13]
     │
  86 │ scalar spec @directiveB @specifiedBy(url: "https://spec.graphql.org/")
     │             ─────┬─────  
-    │                  ╰─────── SCALAR is not a valid location
+    │                  ╰─────── directive cannot be used on SCALAR
     │ 
  89 │ directive @directiveB on ENUM
     │ ──────────────┬──────────────  
-    │               ╰──────────────── consider adding SCALAR directive location here
+    │               ╰──────────────── directive defined here
     │ 
-    │ Help: the directive must be used in a location that the service has declared support for
+    │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0051_subscription_operation_with_root_introspection_field.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0051_subscription_operation_with_root_introspection_field.txt
@@ -1,4 +1,4 @@
-Error: subscription operations can not have an introspection field as a root field
+Error: subscription `sub` can not have an introspection field as a root field
    ╭─[0051_subscription_operation_with_root_introspection_field.graphql:2:3]
    │
  2 │   __typename

--- a/crates/apollo-compiler/test_data/diagnostics/0052_undefined_directive.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0052_undefined_directive.txt
@@ -1,4 +1,4 @@
-Error: cannot find directive `directiveA` in this document
+Error: cannot find directive `@directiveA` in this document
    ╭─[0052_undefined_directive.graphql:3:17]
    │
  3 │     status: Int @directiveA

--- a/crates/apollo-compiler/test_data/diagnostics/0053_argument_name_is_not_defined.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0053_argument_name_is_not_defined.txt
@@ -1,34 +1,34 @@
-Error: the argument `arg2` is not supported
+Error: the argument `arg2` is not supported by `Field.field`
     ╭─[0053_argument_name_is_not_defined.graphql:11:18]
     │
   7 │   field(arg4: Int): Int
     │   ──────────┬──────────  
-    │             ╰──────────── field declared here
+    │             ╰──────────── Field.field defined here
     │ 
  11 │   field(arg4: 1, arg2: 2, arg3: 3)
     │                  ───┬───  
-    │                     ╰───── argument name not found
+    │                     ╰───── argument by this name not found
 ────╯
-Error: the argument `arg3` is not supported
+Error: the argument `arg3` is not supported by `Field.field`
     ╭─[0053_argument_name_is_not_defined.graphql:11:27]
     │
   7 │   field(arg4: Int): Int
     │   ──────────┬──────────  
-    │             ╰──────────── field declared here
+    │             ╰──────────── Field.field defined here
     │ 
  11 │   field(arg4: 1, arg2: 2, arg3: 3)
     │                           ───┬───  
-    │                              ╰───── argument name not found
+    │                              ╰───── argument by this name not found
 ────╯
-Error: the argument `arg2` is not supported
+Error: the argument `arg2` is not supported by `Query.field`
     ╭─[0053_argument_name_is_not_defined.graphql:15:9]
     │
   2 │   field(arg1: Int): Int
     │   ──────────┬──────────  
-    │             ╰──────────── field declared here
+    │             ╰──────────── Query.field defined here
     │ 
  15 │   field(arg2: 3)
     │         ───┬───  
-    │            ╰───── argument name not found
+    │            ╰───── argument by this name not found
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
@@ -1,4 +1,4 @@
-Error: the required argument `req1` is not provided
+Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
     ╭─[0054_argument_not_provided.graphql:14:5]
     │
   2 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -9,7 +9,7 @@ Error: the required argument `req1` is not provided
     │     ──────┬─────  
     │           ╰─────── missing value for argument `req1`
 ────╯
-Error: the required argument `req2` is not provided
+Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
     ╭─[0054_argument_not_provided.graphql:14:5]
     │
   2 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -20,7 +20,7 @@ Error: the required argument `req2` is not provided
     │     ──────┬─────  
     │           ╰─────── missing value for argument `req2`
 ────╯
-Error: the required argument `req1` is not provided
+Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
     ╭─[0054_argument_not_provided.graphql:17:5]
     │
   2 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -31,7 +31,7 @@ Error: the required argument `req1` is not provided
     │     ────────────────┬────────────────  
     │                     ╰────────────────── missing value for argument `req1`
 ────╯
-Error: the required argument `if` is not provided
+Error: the required argument `@skip(if:)` is not provided
     ╭─[0054_argument_not_provided.graphql:21:9]
     │
  21 │   basic @skip @include(wrong: false) {
@@ -45,7 +45,7 @@ Error: the required argument `if` is not provided
     │ │                    
     │ ╰──────────────────── argument defined here
 ────╯
-Error: the required argument `if` is not provided
+Error: the required argument `@include(if:)` is not provided
      ╭─[0054_argument_not_provided.graphql:21:15]
      │
   21 │   basic @skip @include(wrong: false) {
@@ -59,16 +59,16 @@ Error: the required argument `if` is not provided
      │ │                    
      │ ╰──────────────────── argument defined here
 ─────╯
-Error: the argument `wrong` is not supported
+Error: the argument `wrong` is not supported by `@include`
     ╭─[0054_argument_not_provided.graphql:21:24]
     │
  21 │   basic @skip @include(wrong: false) {
-    │               ───────────┬──────────  
-    │                          ╰──────────── argument by this name not found
-    │                          │            
-    │                          ╰──────────── directive declared here
+    │               ───────────┬───┬──────  
+    │                          ╰──────────── @include defined here
+    │                              │        
+    │                              ╰──────── argument by this name not found
 ────╯
-Error: the required argument `req1` is not provided
+Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
     ╭─[0054_argument_not_provided.graphql:26:5]
     │
   2 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -79,7 +79,7 @@ Error: the required argument `req1` is not provided
     │     ────────────┬───────────  
     │                 ╰───────────── missing value for argument `req1`
 ────╯
-Error: the required argument `req2` is not provided
+Error: the required argument `ComplicatedArgs.multipleOptAndReq(req2:)` is not provided
     ╭─[0054_argument_not_provided.graphql:27:5]
     │
   3 │   multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String
@@ -90,7 +90,7 @@ Error: the required argument `req2` is not provided
     │     ──────────────┬──────────────  
     │                   ╰──────────────── missing value for argument `req2`
 ────╯
-Error: the required argument `req2` is not provided
+Error: the required argument `ComplicatedArgs.multipleOptAndReq(req2:)` is not provided
     ╭─[0054_argument_not_provided.graphql:28:5]
     │
   3 │   multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String

--- a/crates/apollo-compiler/test_data/diagnostics/0055_duplicate_variable_definitions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0055_duplicate_variable_definitions.txt
@@ -1,12 +1,10 @@
-Error: the variable `atOtherHomes` is defined multiple times in the document
+Error: the variable `$atOtherHomes` is declared multiple times
    ╭─[0055_duplicate_variable_definitions.graphql:1:49]
    │
  1 │ query houseTrainedQuery($atOtherHomes: Boolean, $atOtherHomes: Boolean) {
    │                         ───────────┬──────────  ───────────┬──────────  
-   │                                    ╰──────────────────────────────────── previous definition of `atOtherHomes` here
+   │                                    ╰──────────────────────────────────── previous definition of `$atOtherHomes` here
    │                                                            │            
-   │                                                            ╰──────────── `atOtherHomes` redefined here
-   │ 
-   │ Help: atOtherHomes must only be defined once in this enum.
+   │                                                            ╰──────────── `$atOtherHomes` defined again here
 ───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0056_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0056_variables_are_input_types.txt
@@ -1,98 +1,98 @@
-Error: `cat` field must be of an input type
+Error: `$cat` variable must be of an input type
    ╭─[0056_variables_are_input_types.graphql:1:16]
    │
  1 │ query takesCat($cat: Cat) {
    │                      ─┬─  
-   │                       ╰─── this is of `object` type
+   │                       ╰─── this is an object
    │ 
    │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ───╯
-Error: variable `cat` cannot be used for argument `atOtherHomes` as their types mismatch
+Error: variable `$cat` of type `Cat` cannot be used for argument `atOtherHomes` of type `Boolean`
    ╭─[0056_variables_are_input_types.graphql:3:20]
    │
  1 │ query takesCat($cat: Cat) {
    │                ────┬────  
-   │                    ╰────── variable `cat` of type `Cat` is declared here
+   │                    ╰────── variable `$cat` of type `Cat` is declared here
    │ 
  3 │     isHouseTrained(atOtherHomes: $cat)
    │                    ─────────┬────────  
-   │                             ╰────────── argument `atOtherHomes` of type `Boolean` is declared here
+   │                             ╰────────── variable `$cat` used here
 ───╯
-Error: `dog` field must be of an input type
+Error: `$dog` variable must be of an input type
    ╭─[0056_variables_are_input_types.graphql:7:20]
    │
  7 │ query takesDogBang($dog: Dog!) {
-   │                          ─┬─  
-   │                           ╰─── this is of `object` type
+   │                          ──┬─  
+   │                            ╰─── this is an object
    │ 
    │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ───╯
-Error: variable `dog` cannot be used for argument `atOtherHomes` as their types mismatch
+Error: variable `$dog` of type `Dog!` cannot be used for argument `atOtherHomes` of type `Boolean`
    ╭─[0056_variables_are_input_types.graphql:9:20]
    │
  7 │ query takesDogBang($dog: Dog!) {
    │                    ─────┬────  
-   │                         ╰────── variable `dog` of type `Dog!` is declared here
+   │                         ╰────── variable `$dog` of type `Dog!` is declared here
    │ 
  9 │     isHouseTrained(atOtherHomes: $dog)
    │                    ─────────┬────────  
-   │                             ╰────────── argument `atOtherHomes` of type `Boolean` is declared here
+   │                             ╰────────── variable `$dog` used here
 ───╯
-Error: `pets` field must be of an input type
+Error: `$pets` variable must be of an input type
     ╭─[0056_variables_are_input_types.graphql:13:22]
     │
  13 │ query takesListOfPet($pets: [Pet]) {
-    │                              ─┬─  
-    │                               ╰─── this is of `interface` type
+    │                             ──┬──  
+    │                               ╰──── this is an interface
     │ 
     │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ────╯
-Error: variable `pets` cannot be used for argument `booleanListArg` as their types mismatch
+Error: variable `$pets` of type `[Pet]` cannot be used for argument `booleanListArg` of type `[Boolean!]`
     ╭─[0056_variables_are_input_types.graphql:14:15]
     │
  13 │ query takesListOfPet($pets: [Pet]) {
     │                      ──────┬─────  
-    │                            ╰─────── variable `pets` of type `[Pet]` is declared here
+    │                            ╰─────── variable `$pets` of type `[Pet]` is declared here
  14 │   booleanList(booleanListArg: $pets)
     │               ──────────┬──────────  
-    │                         ╰──────────── argument `booleanListArg` of type `[Boolean!]` is declared here
+    │                         ╰──────────── variable `$pets` used here
 ────╯
-Error: `catOrDog` field must be of an input type
+Error: `$catOrDog` variable must be of an input type
     ╭─[0056_variables_are_input_types.graphql:17:21]
     │
  17 │ query takesCatOrDog($catOrDog: CatOrDog) {
     │                                ────┬───  
-    │                                    ╰───── this is of `union` type
+    │                                    ╰───── this is a union
     │ 
     │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ────╯
-Error: variable `catOrDog` cannot be used for argument `atOtherHomes` as their types mismatch
+Error: variable `$catOrDog` of type `CatOrDog` cannot be used for argument `atOtherHomes` of type `Boolean`
     ╭─[0056_variables_are_input_types.graphql:19:20]
     │
  17 │ query takesCatOrDog($catOrDog: CatOrDog) {
     │                     ─────────┬─────────  
-    │                              ╰─────────── variable `catOrDog` of type `CatOrDog` is declared here
+    │                              ╰─────────── variable `$catOrDog` of type `CatOrDog` is declared here
     │ 
  19 │     isHouseTrained(atOtherHomes: $catOrDog)
     │                    ───────────┬───────────  
-    │                               ╰───────────── argument `atOtherHomes` of type `Boolean` is declared here
+    │                               ╰───────────── variable `$catOrDog` used here
 ────╯
 Error: cannot find type `Dragon` in this document
     ╭─[0056_variables_are_input_types.graphql:23:22]
     │
  23 │ query takesCatOrDog2($catOrDog: Dragon) {
-    │                                 ───┬──  
-    │                                    ╰──── not found in the type system
+    │                      ────────┬────────  
+    │                              ╰────────── not found in this scope
 ────╯
-Error: variable `catOrDog` cannot be used for argument `atOtherHomes` as their types mismatch
+Error: variable `$catOrDog` of type `Dragon` cannot be used for argument `atOtherHomes` of type `Boolean`
     ╭─[0056_variables_are_input_types.graphql:25:20]
     │
  23 │ query takesCatOrDog2($catOrDog: Dragon) {
     │                      ────────┬────────  
-    │                              ╰────────── variable `catOrDog` of type `Dragon` is declared here
+    │                              ╰────────── variable `$catOrDog` of type `Dragon` is declared here
     │ 
  25 │     isHouseTrained(atOtherHomes: $catOrDog)
     │                    ───────────┬───────────  
-    │                               ╰───────────── argument `atOtherHomes` of type `Boolean` is declared here
+    │                               ╰───────────── variable `$catOrDog` used here
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0056_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0056_variables_are_input_types.txt
@@ -3,7 +3,7 @@ Error: `$cat` variable must be of an input type
    │
  1 │ query takesCat($cat: Cat) {
    │                      ─┬─  
-   │                       ╰─── this is an object
+   │                       ╰─── this is an object type
    │ 
    │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ───╯
@@ -23,7 +23,7 @@ Error: `$dog` variable must be of an input type
    │
  7 │ query takesDogBang($dog: Dog!) {
    │                          ──┬─  
-   │                            ╰─── this is an object
+   │                            ╰─── this is an object type
    │ 
    │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ───╯
@@ -43,7 +43,7 @@ Error: `$pets` variable must be of an input type
     │
  13 │ query takesListOfPet($pets: [Pet]) {
     │                             ──┬──  
-    │                               ╰──── this is an interface
+    │                               ╰──── this is an interface type
     │ 
     │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ────╯
@@ -62,7 +62,7 @@ Error: `$catOrDog` variable must be of an input type
     │
  17 │ query takesCatOrDog($catOrDog: CatOrDog) {
     │                                ────┬───  
-    │                                    ╰───── this is a union
+    │                                    ╰───── this is a union type
     │ 
     │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0059_root_operation_object_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0059_root_operation_object_type.txt
@@ -3,8 +3,8 @@ Error: `SomeInterface` field must return an object type
    │
  2 │     query: SomeInterface
    │            ──────┬──────  
-   │                  ╰──────── This is an interface
+   │                  ╰──────── this is an interface
    │ 
-   │ Help: root operation type must be an object type
+   │ Help: Root operation type must be an object type.
 ───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0059_root_operation_object_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0059_root_operation_object_type.txt
@@ -3,7 +3,7 @@ Error: `SomeInterface` field must return an object type
    │
  2 │     query: SomeInterface
    │            ──────┬──────  
-   │                  ╰──────── this is an interface
+   │                  ╰──────── this is an interface type
    │ 
    │ Help: Root operation type must be an object type.
 ───╯

--- a/crates/apollo-compiler/test_data/diagnostics/0064_extension_wrong_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0064_extension_wrong_type.txt
@@ -1,11 +1,11 @@
-Error: `Scalar` field must return an object type
+Error: union member `Scalar` must be an object type
    ╭─[0064_extension_wrong_type.graphql:8:15]
    │
  8 │ union Union = Scalar | Object
    │               ───┬──  
-   │                  ╰──── This is a a scalar
+   │                  ╰──── this is a scalar
    │ 
-   │ Help: Union members must be of base Object Type.
+   │ Help: Union members must be object types.
 ───╯
 Error: adding a union type extension, but `Scalar` is a scalar type
     ╭─[0064_extension_wrong_type.graphql:16:14]

--- a/crates/apollo-compiler/test_data/diagnostics/0064_extension_wrong_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0064_extension_wrong_type.txt
@@ -3,7 +3,7 @@ Error: union member `Scalar` must be an object type
    │
  8 │ union Union = Scalar | Object
    │               ───┬──  
-   │                  ╰──── this is a scalar
+   │                  ╰──── this is a scalar type
    │ 
    │ Help: Union members must be object types.
 ───╯

--- a/crates/apollo-compiler/test_data/diagnostics/0067_subselection_of_interface.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0067_subselection_of_interface.txt
@@ -1,79 +1,43 @@
 Error: interface, union and object types must have a subselection set
-    ╭─[0067_subselection_of_interface.graphql:2:3]
-    │
-  2 │       pet1
-    │       ──┬─  
-    │         ╰─── field `pet1` type `Pet` is an interface and must select fields
-    │ 
- 19 │ ╭─▶ interface Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0067_subselection_of_interface.graphql:2:3]
+   │
+ 2 │   pet1
+   │   ──┬─  
+   │     ╰─── Pet.pet1 is an interface type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0067_subselection_of_interface.graphql:3:3]
-    │
-  3 │       pet2
-    │       ──┬─  
-    │         ╰─── field `pet2` type `Pet` is an interface and must select fields
-    │ 
- 19 │ ╭─▶ interface Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0067_subselection_of_interface.graphql:3:3]
+   │
+ 3 │   pet2
+   │   ──┬─  
+   │     ╰─── Pet.pet2 is an interface type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0067_subselection_of_interface.graphql:4:3]
-    │
-  4 │       pet3
-    │       ──┬─  
-    │         ╰─── field `pet3` type `Pet` is an interface and must select fields
-    │ 
- 19 │ ╭─▶ interface Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0067_subselection_of_interface.graphql:4:3]
+   │
+ 4 │   pet3
+   │   ──┬─  
+   │     ╰─── Pet.pet3 is an interface type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0067_subselection_of_interface.graphql:5:3]
-    │
-  5 │       pet4
-    │       ──┬─  
-    │         ╰─── field `pet4` type `Pet` is an interface and must select fields
-    │ 
- 19 │ ╭─▶ interface Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0067_subselection_of_interface.graphql:5:3]
+   │
+ 5 │   pet4
+   │   ──┬─  
+   │     ╰─── Pet.pet4 is an interface type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0067_subselection_of_interface.graphql:6:3]
-    │
-  6 │       pet5
-    │       ──┬─  
-    │         ╰─── field `pet5` type `Pet` is an interface and must select fields
-    │ 
- 19 │ ╭─▶ interface Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0067_subselection_of_interface.graphql:6:3]
+   │
+ 6 │   pet5
+   │   ──┬─  
+   │     ╰─── Pet.pet5 is an interface type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0067_subselection_of_interface.graphql:7:3]
-    │
-  7 │       pet6
-    │       ──┬─  
-    │         ╰─── field `pet6` type `Pet` is an interface and must select fields
-    │ 
- 19 │ ╭─▶ interface Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0067_subselection_of_interface.graphql:7:3]
+   │
+ 7 │   pet6
+   │   ──┬─  
+   │     ╰─── Pet.pet6 is an interface type and must select fields
+───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0068_subselection_of_union.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0068_subselection_of_union.txt
@@ -1,67 +1,43 @@
 Error: interface, union and object types must have a subselection set
-    ╭─[0068_subselection_of_union.graphql:2:3]
-    │
-  2 │   pet1
-    │   ──┬─  
-    │     ╰─── field `pet1` type `CatOrDog` is an union and must select fields
-    │ 
- 21 │ union CatOrDog = Cat | Dog
-    │ ─────────────┬────────────  
-    │              ╰────────────── `CatOrDog` declared here
-────╯
+   ╭─[0068_subselection_of_union.graphql:2:3]
+   │
+ 2 │   pet1
+   │   ──┬─  
+   │     ╰─── CatOrDog.pet1 is a union type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0068_subselection_of_union.graphql:3:3]
-    │
-  3 │   pet2
-    │   ──┬─  
-    │     ╰─── field `pet2` type `CatOrDog` is an union and must select fields
-    │ 
- 21 │ union CatOrDog = Cat | Dog
-    │ ─────────────┬────────────  
-    │              ╰────────────── `CatOrDog` declared here
-────╯
+   ╭─[0068_subselection_of_union.graphql:3:3]
+   │
+ 3 │   pet2
+   │   ──┬─  
+   │     ╰─── CatOrDog.pet2 is a union type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0068_subselection_of_union.graphql:4:3]
-    │
-  4 │   pet3
-    │   ──┬─  
-    │     ╰─── field `pet3` type `CatOrDog` is an union and must select fields
-    │ 
- 21 │ union CatOrDog = Cat | Dog
-    │ ─────────────┬────────────  
-    │              ╰────────────── `CatOrDog` declared here
-────╯
+   ╭─[0068_subselection_of_union.graphql:4:3]
+   │
+ 4 │   pet3
+   │   ──┬─  
+   │     ╰─── CatOrDog.pet3 is a union type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0068_subselection_of_union.graphql:5:3]
-    │
-  5 │   pet4
-    │   ──┬─  
-    │     ╰─── field `pet4` type `CatOrDog` is an union and must select fields
-    │ 
- 21 │ union CatOrDog = Cat | Dog
-    │ ─────────────┬────────────  
-    │              ╰────────────── `CatOrDog` declared here
-────╯
+   ╭─[0068_subselection_of_union.graphql:5:3]
+   │
+ 5 │   pet4
+   │   ──┬─  
+   │     ╰─── CatOrDog.pet4 is a union type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0068_subselection_of_union.graphql:6:3]
-    │
-  6 │   pet5
-    │   ──┬─  
-    │     ╰─── field `pet5` type `CatOrDog` is an union and must select fields
-    │ 
- 21 │ union CatOrDog = Cat | Dog
-    │ ─────────────┬────────────  
-    │              ╰────────────── `CatOrDog` declared here
-────╯
+   ╭─[0068_subselection_of_union.graphql:6:3]
+   │
+ 6 │   pet5
+   │   ──┬─  
+   │     ╰─── CatOrDog.pet5 is a union type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0068_subselection_of_union.graphql:7:3]
-    │
-  7 │   pet6
-    │   ──┬─  
-    │     ╰─── field `pet6` type `CatOrDog` is an union and must select fields
-    │ 
- 21 │ union CatOrDog = Cat | Dog
-    │ ─────────────┬────────────  
-    │              ╰────────────── `CatOrDog` declared here
-────╯
+   ╭─[0068_subselection_of_union.graphql:7:3]
+   │
+ 7 │   pet6
+   │   ──┬─  
+   │     ╰─── CatOrDog.pet6 is a union type and must select fields
+───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0069_subselection_of_object.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0069_subselection_of_object.txt
@@ -1,79 +1,43 @@
 Error: interface, union and object types must have a subselection set
-    ╭─[0069_subselection_of_object.graphql:2:3]
-    │
-  2 │       pet1
-    │       ──┬─  
-    │         ╰─── field `pet1` type `Pet` is an object and must select fields
-    │ 
- 19 │ ╭─▶ type Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0069_subselection_of_object.graphql:2:3]
+   │
+ 2 │   pet1
+   │   ──┬─  
+   │     ╰─── Pet.pet1 is an object type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0069_subselection_of_object.graphql:3:3]
-    │
-  3 │       pet2
-    │       ──┬─  
-    │         ╰─── field `pet2` type `Pet` is an object and must select fields
-    │ 
- 19 │ ╭─▶ type Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0069_subselection_of_object.graphql:3:3]
+   │
+ 3 │   pet2
+   │   ──┬─  
+   │     ╰─── Pet.pet2 is an object type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0069_subselection_of_object.graphql:4:3]
-    │
-  4 │       pet3
-    │       ──┬─  
-    │         ╰─── field `pet3` type `Pet` is an object and must select fields
-    │ 
- 19 │ ╭─▶ type Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0069_subselection_of_object.graphql:4:3]
+   │
+ 4 │   pet3
+   │   ──┬─  
+   │     ╰─── Pet.pet3 is an object type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0069_subselection_of_object.graphql:5:3]
-    │
-  5 │       pet4
-    │       ──┬─  
-    │         ╰─── field `pet4` type `Pet` is an object and must select fields
-    │ 
- 19 │ ╭─▶ type Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0069_subselection_of_object.graphql:5:3]
+   │
+ 5 │   pet4
+   │   ──┬─  
+   │     ╰─── Pet.pet4 is an object type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0069_subselection_of_object.graphql:6:3]
-    │
-  6 │       pet5
-    │       ──┬─  
-    │         ╰─── field `pet5` type `Pet` is an object and must select fields
-    │ 
- 19 │ ╭─▶ type Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0069_subselection_of_object.graphql:6:3]
+   │
+ 6 │   pet5
+   │   ──┬─  
+   │     ╰─── Pet.pet5 is an object type and must select fields
+───╯
 Error: interface, union and object types must have a subselection set
-    ╭─[0069_subselection_of_object.graphql:7:3]
-    │
-  7 │       pet6
-    │       ──┬─  
-    │         ╰─── field `pet6` type `Pet` is an object and must select fields
-    │ 
- 19 │ ╭─▶ type Pet {
-    ┆ ┆   
- 21 │ ├─▶ }
-    │ │       
-    │ ╰─────── `Pet` declared here
-────╯
+   ╭─[0069_subselection_of_object.graphql:7:3]
+   │
+ 7 │   pet6
+   │   ──┬─  
+   │     ╰─── Pet.pet6 is an object type and must select fields
+───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0074_merge_identical_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0074_merge_identical_fields.txt
@@ -1,14 +1,4 @@
-Error: operation must not select different types using the same field name `nickname`
-    ╭─[0074_merge_identical_fields.graphql:19:3]
-    │
- 18 │   name: nickname
-    │   ───────┬──────  
-    │          ╰──────── `name` has type `String` here
- 19 │   name
-    │   ──┬─  
-    │     ╰─── but the same field name has type `String!` here
-────╯
-Error: operation must not select different types using the same field name `nickname`
+Error: operation must not select different types using the same field name `name`
     ╭─[0074_merge_identical_fields.graphql:19:3]
     │
  18 │   name: nickname
@@ -19,6 +9,16 @@ Error: operation must not select different types using the same field name `nick
     │     ╰─── but the same field name has type `String!` here
 ────╯
 Error: operation must not select different types using the same field name `name`
+    ╭─[0074_merge_identical_fields.graphql:19:3]
+    │
+ 18 │   name: nickname
+    │   ───────┬──────  
+    │          ╰──────── `name` has type `String` here
+ 19 │   name
+    │   ──┬─  
+    │     ╰─── but the same field name has type `String!` here
+────╯
+Error: operation must not select different types using the same field name `fido`
     ╭─[0074_merge_identical_fields.graphql:24:3]
     │
  23 │   fido: name
@@ -28,7 +28,7 @@ Error: operation must not select different types using the same field name `name
     │   ───────┬──────  
     │          ╰──────── but the same field name has type `String` here
 ────╯
-Error: operation must not select different types using the same field name `name`
+Error: operation must not select different types using the same field name `fido`
     ╭─[0074_merge_identical_fields.graphql:24:3]
     │
  23 │   fido: name

--- a/crates/apollo-compiler/test_data/diagnostics/0075_merge_conflicting_args.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0075_merge_conflicting_args.txt
@@ -1,117 +1,117 @@
-Error: operation must not select different types using the same field name `doesKnowCommand`
+Error: operation must not provide conflicting field arguments for the same field name `doesKnowCommand`
     ╭─[0075_merge_conflicting_args.graphql:47:3]
     │
  46 │   doesKnowCommand(dogCommand: SIT)
-    │                   ───────┬───────  
-    │                          ╰───────── field `doesKnowCommand` provides one argument value here
+    │   ────────────────┬───────────────  
+    │                   ╰───────────────── field `doesKnowCommand` provides one argument value here
  47 │   doesKnowCommand(dogCommand: HEEL)
-    │                   ────────┬───────  
-    │                           ╰───────── but a different value here
+    │   ────────────────┬────────────────  
+    │                   ╰────────────────── but a different value here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `doesKnowCommand`
+Error: operation must not provide conflicting field arguments for the same field name `doesKnowCommand`
     ╭─[0075_merge_conflicting_args.graphql:47:3]
     │
  46 │   doesKnowCommand(dogCommand: SIT)
-    │                   ───────┬───────  
-    │                          ╰───────── field `doesKnowCommand` provides one argument value here
+    │   ────────────────┬───────────────  
+    │                   ╰───────────────── field `doesKnowCommand` provides one argument value here
  47 │   doesKnowCommand(dogCommand: HEEL)
-    │                   ────────┬───────  
-    │                           ╰───────── but a different value here
+    │   ────────────────┬────────────────  
+    │                   ╰────────────────── but a different value here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `doesKnowCommand`
+Error: operation must not provide conflicting field arguments for the same field name `doesKnowCommand`
     ╭─[0075_merge_conflicting_args.graphql:52:3]
     │
  51 │   doesKnowCommand(dogCommand: SIT)
-    │                   ───────┬───────  
-    │                          ╰───────── field `doesKnowCommand` provides one argument value here
+    │   ────────────────┬───────────────  
+    │                   ╰───────────────── field `doesKnowCommand` provides one argument value here
  52 │   doesKnowCommand(dogCommand: $dogCommand)
-    │                   ───────────┬───────────  
-    │                              ╰───────────── but a different value here
+    │   ────────────────────┬───────────────────  
+    │                       ╰───────────────────── but a different value here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `doesKnowCommand`
+Error: operation must not provide conflicting field arguments for the same field name `doesKnowCommand`
     ╭─[0075_merge_conflicting_args.graphql:52:3]
     │
  51 │   doesKnowCommand(dogCommand: SIT)
-    │                   ───────┬───────  
-    │                          ╰───────── field `doesKnowCommand` provides one argument value here
+    │   ────────────────┬───────────────  
+    │                   ╰───────────────── field `doesKnowCommand` provides one argument value here
  52 │   doesKnowCommand(dogCommand: $dogCommand)
-    │                   ───────────┬───────────  
-    │                              ╰───────────── but a different value here
+    │   ────────────────────┬───────────────────  
+    │                       ╰───────────────────── but a different value here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `doesKnowCommand`
+Error: operation must not provide conflicting field arguments for the same field name `doesKnowCommand`
     ╭─[0075_merge_conflicting_args.graphql:57:3]
     │
  56 │   doesKnowCommand(dogCommand: $varOne)
-    │                   ─────────┬─────────  
-    │                            ╰─────────── field `doesKnowCommand` provides one argument value here
+    │   ──────────────────┬─────────────────  
+    │                     ╰─────────────────── field `doesKnowCommand` provides one argument value here
  57 │   doesKnowCommand(dogCommand: $varTwo)
-    │                   ─────────┬─────────  
-    │                            ╰─────────── but a different value here
+    │   ──────────────────┬─────────────────  
+    │                     ╰─────────────────── but a different value here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `doesKnowCommand`
+Error: operation must not provide conflicting field arguments for the same field name `doesKnowCommand`
     ╭─[0075_merge_conflicting_args.graphql:57:3]
     │
  56 │   doesKnowCommand(dogCommand: $varOne)
-    │                   ─────────┬─────────  
-    │                            ╰─────────── field `doesKnowCommand` provides one argument value here
+    │   ──────────────────┬─────────────────  
+    │                     ╰─────────────────── field `doesKnowCommand` provides one argument value here
  57 │   doesKnowCommand(dogCommand: $varTwo)
-    │                   ─────────┬─────────  
-    │                            ╰─────────── but a different value here
+    │   ──────────────────┬─────────────────  
+    │                     ╰─────────────────── but a different value here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `doesKnowCommand`
+Error: operation must not provide conflicting field arguments for the same field name `doesKnowCommand`
     ╭─[0075_merge_conflicting_args.graphql:62:3]
     │
  61 │   doesKnowCommand(dogCommand: SIT)
-    │                   ───────┬───────  
-    │                          ╰───────── field `doesKnowCommand` is selected with argument `dogCommand` here
+    │   ────────────────┬───────────────  
+    │                   ╰───────────────── field `doesKnowCommand` is selected with argument `dogCommand` here
  62 │   doesKnowCommand
     │   ───────┬───────  
     │          ╰───────── but argument `dogCommand` is not provided here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `doesKnowCommand`
+Error: operation must not provide conflicting field arguments for the same field name `doesKnowCommand`
     ╭─[0075_merge_conflicting_args.graphql:62:3]
     │
  61 │   doesKnowCommand(dogCommand: SIT)
-    │                   ───────┬───────  
-    │                          ╰───────── field `doesKnowCommand` is selected with argument `dogCommand` here
+    │   ────────────────┬───────────────  
+    │                   ╰───────────────── field `doesKnowCommand` is selected with argument `dogCommand` here
  62 │   doesKnowCommand
     │   ───────┬───────  
     │          ╰───────── but argument `dogCommand` is not provided here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `isAtLocation`
+Error: operation must not provide conflicting field arguments for the same field name `isAtLocation`
     ╭─[0075_merge_conflicting_args.graphql:67:3]
     │
  66 │   isAtLocation(x: 0)
-    │                ──┬─  
-    │                  ╰─── field `isAtLocation` is selected with argument `x` here
+    │   ─────────┬────────  
+    │            ╰────────── field `isAtLocation` is selected with argument `x` here
  67 │   isAtLocation(y: 0)
     │   ─────────┬────────  
     │            ╰────────── but argument `x` is not provided here
     │ 
     │ Help: Fields with the same response name must provide the same set of arguments. Consider adding an alias if you need to select fields with different arguments.
 ────╯
-Error: operation must not select different types using the same field name `isAtLocation`
+Error: operation must not provide conflicting field arguments for the same field name `isAtLocation`
     ╭─[0075_merge_conflicting_args.graphql:67:3]
     │
  66 │   isAtLocation(x: 0)
-    │                ──┬─  
-    │                  ╰─── field `isAtLocation` is selected with argument `x` here
+    │   ─────────┬────────  
+    │            ╰────────── field `isAtLocation` is selected with argument `x` here
  67 │   isAtLocation(y: 0)
     │   ─────────┬────────  
     │            ╰────────── but argument `x` is not provided here

--- a/crates/apollo-compiler/test_data/diagnostics/0076_merge_differing_responses.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0076_merge_differing_responses.txt
@@ -1,4 +1,4 @@
-Error: operation must not select different types using the same field name `nickname`
+Error: operation must not select different types using the same field name `someValue`
     ╭─[0076_merge_differing_responses.graphql:42:5]
     │
  39 │     someValue: nickname
@@ -9,7 +9,7 @@ Error: operation must not select different types using the same field name `nick
     │     ──────────┬──────────  
     │               ╰──────────── but the same field name has type `Int!` here
 ────╯
-Error: operation must not select different types using the same field name `nickname`
+Error: operation must not select different types using the same field name `someValue`
     ╭─[0076_merge_differing_responses.graphql:42:5]
     │
  39 │     someValue: nickname

--- a/crates/apollo-compiler/test_data/diagnostics/0077_merge_conflict_deep.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0077_merge_conflict_deep.txt
@@ -1,4 +1,4 @@
-Error: operation must not select different types using the same field name `b`
+Error: operation must not select different fields to the same alias `x`
     ╭─[0077_merge_conflict_deep.graphql:14:5]
     │
  11 │     x: a
@@ -8,7 +8,5 @@ Error: operation must not select different types using the same field name `b`
  14 │     x: b
     │     ──┬─  
     │       ╰─── but the same field `x` is also selected from field `b` here
-    │ 
-    │ Help: Alias is already used for a different field
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0078_merge_conflict_nested_fragments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0078_merge_conflict_nested_fragments.txt
@@ -1,4 +1,4 @@
-Error: operation must not select different types using the same field name `d`
+Error: operation must not select different fields to the same alias `y`
     ╭─[0078_merge_conflict_nested_fragments.graphql:28:3]
     │
  25 │   y: c
@@ -8,10 +8,8 @@ Error: operation must not select different types using the same field name `d`
  28 │   y: d
     │   ──┬─  
     │     ╰─── but the same field `y` is also selected from field `d` here
-    │ 
-    │ Help: Alias is already used for a different field
 ────╯
-Error: operation must not select different types using the same field name `b`
+Error: operation must not select different fields to the same alias `x`
     ╭─[0078_merge_conflict_nested_fragments.graphql:32:3]
     │
  21 │   x: a
@@ -21,7 +19,5 @@ Error: operation must not select different types using the same field name `b`
  32 │   x: b
     │   ──┬─  
     │     ╰─── but the same field `x` is also selected from field `b` here
-    │ 
-    │ Help: Alias is already used for a different field
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0079_directive_is_unique.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0079_directive_is_unique.txt
@@ -3,8 +3,8 @@ Error: non-repeatable directive unique can only be used once per location
     │
  11 │   fieldB @unique @unique
     │          ───┬─── ───┬───  
-    │             ╰───────────── directive unique first called here
+    │             ╰───────────── directive `@unique` first called here
     │                     │     
-    │                     ╰───── directive unique called again here
+    │                     ╰───── directive `@unique` called again here
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
@@ -3,30 +3,30 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │
  2 │ extend type TestObject @nonRepeatable
    │                        ───────┬──────  
-   │                               ╰──────── directive nonRepeatable called again here
+   │                               ╰──────── directive `@nonRepeatable` called again here
  3 │ type TestObject @nonRepeatable
    │                 ───────┬──────  
-   │                        ╰──────── directive nonRepeatable first called here
+   │                        ╰──────── directive `@nonRepeatable` first called here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0080_directive_is_unique_with_extensions.graphql:4:24]
    │
  3 │ type TestObject @nonRepeatable
    │                 ───────┬──────  
-   │                        ╰──────── directive nonRepeatable first called here
+   │                        ╰──────── directive `@nonRepeatable` first called here
  4 │ extend type TestObject @nonRepeatable
    │                        ───────┬──────  
-   │                               ╰──────── directive nonRepeatable called again here
+   │                               ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0080_directive_is_unique_with_extensions.graphql:7:22]
    │
  6 │ scalar Scalar @nonRepeatable
    │               ───────┬──────  
-   │                      ╰──────── directive nonRepeatable first called here
+   │                      ╰──────── directive `@nonRepeatable` first called here
  7 │ extend scalar Scalar @nonRepeatable @specifiedBy(url: "example.com")
    │                      ───────┬──────  
-   │                             ╰──────── directive nonRepeatable called again here
+   │                             ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: the type `Intf` is defined multiple times in the schema
     ╭─[0080_directive_is_unique_with_extensions.graphql:12:11]

--- a/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
@@ -3,53 +3,53 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │
  3 │ schema @nonRepeatable @nonRepeatable { query: Dummy }
    │        ───────┬────── ───────┬──────  
-   │               ╰─────────────────────── directive nonRepeatable first called here
+   │               ╰─────────────────────── directive `@nonRepeatable` first called here
    │                              │        
-   │                              ╰──────── directive nonRepeatable called again here
+   │                              ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:4:34]
    │
  4 │ scalar TestScalar @nonRepeatable @nonRepeatable @specifiedBy(url: "example.com")
    │                   ───────┬────── ───────┬──────  
-   │                          ╰─────────────────────── directive nonRepeatable first called here
+   │                          ╰─────────────────────── directive `@nonRepeatable` first called here
    │                                         │        
-   │                                         ╰──────── directive nonRepeatable called again here
+   │                                         ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:5:27]
    │
  5 │ type Dummy @nonRepeatable @nonRepeatable
    │            ───────┬────── ───────┬──────  
-   │                   ╰─────────────────────── directive nonRepeatable first called here
+   │                   ╰─────────────────────── directive `@nonRepeatable` first called here
    │                                  │        
-   │                                  ╰──────── directive nonRepeatable called again here
+   │                                  ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:6:40]
    │
  6 │ interface TestInterface @nonRepeatable @nonRepeatable
    │                         ───────┬────── ───────┬──────  
-   │                                ╰─────────────────────── directive nonRepeatable first called here
+   │                                ╰─────────────────────── directive `@nonRepeatable` first called here
    │                                               │        
-   │                                               ╰──────── directive nonRepeatable called again here
+   │                                               ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:7:32]
    │
  7 │ union TestUnion @nonRepeatable @nonRepeatable
    │                 ───────┬────── ───────┬──────  
-   │                        ╰─────────────────────── directive nonRepeatable first called here
+   │                        ╰─────────────────────── directive `@nonRepeatable` first called here
    │                                       │        
-   │                                       ╰──────── directive nonRepeatable called again here
+   │                                       ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:8:32]
    │
  8 │ input TestInput @nonRepeatable @nonRepeatable
    │                 ───────┬────── ───────┬──────  
-   │                        ╰─────────────────────── directive nonRepeatable first called here
+   │                        ╰─────────────────────── directive `@nonRepeatable` first called here
    │                                       │        
-   │                                       ╰──────── directive nonRepeatable called again here
+   │                                       ╰──────── directive `@nonRepeatable` called again here
 ───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0084_circular_non_nullable_input_objects.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0084_circular_non_nullable_input_objects.txt
@@ -20,14 +20,14 @@ Error: `First` input object cannot reference itself
     │ 
  22 │       first: First!
     │       ──────┬──────  
-    │             ╰──────── `fourth` circularly references `first` here
+    │             ╰──────── `fourth` circularly references `First` here
 ────╯
 Error: `Second` input object cannot reference itself
     ╭─[0084_circular_non_nullable_input_objects.graphql:11:1]
     │
   7 │       second: Second!
     │       ───────┬───────  
-    │              ╰───────── `first` circularly references `second` here
+    │              ╰───────── `first` circularly references `Second` here
     │ 
  11 │ ╭─▶ input Second {
  12 │ │     third: Third!
@@ -55,7 +55,7 @@ Error: `Third` input object cannot reference itself
     │ 
  12 │       third: Third!
     │       ──────┬──────  
-    │             ╰──────── `second` circularly references `third` here
+    │             ╰──────── `second` circularly references `Third` here
     │ 
  16 │ ╭─▶ input Third {
  17 │ │     fourth: Fourth!
@@ -83,7 +83,7 @@ Error: `Fourth` input object cannot reference itself
     │ 
  17 │       fourth: Fourth!
     │       ───────┬───────  
-    │              ╰───────── `third` circularly references `fourth` here
+    │              ╰───────── `third` circularly references `Fourth` here
     │ 
  21 │ ╭─▶ input Fourth {
  22 │ │     first: First!

--- a/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
@@ -7,25 +7,17 @@ Error: field selection of scalar type `Int` must not have subselections
    │ 
    │ Note: path to the field: `query Query → products → price`
 ───╯
-Error: fragments can not be declared on primitive types
-     ╭─[0087_fragment_type_condition_on_composite_types.graphql:7:5]
-     │
-   7 │ ╭─▶     ... on Int {
-     ┆ ┆   
-   9 │ ├─▶     }
-     │ │           
-     │ ╰─────────── fragment declares unsupported type condition `Int`
-     │
-     ├─[built_in.graphql:125:1]
-     │
- 125 │ ╭─▶ """
-     ┆ ┆   
- 129 │ ├─▶ scalar Int
-     │ │                
-     │ ╰──────────────── `Int` is defined here
-     │     
-     │     Help: fragments cannot be defined on enums, scalars and input objects
-─────╯
+Error: inline fragment must have a composite type in its type condition
+   ╭─[0087_fragment_type_condition_on_composite_types.graphql:7:5]
+   │
+ 7 │ ╭─▶     ... on Int {
+   ┆ ┆   
+ 9 │ ├─▶     }
+   │ │           
+   │ ╰─────────── fragment declares unsupported type condition `Int`
+   │     
+   │     Help: fragments cannot be defined on enums, scalars and input objects
+───╯
 Error: type `Int` does not have a field `name`
      ╭─[0087_fragment_type_condition_on_composite_types.graphql:8:7]
      │
@@ -67,25 +59,17 @@ Error: type `Int` does not have a field `name`
      │ 
      │ Note: path to the field: `fragment fragOnScalar → name`
 ─────╯
-Error: fragments can not be declared on primitive types
-     ╭─[0087_fragment_type_condition_on_composite_types.graphql:26:3]
-     │
-  26 │ ╭─▶   ... on Int {
-     ┆ ┆   
-  28 │ ├─▶   }
-     │ │         
-     │ ╰───────── fragment declares unsupported type condition `Int`
-     │
-     ├─[built_in.graphql:125:1]
-     │
- 125 │ ╭─▶ """
-     ┆ ┆   
- 129 │ ├─▶ scalar Int
-     │ │                
-     │ ╰──────────────── `Int` is defined here
-     │     
-     │     Help: fragments cannot be defined on enums, scalars and input objects
-─────╯
+Error: inline fragment must have a composite type in its type condition
+    ╭─[0087_fragment_type_condition_on_composite_types.graphql:26:3]
+    │
+ 26 │ ╭─▶   ... on Int {
+    ┆ ┆   
+ 28 │ ├─▶   }
+    │ │         
+    │ ╰───────── fragment declares unsupported type condition `Int`
+    │     
+    │     Help: fragments cannot be defined on enums, scalars and input objects
+────╯
 Error: type `Int` does not have a field `name`
      ╭─[0087_fragment_type_condition_on_composite_types.graphql:27:5]
      │

--- a/crates/apollo-compiler/test_data/diagnostics/0090_fragment_spread_impossible.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0090_fragment_spread_impossible.txt
@@ -1,4 +1,4 @@
-Error: fragment cannot be applied to this type
+Error: fragment `catInDogFragmentInvalid` with type condition `Dog` cannot be applied to `Human`
     ╭─[0090_fragment_spread_impossible.graphql:39:9]
     │
  25 │   ╭─▶ type Human implements Sentient {
@@ -17,7 +17,7 @@ Error: fragment cannot be applied to this type
     │ │         
     │ ╰───────── fragment declared with type condition `Dog` here
 ────╯
-Error: fragment cannot be applied to this type
+Error: fragment `nonIntersectingInterfaces` with type condition `Pet` cannot be applied to `Human`
     ╭─[0090_fragment_spread_impossible.graphql:42:9]
     │
  25 │   ╭─▶ type Human implements Sentient {
@@ -36,7 +36,7 @@ Error: fragment cannot be applied to this type
     │ │         
     │ ╰───────── fragment declared with type condition `Pet` here
 ────╯
-Error: fragment cannot be applied to this type
+Error: inline fragment with type condition `Cat` cannot be applied to `Dog`
     ╭─[0090_fragment_spread_impossible.graphql:48:3]
     │
  13 │ ╭───▶ type Dog implements Pet {
@@ -49,9 +49,9 @@ Error: fragment cannot be applied to this type
     ┆   ┆   
  50 │   ├─▶   }
     │   │         
-    │   ╰───────── fragment applied with type condition `Cat` here
+    │   ╰───────── inline fragment cannot be applied
 ────╯
-Error: fragment cannot be applied to this type
+Error: inline fragment with type condition `Dog` cannot be applied to `Sentient`
     ╭─[0090_fragment_spread_impossible.graphql:54:3]
     │
   5 │ ╭───▶ interface Sentient {
@@ -64,9 +64,9 @@ Error: fragment cannot be applied to this type
     ┆   ┆   
  56 │   ├─▶   }
     │   │         
-    │   ╰───────── fragment applied with type condition `Dog` here
+    │   ╰───────── inline fragment cannot be applied
 ────╯
-Error: fragment cannot be applied to this type
+Error: inline fragment with type condition `Cat` cannot be applied to `HumanOrAlien`
     ╭─[0090_fragment_spread_impossible.graphql:60:3]
     │
  35 │     union HumanOrAlien = Human | Alien
@@ -77,9 +77,9 @@ Error: fragment cannot be applied to this type
     ┆ ┆   
  62 │ ├─▶   }
     │ │         
-    │ ╰───────── fragment applied with type condition `Cat` here
+    │ ╰───────── inline fragment cannot be applied
 ────╯
-Error: fragment cannot be applied to this type
+Error: fragment `sentientFragment2` with type condition `Sentient` cannot be applied to `Pet`
     ╭─[0090_fragment_spread_impossible.graphql:66:3]
     │
   9 │   ╭─▶ interface Pet {

--- a/crates/apollo-compiler/test_data/diagnostics/0091_recursive_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0091_recursive_interface_definition.txt
@@ -23,7 +23,7 @@ Error: Transitively implemented interfaces must also be defined on an implementi
    │ │       
    │ ╰─────── B must also be implemented here
 ───╯
-Error: fragment cannot be applied to this type
+Error: fragment `recursive` with type condition `A` cannot be applied to `A`
     ╭─[0091_recursive_interface_definition.graphql:15:9]
     │
   1 │ ╭───▶ interface A implements B {

--- a/crates/apollo-compiler/test_data/diagnostics/0091_recursive_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0091_recursive_interface_definition.txt
@@ -1,4 +1,4 @@
-Error: Transitively implemented interfaces must also be defined on an implementing interface or object
+Error: interface `A` declares that it implements `B`, but to do so it must also implement `A`
    ╭─[0091_recursive_interface_definition.graphql:1:1]
    │
  1 │ ╭─▶ interface A implements B {
@@ -10,7 +10,7 @@ Error: Transitively implemented interfaces must also be defined on an implementi
    │                            ┬  
    │                            ╰── implementation of A declared by B here
 ───╯
-Error: Transitively implemented interfaces must also be defined on an implementing interface or object
+Error: interface `B` declares that it implements `A`, but to do so it must also implement `B`
    ╭─[0091_recursive_interface_definition.graphql:4:1]
    │
  1 │     interface A implements B {

--- a/crates/apollo-compiler/test_data/diagnostics/0093_fragment_validation_with_recursive_type_system.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0093_fragment_validation_with_recursive_type_system.txt
@@ -1,4 +1,4 @@
-Error: Transitively implemented interfaces must also be defined on an implementing interface or object
+Error: interface `A` declares that it implements `B`, but to do so it must also implement `A`
    ╭─[0093_fragment_validation_with_recursive_type_system.graphql:2:1]
    │
  2 │ ╭─▶ interface A implements B {
@@ -10,7 +10,7 @@ Error: Transitively implemented interfaces must also be defined on an implementi
    │                            ┬  
    │                            ╰── implementation of A declared by B here
 ───╯
-Error: Transitively implemented interfaces must also be defined on an implementing interface or object
+Error: interface `B` declares that it implements `A`, but to do so it must also implement `B`
    ╭─[0093_fragment_validation_with_recursive_type_system.graphql:6:1]
    │
  2 │     interface A implements B {

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
@@ -24,11 +24,11 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │
  17 │ type UniqueDirective @nonRepeatable {
     │                      ───────┬──────  
-    │                             ╰──────── directive nonRepeatable first called here
+    │                             ╰──────── directive `@nonRepeatable` first called here
     │ 
  20 │ extend type UniqueDirective @nonRepeatable {
     │                             ───────┬──────  
-    │                                    ╰──────── directive nonRepeatable called again here
+    │                                    ╰──────── directive `@nonRepeatable` called again here
 ────╯
 Error: object type `UniqueInterfaces` implements interface `Base` more than once
     ╭─[0094_object_type_extensions.graphql:31:41]
@@ -41,7 +41,7 @@ Error: object type `UniqueInterfaces` implements interface `Base` more than once
     │                                         ──┬─  
     │                                           ╰─── `Base` implemented again here
 ────╯
-Error: type does not satisfy interface `ExtendedInterface`: missing field `fail`
+Error: type `ExtendedInterface` does not satisfy interface `ExtendedInterface`: missing field `fail`
     ╭─[0094_object_type_extensions.graphql:38:1]
     │
  38 │ ╭─▶ type ImplementsBaseButNotExtension implements ExtendedInterface {
@@ -50,12 +50,12 @@ Error: type does not satisfy interface `ExtendedInterface`: missing field `fail`
     ┆ ┆   
  40 │ ├─▶ }
     │ │       
-    │ ╰─────── add `fail` field to this object
+    │ ╰─────── add `fail` field to this type
     │ 
  42 │       fail: Boolean
     │       ──────┬──────  
-    │             ╰──────── `fail` was originally defined by ExtendedInterface here
+    │             ╰──────── `ExtendedInterface.fail` originally defined here
     │     
-    │     Help: An object must provide all fields required by the interfaces it implements
+    │     Help: An object or interface must declare all fields required by the interfaces it implements
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
@@ -41,7 +41,7 @@ Error: object type `UniqueInterfaces` implements interface `Base` more than once
     │                                         ──┬─  
     │                                           ╰─── `Base` implemented again here
 ────╯
-Error: type `ExtendedInterface` does not satisfy interface `ExtendedInterface`: missing field `fail`
+Error: type `ImplementsBaseButNotExtension` does not satisfy interface `ExtendedInterface`: missing field `fail`
     ╭─[0094_object_type_extensions.graphql:38:1]
     │
  38 │ ╭─▶ type ImplementsBaseButNotExtension implements ExtendedInterface {

--- a/crates/apollo-compiler/test_data/diagnostics/0096_schema_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0096_schema_extensions.txt
@@ -3,10 +3,10 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │
   8 │ schema @nonRepeatable {
     │        ───────┬──────  
-    │               ╰──────── directive nonRepeatable first called here
+    │               ╰──────── directive `@nonRepeatable` first called here
     │ 
  11 │ extend schema @nonRepeatable
     │               ───────┬──────  
-    │                      ╰──────── directive nonRepeatable called again here
+    │                      ╰──────── directive `@nonRepeatable` called again here
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
@@ -3,11 +3,11 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │
   8 │ extend enum E @nonRepeatable {
     │               ───────┬──────  
-    │                      ╰──────── directive nonRepeatable first called here
+    │                      ╰──────── directive `@nonRepeatable` first called here
     │ 
  13 │ extend enum E @nonRepeatable {
     │               ───────┬──────  
-    │                      ╰──────── directive nonRepeatable called again here
+    │                      ╰──────── directive `@nonRepeatable` called again here
 ────╯
 Error: duplicate definitions for the `MEMBER_2` value of enum type `E`
     ╭─[0097_enum_extensions.graphql:14:3]

--- a/crates/apollo-compiler/test_data/diagnostics/0098_interface_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0098_interface_extensions.txt
@@ -14,28 +14,28 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │
  10 │ interface Directives @nonRepeatable {
     │                      ───────┬──────  
-    │                             ╰──────── directive nonRepeatable first called here
+    │                             ╰──────── directive `@nonRepeatable` first called here
     │ 
  14 │ extend interface Directives @nonRepeatable
     │                             ───────┬──────  
-    │                                    ╰──────── directive nonRepeatable called again here
+    │                                    ╰──────── directive `@nonRepeatable` called again here
 ────╯
-Error: type does not satisfy interface `Base`: missing field `b`
+Error: type `Derived` does not satisfy interface `Base`: missing field `b`
     ╭─[0098_interface_extensions.graphql:21:1]
     │
  18 │       b: Int
     │       ───┬──  
-    │          ╰──── `b` was originally defined by Base here
+    │          ╰──── `Base.b` originally defined here
     │ 
  21 │ ╭─▶ interface Derived {
     ┆ ┆   
  23 │ ├─▶ }
     │ │       
-    │ ╰─────── add `b` field to this interface
+    │ ╰─────── add `b` field to this type
  24 │     extend interface Derived implements Base {
     │                                         ──┬─  
     │                                           ╰─── implementation of interface Base declared here
     │     
-    │     Help: An interface must be a super-set of all interfaces it implements
+    │     Help: An object or interface must declare all fields required by the interfaces it implements
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.txt
@@ -14,10 +14,10 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │
   9 │ input UniqueDirective @nonRepeatable {
     │                       ───────┬──────  
-    │                              ╰──────── directive nonRepeatable first called here
+    │                              ╰──────── directive `@nonRepeatable` first called here
     │ 
  12 │ extend input UniqueDirective @nonRepeatable
     │                              ───────┬──────  
-    │                                     ╰──────── directive nonRepeatable called again here
+    │                                     ╰──────── directive `@nonRepeatable` called again here
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0100_union_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0100_union_extensions.txt
@@ -1,11 +1,11 @@
-Error: `ThisIsAScalar` field must return an object type
+Error: union member `ThisIsAScalar` must be an object type
    ╭─[0100_union_extensions.graphql:8:30]
    │
  8 │ extend union NonObjectType = ThisIsAScalar
    │                              ──────┬──────  
-   │                                    ╰──────── This is a a scalar
+   │                                    ╰──────── this is a scalar
    │ 
-   │ Help: Union members must be of base Object Type.
+   │ Help: Union members must be object types.
 ───╯
 Error: duplicate definitions for the `WithFieldA` member of union type `DuplicateMembers`
     ╭─[0100_union_extensions.graphql:12:33]
@@ -22,9 +22,9 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │
  16 │ union DuplicateDirective @nonRepeatable = WithFieldA
     │                          ───────┬──────  
-    │                                 ╰──────── directive nonRepeatable first called here
+    │                                 ╰──────── directive `@nonRepeatable` first called here
  17 │ extend union DuplicateDirective @nonRepeatable = WithFieldB
     │                                 ───────┬──────  
-    │                                        ╰──────── directive nonRepeatable called again here
+    │                                        ╰──────── directive `@nonRepeatable` called again here
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0100_union_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0100_union_extensions.txt
@@ -3,7 +3,7 @@ Error: union member `ThisIsAScalar` must be an object type
    │
  8 │ extend union NonObjectType = ThisIsAScalar
    │                              ──────┬──────  
-   │                                    ╰──────── this is a scalar
+   │                                    ╰──────── this is a scalar type
    │ 
    │ Help: Union members must be object types.
 ───╯

--- a/crates/apollo-compiler/test_data/diagnostics/0101_mismatched_variable_usage.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0101_mismatched_variable_usage.txt
@@ -1,67 +1,67 @@
-Error: variable `intArg` cannot be used for argument `booleanArg` as their types mismatch
+Error: variable `$intArg` of type `Int` cannot be used for argument `booleanArg` of type `Boolean`
    ╭─[0101_mismatched_variable_usage.graphql:3:21]
    │
  1 │ query intCannotGoIntoBoolean($intArg: Int) {
    │                              ──────┬─────  
-   │                                    ╰─────── variable `intArg` of type `Int` is declared here
+   │                                    ╰─────── variable `$intArg` of type `Int` is declared here
    │ 
  3 │     booleanArgField(booleanArg: $intArg)
    │                     ─────────┬─────────  
-   │                              ╰─────────── argument `booleanArg` of type `Boolean` is declared here
+   │                              ╰─────────── variable `$intArg` used here
 ───╯
-Error: variable `booleanListArg` cannot be used for argument `booleanArg` as their types mismatch
+Error: variable `$booleanListArg` of type `[Boolean]` cannot be used for argument `booleanArg` of type `Boolean`
    ╭─[0101_mismatched_variable_usage.graphql:9:21]
    │
  7 │ query booleanListCannotGoIntoBoolean($booleanListArg: [Boolean]) {
    │                                      ─────────────┬────────────  
-   │                                                   ╰────────────── variable `booleanListArg` of type `[Boolean]` is declared here
+   │                                                   ╰────────────── variable `$booleanListArg` of type `[Boolean]` is declared here
    │ 
  9 │     booleanArgField(booleanArg: $booleanListArg)
    │                     ─────────────┬─────────────  
-   │                                  ╰─────────────── argument `booleanArg` of type `Boolean` is declared here
+   │                                  ╰─────────────── variable `$booleanListArg` used here
 ───╯
-Error: variable `booleanArg` cannot be used for argument `nonNullBooleanArg` as their types mismatch
+Error: variable `$booleanArg` of type `Boolean` cannot be used for argument `nonNullBooleanArg` of type `Boolean!`
     ╭─[0101_mismatched_variable_usage.graphql:15:28]
     │
  13 │ query booleanArgQuery($booleanArg: Boolean) {
     │                       ──────────┬─────────  
-    │                                 ╰─────────── variable `booleanArg` of type `Boolean` is declared here
+    │                                 ╰─────────── variable `$booleanArg` of type `Boolean` is declared here
     │ 
  15 │     nonNullBooleanArgField(nonNullBooleanArg: $booleanArg)
     │                            ───────────────┬──────────────  
-    │                                           ╰──────────────── argument `nonNullBooleanArg` of type `Boolean!` is declared here
+    │                                           ╰──────────────── variable `$booleanArg` used here
 ────╯
-Error: variable `booleanList` cannot be used for argument `nonNullBooleanListArg` as their types mismatch
+Error: variable `$booleanList` of type `[Boolean]` cannot be used for argument `nonNullBooleanListArg` of type `[Boolean]!`
     ╭─[0101_mismatched_variable_usage.graphql:21:29]
     │
  19 │ query listToNonNullList($booleanList: [Boolean]) {
     │                         ───────────┬───────────  
-    │                                    ╰───────────── variable `booleanList` of type `[Boolean]` is declared here
+    │                                    ╰───────────── variable `$booleanList` of type `[Boolean]` is declared here
     │ 
  21 │     nonNullBooleanListField(nonNullBooleanListArg: $booleanList)
     │                             ─────────────────┬─────────────────  
-    │                                              ╰─────────────────── argument `nonNullBooleanListArg` of type `[Boolean]!` is declared here
+    │                                              ╰─────────────────── variable `$booleanList` used here
 ────╯
-Error: variable `intArg` cannot be used for argument `nonNullIntArg` as their types mismatch
+Error: variable `$intArg` of type `Int` cannot be used for argument `nonNullIntArg` of type `Int!`
     ╭─[0101_mismatched_variable_usage.graphql:26:24]
     │
  26 │     nonNullIntArgField(nonNullIntArg: $intArg)
     │                        ───────────┬──────────  
-    │                                   ╰──────────── argument `nonNullIntArg` of type `Int!` is declared here
+    │                                   ╰──────────── variable `$intArg` used here
     │ 
  29 │ query fragmentNonNullIntArgField($intArg: Int) {
     │                                  ──────┬─────  
-    │                                        ╰─────── variable `intArg` of type `Int` is declared here
+    │                                        ╰─────── variable `$intArg` of type `Int` is declared here
 ────╯
-Error: variable `intArg` cannot be used for argument `nonNullIntArg` as their types mismatch
+Error: variable `$intArg` of type `Int` cannot be used for argument `nonNullIntArg` of type `Int!`
     ╭─[0101_mismatched_variable_usage.graphql:40:24]
     │
  40 │     nonNullIntArgField(nonNullIntArg: $intArg)
     │                        ───────────┬──────────  
-    │                                   ╰──────────── argument `nonNullIntArg` of type `Int!` is declared here
+    │                                   ╰──────────── variable `$intArg` used here
     │ 
  43 │ query doubleNestedFragmentNonNullIntArgField($intArg: Int) {
     │                                              ──────┬─────  
-    │                                                    ╰─────── variable `intArg` of type `Int` is declared here
+    │                                                    ╰─────── variable `$intArg` of type `Int` is declared here
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
@@ -3,309 +3,321 @@ Error: expected value of type String, found Int
     │
   8 │   stringArgField(stringArg: String): String
     │                             ───┬──  
-    │                                ╰──── field declared here as String type
+    │                                ╰──── expected type declared here as String
     │ 
  71 │     stringArgField(stringArg: 1)
     │                               ┬  
-    │                               ╰── argument declared here is of Int type
+    │                               ╰── provided value is of Int type
 ────╯
 Error: expected value of type String, found Float
     ╭─[0102_invalid_string_values.graphql:77:31]
     │
   8 │   stringArgField(stringArg: String): String
     │                             ───┬──  
-    │                                ╰──── field declared here as String type
+    │                                ╰──── expected type declared here as String
     │ 
  77 │     stringArgField(stringArg: 1.0)
     │                               ─┬─  
-    │                                ╰─── argument declared here is of Float type
+    │                                ╰─── provided value is of Float type
 ────╯
 Error: expected value of type String, found Boolean
     ╭─[0102_invalid_string_values.graphql:83:31]
     │
   8 │   stringArgField(stringArg: String): String
     │                             ───┬──  
-    │                                ╰──── field declared here as String type
+    │                                ╰──── expected type declared here as String
     │ 
  83 │     stringArgField(stringArg: true)
     │                               ──┬─  
-    │                                 ╰─── argument declared here is of Boolean type
+    │                                 ╰─── provided value is of Boolean type
 ────╯
 Error: expected value of type String, found Enum
     ╭─[0102_invalid_string_values.graphql:89:31]
     │
   8 │   stringArgField(stringArg: String): String
     │                             ───┬──  
-    │                                ╰──── field declared here as String type
+    │                                ╰──── expected type declared here as String
     │ 
  89 │     stringArgField(stringArg: BAR)
     │                               ─┬─  
-    │                                ╰─── argument declared here is of Enum type
+    │                                ╰─── provided value is of Enum type
 ────╯
 Error: expected value of type Int, found String
     ╭─[0102_invalid_string_values.graphql:95:25]
     │
   6 │   intArgField(intArg: Int): String
     │                       ─┬─  
-    │                        ╰─── field declared here as Int type
+    │                        ╰─── expected type declared here as Int
     │ 
  95 │     intArgField(intArg: "3")
     │                         ─┬─  
-    │                          ╰─── argument declared here is of String type
+    │                          ╰─── provided value is of String type
 ────╯
 Error: int cannot represent non 32-bit signed integer value
      ╭─[0102_invalid_string_values.graphql:101:25]
      │
  101 │     intArgField(intArg: 829384293849283498239482938)
      │                         ─────────────┬─────────────  
-     │                                      ╰─────────────── cannot be coerced to an 32-bit integer
+     │                                      ╰─────────────── cannot be coerced to a 32-bit integer
 ─────╯
 Error: expected value of type Int, found Enum
      ╭─[0102_invalid_string_values.graphql:107:25]
      │
    6 │   intArgField(intArg: Int): String
      │                       ─┬─  
-     │                        ╰─── field declared here as Int type
+     │                        ╰─── expected type declared here as Int
      │ 
  107 │     intArgField(intArg: FOO)
      │                         ─┬─  
-     │                          ╰─── argument declared here is of Enum type
+     │                          ╰─── provided value is of Enum type
 ─────╯
 Error: expected value of type Int, found Float
      ╭─[0102_invalid_string_values.graphql:113:25]
      │
    6 │   intArgField(intArg: Int): String
      │                       ─┬─  
-     │                        ╰─── field declared here as Int type
+     │                        ╰─── expected type declared here as Int
      │ 
  113 │     intArgField(intArg: 3.0)
      │                         ─┬─  
-     │                          ╰─── argument declared here is of Float type
+     │                          ╰─── provided value is of Float type
 ─────╯
 Error: expected value of type Int, found Float
      ╭─[0102_invalid_string_values.graphql:119:25]
      │
    6 │   intArgField(intArg: Int): String
      │                       ─┬─  
-     │                        ╰─── field declared here as Int type
+     │                        ╰─── expected type declared here as Int
      │ 
  119 │     intArgField(intArg: 3.333)
      │                         ──┬──  
-     │                           ╰──── argument declared here is of Float type
+     │                           ╰──── provided value is of Float type
 ─────╯
 Error: expected value of type Float, found String
      ╭─[0102_invalid_string_values.graphql:125:29]
      │
   11 │   floatArgField(floatArg: Float): String
      │                           ──┬──  
-     │                             ╰──── field declared here as Float type
+     │                             ╰──── expected type declared here as Float
      │ 
  125 │     floatArgField(floatArg: "3.333")
      │                             ───┬───  
-     │                                ╰───── argument declared here is of String type
+     │                                ╰───── provided value is of String type
 ─────╯
 Error: expected value of type Float, found Boolean
      ╭─[0102_invalid_string_values.graphql:131:29]
      │
   11 │   floatArgField(floatArg: Float): String
      │                           ──┬──  
-     │                             ╰──── field declared here as Float type
+     │                             ╰──── expected type declared here as Float
      │ 
  131 │     floatArgField(floatArg: true)
      │                             ──┬─  
-     │                               ╰─── argument declared here is of Boolean type
+     │                               ╰─── provided value is of Boolean type
 ─────╯
 Error: expected value of type Float, found Enum
      ╭─[0102_invalid_string_values.graphql:137:29]
      │
   11 │   floatArgField(floatArg: Float): String
      │                           ──┬──  
-     │                             ╰──── field declared here as Float type
+     │                             ╰──── expected type declared here as Float
      │ 
  137 │     floatArgField(floatArg: FOO)
      │                             ─┬─  
-     │                              ╰─── argument declared here is of Enum type
+     │                              ╰─── provided value is of Enum type
 ─────╯
 Error: expected value of type Boolean, found Int
      ╭─[0102_invalid_string_values.graphql:143:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
      │                               ───┬───  
-     │                                  ╰───── field declared here as Boolean type
+     │                                  ╰───── expected type declared here as Boolean
      │ 
  143 │     booleanArgField(booleanArg: 2)
      │                                 ┬  
-     │                                 ╰── argument declared here is of Int type
+     │                                 ╰── provided value is of Int type
 ─────╯
 Error: expected value of type Boolean, found Float
      ╭─[0102_invalid_string_values.graphql:149:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
      │                               ───┬───  
-     │                                  ╰───── field declared here as Boolean type
+     │                                  ╰───── expected type declared here as Boolean
      │ 
  149 │     booleanArgField(booleanArg: 1.0)
      │                                 ─┬─  
-     │                                  ╰─── argument declared here is of Float type
+     │                                  ╰─── provided value is of Float type
 ─────╯
 Error: expected value of type Boolean, found String
      ╭─[0102_invalid_string_values.graphql:155:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
      │                               ───┬───  
-     │                                  ╰───── field declared here as Boolean type
+     │                                  ╰───── expected type declared here as Boolean
      │ 
  155 │     booleanArgField(booleanArg: "true")
      │                                 ───┬──  
-     │                                    ╰──── argument declared here is of String type
+     │                                    ╰──── provided value is of String type
 ─────╯
 Error: expected value of type Boolean, found Enum
      ╭─[0102_invalid_string_values.graphql:161:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
      │                               ───┬───  
-     │                                  ╰───── field declared here as Boolean type
+     │                                  ╰───── expected type declared here as Boolean
      │ 
  161 │     booleanArgField(booleanArg: TRUE)
      │                                 ──┬─  
-     │                                   ╰─── argument declared here is of Enum type
+     │                                   ╰─── provided value is of Enum type
 ─────╯
 Error: expected value of type ID, found Float
      ╭─[0102_invalid_string_values.graphql:167:23]
      │
   12 │   idArgField(idArg: ID): String
      │                     ─┬  
-     │                      ╰── field declared here as ID type
+     │                      ╰── expected type declared here as ID
      │ 
  167 │     idArgField(idArg: 1.0)
      │                       ─┬─  
-     │                        ╰─── argument declared here is of Float type
+     │                        ╰─── provided value is of Float type
 ─────╯
 Error: expected value of type ID, found Boolean
      ╭─[0102_invalid_string_values.graphql:173:23]
      │
   12 │   idArgField(idArg: ID): String
      │                     ─┬  
-     │                      ╰── field declared here as ID type
+     │                      ╰── expected type declared here as ID
      │ 
  173 │     idArgField(idArg: true)
      │                       ──┬─  
-     │                         ╰─── argument declared here is of Boolean type
+     │                         ╰─── provided value is of Boolean type
 ─────╯
 Error: expected value of type ID, found Enum
      ╭─[0102_invalid_string_values.graphql:179:23]
      │
   12 │   idArgField(idArg: ID): String
      │                     ─┬  
-     │                      ╰── field declared here as ID type
+     │                      ╰── expected type declared here as ID
      │ 
  179 │     idArgField(idArg: SOMETHING)
      │                       ────┬────  
-     │                           ╰────── argument declared here is of Enum type
+     │                           ╰────── provided value is of Enum type
 ─────╯
 Error: expected value of type DogCommand, found Int
      ╭─[0102_invalid_string_values.graphql:186:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
      │                               ─────┬────  
-     │                                    ╰────── field declared here as DogCommand type
+     │                                    ╰────── expected type declared here as DogCommand
      │ 
  186 │     doesKnowCommand(dogCommand: 2)
      │                                 ┬  
-     │                                 ╰── argument declared here is of Int type
+     │                                 ╰── provided value is of Int type
 ─────╯
 Error: expected value of type DogCommand, found Float
      ╭─[0102_invalid_string_values.graphql:192:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
      │                               ─────┬────  
-     │                                    ╰────── field declared here as DogCommand type
+     │                                    ╰────── expected type declared here as DogCommand
      │ 
  192 │     doesKnowCommand(dogCommand: 1.0)
      │                                 ─┬─  
-     │                                  ╰─── argument declared here is of Float type
+     │                                  ╰─── provided value is of Float type
 ─────╯
 Error: expected value of type DogCommand, found String
      ╭─[0102_invalid_string_values.graphql:198:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
      │                               ─────┬────  
-     │                                    ╰────── field declared here as DogCommand type
+     │                                    ╰────── expected type declared here as DogCommand
      │ 
  198 │     doesKnowCommand(dogCommand: "SIT")
      │                                 ──┬──  
-     │                                   ╰──── argument declared here is of String type
+     │                                   ╰──── provided value is of String type
 ─────╯
 Error: expected value of type DogCommand, found Boolean
      ╭─[0102_invalid_string_values.graphql:204:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
      │                               ─────┬────  
-     │                                    ╰────── field declared here as DogCommand type
+     │                                    ╰────── expected type declared here as DogCommand
      │ 
  204 │     doesKnowCommand(dogCommand: true)
      │                                 ──┬─  
-     │                                   ╰─── argument declared here is of Boolean type
+     │                                   ╰─── provided value is of Boolean type
 ─────╯
-Error: value `JUGGLE` does not exist on `DogCommand` type
+Error: value `JUGGLE` does not exist on `DogCommand`
      ╭─[0102_invalid_string_values.graphql:210:33]
      │
- 210 │     doesKnowCommand(dogCommand: JUGGLE)
-     │                                 ───┬──  
-     │                                    ╰──── does not exist on `DogCommand` type
+  40 │ ╭─▶ enum DogCommand {
+     ┆ ┆   
+  44 │ ├─▶ }
+     │ │       
+     │ ╰─────── enum defined here
+     │ 
+ 210 │         doesKnowCommand(dogCommand: JUGGLE)
+     │                                     ───┬──  
+     │                                        ╰──── value does not exist on `DogCommand` enum
 ─────╯
-Error: value `sit` does not exist on `DogCommand` type
+Error: value `sit` does not exist on `DogCommand`
      ╭─[0102_invalid_string_values.graphql:216:33]
      │
- 216 │     doesKnowCommand(dogCommand: sit)
-     │                                 ─┬─  
-     │                                  ╰─── does not exist on `DogCommand` type
+  40 │ ╭─▶ enum DogCommand {
+     ┆ ┆   
+  44 │ ├─▶ }
+     │ │       
+     │ ╰─────── enum defined here
+     │ 
+ 216 │         doesKnowCommand(dogCommand: sit)
+     │                                     ─┬─  
+     │                                      ╰─── value does not exist on `DogCommand` enum
 ─────╯
 Error: expected value of type String, found Int
      ╭─[0102_invalid_string_values.graphql:222:47]
      │
   13 │   stringListArgField(stringListArg: [String]): String
      │                                     ────┬───  
-     │                                         ╰───── field declared here as String type
+     │                                         ╰───── expected type declared here as String
      │ 
  222 │     stringListArgField(stringListArg: ["one", 2])
      │                                               ┬  
-     │                                               ╰── argument declared here is of Int type
+     │                                               ╰── provided value is of Int type
 ─────╯
 Error: expected value of type [String], found Int
      ╭─[0102_invalid_string_values.graphql:228:39]
      │
   13 │   stringListArgField(stringListArg: [String]): String
      │                                     ────┬───  
-     │                                         ╰───── field declared here as [String] type
+     │                                         ╰───── expected type declared here as [String]
      │ 
  228 │     stringListArgField(stringListArg: 1)
      │                                       ┬  
-     │                                       ╰── argument declared here is of Int type
+     │                                       ╰── provided value is of Int type
 ─────╯
 Error: expected value of type Int!, found String
      ╭─[0102_invalid_string_values.graphql:235:24]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                                  ──┬─  
-     │                                    ╰─── field declared here as Int! type
+     │                                    ╰─── expected type declared here as Int!
      │ 
  235 │     multipleReqs(req2: "two", req1: "one")
      │                        ──┬──  
-     │                          ╰──── argument declared here is of String type
+     │                          ╰──── provided value is of String type
 ─────╯
 Error: expected value of type Int!, found String
      ╭─[0102_invalid_string_values.graphql:235:37]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                      ──┬─  
-     │                        ╰─── field declared here as Int! type
+     │                        ╰─── expected type declared here as Int!
      │ 
  235 │     multipleReqs(req2: "two", req1: "one")
      │                                     ──┬──  
-     │                                       ╰──── argument declared here is of String type
+     │                                       ╰──── provided value is of String type
 ─────╯
-Error: the required argument `req2` is not provided
+Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
      ╭─[0102_invalid_string_values.graphql:241:5]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -321,13 +333,13 @@ Error: expected value of type Int!, found String
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                      ──┬─  
-     │                        ╰─── field declared here as Int! type
+     │                        ╰─── expected type declared here as Int!
      │ 
  241 │     multipleReqs(req1: "one")
      │                        ──┬──  
-     │                          ╰──── argument declared here is of String type
+     │                          ╰──── provided value is of String type
 ─────╯
-Error: the required argument `req1` is not provided
+Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
      ╭─[0102_invalid_string_values.graphql:247:5]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -338,7 +350,7 @@ Error: the required argument `req1` is not provided
      │     ────────────┬───────────  
      │                 ╰───────────── missing value for argument `req1`
 ─────╯
-Error: the required argument `req2` is not provided
+Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
      ╭─[0102_invalid_string_values.graphql:247:5]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -354,13 +366,13 @@ Error: expected value of type Int!, found Null
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                      ──┬─  
-     │                        ╰─── field declared here as Int! type
+     │                        ╰─── expected type declared here as Int!
      │ 
  247 │     multipleReqs(req1: null)
      │                        ──┬─  
-     │                          ╰─── argument declared here is of Null type
+     │                          ╰─── provided value is of Null type
 ─────╯
-Error: the required argument `requiredField` is not provided
+Error: the required argument `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:254:33]
      │
   32 │   requiredField: Boolean!
@@ -376,63 +388,81 @@ Error: expected value of type String, found Int
      │
   37 │   stringListField: [String]
      │                    ────┬───  
-     │                        ╰───── field declared here as String type
+     │                        ╰───── expected type declared here as String
      │ 
  261 │       stringListField: ["one", 2],
      │                                ┬  
-     │                                ╰── argument declared here is of Int type
+     │                                ╰── provided value is of Int type
 ─────╯
 Error: expected value of type Boolean!, found Null
      ╭─[0102_invalid_string_values.graphql:271:7]
      │
   33 │   nonNullField: Boolean! = false
      │                 ────┬───  
-     │                     ╰───── field declared here as Boolean! type
+     │                     ╰───── expected type declared here as Boolean!
      │ 
  271 │       nonNullField: null,
      │       ─────────┬────────  
-     │                ╰────────── argument declared here is of Null type
+     │                ╰────────── provided value is of Null type
 ─────╯
-Error: value `invalidField` does not exist on `ComplexInput` type
+Error: field `invalidField` does not exist on `ComplexInput`
      ╭─[0102_invalid_string_values.graphql:280:7]
      │
- 280 │       invalidField: "value"
-     │       ──────────┬──────────  
-     │                 ╰──────────── does not exist on `ComplexInput` type
+  31 │ ╭─▶ input ComplexInput {
+     ┆ ┆   
+  38 │ ├─▶ }
+     │ │       
+     │ ╰─────── input object defined here
+     │ 
+ 280 │           invalidField: "value"
+     │           ──────────┬──────────  
+     │                     ╰──────────── value does not exist on `ComplexInput` input object
 ─────╯
 Error: expected value of type Boolean!, found String
      ╭─[0102_invalid_string_values.graphql:287:20]
      │
  287 │   dog @include(if: "yes") {
      │                    ──┬──  
-     │                      ╰──── argument declared here is of String type
+     │                      ╰──── provided value is of String type
+     │
+     ├─[built_in.graphql:105:7]
+     │
+ 105 │   if: Boolean!
+     │       ────┬───  
+     │           ╰───── expected type declared here as Boolean!
 ─────╯
 Error: expected value of type Boolean!, found Enum
      ╭─[0102_invalid_string_values.graphql:288:20]
      │
  288 │     name @skip(if: ENUM)
      │                    ──┬─  
-     │                      ╰─── argument declared here is of Enum type
+     │                      ╰─── provided value is of Enum type
+     │
+     ├─[built_in.graphql:99:7]
+     │
+  99 │   if: Boolean!
+     │       ────┬───  
+     │           ╰───── expected type declared here as Boolean!
 ─────╯
 Error: expected value of type Int!, found Null
      ╭─[0102_invalid_string_values.graphql:294:14]
      │
  294 │   $a: Int! = null,
      │       ──┬─   ──┬─  
-     │         ╰────────── field declared here as Int! type
+     │         ╰────────── expected type declared here as Int!
      │                │   
-     │                ╰─── argument declared here is of Null type
+     │                ╰─── provided value is of Null type
 ─────╯
 Error: expected value of type String!, found Null
      ╭─[0102_invalid_string_values.graphql:295:17]
      │
  295 │   $b: String! = null,
      │       ───┬───   ──┬─  
-     │          ╰──────────── field declared here as String! type
+     │          ╰──────────── expected type declared here as String!
      │                   │   
-     │                   ╰─── argument declared here is of Null type
+     │                   ╰─── provided value is of Null type
 ─────╯
-Error: the required argument `requiredField` is not provided
+Error: the required argument `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:296:22]
      │
   32 │   requiredField: Boolean!
@@ -448,62 +478,62 @@ Error: expected value of type Boolean!, found Null
      │
   32 │   requiredField: Boolean!
      │                  ────┬───  
-     │                      ╰───── field declared here as Boolean! type
+     │                      ╰───── expected type declared here as Boolean!
      │ 
  296 │   $c: ComplexInput = { requiredField: null, intField: null }
      │                        ─────────┬─────────  
-     │                                 ╰─────────── argument declared here is of Null type
+     │                                 ╰─────────── provided value is of Null type
 ─────╯
 Error: expected value of type Int, found String
      ╭─[0102_invalid_string_values.graphql:306:13]
      │
  306 │   $a: Int = "one",
      │       ─┬─   ──┬──  
-     │        ╰─────────── field declared here as Int type
+     │        ╰─────────── expected type declared here as Int
      │               │    
-     │               ╰──── argument declared here is of String type
+     │               ╰──── provided value is of String type
 ─────╯
 Error: expected value of type String, found Int
      ╭─[0102_invalid_string_values.graphql:307:16]
      │
  307 │   $b: String = 4,
      │       ───┬──   ┬  
-     │          ╰──────── field declared here as String type
+     │          ╰──────── expected type declared here as String
      │                │  
-     │                ╰── argument declared here is of Int type
+     │                ╰── provided value is of Int type
 ─────╯
 Error: expected value of type ComplexInput, found String
      ╭─[0102_invalid_string_values.graphql:308:22]
      │
  308 │   $c: ComplexInput = "NotVeryComplex"
      │       ──────┬─────   ────────┬───────  
-     │             ╰────────────────────────── field declared here as ComplexInput type
+     │             ╰────────────────────────── expected type declared here as ComplexInput
      │                              │         
-     │                              ╰───────── argument declared here is of String type
+     │                              ╰───────── provided value is of String type
 ─────╯
 Error: expected value of type Boolean!, found Int
      ╭─[0102_invalid_string_values.graphql:318:24]
      │
   32 │   requiredField: Boolean!
      │                  ────┬───  
-     │                      ╰───── field declared here as Boolean! type
+     │                      ╰───── expected type declared here as Boolean!
      │ 
  318 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
      │                        ─────────┬────────  
-     │                                 ╰────────── argument declared here is of Int type
+     │                                 ╰────────── provided value is of Int type
 ─────╯
 Error: expected value of type Int, found String
      ╭─[0102_invalid_string_values.graphql:318:44]
      │
   34 │   intField: Int
      │             ─┬─  
-     │              ╰─── field declared here as Int type
+     │              ╰─── expected type declared here as Int
      │ 
  318 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
      │                                            ───────┬───────  
-     │                                                   ╰───────── argument declared here is of String type
+     │                                                   ╰───────── provided value is of String type
 ─────╯
-Error: the required argument `requiredField` is not provided
+Error: the required argument `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:326:22]
      │
   32 │   requiredField: Boolean!
@@ -519,8 +549,8 @@ Error: expected value of type String, found Int
      │
  335 │   $a: [String] = ["one", 2]
      │       ────┬───           ┬  
-     │           ╰───────────────── field declared here as String type
+     │           ╰───────────────── expected type declared here as String
      │                          │  
-     │                          ╰── argument declared here is of Int type
+     │                          ╰── provided value is of Int type
 ─────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
@@ -1,4 +1,4 @@
-Error: expected value of type String, found Int
+Error: expected value of type String, found an integer
     ╭─[0102_invalid_string_values.graphql:71:31]
     │
   8 │   stringArgField(stringArg: String): String
@@ -7,9 +7,9 @@ Error: expected value of type String, found Int
     │ 
  71 │     stringArgField(stringArg: 1)
     │                               ┬  
-    │                               ╰── provided value is of Int type
+    │                               ╰── provided value is an integer
 ────╯
-Error: expected value of type String, found Float
+Error: expected value of type String, found a float
     ╭─[0102_invalid_string_values.graphql:77:31]
     │
   8 │   stringArgField(stringArg: String): String
@@ -18,9 +18,9 @@ Error: expected value of type String, found Float
     │ 
  77 │     stringArgField(stringArg: 1.0)
     │                               ─┬─  
-    │                                ╰─── provided value is of Float type
+    │                                ╰─── provided value is a float
 ────╯
-Error: expected value of type String, found Boolean
+Error: expected value of type String, found a boolean
     ╭─[0102_invalid_string_values.graphql:83:31]
     │
   8 │   stringArgField(stringArg: String): String
@@ -29,9 +29,9 @@ Error: expected value of type String, found Boolean
     │ 
  83 │     stringArgField(stringArg: true)
     │                               ──┬─  
-    │                                 ╰─── provided value is of Boolean type
+    │                                 ╰─── provided value is a boolean
 ────╯
-Error: expected value of type String, found Enum
+Error: expected value of type String, found an enum
     ╭─[0102_invalid_string_values.graphql:89:31]
     │
   8 │   stringArgField(stringArg: String): String
@@ -40,9 +40,9 @@ Error: expected value of type String, found Enum
     │ 
  89 │     stringArgField(stringArg: BAR)
     │                               ─┬─  
-    │                                ╰─── provided value is of Enum type
+    │                                ╰─── provided value is an enum
 ────╯
-Error: expected value of type Int, found String
+Error: expected value of type Int, found a string
     ╭─[0102_invalid_string_values.graphql:95:25]
     │
   6 │   intArgField(intArg: Int): String
@@ -51,7 +51,7 @@ Error: expected value of type Int, found String
     │ 
  95 │     intArgField(intArg: "3")
     │                         ─┬─  
-    │                          ╰─── provided value is of String type
+    │                          ╰─── provided value is a string
 ────╯
 Error: int cannot represent non 32-bit signed integer value
      ╭─[0102_invalid_string_values.graphql:101:25]
@@ -60,7 +60,7 @@ Error: int cannot represent non 32-bit signed integer value
      │                         ─────────────┬─────────────  
      │                                      ╰─────────────── cannot be coerced to a 32-bit integer
 ─────╯
-Error: expected value of type Int, found Enum
+Error: expected value of type Int, found an enum
      ╭─[0102_invalid_string_values.graphql:107:25]
      │
    6 │   intArgField(intArg: Int): String
@@ -69,9 +69,9 @@ Error: expected value of type Int, found Enum
      │ 
  107 │     intArgField(intArg: FOO)
      │                         ─┬─  
-     │                          ╰─── provided value is of Enum type
+     │                          ╰─── provided value is an enum
 ─────╯
-Error: expected value of type Int, found Float
+Error: expected value of type Int, found a float
      ╭─[0102_invalid_string_values.graphql:113:25]
      │
    6 │   intArgField(intArg: Int): String
@@ -80,9 +80,9 @@ Error: expected value of type Int, found Float
      │ 
  113 │     intArgField(intArg: 3.0)
      │                         ─┬─  
-     │                          ╰─── provided value is of Float type
+     │                          ╰─── provided value is a float
 ─────╯
-Error: expected value of type Int, found Float
+Error: expected value of type Int, found a float
      ╭─[0102_invalid_string_values.graphql:119:25]
      │
    6 │   intArgField(intArg: Int): String
@@ -91,9 +91,9 @@ Error: expected value of type Int, found Float
      │ 
  119 │     intArgField(intArg: 3.333)
      │                         ──┬──  
-     │                           ╰──── provided value is of Float type
+     │                           ╰──── provided value is a float
 ─────╯
-Error: expected value of type Float, found String
+Error: expected value of type Float, found a string
      ╭─[0102_invalid_string_values.graphql:125:29]
      │
   11 │   floatArgField(floatArg: Float): String
@@ -102,9 +102,9 @@ Error: expected value of type Float, found String
      │ 
  125 │     floatArgField(floatArg: "3.333")
      │                             ───┬───  
-     │                                ╰───── provided value is of String type
+     │                                ╰───── provided value is a string
 ─────╯
-Error: expected value of type Float, found Boolean
+Error: expected value of type Float, found a boolean
      ╭─[0102_invalid_string_values.graphql:131:29]
      │
   11 │   floatArgField(floatArg: Float): String
@@ -113,9 +113,9 @@ Error: expected value of type Float, found Boolean
      │ 
  131 │     floatArgField(floatArg: true)
      │                             ──┬─  
-     │                               ╰─── provided value is of Boolean type
+     │                               ╰─── provided value is a boolean
 ─────╯
-Error: expected value of type Float, found Enum
+Error: expected value of type Float, found an enum
      ╭─[0102_invalid_string_values.graphql:137:29]
      │
   11 │   floatArgField(floatArg: Float): String
@@ -124,9 +124,9 @@ Error: expected value of type Float, found Enum
      │ 
  137 │     floatArgField(floatArg: FOO)
      │                             ─┬─  
-     │                              ╰─── provided value is of Enum type
+     │                              ╰─── provided value is an enum
 ─────╯
-Error: expected value of type Boolean, found Int
+Error: expected value of type Boolean, found an integer
      ╭─[0102_invalid_string_values.graphql:143:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
@@ -135,9 +135,9 @@ Error: expected value of type Boolean, found Int
      │ 
  143 │     booleanArgField(booleanArg: 2)
      │                                 ┬  
-     │                                 ╰── provided value is of Int type
+     │                                 ╰── provided value is an integer
 ─────╯
-Error: expected value of type Boolean, found Float
+Error: expected value of type Boolean, found a float
      ╭─[0102_invalid_string_values.graphql:149:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
@@ -146,9 +146,9 @@ Error: expected value of type Boolean, found Float
      │ 
  149 │     booleanArgField(booleanArg: 1.0)
      │                                 ─┬─  
-     │                                  ╰─── provided value is of Float type
+     │                                  ╰─── provided value is a float
 ─────╯
-Error: expected value of type Boolean, found String
+Error: expected value of type Boolean, found a string
      ╭─[0102_invalid_string_values.graphql:155:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
@@ -157,9 +157,9 @@ Error: expected value of type Boolean, found String
      │ 
  155 │     booleanArgField(booleanArg: "true")
      │                                 ───┬──  
-     │                                    ╰──── provided value is of String type
+     │                                    ╰──── provided value is a string
 ─────╯
-Error: expected value of type Boolean, found Enum
+Error: expected value of type Boolean, found an enum
      ╭─[0102_invalid_string_values.graphql:161:33]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
@@ -168,9 +168,9 @@ Error: expected value of type Boolean, found Enum
      │ 
  161 │     booleanArgField(booleanArg: TRUE)
      │                                 ──┬─  
-     │                                   ╰─── provided value is of Enum type
+     │                                   ╰─── provided value is an enum
 ─────╯
-Error: expected value of type ID, found Float
+Error: expected value of type ID, found a float
      ╭─[0102_invalid_string_values.graphql:167:23]
      │
   12 │   idArgField(idArg: ID): String
@@ -179,9 +179,9 @@ Error: expected value of type ID, found Float
      │ 
  167 │     idArgField(idArg: 1.0)
      │                       ─┬─  
-     │                        ╰─── provided value is of Float type
+     │                        ╰─── provided value is a float
 ─────╯
-Error: expected value of type ID, found Boolean
+Error: expected value of type ID, found a boolean
      ╭─[0102_invalid_string_values.graphql:173:23]
      │
   12 │   idArgField(idArg: ID): String
@@ -190,9 +190,9 @@ Error: expected value of type ID, found Boolean
      │ 
  173 │     idArgField(idArg: true)
      │                       ──┬─  
-     │                         ╰─── provided value is of Boolean type
+     │                         ╰─── provided value is a boolean
 ─────╯
-Error: expected value of type ID, found Enum
+Error: expected value of type ID, found an enum
      ╭─[0102_invalid_string_values.graphql:179:23]
      │
   12 │   idArgField(idArg: ID): String
@@ -201,9 +201,9 @@ Error: expected value of type ID, found Enum
      │ 
  179 │     idArgField(idArg: SOMETHING)
      │                       ────┬────  
-     │                           ╰────── provided value is of Enum type
+     │                           ╰────── provided value is an enum
 ─────╯
-Error: expected value of type DogCommand, found Int
+Error: expected value of type DogCommand, found an integer
      ╭─[0102_invalid_string_values.graphql:186:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
@@ -212,9 +212,9 @@ Error: expected value of type DogCommand, found Int
      │ 
  186 │     doesKnowCommand(dogCommand: 2)
      │                                 ┬  
-     │                                 ╰── provided value is of Int type
+     │                                 ╰── provided value is an integer
 ─────╯
-Error: expected value of type DogCommand, found Float
+Error: expected value of type DogCommand, found a float
      ╭─[0102_invalid_string_values.graphql:192:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
@@ -223,9 +223,9 @@ Error: expected value of type DogCommand, found Float
      │ 
  192 │     doesKnowCommand(dogCommand: 1.0)
      │                                 ─┬─  
-     │                                  ╰─── provided value is of Float type
+     │                                  ╰─── provided value is a float
 ─────╯
-Error: expected value of type DogCommand, found String
+Error: expected value of type DogCommand, found a string
      ╭─[0102_invalid_string_values.graphql:198:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
@@ -234,9 +234,9 @@ Error: expected value of type DogCommand, found String
      │ 
  198 │     doesKnowCommand(dogCommand: "SIT")
      │                                 ──┬──  
-     │                                   ╰──── provided value is of String type
+     │                                   ╰──── provided value is a string
 ─────╯
-Error: expected value of type DogCommand, found Boolean
+Error: expected value of type DogCommand, found a boolean
      ╭─[0102_invalid_string_values.graphql:204:33]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
@@ -245,7 +245,7 @@ Error: expected value of type DogCommand, found Boolean
      │ 
  204 │     doesKnowCommand(dogCommand: true)
      │                                 ──┬─  
-     │                                   ╰─── provided value is of Boolean type
+     │                                   ╰─── provided value is a boolean
 ─────╯
 Error: value `JUGGLE` does not exist on `DogCommand`
      ╭─[0102_invalid_string_values.graphql:210:33]
@@ -273,7 +273,7 @@ Error: value `sit` does not exist on `DogCommand`
      │                                     ─┬─  
      │                                      ╰─── value does not exist on `DogCommand` enum
 ─────╯
-Error: expected value of type String, found Int
+Error: expected value of type String, found an integer
      ╭─[0102_invalid_string_values.graphql:222:47]
      │
   13 │   stringListArgField(stringListArg: [String]): String
@@ -282,9 +282,9 @@ Error: expected value of type String, found Int
      │ 
  222 │     stringListArgField(stringListArg: ["one", 2])
      │                                               ┬  
-     │                                               ╰── provided value is of Int type
+     │                                               ╰── provided value is an integer
 ─────╯
-Error: expected value of type [String], found Int
+Error: expected value of type [String], found an integer
      ╭─[0102_invalid_string_values.graphql:228:39]
      │
   13 │   stringListArgField(stringListArg: [String]): String
@@ -293,9 +293,9 @@ Error: expected value of type [String], found Int
      │ 
  228 │     stringListArgField(stringListArg: 1)
      │                                       ┬  
-     │                                       ╰── provided value is of Int type
+     │                                       ╰── provided value is an integer
 ─────╯
-Error: expected value of type Int!, found String
+Error: expected value of type Int!, found a string
      ╭─[0102_invalid_string_values.graphql:235:24]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -304,9 +304,9 @@ Error: expected value of type Int!, found String
      │ 
  235 │     multipleReqs(req2: "two", req1: "one")
      │                        ──┬──  
-     │                          ╰──── provided value is of String type
+     │                          ╰──── provided value is a string
 ─────╯
-Error: expected value of type Int!, found String
+Error: expected value of type Int!, found a string
      ╭─[0102_invalid_string_values.graphql:235:37]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -315,7 +315,7 @@ Error: expected value of type Int!, found String
      │ 
  235 │     multipleReqs(req2: "two", req1: "one")
      │                                     ──┬──  
-     │                                       ╰──── provided value is of String type
+     │                                       ╰──── provided value is a string
 ─────╯
 Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
      ╭─[0102_invalid_string_values.graphql:241:5]
@@ -328,7 +328,7 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provid
      │     ────────────┬────────────  
      │                 ╰────────────── missing value for argument `req2`
 ─────╯
-Error: expected value of type Int!, found String
+Error: expected value of type Int!, found a string
      ╭─[0102_invalid_string_values.graphql:241:24]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -337,7 +337,7 @@ Error: expected value of type Int!, found String
      │ 
  241 │     multipleReqs(req1: "one")
      │                        ──┬──  
-     │                          ╰──── provided value is of String type
+     │                          ╰──── provided value is a string
 ─────╯
 Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
      ╭─[0102_invalid_string_values.graphql:247:5]
@@ -361,7 +361,7 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provid
      │     ────────────┬───────────  
      │                 ╰───────────── missing value for argument `req2`
 ─────╯
-Error: expected value of type Int!, found Null
+Error: expected value of type Int!, found null
      ╭─[0102_invalid_string_values.graphql:247:24]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
@@ -370,7 +370,7 @@ Error: expected value of type Int!, found Null
      │ 
  247 │     multipleReqs(req1: null)
      │                        ──┬─  
-     │                          ╰─── provided value is of Null type
+     │                          ╰─── provided value is null
 ─────╯
 Error: the required argument `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:254:33]
@@ -383,7 +383,7 @@ Error: the required argument `ComplexInput.requiredField` is not provided
      │                                 ───────┬───────  
      │                                        ╰───────── missing value for argument `requiredField`
 ─────╯
-Error: expected value of type String, found Int
+Error: expected value of type String, found an integer
      ╭─[0102_invalid_string_values.graphql:261:32]
      │
   37 │   stringListField: [String]
@@ -392,9 +392,9 @@ Error: expected value of type String, found Int
      │ 
  261 │       stringListField: ["one", 2],
      │                                ┬  
-     │                                ╰── provided value is of Int type
+     │                                ╰── provided value is an integer
 ─────╯
-Error: expected value of type Boolean!, found Null
+Error: expected value of type Boolean!, found null
      ╭─[0102_invalid_string_values.graphql:271:7]
      │
   33 │   nonNullField: Boolean! = false
@@ -403,7 +403,7 @@ Error: expected value of type Boolean!, found Null
      │ 
  271 │       nonNullField: null,
      │       ─────────┬────────  
-     │                ╰────────── provided value is of Null type
+     │                ╰────────── provided value is null
 ─────╯
 Error: field `invalidField` does not exist on `ComplexInput`
      ╭─[0102_invalid_string_values.graphql:280:7]
@@ -418,12 +418,12 @@ Error: field `invalidField` does not exist on `ComplexInput`
      │           ──────────┬──────────  
      │                     ╰──────────── value does not exist on `ComplexInput` input object
 ─────╯
-Error: expected value of type Boolean!, found String
+Error: expected value of type Boolean!, found a string
      ╭─[0102_invalid_string_values.graphql:287:20]
      │
  287 │   dog @include(if: "yes") {
      │                    ──┬──  
-     │                      ╰──── provided value is of String type
+     │                      ╰──── provided value is a string
      │
      ├─[built_in.graphql:105:7]
      │
@@ -431,12 +431,12 @@ Error: expected value of type Boolean!, found String
      │       ────┬───  
      │           ╰───── expected type declared here as Boolean!
 ─────╯
-Error: expected value of type Boolean!, found Enum
+Error: expected value of type Boolean!, found an enum
      ╭─[0102_invalid_string_values.graphql:288:20]
      │
  288 │     name @skip(if: ENUM)
      │                    ──┬─  
-     │                      ╰─── provided value is of Enum type
+     │                      ╰─── provided value is an enum
      │
      ├─[built_in.graphql:99:7]
      │
@@ -444,23 +444,23 @@ Error: expected value of type Boolean!, found Enum
      │       ────┬───  
      │           ╰───── expected type declared here as Boolean!
 ─────╯
-Error: expected value of type Int!, found Null
+Error: expected value of type Int!, found null
      ╭─[0102_invalid_string_values.graphql:294:14]
      │
  294 │   $a: Int! = null,
      │       ──┬─   ──┬─  
      │         ╰────────── expected type declared here as Int!
      │                │   
-     │                ╰─── provided value is of Null type
+     │                ╰─── provided value is null
 ─────╯
-Error: expected value of type String!, found Null
+Error: expected value of type String!, found null
      ╭─[0102_invalid_string_values.graphql:295:17]
      │
  295 │   $b: String! = null,
      │       ───┬───   ──┬─  
      │          ╰──────────── expected type declared here as String!
      │                   │   
-     │                   ╰─── provided value is of Null type
+     │                   ╰─── provided value is null
 ─────╯
 Error: the required argument `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:296:22]
@@ -473,7 +473,7 @@ Error: the required argument `ComplexInput.requiredField` is not provided
      │                      ───────────────────┬───────────────────  
      │                                         ╰───────────────────── missing value for argument `requiredField`
 ─────╯
-Error: expected value of type Boolean!, found Null
+Error: expected value of type Boolean!, found null
      ╭─[0102_invalid_string_values.graphql:296:24]
      │
   32 │   requiredField: Boolean!
@@ -482,36 +482,36 @@ Error: expected value of type Boolean!, found Null
      │ 
  296 │   $c: ComplexInput = { requiredField: null, intField: null }
      │                        ─────────┬─────────  
-     │                                 ╰─────────── provided value is of Null type
+     │                                 ╰─────────── provided value is null
 ─────╯
-Error: expected value of type Int, found String
+Error: expected value of type Int, found a string
      ╭─[0102_invalid_string_values.graphql:306:13]
      │
  306 │   $a: Int = "one",
      │       ─┬─   ──┬──  
      │        ╰─────────── expected type declared here as Int
      │               │    
-     │               ╰──── provided value is of String type
+     │               ╰──── provided value is a string
 ─────╯
-Error: expected value of type String, found Int
+Error: expected value of type String, found an integer
      ╭─[0102_invalid_string_values.graphql:307:16]
      │
  307 │   $b: String = 4,
      │       ───┬──   ┬  
      │          ╰──────── expected type declared here as String
      │                │  
-     │                ╰── provided value is of Int type
+     │                ╰── provided value is an integer
 ─────╯
-Error: expected value of type ComplexInput, found String
+Error: expected value of type ComplexInput, found a string
      ╭─[0102_invalid_string_values.graphql:308:22]
      │
  308 │   $c: ComplexInput = "NotVeryComplex"
      │       ──────┬─────   ────────┬───────  
      │             ╰────────────────────────── expected type declared here as ComplexInput
      │                              │         
-     │                              ╰───────── provided value is of String type
+     │                              ╰───────── provided value is a string
 ─────╯
-Error: expected value of type Boolean!, found Int
+Error: expected value of type Boolean!, found an integer
      ╭─[0102_invalid_string_values.graphql:318:24]
      │
   32 │   requiredField: Boolean!
@@ -520,9 +520,9 @@ Error: expected value of type Boolean!, found Int
      │ 
  318 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
      │                        ─────────┬────────  
-     │                                 ╰────────── provided value is of Int type
+     │                                 ╰────────── provided value is an integer
 ─────╯
-Error: expected value of type Int, found String
+Error: expected value of type Int, found a string
      ╭─[0102_invalid_string_values.graphql:318:44]
      │
   34 │   intField: Int
@@ -531,7 +531,7 @@ Error: expected value of type Int, found String
      │ 
  318 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
      │                                            ───────┬───────  
-     │                                                   ╰───────── provided value is of String type
+     │                                                   ╰───────── provided value is a string
 ─────╯
 Error: the required argument `ComplexInput.requiredField` is not provided
      ╭─[0102_invalid_string_values.graphql:326:22]
@@ -544,13 +544,13 @@ Error: the required argument `ComplexInput.requiredField` is not provided
      │                      ──────┬──────  
      │                            ╰──────── missing value for argument `requiredField`
 ─────╯
-Error: expected value of type String, found Int
+Error: expected value of type String, found an integer
      ╭─[0102_invalid_string_values.graphql:335:26]
      │
  335 │   $a: [String] = ["one", 2]
      │       ────┬───           ┬  
      │           ╰───────────────── expected type declared here as String
      │                          │  
-     │                          ╰── provided value is of Int type
+     │                          ╰── provided value is an integer
 ─────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0103_invalid_directive_on_input_value.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0103_invalid_directive_on_input_value.txt
@@ -1,4 +1,4 @@
-Error: the required argument `arg` is not provided
+Error: the required argument `@example(arg:)` is not provided
    ╭─[0103_invalid_directive_on_input_value.graphql:4:16]
    │
  1 │ directive @example(arg: String!) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
@@ -9,7 +9,7 @@ Error: the required argument `arg` is not provided
    │                ────┬───  
    │                    ╰───── missing value for argument `arg`
 ───╯
-Error: the required argument `arg` is not provided
+Error: the required argument `@example(arg:)` is not provided
    ╭─[0103_invalid_directive_on_input_value.graphql:7:32]
    │
  1 │ directive @example(arg: String!) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION

--- a/crates/apollo-compiler/test_data/diagnostics/0104_invalid_type_in_arg.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0104_invalid_type_in_arg.txt
@@ -2,8 +2,8 @@ Error: `thisIsWrong` field must be of an input type
    ╭─[0104_invalid_type_in_arg.graphql:7:3]
    │
  7 │   thisIsWrong: OutputType
-   │   ───────────┬───────────  
-   │              ╰───────────── this is an object
+   │                ─────┬────  
+   │                     ╰────── this is an object
    │ 
    │ Help: Scalars, Enums, and Input Objects are input types. Change `thisIsWrong` field to take one of these input types.
 ───╯
@@ -25,8 +25,8 @@ Error: `a` field must be of an input type
     ╭─[0104_invalid_type_in_arg.graphql:13:15]
     │
  13 │   outputTypes(a: OutputType, b: OperationResult): ID!
-    │               ──────┬──────  
-    │                     ╰──────── this is an object
+    │                  ─────┬────  
+    │                       ╰────── this is an object
     │ 
     │ Help: Scalars, Enums, and Input Objects are input types. Change `a` field to take one of these input types.
 ────╯
@@ -34,8 +34,8 @@ Error: `b` field must be of an input type
     ╭─[0104_invalid_type_in_arg.graphql:13:30]
     │
  13 │   outputTypes(a: OutputType, b: OperationResult): ID!
-    │                              ─────────┬────────  
-    │                                       ╰────────── this is a union
+    │                                 ───────┬───────  
+    │                                        ╰───────── this is a union
     │ 
     │ Help: Scalars, Enums, and Input Objects are input types. Change `b` field to take one of these input types.
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0104_invalid_type_in_arg.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0104_invalid_type_in_arg.txt
@@ -3,7 +3,7 @@ Error: `thisIsWrong` field must be of an input type
    │
  7 │   thisIsWrong: OutputType
    │                ─────┬────  
-   │                     ╰────── this is an object
+   │                     ╰────── this is an object type
    │ 
    │ Help: Scalars, Enums, and Input Objects are input types. Change `thisIsWrong` field to take one of these input types.
 ───╯
@@ -26,7 +26,7 @@ Error: `a` field must be of an input type
     │
  13 │   outputTypes(a: OutputType, b: OperationResult): ID!
     │                  ─────┬────  
-    │                       ╰────── this is an object
+    │                       ╰────── this is an object type
     │ 
     │ Help: Scalars, Enums, and Input Objects are input types. Change `a` field to take one of these input types.
 ────╯
@@ -35,7 +35,7 @@ Error: `b` field must be of an input type
     │
  13 │   outputTypes(a: OutputType, b: OperationResult): ID!
     │                                 ───────┬───────  
-    │                                        ╰───────── this is a union
+    │                                        ╰───────── this is a union type
     │ 
     │ Help: Scalars, Enums, and Input Objects are input types. Change `b` field to take one of these input types.
 ────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
@@ -3,54 +3,54 @@ Error: expected value of type CustomScalar!, found Null
     │
   8 │   foo(arg: [CustomScalar!]!): String!
     │            ────────┬───────  
-    │                    ╰───────── field declared here as CustomScalar! type
+    │                    ╰───────── expected type declared here as CustomScalar!
     │ 
  14 │   a: foo(arg: [null, 1])
     │                ──┬─  
-    │                  ╰─── argument declared here is of Null type
+    │                  ╰─── provided value is of Null type
 ────╯
 Error: expected value of type CustomScalar!, found Null
     ╭─[0109_null_in_list_issue_738.graphql:15:16]
     │
   8 │   foo(arg: [CustomScalar!]!): String!
     │            ────────┬───────  
-    │                    ╰───────── field declared here as CustomScalar! type
+    │                    ╰───────── expected type declared here as CustomScalar!
     │ 
  15 │   b: foo(arg: [null, null, "hello"])
     │                ──┬─  
-    │                  ╰─── argument declared here is of Null type
+    │                  ╰─── provided value is of Null type
 ────╯
 Error: expected value of type CustomScalar!, found Null
     ╭─[0109_null_in_list_issue_738.graphql:15:22]
     │
   8 │   foo(arg: [CustomScalar!]!): String!
     │            ────────┬───────  
-    │                    ╰───────── field declared here as CustomScalar! type
+    │                    ╰───────── expected type declared here as CustomScalar!
     │ 
  15 │   b: foo(arg: [null, null, "hello"])
     │                      ──┬─  
-    │                        ╰─── argument declared here is of Null type
+    │                        ╰─── provided value is of Null type
 ────╯
 Error: expected value of type String!, found Null
     ╭─[0109_null_in_list_issue_738.graphql:16:13]
     │
   9 │   bar(arg: [String!]): String!
     │            ────┬────  
-    │                ╰────── field declared here as String! type
+    │                ╰────── expected type declared here as String!
     │ 
  16 │   bar(arg: [null])
     │             ──┬─  
-    │               ╰─── argument declared here is of Null type
+    │               ╰─── provided value is of Null type
 ────╯
 Error: expected value of type String!, found Null
     ╭─[0109_null_in_list_issue_738.graphql:17:27]
     │
   4 │   list: [String!]
     │         ────┬────  
-    │             ╰────── field declared here as String! type
+    │             ╰────── expected type declared here as String!
     │ 
  17 │   list(arg: {list: ["ok", null]})
     │                           ──┬─  
-    │                             ╰─── argument declared here is of Null type
+    │                             ╰─── provided value is of Null type
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
@@ -1,4 +1,4 @@
-Error: expected value of type CustomScalar!, found Null
+Error: expected value of type CustomScalar!, found null
     ╭─[0109_null_in_list_issue_738.graphql:14:16]
     │
   8 │   foo(arg: [CustomScalar!]!): String!
@@ -7,9 +7,9 @@ Error: expected value of type CustomScalar!, found Null
     │ 
  14 │   a: foo(arg: [null, 1])
     │                ──┬─  
-    │                  ╰─── provided value is of Null type
+    │                  ╰─── provided value is null
 ────╯
-Error: expected value of type CustomScalar!, found Null
+Error: expected value of type CustomScalar!, found null
     ╭─[0109_null_in_list_issue_738.graphql:15:16]
     │
   8 │   foo(arg: [CustomScalar!]!): String!
@@ -18,9 +18,9 @@ Error: expected value of type CustomScalar!, found Null
     │ 
  15 │   b: foo(arg: [null, null, "hello"])
     │                ──┬─  
-    │                  ╰─── provided value is of Null type
+    │                  ╰─── provided value is null
 ────╯
-Error: expected value of type CustomScalar!, found Null
+Error: expected value of type CustomScalar!, found null
     ╭─[0109_null_in_list_issue_738.graphql:15:22]
     │
   8 │   foo(arg: [CustomScalar!]!): String!
@@ -29,9 +29,9 @@ Error: expected value of type CustomScalar!, found Null
     │ 
  15 │   b: foo(arg: [null, null, "hello"])
     │                      ──┬─  
-    │                        ╰─── provided value is of Null type
+    │                        ╰─── provided value is null
 ────╯
-Error: expected value of type String!, found Null
+Error: expected value of type String!, found null
     ╭─[0109_null_in_list_issue_738.graphql:16:13]
     │
   9 │   bar(arg: [String!]): String!
@@ -40,9 +40,9 @@ Error: expected value of type String!, found Null
     │ 
  16 │   bar(arg: [null])
     │             ──┬─  
-    │               ╰─── provided value is of Null type
+    │               ╰─── provided value is null
 ────╯
-Error: expected value of type String!, found Null
+Error: expected value of type String!, found null
     ╭─[0109_null_in_list_issue_738.graphql:17:27]
     │
   4 │   list: [String!]
@@ -51,6 +51,6 @@ Error: expected value of type String!, found Null
     │ 
  17 │   list(arg: {list: ["ok", null]})
     │                           ──┬─  
-    │                             ╰─── provided value is of Null type
+    │                             ╰─── provided value is null
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.txt
@@ -3,54 +3,54 @@ Error: expected value of type Int!, found List
     │
   5 │   int: Int!
     │        ──┬─  
-    │          ╰─── field declared here as Int! type
+    │          ╰─── expected type declared here as Int!
     │ 
  20 │     int: [1, 2, 3]
     │     ───────┬──────  
-    │            ╰──────── argument declared here is of List type
+    │            ╰──────── provided value is of List type
 ────╯
 Error: expected value of type String!, found List
     ╭─[0110_list_usage_in_non_list_type.graphql:21:5]
     │
   6 │   str: String!
     │        ───┬───  
-    │           ╰───── field declared here as String! type
+    │           ╰───── expected type declared here as String!
     │ 
  21 │     str: ["1"]
     │     ─────┬────  
-    │          ╰────── argument declared here is of List type
+    │          ╰────── provided value is of List type
 ────╯
 Error: expected value of type Boolean!, found List
     ╭─[0110_list_usage_in_non_list_type.graphql:22:5]
     │
   7 │   bool: Boolean!
     │         ────┬───  
-    │             ╰───── field declared here as Boolean! type
+    │             ╰───── expected type declared here as Boolean!
     │ 
  22 │     bool: [true, false]
     │     ─────────┬─────────  
-    │              ╰─────────── argument declared here is of List type
+    │              ╰─────────── provided value is of List type
 ────╯
 Error: expected value of type Int, found List
     ╭─[0110_list_usage_in_non_list_type.graphql:23:5]
     │
   8 │   opt: Int
     │        ─┬─  
-    │         ╰─── field declared here as Int type
+    │         ╰─── expected type declared here as Int
     │ 
  23 │     opt: [1, 2, 3]
     │     ───────┬──────  
-    │            ╰──────── argument declared here is of List type
+    │            ╰──────── provided value is of List type
 ────╯
 Error: expected value of type ID!, found List
     ╭─[0110_list_usage_in_non_list_type.graphql:24:5]
     │
   9 │   id: ID!
     │       ─┬─  
-    │        ╰─── field declared here as ID! type
+    │        ╰─── expected type declared here as ID!
     │ 
  24 │     id: [1, "2", 3]
     │     ───────┬───────  
-    │            ╰───────── argument declared here is of List type
+    │            ╰───────── provided value is of List type
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.txt
@@ -1,4 +1,4 @@
-Error: expected value of type Int!, found List
+Error: expected value of type Int!, found a list
     ╭─[0110_list_usage_in_non_list_type.graphql:20:5]
     │
   5 │   int: Int!
@@ -7,9 +7,9 @@ Error: expected value of type Int!, found List
     │ 
  20 │     int: [1, 2, 3]
     │     ───────┬──────  
-    │            ╰──────── provided value is of List type
+    │            ╰──────── provided value is a list
 ────╯
-Error: expected value of type String!, found List
+Error: expected value of type String!, found a list
     ╭─[0110_list_usage_in_non_list_type.graphql:21:5]
     │
   6 │   str: String!
@@ -18,9 +18,9 @@ Error: expected value of type String!, found List
     │ 
  21 │     str: ["1"]
     │     ─────┬────  
-    │          ╰────── provided value is of List type
+    │          ╰────── provided value is a list
 ────╯
-Error: expected value of type Boolean!, found List
+Error: expected value of type Boolean!, found a list
     ╭─[0110_list_usage_in_non_list_type.graphql:22:5]
     │
   7 │   bool: Boolean!
@@ -29,9 +29,9 @@ Error: expected value of type Boolean!, found List
     │ 
  22 │     bool: [true, false]
     │     ─────────┬─────────  
-    │              ╰─────────── provided value is of List type
+    │              ╰─────────── provided value is a list
 ────╯
-Error: expected value of type Int, found List
+Error: expected value of type Int, found a list
     ╭─[0110_list_usage_in_non_list_type.graphql:23:5]
     │
   8 │   opt: Int
@@ -40,9 +40,9 @@ Error: expected value of type Int, found List
     │ 
  23 │     opt: [1, 2, 3]
     │     ───────┬──────  
-    │            ╰──────── provided value is of List type
+    │            ╰──────── provided value is a list
 ────╯
-Error: expected value of type ID!, found List
+Error: expected value of type ID!, found a list
     ╭─[0110_list_usage_in_non_list_type.graphql:24:5]
     │
   9 │   id: ID!
@@ -51,6 +51,6 @@ Error: expected value of type ID!, found List
     │ 
  24 │     id: [1, "2", 3]
     │     ───────┬───────  
-    │            ╰───────── provided value is of List type
+    │            ╰───────── provided value is a list
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0111_const_value.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0111_const_value.txt
@@ -5,18 +5,18 @@ Error: syntax error: unexpected variable value in a Const context
    │                       ┬  
    │                       ╰── unexpected variable value in a Const context
 ───╯
-Error: variable `var1` is not defined
-    ╭─[0111_const_value.graphql:11:21]
-    │
- 11 │ type Query @someDir(arg: $var1) {
-    │                          ──┬──  
-    │                            ╰──── not found in this scope
-────╯
 Error: syntax error: unexpected variable value in a Const context
     ╭─[0111_const_value.graphql:11:26]
     │
  11 │ type Query @someDir(arg: $var1) {
     │                          ┬  
     │                          ╰── unexpected variable value in a Const context
+────╯
+Error: variable `$var1` is not defined
+    ╭─[0111_const_value.graphql:11:26]
+    │
+ 11 │ type Query @someDir(arg: $var1) {
+    │                          ──┬──  
+    │                            ╰──── not found in this scope
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0112_anonymous_subscription_with_multiple_root_fields.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0112_anonymous_subscription_with_multiple_root_fields.graphql
@@ -1,0 +1,21 @@
+subscription {
+  newMessage {
+    body
+    sender
+  }
+  disallowedSecondRootField
+}
+
+type Subscription {
+  newMessage: Result
+  disallowedSecondRootField: String
+}
+
+type Result {
+  body: String,
+  sender: String
+}
+
+type Query {
+  message: String
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0112_anonymous_subscription_with_multiple_root_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0112_anonymous_subscription_with_multiple_root_fields.txt
@@ -1,7 +1,7 @@
-Error: subscription `sub` can only have one root field
-   ╭─[0004_subscription_with_multiple_root_fields.graphql:1:1]
+Error: anonymous subscription can only have one root field
+   ╭─[0112_anonymous_subscription_with_multiple_root_fields.graphql:1:1]
    │
- 1 │ ╭─▶ subscription sub {
+ 1 │ ╭─▶ subscription {
    ┆ ┆   
  7 │ ├─▶ }
    │ │       

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0112_anonymous_subscription_with_multiple_root_fields.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0112_anonymous_subscription_with_multiple_root_fields.graphql
@@ -1,0 +1,21 @@
+subscription {
+  newMessage {
+    body
+    sender
+  }
+  disallowedSecondRootField
+}
+
+type Subscription {
+  newMessage: Result
+  disallowedSecondRootField: String
+}
+
+type Result {
+  body: String
+  sender: String
+}
+
+type Query {
+  message: String
+}

--- a/crates/apollo-compiler/tests/field_set.rs
+++ b/crates/apollo-compiler/tests/field_set.rs
@@ -51,7 +51,7 @@ fn test_invalid_field_sets() {
         "{errors}"
     );
     assert!(
-        errors.contains("field `organization` type `Org` is an object and must select fields"),
+        errors.contains("Org.organization is an object type and must select fields"),
         "{errors}"
     );
 

--- a/crates/apollo-compiler/tests/validation/interface.rs
+++ b/crates/apollo-compiler/tests/validation/interface.rs
@@ -140,7 +140,8 @@ interface Image implements Resource & Node {
         .errors
         .to_string();
     assert!(
-        errors.contains("type does not satisfy interface `Resource`: missing field `width`"),
+        errors
+            .contains("type `Image` does not satisfy interface `Resource`: missing field `width`"),
         "{errors}"
     );
 }

--- a/crates/apollo-compiler/tests/validation/mod.rs
+++ b/crates/apollo-compiler/tests/validation/mod.rs
@@ -128,15 +128,15 @@ fragment q on TestObject {
 }
 "#;
     let json = expect_test::expect![[r#"
-{
-  "message": "compiler error: `q` fragment cannot reference itself",
-  "locations": [
-    {
-      "line": 8,
-      "column": 1
-    }
-  ]
-}"#]];
+        {
+          "message": "`q` fragment cannot reference itself",
+          "locations": [
+            {
+              "line": 8,
+              "column": 1
+            }
+          ]
+        }"#]];
 
     let schema = Schema::parse_and_validate(input_type_system, "schema.graphql").unwrap();
     let diagnostics =
@@ -172,15 +172,15 @@ fn validation_without_type_system() {
     )
     .unwrap();
     let json = expect_test::expect![[r#"
-{
-  "message": "compiler error: fragment `A` must be used in an operation",
-  "locations": [
-    {
-      "line": 2,
-      "column": 13
-    }
-  ]
-}"#]];
+        {
+          "message": "fragment `A` must be used in an operation",
+          "locations": [
+            {
+              "line": 2,
+              "column": 13
+            }
+          ]
+        }"#]];
     let diagnostics = doc.validate_standalone_executable().unwrap_err();
     let errors = diagnostics.to_string();
     assert!(
@@ -236,15 +236,15 @@ fn validation_without_type_system() {
 
     let doc = ast::Document::parse(r#"{ ...A }"#, "unknown_frag.graphql").unwrap();
     let json = expect_test::expect![[r#"
-{
-  "message": "compiler error: cannot find fragment `A` in this document",
-  "locations": [
-    {
-      "line": 1,
-      "column": 3
-    }
-  ]
-}"#]];
+        {
+          "message": "cannot find fragment `A` in this document",
+          "locations": [
+            {
+              "line": 1,
+              "column": 3
+            }
+          ]
+        }"#]];
     let diagnostics = doc.validate_standalone_executable().unwrap_err();
     let errors = diagnostics.to_string();
     assert!(

--- a/crates/apollo-compiler/tests/validation/recursion.rs
+++ b/crates/apollo-compiler/tests/validation/recursion.rs
@@ -111,7 +111,7 @@ fn long_fragment_chains_do_not_overflow_stack() {
             │
          11 │           fragment typeFragment1 on __Type {
             │           ───────────┬──────────  
-            │                      ╰──────────── fragment references a very long chain of fragments
+            │                      ╰──────────── references a very long chain of fragments in its definition
         ────╯
     "#]];
     expected.assert_eq(&errors.to_string());

--- a/crates/apollo-compiler/tests/validation/types.rs
+++ b/crates/apollo-compiler/tests/validation/types.rs
@@ -343,17 +343,17 @@ mod invalid_string_values {
       ",
             expect![[r#"
                 Error: expected value of type String, found Int
-                    ╭─[schema.graphql:80:29]
-                    │
-                 80 │   stringArgField(stringArg: String): String
-                    │                             ───┬──  
-                    │                                ╰──── field declared here as String type
-                    │
-                    ├─[query.graphql:3:31]
+                    ╭─[query.graphql:3:31]
                     │
                   3 │     stringArgField(stringArg: 1)
                     │                               ┬  
-                    │                               ╰── argument declared here is of Int type
+                    │                               ╰── provided value is of Int type
+                    │
+                    ├─[schema.graphql:80:29]
+                    │
+                 80 │   stringArgField(stringArg: String): String
+                    │                             ───┬──  
+                    │                                ╰──── expected type declared here as String
                 ────╯
             "#]],
         );
@@ -371,17 +371,17 @@ mod invalid_string_values {
       ",
             expect![[r#"
                 Error: expected value of type String, found Float
-                    ╭─[schema.graphql:80:29]
-                    │
-                 80 │   stringArgField(stringArg: String): String
-                    │                             ───┬──  
-                    │                                ╰──── field declared here as String type
-                    │
-                    ├─[query.graphql:3:31]
+                    ╭─[query.graphql:3:31]
                     │
                   3 │     stringArgField(stringArg: 1.0)
                     │                               ─┬─  
-                    │                                ╰─── argument declared here is of Float type
+                    │                                ╰─── provided value is of Float type
+                    │
+                    ├─[schema.graphql:80:29]
+                    │
+                 80 │   stringArgField(stringArg: String): String
+                    │                             ───┬──  
+                    │                                ╰──── expected type declared here as String
                 ────╯
             "#]],
         );
@@ -399,17 +399,17 @@ mod invalid_string_values {
       ",
             expect![[r#"
                 Error: expected value of type String, found Boolean
-                    ╭─[schema.graphql:80:29]
-                    │
-                 80 │   stringArgField(stringArg: String): String
-                    │                             ───┬──  
-                    │                                ╰──── field declared here as String type
-                    │
-                    ├─[query.graphql:3:31]
+                    ╭─[query.graphql:3:31]
                     │
                   3 │     stringArgField(stringArg: true)
                     │                               ──┬─  
-                    │                                 ╰─── argument declared here is of Boolean type
+                    │                                 ╰─── provided value is of Boolean type
+                    │
+                    ├─[schema.graphql:80:29]
+                    │
+                 80 │   stringArgField(stringArg: String): String
+                    │                             ───┬──  
+                    │                                ╰──── expected type declared here as String
                 ────╯
             "#]],
         );
@@ -427,17 +427,17 @@ mod invalid_string_values {
       ",
             expect![[r#"
                 Error: expected value of type String, found Enum
-                    ╭─[schema.graphql:80:29]
-                    │
-                 80 │   stringArgField(stringArg: String): String
-                    │                             ───┬──  
-                    │                                ╰──── field declared here as String type
-                    │
-                    ├─[query.graphql:3:31]
+                    ╭─[query.graphql:3:31]
                     │
                   3 │     stringArgField(stringArg: BAR)
                     │                               ─┬─  
-                    │                                ╰─── argument declared here is of Enum type
+                    │                                ╰─── provided value is of Enum type
+                    │
+                    ├─[schema.graphql:80:29]
+                    │
+                 80 │   stringArgField(stringArg: String): String
+                    │                             ───┬──  
+                    │                                ╰──── expected type declared here as String
                 ────╯
             "#]],
         );
@@ -460,17 +460,17 @@ mod invalid_int_values {
       "#,
             expect![[r#"
                 Error: expected value of type Int, found String
-                    ╭─[schema.graphql:78:23]
-                    │
-                 78 │   intArgField(intArg: Int): String
-                    │                       ─┬─  
-                    │                        ╰─── field declared here as Int type
-                    │
-                    ├─[query.graphql:3:25]
+                    ╭─[query.graphql:3:25]
                     │
                   3 │     intArgField(intArg: "3")
                     │                         ─┬─  
-                    │                          ╰─── argument declared here is of String type
+                    │                          ╰─── provided value is of String type
+                    │
+                    ├─[schema.graphql:78:23]
+                    │
+                 78 │   intArgField(intArg: Int): String
+                    │                       ─┬─  
+                    │                        ╰─── expected type declared here as Int
                 ────╯
             "#]],
         );
@@ -492,7 +492,7 @@ mod invalid_int_values {
                    │
                  3 │     intArgField(intArg: 829384293849283498239482938)
                    │                         ─────────────┬─────────────  
-                   │                                      ╰─────────────── cannot be coerced to an 32-bit integer
+                   │                                      ╰─────────────── cannot be coerced to a 32-bit integer
                 ───╯
             "#]],
         );
@@ -510,17 +510,17 @@ mod invalid_int_values {
       ",
             expect![[r#"
                 Error: expected value of type Int, found Enum
-                    ╭─[schema.graphql:78:23]
-                    │
-                 78 │   intArgField(intArg: Int): String
-                    │                       ─┬─  
-                    │                        ╰─── field declared here as Int type
-                    │
-                    ├─[query.graphql:3:25]
+                    ╭─[query.graphql:3:25]
                     │
                   3 │     intArgField(intArg: FOO)
                     │                         ─┬─  
-                    │                          ╰─── argument declared here is of Enum type
+                    │                          ╰─── provided value is of Enum type
+                    │
+                    ├─[schema.graphql:78:23]
+                    │
+                 78 │   intArgField(intArg: Int): String
+                    │                       ─┬─  
+                    │                        ╰─── expected type declared here as Int
                 ────╯
             "#]],
         );
@@ -538,17 +538,17 @@ mod invalid_int_values {
       ",
             expect![[r#"
                 Error: expected value of type Int, found Float
-                    ╭─[schema.graphql:78:23]
-                    │
-                 78 │   intArgField(intArg: Int): String
-                    │                       ─┬─  
-                    │                        ╰─── field declared here as Int type
-                    │
-                    ├─[query.graphql:3:25]
+                    ╭─[query.graphql:3:25]
                     │
                   3 │     intArgField(intArg: 3.0)
                     │                         ─┬─  
-                    │                          ╰─── argument declared here is of Float type
+                    │                          ╰─── provided value is of Float type
+                    │
+                    ├─[schema.graphql:78:23]
+                    │
+                 78 │   intArgField(intArg: Int): String
+                    │                       ─┬─  
+                    │                        ╰─── expected type declared here as Int
                 ────╯
             "#]],
         );
@@ -566,17 +566,17 @@ mod invalid_int_values {
       ",
             expect![[r#"
                 Error: expected value of type Int, found Float
-                    ╭─[schema.graphql:78:23]
-                    │
-                 78 │   intArgField(intArg: Int): String
-                    │                       ─┬─  
-                    │                        ╰─── field declared here as Int type
-                    │
-                    ├─[query.graphql:3:25]
+                    ╭─[query.graphql:3:25]
                     │
                   3 │     intArgField(intArg: 3.333)
                     │                         ──┬──  
-                    │                           ╰──── argument declared here is of Float type
+                    │                           ╰──── provided value is of Float type
+                    │
+                    ├─[schema.graphql:78:23]
+                    │
+                 78 │   intArgField(intArg: Int): String
+                    │                       ─┬─  
+                    │                        ╰─── expected type declared here as Int
                 ────╯
             "#]],
         );
@@ -599,17 +599,17 @@ mod invalid_float_values {
       "#,
             expect![[r#"
                 Error: expected value of type Float, found String
-                    ╭─[schema.graphql:83:27]
-                    │
-                 83 │   floatArgField(floatArg: Float): String
-                    │                           ──┬──  
-                    │                             ╰──── field declared here as Float type
-                    │
-                    ├─[query.graphql:3:29]
+                    ╭─[query.graphql:3:29]
                     │
                   3 │     floatArgField(floatArg: "3.333")
                     │                             ───┬───  
-                    │                                ╰───── argument declared here is of String type
+                    │                                ╰───── provided value is of String type
+                    │
+                    ├─[schema.graphql:83:27]
+                    │
+                 83 │   floatArgField(floatArg: Float): String
+                    │                           ──┬──  
+                    │                             ╰──── expected type declared here as Float
                 ────╯
             "#]],
         );
@@ -627,17 +627,17 @@ mod invalid_float_values {
       ",
             expect![[r#"
                 Error: expected value of type Float, found Boolean
-                    ╭─[schema.graphql:83:27]
-                    │
-                 83 │   floatArgField(floatArg: Float): String
-                    │                           ──┬──  
-                    │                             ╰──── field declared here as Float type
-                    │
-                    ├─[query.graphql:3:29]
+                    ╭─[query.graphql:3:29]
                     │
                   3 │     floatArgField(floatArg: true)
                     │                             ──┬─  
-                    │                               ╰─── argument declared here is of Boolean type
+                    │                               ╰─── provided value is of Boolean type
+                    │
+                    ├─[schema.graphql:83:27]
+                    │
+                 83 │   floatArgField(floatArg: Float): String
+                    │                           ──┬──  
+                    │                             ╰──── expected type declared here as Float
                 ────╯
             "#]],
         );
@@ -655,17 +655,17 @@ mod invalid_float_values {
       ",
             expect![[r#"
                 Error: expected value of type Float, found Enum
-                    ╭─[schema.graphql:83:27]
-                    │
-                 83 │   floatArgField(floatArg: Float): String
-                    │                           ──┬──  
-                    │                             ╰──── field declared here as Float type
-                    │
-                    ├─[query.graphql:3:29]
+                    ╭─[query.graphql:3:29]
                     │
                   3 │     floatArgField(floatArg: FOO)
                     │                             ─┬─  
-                    │                              ╰─── argument declared here is of Enum type
+                    │                              ╰─── provided value is of Enum type
+                    │
+                    ├─[schema.graphql:83:27]
+                    │
+                 83 │   floatArgField(floatArg: Float): String
+                    │                           ──┬──  
+                    │                             ╰──── expected type declared here as Float
                 ────╯
             "#]],
         );
@@ -688,17 +688,17 @@ mod invalid_boolean_values {
       ",
             expect![[r#"
                 Error: expected value of type Boolean, found Int
-                    ╭─[schema.graphql:81:31]
-                    │
-                 81 │   booleanArgField(booleanArg: Boolean): String
-                    │                               ───┬───  
-                    │                                  ╰───── field declared here as Boolean type
-                    │
-                    ├─[query.graphql:3:33]
+                    ╭─[query.graphql:3:33]
                     │
                   3 │     booleanArgField(booleanArg: 2)
                     │                                 ┬  
-                    │                                 ╰── argument declared here is of Int type
+                    │                                 ╰── provided value is of Int type
+                    │
+                    ├─[schema.graphql:81:31]
+                    │
+                 81 │   booleanArgField(booleanArg: Boolean): String
+                    │                               ───┬───  
+                    │                                  ╰───── expected type declared here as Boolean
                 ────╯
             "#]],
         );
@@ -716,17 +716,17 @@ mod invalid_boolean_values {
       ",
             expect![[r#"
                 Error: expected value of type Boolean, found Float
-                    ╭─[schema.graphql:81:31]
-                    │
-                 81 │   booleanArgField(booleanArg: Boolean): String
-                    │                               ───┬───  
-                    │                                  ╰───── field declared here as Boolean type
-                    │
-                    ├─[query.graphql:3:33]
+                    ╭─[query.graphql:3:33]
                     │
                   3 │     booleanArgField(booleanArg: 1.0)
                     │                                 ─┬─  
-                    │                                  ╰─── argument declared here is of Float type
+                    │                                  ╰─── provided value is of Float type
+                    │
+                    ├─[schema.graphql:81:31]
+                    │
+                 81 │   booleanArgField(booleanArg: Boolean): String
+                    │                               ───┬───  
+                    │                                  ╰───── expected type declared here as Boolean
                 ────╯
             "#]],
         );
@@ -744,17 +744,17 @@ mod invalid_boolean_values {
       "#,
             expect![[r#"
                 Error: expected value of type Boolean, found String
-                    ╭─[schema.graphql:81:31]
-                    │
-                 81 │   booleanArgField(booleanArg: Boolean): String
-                    │                               ───┬───  
-                    │                                  ╰───── field declared here as Boolean type
-                    │
-                    ├─[query.graphql:3:33]
+                    ╭─[query.graphql:3:33]
                     │
                   3 │     booleanArgField(booleanArg: "true")
                     │                                 ───┬──  
-                    │                                    ╰──── argument declared here is of String type
+                    │                                    ╰──── provided value is of String type
+                    │
+                    ├─[schema.graphql:81:31]
+                    │
+                 81 │   booleanArgField(booleanArg: Boolean): String
+                    │                               ───┬───  
+                    │                                  ╰───── expected type declared here as Boolean
                 ────╯
             "#]],
         );
@@ -772,17 +772,17 @@ mod invalid_boolean_values {
       ",
             expect![[r#"
                 Error: expected value of type Boolean, found Enum
-                    ╭─[schema.graphql:81:31]
-                    │
-                 81 │   booleanArgField(booleanArg: Boolean): String
-                    │                               ───┬───  
-                    │                                  ╰───── field declared here as Boolean type
-                    │
-                    ├─[query.graphql:3:33]
+                    ╭─[query.graphql:3:33]
                     │
                   3 │     booleanArgField(booleanArg: TRUE)
                     │                                 ──┬─  
-                    │                                   ╰─── argument declared here is of Enum type
+                    │                                   ╰─── provided value is of Enum type
+                    │
+                    ├─[schema.graphql:81:31]
+                    │
+                 81 │   booleanArgField(booleanArg: Boolean): String
+                    │                               ───┬───  
+                    │                                  ╰───── expected type declared here as Boolean
                 ────╯
             "#]],
         );
@@ -805,17 +805,17 @@ mod invalid_id_values {
       ",
             expect![[r#"
                 Error: expected value of type ID, found Float
-                    ╭─[schema.graphql:84:21]
-                    │
-                 84 │   idArgField(idArg: ID): String
-                    │                     ─┬  
-                    │                      ╰── field declared here as ID type
-                    │
-                    ├─[query.graphql:3:23]
+                    ╭─[query.graphql:3:23]
                     │
                   3 │     idArgField(idArg: 1.0)
                     │                       ─┬─  
-                    │                        ╰─── argument declared here is of Float type
+                    │                        ╰─── provided value is of Float type
+                    │
+                    ├─[schema.graphql:84:21]
+                    │
+                 84 │   idArgField(idArg: ID): String
+                    │                     ─┬  
+                    │                      ╰── expected type declared here as ID
                 ────╯
             "#]],
         );
@@ -833,17 +833,17 @@ mod invalid_id_values {
       ",
             expect![[r#"
                 Error: expected value of type ID, found Boolean
-                    ╭─[schema.graphql:84:21]
-                    │
-                 84 │   idArgField(idArg: ID): String
-                    │                     ─┬  
-                    │                      ╰── field declared here as ID type
-                    │
-                    ├─[query.graphql:3:23]
+                    ╭─[query.graphql:3:23]
                     │
                   3 │     idArgField(idArg: true)
                     │                       ──┬─  
-                    │                         ╰─── argument declared here is of Boolean type
+                    │                         ╰─── provided value is of Boolean type
+                    │
+                    ├─[schema.graphql:84:21]
+                    │
+                 84 │   idArgField(idArg: ID): String
+                    │                     ─┬  
+                    │                      ╰── expected type declared here as ID
                 ────╯
             "#]],
         );
@@ -861,17 +861,17 @@ mod invalid_id_values {
       ",
             expect![[r#"
                 Error: expected value of type ID, found Enum
-                    ╭─[schema.graphql:84:21]
-                    │
-                 84 │   idArgField(idArg: ID): String
-                    │                     ─┬  
-                    │                      ╰── field declared here as ID type
-                    │
-                    ├─[query.graphql:3:23]
+                    ╭─[query.graphql:3:23]
                     │
                   3 │     idArgField(idArg: SOMETHING)
                     │                       ────┬────  
-                    │                           ╰────── argument declared here is of Enum type
+                    │                           ╰────── provided value is of Enum type
+                    │
+                    ├─[schema.graphql:84:21]
+                    │
+                 84 │   idArgField(idArg: ID): String
+                    │                     ─┬  
+                    │                      ╰── expected type declared here as ID
                 ────╯
             "#]],
         );
@@ -894,17 +894,17 @@ mod invalid_enum_values {
       ",
             expect![[r#"
                 Error: expected value of type DogCommand, found Int
-                    ╭─[schema.graphql:27:31]
-                    │
-                 27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
-                    │                               ─────┬────  
-                    │                                    ╰────── field declared here as DogCommand type
-                    │
-                    ├─[query.graphql:3:33]
+                    ╭─[query.graphql:3:33]
                     │
                   3 │     doesKnowCommand(dogCommand: 2)
                     │                                 ┬  
-                    │                                 ╰── argument declared here is of Int type
+                    │                                 ╰── provided value is of Int type
+                    │
+                    ├─[schema.graphql:27:31]
+                    │
+                 27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
+                    │                               ─────┬────  
+                    │                                    ╰────── expected type declared here as DogCommand
                 ────╯
             "#]],
         );
@@ -922,17 +922,17 @@ mod invalid_enum_values {
       ",
             expect![[r#"
                 Error: expected value of type DogCommand, found Float
-                    ╭─[schema.graphql:27:31]
-                    │
-                 27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
-                    │                               ─────┬────  
-                    │                                    ╰────── field declared here as DogCommand type
-                    │
-                    ├─[query.graphql:3:33]
+                    ╭─[query.graphql:3:33]
                     │
                   3 │     doesKnowCommand(dogCommand: 1.0)
                     │                                 ─┬─  
-                    │                                  ╰─── argument declared here is of Float type
+                    │                                  ╰─── provided value is of Float type
+                    │
+                    ├─[schema.graphql:27:31]
+                    │
+                 27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
+                    │                               ─────┬────  
+                    │                                    ╰────── expected type declared here as DogCommand
                 ────╯
             "#]],
         );
@@ -950,17 +950,17 @@ mod invalid_enum_values {
       "#,
             expect![[r#"
                 Error: expected value of type DogCommand, found String
-                    ╭─[schema.graphql:27:31]
-                    │
-                 27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
-                    │                               ─────┬────  
-                    │                                    ╰────── field declared here as DogCommand type
-                    │
-                    ├─[query.graphql:3:33]
+                    ╭─[query.graphql:3:33]
                     │
                   3 │     doesKnowCommand(dogCommand: "SIT")
                     │                                 ──┬──  
-                    │                                   ╰──── argument declared here is of String type
+                    │                                   ╰──── provided value is of String type
+                    │
+                    ├─[schema.graphql:27:31]
+                    │
+                 27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
+                    │                               ─────┬────  
+                    │                                    ╰────── expected type declared here as DogCommand
                 ────╯
             "#]],
         );
@@ -978,17 +978,17 @@ mod invalid_enum_values {
       ",
             expect![[r#"
                 Error: expected value of type DogCommand, found Boolean
-                    ╭─[schema.graphql:27:31]
-                    │
-                 27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
-                    │                               ─────┬────  
-                    │                                    ╰────── field declared here as DogCommand type
-                    │
-                    ├─[query.graphql:3:33]
+                    ╭─[query.graphql:3:33]
                     │
                   3 │     doesKnowCommand(dogCommand: true)
                     │                                 ──┬─  
-                    │                                   ╰─── argument declared here is of Boolean type
+                    │                                   ╰─── provided value is of Boolean type
+                    │
+                    ├─[schema.graphql:27:31]
+                    │
+                 27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
+                    │                               ─────┬────  
+                    │                                    ╰────── expected type declared here as DogCommand
                 ────╯
             "#]],
         );
@@ -1005,13 +1005,21 @@ mod invalid_enum_values {
         }
       ",
             expect![[r#"
-                Error: value `JUGGLE` does not exist on `DogCommand` type
-                   ╭─[query.graphql:3:33]
-                   │
-                 3 │     doesKnowCommand(dogCommand: JUGGLE)
-                   │                                 ───┬──  
-                   │                                    ╰──── does not exist on `DogCommand` type
-                ───╯
+                Error: value `JUGGLE` does not exist on `DogCommand`
+                    ╭─[query.graphql:3:33]
+                    │
+                  3 │     doesKnowCommand(dogCommand: JUGGLE)
+                    │                                 ───┬──  
+                    │                                    ╰──── value does not exist on `DogCommand` enum
+                    │
+                    ├─[schema.graphql:16:1]
+                    │
+                 16 │ ╭─▶ enum DogCommand {
+                    ┆ ┆   
+                 20 │ ├─▶ }
+                    │ │       
+                    │ ╰─────── enum defined here
+                ────╯
             "#]],
         );
     }
@@ -1027,13 +1035,21 @@ mod invalid_enum_values {
         }
       ",
             expect![[r#"
-                Error: value `sit` does not exist on `DogCommand` type
-                   ╭─[query.graphql:3:33]
-                   │
-                 3 │     doesKnowCommand(dogCommand: sit)
-                   │                                 ─┬─  
-                   │                                  ╰─── does not exist on `DogCommand` type
-                ───╯
+                Error: value `sit` does not exist on `DogCommand`
+                    ╭─[query.graphql:3:33]
+                    │
+                  3 │     doesKnowCommand(dogCommand: sit)
+                    │                                 ─┬─  
+                    │                                  ╰─── value does not exist on `DogCommand` enum
+                    │
+                    ├─[schema.graphql:16:1]
+                    │
+                 16 │ ╭─▶ enum DogCommand {
+                    ┆ ┆   
+                 20 │ ├─▶ }
+                    │ │       
+                    │ ╰─────── enum defined here
+                ────╯
             "#]],
         );
     }
@@ -1111,17 +1127,17 @@ mod invalid_list_values {
       "#,
             expect![[r#"
                 Error: expected value of type String, found Int
-                    ╭─[schema.graphql:85:37]
-                    │
-                 85 │   stringListArgField(stringListArg: [String]): String
-                    │                                     ────┬───  
-                    │                                         ╰───── field declared here as String type
-                    │
-                    ├─[query.graphql:3:47]
+                    ╭─[query.graphql:3:47]
                     │
                   3 │     stringListArgField(stringListArg: ["one", 2])
                     │                                               ┬  
-                    │                                               ╰── argument declared here is of Int type
+                    │                                               ╰── provided value is of Int type
+                    │
+                    ├─[schema.graphql:85:37]
+                    │
+                 85 │   stringListArgField(stringListArg: [String]): String
+                    │                                     ────┬───  
+                    │                                         ╰───── expected type declared here as String
                 ────╯
             "#]],
         );
@@ -1139,17 +1155,17 @@ mod invalid_list_values {
       ",
             expect![[r#"
                 Error: expected value of type [String], found Int
-                    ╭─[schema.graphql:85:37]
-                    │
-                 85 │   stringListArgField(stringListArg: [String]): String
-                    │                                     ────┬───  
-                    │                                         ╰───── field declared here as [String] type
-                    │
-                    ├─[query.graphql:3:39]
+                    ╭─[query.graphql:3:39]
                     │
                   3 │     stringListArgField(stringListArg: 1)
                     │                                       ┬  
-                    │                                       ╰── argument declared here is of Int type
+                    │                                       ╰── provided value is of Int type
+                    │
+                    ├─[schema.graphql:85:37]
+                    │
+                 85 │   stringListArgField(stringListArg: [String]): String
+                    │                                     ────┬───  
+                    │                                         ╰───── expected type declared here as [String]
                 ────╯
             "#]],
         );
@@ -1306,30 +1322,30 @@ mod invalid_non_nullable_values {
       "#,
             expect![[r#"
                 Error: expected value of type Int!, found String
-                    ╭─[schema.graphql:89:34]
-                    │
-                 89 │   multipleReqs(req1: Int!, req2: Int!): String
-                    │                                  ──┬─  
-                    │                                    ╰─── field declared here as Int! type
-                    │
-                    ├─[query.graphql:3:24]
+                    ╭─[query.graphql:3:24]
                     │
                   3 │     multipleReqs(req2: "two", req1: "one")
                     │                        ──┬──  
-                    │                          ╰──── argument declared here is of String type
-                ────╯
-                Error: expected value of type Int!, found String
-                    ╭─[schema.graphql:89:22]
+                    │                          ╰──── provided value is of String type
+                    │
+                    ├─[schema.graphql:89:34]
                     │
                  89 │   multipleReqs(req1: Int!, req2: Int!): String
-                    │                      ──┬─  
-                    │                        ╰─── field declared here as Int! type
-                    │
-                    ├─[query.graphql:3:37]
+                    │                                  ──┬─  
+                    │                                    ╰─── expected type declared here as Int!
+                ────╯
+                Error: expected value of type Int!, found String
+                    ╭─[query.graphql:3:37]
                     │
                   3 │     multipleReqs(req2: "two", req1: "one")
                     │                                     ──┬──  
-                    │                                       ╰──── argument declared here is of String type
+                    │                                       ╰──── provided value is of String type
+                    │
+                    ├─[schema.graphql:89:22]
+                    │
+                 89 │   multipleReqs(req1: Int!, req2: Int!): String
+                    │                      ──┬─  
+                    │                        ╰─── expected type declared here as Int!
                 ────╯
             "#]],
         );
@@ -1346,7 +1362,7 @@ mod invalid_non_nullable_values {
         }
       "#,
             expect![[r#"
-                Error: the required argument `req2` is not provided
+                Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
                     ╭─[query.graphql:3:5]
                     │
                   3 │     multipleReqs(req1: "one")
@@ -1360,17 +1376,17 @@ mod invalid_non_nullable_values {
                     │                                 ╰────── argument defined here
                 ────╯
                 Error: expected value of type Int!, found String
-                    ╭─[schema.graphql:89:22]
-                    │
-                 89 │   multipleReqs(req1: Int!, req2: Int!): String
-                    │                      ──┬─  
-                    │                        ╰─── field declared here as Int! type
-                    │
-                    ├─[query.graphql:3:24]
+                    ╭─[query.graphql:3:24]
                     │
                   3 │     multipleReqs(req1: "one")
                     │                        ──┬──  
-                    │                          ╰──── argument declared here is of String type
+                    │                          ╰──── provided value is of String type
+                    │
+                    ├─[schema.graphql:89:22]
+                    │
+                 89 │   multipleReqs(req1: Int!, req2: Int!): String
+                    │                      ──┬─  
+                    │                        ╰─── expected type declared here as Int!
                 ────╯
             "#]],
         );
@@ -1387,7 +1403,7 @@ mod invalid_non_nullable_values {
         }
       ",
             expect![[r#"
-                Error: the required argument `req1` is not provided
+                Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
                     ╭─[query.graphql:3:5]
                     │
                   3 │     multipleReqs(req1: null)
@@ -1400,7 +1416,7 @@ mod invalid_non_nullable_values {
                     │                ─────┬────  
                     │                     ╰────── argument defined here
                 ────╯
-                Error: the required argument `req2` is not provided
+                Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
                     ╭─[query.graphql:3:5]
                     │
                   3 │     multipleReqs(req1: null)
@@ -1414,17 +1430,17 @@ mod invalid_non_nullable_values {
                     │                                 ╰────── argument defined here
                 ────╯
                 Error: expected value of type Int!, found Null
-                    ╭─[schema.graphql:89:22]
-                    │
-                 89 │   multipleReqs(req1: Int!, req2: Int!): String
-                    │                      ──┬─  
-                    │                        ╰─── field declared here as Int! type
-                    │
-                    ├─[query.graphql:3:24]
+                    ╭─[query.graphql:3:24]
                     │
                   3 │     multipleReqs(req1: null)
                     │                        ──┬─  
-                    │                          ╰─── argument declared here is of Null type
+                    │                          ╰─── provided value is of Null type
+                    │
+                    ├─[schema.graphql:89:22]
+                    │
+                 89 │   multipleReqs(req1: Int!, req2: Int!): String
+                    │                      ──┬─  
+                    │                        ╰─── expected type declared here as Int!
                 ────╯
             "#]],
         );
@@ -1540,7 +1556,7 @@ mod invalid_input_object_values {
         }
       ",
             expect![[r#"
-                Error: the required argument `requiredField` is not provided
+                Error: the required argument `ComplexInput.requiredField` is not provided
                     ╭─[query.graphql:3:33]
                     │
                   3 │     complexArgField(complexArg: { intField: 4 })
@@ -1572,17 +1588,17 @@ mod invalid_input_object_values {
       "#,
             expect![[r#"
                 Error: expected value of type String, found Int
-                    ╭─[schema.graphql:65:20]
-                    │
-                 65 │   stringListField: [String]
-                    │                    ────┬───  
-                    │                        ╰───── field declared here as String type
-                    │
-                    ├─[query.graphql:4:32]
+                    ╭─[query.graphql:4:32]
                     │
                   4 │       stringListField: ["one", 2],
                     │                                ┬  
-                    │                                ╰── argument declared here is of Int type
+                    │                                ╰── provided value is of Int type
+                    │
+                    ├─[schema.graphql:65:20]
+                    │
+                 65 │   stringListField: [String]
+                    │                    ────┬───  
+                    │                        ╰───── expected type declared here as String
                 ────╯
             "#]],
         );
@@ -1603,17 +1619,17 @@ mod invalid_input_object_values {
       ",
             expect![[r#"
                 Error: expected value of type Boolean!, found Null
-                    ╭─[schema.graphql:61:17]
-                    │
-                 61 │   nonNullField: Boolean! = false
-                    │                 ────┬───  
-                    │                     ╰───── field declared here as Boolean! type
-                    │
-                    ├─[query.graphql:5:7]
+                    ╭─[query.graphql:5:7]
                     │
                   5 │       nonNullField: null,
                     │       ─────────┬────────  
-                    │                ╰────────── argument declared here is of Null type
+                    │                ╰────────── provided value is of Null type
+                    │
+                    ├─[schema.graphql:61:17]
+                    │
+                 61 │   nonNullField: Boolean! = false
+                    │                 ────┬───  
+                    │                     ╰───── expected type declared here as Boolean!
                 ────╯
             "#]],
         );
@@ -1633,13 +1649,21 @@ mod invalid_input_object_values {
         }
       "#,
             expect![[r#"
-                Error: value `invalidField` does not exist on `ComplexInput` type
-                   ╭─[query.graphql:5:7]
-                   │
-                 5 │       invalidField: "value"
-                   │       ──────────┬──────────  
-                   │                 ╰──────────── does not exist on `ComplexInput` type
-                ───╯
+                Error: field `invalidField` does not exist on `ComplexInput`
+                    ╭─[query.graphql:5:7]
+                    │
+                  5 │       invalidField: "value"
+                    │       ──────────┬──────────  
+                    │                 ╰──────────── value does not exist on `ComplexInput` input object
+                    │
+                    ├─[schema.graphql:59:1]
+                    │
+                 59 │ ╭─▶ input ComplexInput {
+                    ┆ ┆   
+                 66 │ ├─▶ }
+                    │ │       
+                    │ ╰─────── input object defined here
+                ────╯
             "#]],
         );
     }
@@ -1709,19 +1733,31 @@ mod directive_arguments {
       "#,
             expect![[r#"
                 Error: expected value of type Boolean!, found String
-                   ╭─[query.graphql:2:20]
-                   │
-                 2 │   dog @include(if: "yes") {
-                   │                    ──┬──  
-                   │                      ╰──── argument declared here is of String type
-                ───╯
+                     ╭─[query.graphql:2:20]
+                     │
+                   2 │   dog @include(if: "yes") {
+                     │                    ──┬──  
+                     │                      ╰──── provided value is of String type
+                     │
+                     ├─[built_in.graphql:105:7]
+                     │
+                 105 │   if: Boolean!
+                     │       ────┬───  
+                     │           ╰───── expected type declared here as Boolean!
+                ─────╯
                 Error: expected value of type Boolean!, found Enum
-                   ╭─[query.graphql:3:20]
-                   │
-                 3 │     name @skip(if: ENUM)
-                   │                    ──┬─  
-                   │                      ╰─── argument declared here is of Enum type
-                ───╯
+                    ╭─[query.graphql:3:20]
+                    │
+                  3 │     name @skip(if: ENUM)
+                    │                    ──┬─  
+                    │                      ╰─── provided value is of Enum type
+                    │
+                    ├─[built_in.graphql:99:7]
+                    │
+                 99 │   if: Boolean!
+                    │       ────┬───  
+                    │           ╰───── expected type declared here as Boolean!
+                ────╯
             "#]],
         );
     }
@@ -1797,20 +1833,20 @@ mod variable_default_values {
                    │
                  2 │   $a: Int! = null,
                    │       ──┬─   ──┬─  
-                   │         ╰────────── field declared here as Int! type
+                   │         ╰────────── expected type declared here as Int!
                    │                │   
-                   │                ╰─── argument declared here is of Null type
+                   │                ╰─── provided value is of Null type
                 ───╯
                 Error: expected value of type String!, found Null
                    ╭─[query.graphql:3:17]
                    │
                  3 │   $b: String! = null,
                    │       ───┬───   ──┬─  
-                   │          ╰──────────── field declared here as String! type
+                   │          ╰──────────── expected type declared here as String!
                    │                   │   
-                   │                   ╰─── argument declared here is of Null type
+                   │                   ╰─── provided value is of Null type
                 ───╯
-                Error: the required argument `requiredField` is not provided
+                Error: the required argument `ComplexInput.requiredField` is not provided
                     ╭─[query.graphql:4:22]
                     │
                   4 │   $c: ComplexInput = { requiredField: null, intField: null }
@@ -1824,17 +1860,17 @@ mod variable_default_values {
                     │              ╰───────────── argument defined here
                 ────╯
                 Error: expected value of type Boolean!, found Null
-                    ╭─[schema.graphql:60:18]
-                    │
-                 60 │   requiredField: Boolean!
-                    │                  ────┬───  
-                    │                      ╰───── field declared here as Boolean! type
-                    │
-                    ├─[query.graphql:4:24]
+                    ╭─[query.graphql:4:24]
                     │
                   4 │   $c: ComplexInput = { requiredField: null, intField: null }
                     │                        ─────────┬─────────  
-                    │                                 ╰─────────── argument declared here is of Null type
+                    │                                 ╰─────────── provided value is of Null type
+                    │
+                    ├─[schema.graphql:60:18]
+                    │
+                 60 │   requiredField: Boolean!
+                    │                  ────┬───  
+                    │                      ╰───── expected type declared here as Boolean!
                 ────╯
             "#]],
         );
@@ -1863,27 +1899,27 @@ mod variable_default_values {
                    │
                  2 │   $a: Int = "one",
                    │       ─┬─   ──┬──  
-                   │        ╰─────────── field declared here as Int type
+                   │        ╰─────────── expected type declared here as Int
                    │               │    
-                   │               ╰──── argument declared here is of String type
+                   │               ╰──── provided value is of String type
                 ───╯
                 Error: expected value of type String, found Int
                    ╭─[query.graphql:3:16]
                    │
                  3 │   $b: String = 4,
                    │       ───┬──   ┬  
-                   │          ╰──────── field declared here as String type
+                   │          ╰──────── expected type declared here as String
                    │                │  
-                   │                ╰── argument declared here is of Int type
+                   │                ╰── provided value is of Int type
                 ───╯
                 Error: expected value of type ComplexInput, found String
                    ╭─[query.graphql:4:22]
                    │
                  4 │   $c: ComplexInput = "NotVeryComplex"
                    │       ──────┬─────   ────────┬───────  
-                   │             ╰────────────────────────── field declared here as ComplexInput type
+                   │             ╰────────────────────────── expected type declared here as ComplexInput
                    │                              │         
-                   │                              ╰───────── argument declared here is of String type
+                   │                              ╰───────── provided value is of String type
                 ───╯
             "#]],
         );
@@ -1902,30 +1938,30 @@ mod variable_default_values {
       "#,
             expect![[r#"
                 Error: expected value of type Boolean!, found Int
-                    ╭─[schema.graphql:60:18]
-                    │
-                 60 │   requiredField: Boolean!
-                    │                  ────┬───  
-                    │                      ╰───── field declared here as Boolean! type
-                    │
-                    ├─[query.graphql:2:24]
+                    ╭─[query.graphql:2:24]
                     │
                   2 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
                     │                        ─────────┬────────  
-                    │                                 ╰────────── argument declared here is of Int type
+                    │                                 ╰────────── provided value is of Int type
+                    │
+                    ├─[schema.graphql:60:18]
+                    │
+                 60 │   requiredField: Boolean!
+                    │                  ────┬───  
+                    │                      ╰───── expected type declared here as Boolean!
                 ────╯
                 Error: expected value of type Int, found String
-                    ╭─[schema.graphql:62:13]
-                    │
-                 62 │   intField: Int
-                    │             ─┬─  
-                    │              ╰─── field declared here as Int type
-                    │
-                    ├─[query.graphql:2:44]
+                    ╭─[query.graphql:2:44]
                     │
                   2 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
                     │                                            ───────┬───────  
-                    │                                                   ╰───────── argument declared here is of String type
+                    │                                                   ╰───────── provided value is of String type
+                    │
+                    ├─[schema.graphql:62:13]
+                    │
+                 62 │   intField: Int
+                    │             ─┬─  
+                    │              ╰─── expected type declared here as Int
                 ────╯
             "#]],
         );
@@ -1941,7 +1977,7 @@ mod variable_default_values {
         }
       ",
             expect![[r#"
-                Error: the required argument `requiredField` is not provided
+                Error: the required argument `ComplexInput.requiredField` is not provided
                     ╭─[query.graphql:1:47]
                     │
                   1 │ query MissingRequiredField($a: ComplexInput = {intField: 3}) {
@@ -1973,9 +2009,9 @@ mod variable_default_values {
                    │
                  1 │ query InvalidItem($a: [String] = ["one", 2]) {
                    │                       ────┬───           ┬  
-                   │                           ╰───────────────── field declared here as String type
+                   │                           ╰───────────────── expected type declared here as String
                    │                                          │  
-                   │                                          ╰── argument declared here is of Int type
+                   │                                          ╰── provided value is of Int type
                 ───╯
             "#]],
         );

--- a/crates/apollo-compiler/tests/validation/types.rs
+++ b/crates/apollo-compiler/tests/validation/types.rs
@@ -342,12 +342,12 @@ mod invalid_string_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type String, found Int
+                Error: expected value of type String, found an integer
                     ╭─[query.graphql:3:31]
                     │
                   3 │     stringArgField(stringArg: 1)
                     │                               ┬  
-                    │                               ╰── provided value is of Int type
+                    │                               ╰── provided value is an integer
                     │
                     ├─[schema.graphql:80:29]
                     │
@@ -370,12 +370,12 @@ mod invalid_string_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type String, found Float
+                Error: expected value of type String, found a float
                     ╭─[query.graphql:3:31]
                     │
                   3 │     stringArgField(stringArg: 1.0)
                     │                               ─┬─  
-                    │                                ╰─── provided value is of Float type
+                    │                                ╰─── provided value is a float
                     │
                     ├─[schema.graphql:80:29]
                     │
@@ -398,12 +398,12 @@ mod invalid_string_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type String, found Boolean
+                Error: expected value of type String, found a boolean
                     ╭─[query.graphql:3:31]
                     │
                   3 │     stringArgField(stringArg: true)
                     │                               ──┬─  
-                    │                                 ╰─── provided value is of Boolean type
+                    │                                 ╰─── provided value is a boolean
                     │
                     ├─[schema.graphql:80:29]
                     │
@@ -426,12 +426,12 @@ mod invalid_string_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type String, found Enum
+                Error: expected value of type String, found an enum
                     ╭─[query.graphql:3:31]
                     │
                   3 │     stringArgField(stringArg: BAR)
                     │                               ─┬─  
-                    │                                ╰─── provided value is of Enum type
+                    │                                ╰─── provided value is an enum
                     │
                     ├─[schema.graphql:80:29]
                     │
@@ -459,12 +459,12 @@ mod invalid_int_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type Int, found String
+                Error: expected value of type Int, found a string
                     ╭─[query.graphql:3:25]
                     │
                   3 │     intArgField(intArg: "3")
                     │                         ─┬─  
-                    │                          ╰─── provided value is of String type
+                    │                          ╰─── provided value is a string
                     │
                     ├─[schema.graphql:78:23]
                     │
@@ -509,12 +509,12 @@ mod invalid_int_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Int, found Enum
+                Error: expected value of type Int, found an enum
                     ╭─[query.graphql:3:25]
                     │
                   3 │     intArgField(intArg: FOO)
                     │                         ─┬─  
-                    │                          ╰─── provided value is of Enum type
+                    │                          ╰─── provided value is an enum
                     │
                     ├─[schema.graphql:78:23]
                     │
@@ -537,12 +537,12 @@ mod invalid_int_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Int, found Float
+                Error: expected value of type Int, found a float
                     ╭─[query.graphql:3:25]
                     │
                   3 │     intArgField(intArg: 3.0)
                     │                         ─┬─  
-                    │                          ╰─── provided value is of Float type
+                    │                          ╰─── provided value is a float
                     │
                     ├─[schema.graphql:78:23]
                     │
@@ -565,12 +565,12 @@ mod invalid_int_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Int, found Float
+                Error: expected value of type Int, found a float
                     ╭─[query.graphql:3:25]
                     │
                   3 │     intArgField(intArg: 3.333)
                     │                         ──┬──  
-                    │                           ╰──── provided value is of Float type
+                    │                           ╰──── provided value is a float
                     │
                     ├─[schema.graphql:78:23]
                     │
@@ -598,12 +598,12 @@ mod invalid_float_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type Float, found String
+                Error: expected value of type Float, found a string
                     ╭─[query.graphql:3:29]
                     │
                   3 │     floatArgField(floatArg: "3.333")
                     │                             ───┬───  
-                    │                                ╰───── provided value is of String type
+                    │                                ╰───── provided value is a string
                     │
                     ├─[schema.graphql:83:27]
                     │
@@ -626,12 +626,12 @@ mod invalid_float_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Float, found Boolean
+                Error: expected value of type Float, found a boolean
                     ╭─[query.graphql:3:29]
                     │
                   3 │     floatArgField(floatArg: true)
                     │                             ──┬─  
-                    │                               ╰─── provided value is of Boolean type
+                    │                               ╰─── provided value is a boolean
                     │
                     ├─[schema.graphql:83:27]
                     │
@@ -654,12 +654,12 @@ mod invalid_float_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Float, found Enum
+                Error: expected value of type Float, found an enum
                     ╭─[query.graphql:3:29]
                     │
                   3 │     floatArgField(floatArg: FOO)
                     │                             ─┬─  
-                    │                              ╰─── provided value is of Enum type
+                    │                              ╰─── provided value is an enum
                     │
                     ├─[schema.graphql:83:27]
                     │
@@ -687,12 +687,12 @@ mod invalid_boolean_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Boolean, found Int
+                Error: expected value of type Boolean, found an integer
                     ╭─[query.graphql:3:33]
                     │
                   3 │     booleanArgField(booleanArg: 2)
                     │                                 ┬  
-                    │                                 ╰── provided value is of Int type
+                    │                                 ╰── provided value is an integer
                     │
                     ├─[schema.graphql:81:31]
                     │
@@ -715,12 +715,12 @@ mod invalid_boolean_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Boolean, found Float
+                Error: expected value of type Boolean, found a float
                     ╭─[query.graphql:3:33]
                     │
                   3 │     booleanArgField(booleanArg: 1.0)
                     │                                 ─┬─  
-                    │                                  ╰─── provided value is of Float type
+                    │                                  ╰─── provided value is a float
                     │
                     ├─[schema.graphql:81:31]
                     │
@@ -743,12 +743,12 @@ mod invalid_boolean_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type Boolean, found String
+                Error: expected value of type Boolean, found a string
                     ╭─[query.graphql:3:33]
                     │
                   3 │     booleanArgField(booleanArg: "true")
                     │                                 ───┬──  
-                    │                                    ╰──── provided value is of String type
+                    │                                    ╰──── provided value is a string
                     │
                     ├─[schema.graphql:81:31]
                     │
@@ -771,12 +771,12 @@ mod invalid_boolean_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Boolean, found Enum
+                Error: expected value of type Boolean, found an enum
                     ╭─[query.graphql:3:33]
                     │
                   3 │     booleanArgField(booleanArg: TRUE)
                     │                                 ──┬─  
-                    │                                   ╰─── provided value is of Enum type
+                    │                                   ╰─── provided value is an enum
                     │
                     ├─[schema.graphql:81:31]
                     │
@@ -804,12 +804,12 @@ mod invalid_id_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type ID, found Float
+                Error: expected value of type ID, found a float
                     ╭─[query.graphql:3:23]
                     │
                   3 │     idArgField(idArg: 1.0)
                     │                       ─┬─  
-                    │                        ╰─── provided value is of Float type
+                    │                        ╰─── provided value is a float
                     │
                     ├─[schema.graphql:84:21]
                     │
@@ -832,12 +832,12 @@ mod invalid_id_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type ID, found Boolean
+                Error: expected value of type ID, found a boolean
                     ╭─[query.graphql:3:23]
                     │
                   3 │     idArgField(idArg: true)
                     │                       ──┬─  
-                    │                         ╰─── provided value is of Boolean type
+                    │                         ╰─── provided value is a boolean
                     │
                     ├─[schema.graphql:84:21]
                     │
@@ -860,12 +860,12 @@ mod invalid_id_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type ID, found Enum
+                Error: expected value of type ID, found an enum
                     ╭─[query.graphql:3:23]
                     │
                   3 │     idArgField(idArg: SOMETHING)
                     │                       ────┬────  
-                    │                           ╰────── provided value is of Enum type
+                    │                           ╰────── provided value is an enum
                     │
                     ├─[schema.graphql:84:21]
                     │
@@ -893,12 +893,12 @@ mod invalid_enum_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type DogCommand, found Int
+                Error: expected value of type DogCommand, found an integer
                     ╭─[query.graphql:3:33]
                     │
                   3 │     doesKnowCommand(dogCommand: 2)
                     │                                 ┬  
-                    │                                 ╰── provided value is of Int type
+                    │                                 ╰── provided value is an integer
                     │
                     ├─[schema.graphql:27:31]
                     │
@@ -921,12 +921,12 @@ mod invalid_enum_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type DogCommand, found Float
+                Error: expected value of type DogCommand, found a float
                     ╭─[query.graphql:3:33]
                     │
                   3 │     doesKnowCommand(dogCommand: 1.0)
                     │                                 ─┬─  
-                    │                                  ╰─── provided value is of Float type
+                    │                                  ╰─── provided value is a float
                     │
                     ├─[schema.graphql:27:31]
                     │
@@ -949,12 +949,12 @@ mod invalid_enum_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type DogCommand, found String
+                Error: expected value of type DogCommand, found a string
                     ╭─[query.graphql:3:33]
                     │
                   3 │     doesKnowCommand(dogCommand: "SIT")
                     │                                 ──┬──  
-                    │                                   ╰──── provided value is of String type
+                    │                                   ╰──── provided value is a string
                     │
                     ├─[schema.graphql:27:31]
                     │
@@ -977,12 +977,12 @@ mod invalid_enum_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type DogCommand, found Boolean
+                Error: expected value of type DogCommand, found a boolean
                     ╭─[query.graphql:3:33]
                     │
                   3 │     doesKnowCommand(dogCommand: true)
                     │                                 ──┬─  
-                    │                                   ╰─── provided value is of Boolean type
+                    │                                   ╰─── provided value is a boolean
                     │
                     ├─[schema.graphql:27:31]
                     │
@@ -1126,12 +1126,12 @@ mod invalid_list_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type String, found Int
+                Error: expected value of type String, found an integer
                     ╭─[query.graphql:3:47]
                     │
                   3 │     stringListArgField(stringListArg: ["one", 2])
                     │                                               ┬  
-                    │                                               ╰── provided value is of Int type
+                    │                                               ╰── provided value is an integer
                     │
                     ├─[schema.graphql:85:37]
                     │
@@ -1154,12 +1154,12 @@ mod invalid_list_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type [String], found Int
+                Error: expected value of type [String], found an integer
                     ╭─[query.graphql:3:39]
                     │
                   3 │     stringListArgField(stringListArg: 1)
                     │                                       ┬  
-                    │                                       ╰── provided value is of Int type
+                    │                                       ╰── provided value is an integer
                     │
                     ├─[schema.graphql:85:37]
                     │
@@ -1321,12 +1321,12 @@ mod invalid_non_nullable_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type Int!, found String
+                Error: expected value of type Int!, found a string
                     ╭─[query.graphql:3:24]
                     │
                   3 │     multipleReqs(req2: "two", req1: "one")
                     │                        ──┬──  
-                    │                          ╰──── provided value is of String type
+                    │                          ╰──── provided value is a string
                     │
                     ├─[schema.graphql:89:34]
                     │
@@ -1334,12 +1334,12 @@ mod invalid_non_nullable_values {
                     │                                  ──┬─  
                     │                                    ╰─── expected type declared here as Int!
                 ────╯
-                Error: expected value of type Int!, found String
+                Error: expected value of type Int!, found a string
                     ╭─[query.graphql:3:37]
                     │
                   3 │     multipleReqs(req2: "two", req1: "one")
                     │                                     ──┬──  
-                    │                                       ╰──── provided value is of String type
+                    │                                       ╰──── provided value is a string
                     │
                     ├─[schema.graphql:89:22]
                     │
@@ -1375,12 +1375,12 @@ mod invalid_non_nullable_values {
                     │                            ─────┬────  
                     │                                 ╰────── argument defined here
                 ────╯
-                Error: expected value of type Int!, found String
+                Error: expected value of type Int!, found a string
                     ╭─[query.graphql:3:24]
                     │
                   3 │     multipleReqs(req1: "one")
                     │                        ──┬──  
-                    │                          ╰──── provided value is of String type
+                    │                          ╰──── provided value is a string
                     │
                     ├─[schema.graphql:89:22]
                     │
@@ -1429,12 +1429,12 @@ mod invalid_non_nullable_values {
                     │                            ─────┬────  
                     │                                 ╰────── argument defined here
                 ────╯
-                Error: expected value of type Int!, found Null
+                Error: expected value of type Int!, found null
                     ╭─[query.graphql:3:24]
                     │
                   3 │     multipleReqs(req1: null)
                     │                        ──┬─  
-                    │                          ╰─── provided value is of Null type
+                    │                          ╰─── provided value is null
                     │
                     ├─[schema.graphql:89:22]
                     │
@@ -1587,12 +1587,12 @@ mod invalid_input_object_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type String, found Int
+                Error: expected value of type String, found an integer
                     ╭─[query.graphql:4:32]
                     │
                   4 │       stringListField: ["one", 2],
                     │                                ┬  
-                    │                                ╰── provided value is of Int type
+                    │                                ╰── provided value is an integer
                     │
                     ├─[schema.graphql:65:20]
                     │
@@ -1618,12 +1618,12 @@ mod invalid_input_object_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Boolean!, found Null
+                Error: expected value of type Boolean!, found null
                     ╭─[query.graphql:5:7]
                     │
                   5 │       nonNullField: null,
                     │       ─────────┬────────  
-                    │                ╰────────── provided value is of Null type
+                    │                ╰────────── provided value is null
                     │
                     ├─[schema.graphql:61:17]
                     │
@@ -1732,12 +1732,12 @@ mod directive_arguments {
         }
       "#,
             expect![[r#"
-                Error: expected value of type Boolean!, found String
+                Error: expected value of type Boolean!, found a string
                      ╭─[query.graphql:2:20]
                      │
                    2 │   dog @include(if: "yes") {
                      │                    ──┬──  
-                     │                      ╰──── provided value is of String type
+                     │                      ╰──── provided value is a string
                      │
                      ├─[built_in.graphql:105:7]
                      │
@@ -1745,12 +1745,12 @@ mod directive_arguments {
                      │       ────┬───  
                      │           ╰───── expected type declared here as Boolean!
                 ─────╯
-                Error: expected value of type Boolean!, found Enum
+                Error: expected value of type Boolean!, found an enum
                     ╭─[query.graphql:3:20]
                     │
                   3 │     name @skip(if: ENUM)
                     │                    ──┬─  
-                    │                      ╰─── provided value is of Enum type
+                    │                      ╰─── provided value is an enum
                     │
                     ├─[built_in.graphql:99:7]
                     │
@@ -1828,23 +1828,23 @@ mod variable_default_values {
         }
       ",
             expect![[r#"
-                Error: expected value of type Int!, found Null
+                Error: expected value of type Int!, found null
                    ╭─[query.graphql:2:14]
                    │
                  2 │   $a: Int! = null,
                    │       ──┬─   ──┬─  
                    │         ╰────────── expected type declared here as Int!
                    │                │   
-                   │                ╰─── provided value is of Null type
+                   │                ╰─── provided value is null
                 ───╯
-                Error: expected value of type String!, found Null
+                Error: expected value of type String!, found null
                    ╭─[query.graphql:3:17]
                    │
                  3 │   $b: String! = null,
                    │       ───┬───   ──┬─  
                    │          ╰──────────── expected type declared here as String!
                    │                   │   
-                   │                   ╰─── provided value is of Null type
+                   │                   ╰─── provided value is null
                 ───╯
                 Error: the required argument `ComplexInput.requiredField` is not provided
                     ╭─[query.graphql:4:22]
@@ -1859,12 +1859,12 @@ mod variable_default_values {
                     │   ───────────┬───────────  
                     │              ╰───────────── argument defined here
                 ────╯
-                Error: expected value of type Boolean!, found Null
+                Error: expected value of type Boolean!, found null
                     ╭─[query.graphql:4:24]
                     │
                   4 │   $c: ComplexInput = { requiredField: null, intField: null }
                     │                        ─────────┬─────────  
-                    │                                 ╰─────────── provided value is of Null type
+                    │                                 ╰─────────── provided value is null
                     │
                     ├─[schema.graphql:60:18]
                     │
@@ -1894,32 +1894,32 @@ mod variable_default_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type Int, found String
+                Error: expected value of type Int, found a string
                    ╭─[query.graphql:2:13]
                    │
                  2 │   $a: Int = "one",
                    │       ─┬─   ──┬──  
                    │        ╰─────────── expected type declared here as Int
                    │               │    
-                   │               ╰──── provided value is of String type
+                   │               ╰──── provided value is a string
                 ───╯
-                Error: expected value of type String, found Int
+                Error: expected value of type String, found an integer
                    ╭─[query.graphql:3:16]
                    │
                  3 │   $b: String = 4,
                    │       ───┬──   ┬  
                    │          ╰──────── expected type declared here as String
                    │                │  
-                   │                ╰── provided value is of Int type
+                   │                ╰── provided value is an integer
                 ───╯
-                Error: expected value of type ComplexInput, found String
+                Error: expected value of type ComplexInput, found a string
                    ╭─[query.graphql:4:22]
                    │
                  4 │   $c: ComplexInput = "NotVeryComplex"
                    │       ──────┬─────   ────────┬───────  
                    │             ╰────────────────────────── expected type declared here as ComplexInput
                    │                              │         
-                   │                              ╰───────── provided value is of String type
+                   │                              ╰───────── provided value is a string
                 ───╯
             "#]],
         );
@@ -1937,12 +1937,12 @@ mod variable_default_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type Boolean!, found Int
+                Error: expected value of type Boolean!, found an integer
                     ╭─[query.graphql:2:24]
                     │
                   2 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
                     │                        ─────────┬────────  
-                    │                                 ╰────────── provided value is of Int type
+                    │                                 ╰────────── provided value is an integer
                     │
                     ├─[schema.graphql:60:18]
                     │
@@ -1950,12 +1950,12 @@ mod variable_default_values {
                     │                  ────┬───  
                     │                      ╰───── expected type declared here as Boolean!
                 ────╯
-                Error: expected value of type Int, found String
+                Error: expected value of type Int, found a string
                     ╭─[query.graphql:2:44]
                     │
                   2 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
                     │                                            ───────┬───────  
-                    │                                                   ╰───────── provided value is of String type
+                    │                                                   ╰───────── provided value is a string
                     │
                     ├─[schema.graphql:62:13]
                     │
@@ -2004,14 +2004,14 @@ mod variable_default_values {
         }
       "#,
             expect![[r#"
-                Error: expected value of type String, found Int
+                Error: expected value of type String, found an integer
                    ╭─[query.graphql:1:42]
                    │
                  1 │ query InvalidItem($a: [String] = ["one", 2]) {
                    │                       ────┬───           ┬  
                    │                           ╰───────────────── expected type declared here as String
                    │                                          │  
-                   │                                          ╰── provided value is of Int type
+                   │                                          ╰── provided value is an integer
                 ───╯
             "#]],
         );

--- a/crates/apollo-compiler/tests/validation/variable.rs
+++ b/crates/apollo-compiler/tests/validation/variable.rs
@@ -41,11 +41,11 @@ type Products {
         .unwrap_err()
         .to_string();
     assert!(
-        errors.contains("variable `undefinedVariable` is not defined"),
+        errors.contains("variable `$undefinedVariable` is not defined"),
         "{errors}"
     );
     assert!(
-        errors.contains("variable `dimensions` is not defined"),
+        errors.contains("variable `$dimensions` is not defined"),
         "{errors}"
     );
 }
@@ -74,7 +74,7 @@ type Product {
         .unwrap_err()
         .to_string();
     assert!(
-        errors.contains("unused variable: `unusedVariable`"),
+        errors.contains("unused variable: `$unusedVariable`"),
         "{errors}"
     );
 }
@@ -124,11 +124,11 @@ type Product {
         .unwrap_err()
         .to_string();
     assert!(
-        errors.contains("variable `goldStatus` is not defined"),
+        errors.contains("variable `$goldStatus` is not defined"),
         "{errors}"
     );
     assert!(
-        errors.contains("variable `dimensions` is not defined"),
+        errors.contains("variable `$dimensions` is not defined"),
         "{errors}"
     );
 }


### PR DESCRIPTION
Based on #747, separated out to make that PR easier to read

Closes #756, closes #691

Ports compiler-based validation from the `ApolloDiagnostic` builder type to a simpler error `ValidationError`. The `validation::diagnostics::{ValidationError, DiagnosticData}` types have the same structure as the `validation::{DiagnosticData, Details}` types, so it can be flattened easily, inlining all build errors and validation errors. That could even be done in this PR 🤔 

Improved some error messages while there, so the main message names relevant types, and they still make sense without additional labels.

Todo:
- [x] fix a mistake in one of the interface error messages
- [ ] flatten into `DiagnosticData`?