### PR TITLE
feat(xtask): add xtask lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ cargo fmt --all
 To lint your code:
 ```bash
 rustup component add clippy
-cargo clippy
+cargo xtask lint
 ```
 
 ### IDEs

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -30,12 +30,31 @@ struct Xtask {
 pub enum Command {
     /// Perform code generation for the parser
     Codegen(codegen::Codegen),
+    /// Run clippy
+    Lint,
+}
+
+fn run_clippy() -> Result<()> {
+    let sh = Shell::new()?;
+
+    cmd!(sh, "cargo fmt --all -- --check").run()?;
+
+    cmd!(
+        sh,
+        "cargo clippy --all-targets --all-features -- -D warnings"
+    )
+    .run()?;
+
+    cmd!(sh, "cargo clippy --benches").run()?;
+
+    Ok(())
 }
 
 impl Xtask {
     pub fn run(&self) -> Result<()> {
         match &self.command {
             Command::Codegen(command) => command.run(self.verbose),
+            Command::Lint => run_clippy(),
         }?;
 
         Ok(())


### PR DESCRIPTION
Runs fmt and clippy with strict settings so when linting passes locally,
it will also pass on CI.
