### PR TITLE
fix(xtask): clippy-linting the benchmarks only once is enough

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           platform: << parameters.platform >>
       - run:
           name: Run cargo clippy
-          command: cargo clippy --all-targets --all-features -- -D warnings && cargo clippy --benches
+          command: cargo clippy --all-targets --all-features -- -D warnings
       - run:
           name: Run cargo fmt check
           command: rustup component add rustfmt && cargo fmt --all -- --check

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -45,8 +45,6 @@ fn run_clippy() -> Result<()> {
     )
     .run()?;
 
-    cmd!(sh, "cargo clippy --benches").run()?;
-
     Ok(())
 }
 


### PR DESCRIPTION
`--all-targets` includes `--benches`.