### PR TITLE
feat(compiler): implement fmt::Display for `ComponentName`

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [x.x.x] (unreleased) - 2024-mm-dd
+
+## Features
+- **Implement `fmt::Display` for `ComponentName` - [goto-bus-stop], [pull/795]**
+
+[goto-bus-stop]: https://github.com/goto-bus-stop]
+[pull/795]: https://github.com/apollographql/apollo-rs/pull/795
+
 # [1.0.0-beta.11](https://crates.io/crates/apollo-compiler/1.0.0-beta.11) - 2023-12-19
 
 This release includes support for GraphQL schema introspection [directly in the

--- a/crates/apollo-compiler/src/schema/component.rs
+++ b/crates/apollo-compiler/src/schema/component.rs
@@ -1,6 +1,7 @@
 use crate::ast::Name;
 use crate::validation::NodeLocation;
 use crate::Node;
+use std::fmt;
 use std::hash;
 use std::ops::Deref;
 use std::ops::DerefMut;
@@ -190,5 +191,11 @@ impl std::borrow::Borrow<str> for ComponentName {
 impl AsRef<str> for ComponentName {
     fn as_ref(&self) -> &str {
         self
+    }
+}
+
+impl fmt::Display for ComponentName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.name.fmt(f)
     }
 }


### PR DESCRIPTION
Instead of going through `.as_str()`

A Debug impl is already derived including the component information.