### PR TITLE
fix(compiler): InputValueDefinition::is_required() returns false if there is a default value

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -19,11 +19,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 # [x.x.x] (unreleased) - 2024-mm-dd
 
+## BREAKING
+- **`InputValueDefinition::is_required()` returns false if it has a default value - [goto-bus-stop], [pull/798]**
+  Now `argument.is_required() == true` only if the type is non-null and there is no
+  default value, meaning a value must be provided when it's used.
+
 ## Features
 - **Implement `fmt::Display` for `ComponentName` - [goto-bus-stop], [pull/795]**
 
 [goto-bus-stop]: https://github.com/goto-bus-stop]
 [pull/795]: https://github.com/apollographql/apollo-rs/pull/795
+[pull/798]: https://github.com/apollographql/apollo-rs/pull/798
 
 # [1.0.0-beta.11](https://crates.io/crates/apollo-compiler/1.0.0-beta.11) - 2023-12-19
 

--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -840,8 +840,13 @@ impl FieldDefinition {
 }
 
 impl InputValueDefinition {
+    /// Returns true if usage sites are required to provide a value for this input value.
+    ///
+    /// That means:
+    /// - its type is non-null, and
+    /// - it does not have a default value
     pub fn is_required(&self) -> bool {
-        matches!(*self.ty, Type::NonNullNamed(_) | Type::NonNullList(_))
+        self.ty.is_non_null() && self.default_value.is_none()
     }
 
     serialize_method!();

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -294,7 +294,7 @@ pub(crate) fn validate_directives<'dir>(
                     Some(value) => value.is_null(),
                 };
 
-                if arg_def.is_required() && is_null && arg_def.default_value.is_none() {
+                if arg_def.is_required() && is_null {
                     diagnostics.push(ValidationError::new(
                         dir.location(),
                         DiagnosticData::RequiredArgument {

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -87,7 +87,7 @@ pub(crate) fn validate_field(
                 Some(value) => value.is_null(),
             };
 
-            if arg_definition.is_required() && is_null && arg_definition.default_value.is_none() {
+            if arg_definition.is_required() && is_null {
                 diagnostics.push(ValidationError::new(
                     field.location(),
                     DiagnosticData::RequiredArgument {


### PR DESCRIPTION
Now `argument.is_required() == true` only if the type is non-null and there is no
default value, meaning a value must be provided when it's used. This is how the
[spec](https://spec.graphql.org/draft/#sec-Required-Arguments) describes required arguments.

This seems more useful as the previous implementation can already be achieved
by checking `argument.ty.is_non_null()`.

It's kind of a fix, kind of just a change, kind of breaking...