### PR TITLE
feat(smith): add link directive to schema definition generation

### DIFF
--- a/crates/apollo-smith/src/directive.rs
+++ b/crates/apollo-smith/src/directive.rs
@@ -1,6 +1,7 @@
 use crate::{
     argument::{Argument, ArgumentsDef},
     description::Description,
+    input_value::InputValueDef,
     name::Name,
     DocumentBuilder,
 };
@@ -319,5 +320,49 @@ impl From<String> for DirectiveLocation {
                 other
             ),
         }
+    }
+}
+
+pub(crate) fn at_link() -> DirectiveDef {
+    let mut directive_locations = IndexSet::new();
+    directive_locations.insert(DirectiveLocation::Schema);
+
+    DirectiveDef {
+        description: None,
+        name: Name::new("link".to_string()),
+        arguments_definition: Some(ArgumentsDef {
+            input_value_definitions: vec![
+                InputValueDef {
+                    description: None,
+                    name: Name::new("url".to_string()),
+                    ty: crate::ty::Ty::Named(Name::new("String".to_string())),
+                    default_value: None,
+                    directives: Default::default(),
+                },
+                InputValueDef {
+                    description: None,
+                    name: Name::new("as".to_string()),
+                    ty: crate::ty::Ty::Named(Name::new("String".to_string())),
+                    default_value: None,
+                    directives: Default::default(),
+                },
+                InputValueDef {
+                    description: None,
+                    name: Name::new("for".to_string()),
+                    ty: crate::ty::Ty::Named(Name::new("link__Purpose".to_string())),
+                    default_value: None,
+                    directives: Default::default(),
+                },
+                InputValueDef {
+                    description: None,
+                    name: Name::new("import".to_string()),
+                    ty: crate::ty::Ty::Named(Name::new("link__Import".to_string())),
+                    default_value: None,
+                    directives: Default::default(),
+                },
+            ],
+        }),
+        repeatable: true,
+        directive_locations,
     }
 }

--- a/crates/apollo-smith/src/enum_.rs
+++ b/crates/apollo-smith/src/enum_.rs
@@ -238,3 +238,29 @@ impl<'a> DocumentBuilder<'a> {
         Ok(enum_values_def)
     }
 }
+
+pub(crate) fn link_purpose() -> EnumTypeDef {
+    let mut enum_values_def = IndexSet::new();
+    enum_values_def.insert(EnumValueDefinition {
+        description: Some(Description::from(String::from(
+            "`SECURITY` features provide metadata necessary to securely resolve fields.",
+        ))),
+        value: Name::new(String::from("SECURITY")),
+        directives: Default::default(),
+    });
+    enum_values_def.insert(EnumValueDefinition {
+        description: Some(Description::from(String::from(
+            "`EXECUTION` features provide metadata necessary for operation execution.",
+        ))),
+        value: Name::new(String::from("EXECUTION")),
+        directives: Default::default(),
+    });
+
+    EnumTypeDef {
+        description: None,
+        name: Name::new(String::from("link__Purpose")),
+        directives: Default::default(),
+        enum_values_def,
+        extend: false,
+    }
+}

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -360,6 +360,7 @@ mod tests {
             stack: Vec::new(),
             chosen_arguments: IndexMap::new(),
             chosen_aliases: IndexMap::new(),
+            is_supergraph: false,
         };
         let my_nested_type = ObjectTypeDef {
             description: None,

--- a/crates/apollo-smith/src/scalar.rs
+++ b/crates/apollo-smith/src/scalar.rs
@@ -117,3 +117,12 @@ impl<'a> DocumentBuilder<'a> {
         })
     }
 }
+
+pub(crate) fn link_import() -> ScalarTypeDef {
+    ScalarTypeDef {
+        name: Name::new(String::from("link__Import")),
+        description: None,
+        directives: Default::default(),
+        extend: false,
+    }
+}

--- a/crates/apollo-smith/src/schema.rs
+++ b/crates/apollo-smith/src/schema.rs
@@ -1,6 +1,8 @@
 use crate::{
+    argument::Argument,
     description::Description,
     directive::{Directive, DirectiveLocation},
+    input_value::InputValue,
     name::Name,
     ty::Ty,
     DocumentBuilder,
@@ -132,7 +134,18 @@ impl<'a> DocumentBuilder<'a> {
             .unwrap_or(false)
             .then(|| self.description())
             .transpose()?;
-        let directives = self.directives(DirectiveLocation::Schema)?;
+        let mut directives = self.directives(DirectiveLocation::Schema)?;
+        if self.is_supergraph {
+            let link_arg = Argument {
+                name: Name::new(String::from("url")),
+                value: InputValue::String("https://specs.apollo.dev/link/v1.0".into()),
+            };
+            let directive = Directive {
+                name: Name::new(String::from("link")),
+                arguments: vec![link_arg],
+            };
+            directives.insert(Name::new("link".to_string()), directive.into());
+        }
         let named_types: Vec<Ty> = self
             .list_existing_object_types()
             .into_iter()

--- a/crates/apollo-smith/src/snapshot_tests.rs
+++ b/crates/apollo-smith/src/snapshot_tests.rs
@@ -4,7 +4,7 @@ use expect_test::expect;
 
 fn gen(len: usize) -> String {
     let entropy: Vec<u8> = (0..len).map(|i| i as u8).collect();
-    DocumentBuilder::new(&mut Unstructured::new(&entropy))
+    DocumentBuilder::new(&mut Unstructured::new(&entropy), false)
         .unwrap()
         .finish()
         .into()

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -6,7 +6,7 @@ pub fn generate_valid_document(input: &[u8]) -> Result<String> {
     drop(env_logger::try_init());
 
     let mut u = Unstructured::new(input);
-    let gql_doc = DocumentBuilder::new(&mut u)?;
+    let gql_doc = DocumentBuilder::new(&mut u, false)?;
     let document = gql_doc.finish();
 
     Ok(document.into())


### PR DESCRIPTION
This add link directive to generated schema definition. 

I run this with our API Schema fuzzer in [apollo-rs-fuzz](https://github.com/apollographql/apollo-rs-fuzz) and it passes the "valid supergraph" validation. We now, however, run into the issue of `apollo-smith` not always generating semantically valid graphql, e.g. #425 #180. I'll start to minimally tweak those next. 