### PR TITLE
feat(compiler): Add `SchemaCoordinate::lookup` methods

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -28,13 +28,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Implement `fmt::Display` for `ComponentName` - [goto-bus-stop], [pull/795]**
 - **Add `FieldDefinition::argument_by_name` and `DirectiveDefinition::argument_by_name` - [goto-bus-stop], [pull/801]**
   - These methods return an argument definition by name, or `None`.
-- **Add `.lookup` methods to schema coordinates - [goto-bus-stop], [pull/FIXME]**
+- **Add `.lookup` methods to schema coordinates - [goto-bus-stop], [pull/803]**
   - `coord!().lookup(&schema)` returns the element at the given coordinate.
 
 [goto-bus-stop]: https://github.com/goto-bus-stop]
 [pull/795]: https://github.com/apollographql/apollo-rs/pull/795
 [pull/798]: https://github.com/apollographql/apollo-rs/pull/798
 [pull/801]: https://github.com/apollographql/apollo-rs/pull/801
+[pull/803]: https://github.com/apollographql/apollo-rs/pull/803
 
 # [1.0.0-beta.11](https://crates.io/crates/apollo-compiler/1.0.0-beta.11) - 2023-12-19
 

--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -28,6 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Implement `fmt::Display` for `ComponentName` - [goto-bus-stop], [pull/795]**
 - **Add `FieldDefinition::argument_by_name` and `DirectiveDefinition::argument_by_name` - [goto-bus-stop], [pull/FIXME]**
   - These methods return an argument definition by name, or `None`.
+- **Add `.lookup` methods to schema coordinates - [goto-bus-stop], [pull/FIXME]**
+  - `coord!().lookup(&schema)` returns the element at the given coordinate.
 
 [goto-bus-stop]: https://github.com/goto-bus-stop]
 [pull/795]: https://github.com/apollographql/apollo-rs/pull/795


### PR DESCRIPTION
All the coordinate types have a `.lookup(&schema)` method.

I omitted the `SchemaLookup` trait that used to be in #757. It was only there to support `schema.lookup(&coord)`, but that's exactly the same as writing `coord.lookup(&schema)`, and it's simpler not to have both.

```rust
assert!(coord!(ObjectDefault.someField(privateArg:)).lookup(&schema).is_ok());
// vs.
assert!(schema.type_field("ObjectDefault", "someField").is_some_and(|f| f.arguments.iter().any(|arg| arg.name == "privateArg")));
```

Type attribute coordinate syntax can refer to object or interface field definitions, input
field definitions, and enum values. `TypeAttributeCoordinate::lookup` returns an enum to
account for those possibilities. To look up a specific kind of type attribute, there are
convenience methods:
- `TypeAttributeCoordinate::lookup_field` for object or interface fields
- `TypeAttributeCoordinate::lookup_input_field` for input fields
- `TypeAttributeCoordinate::lookup_enum_value` for enum values

This should help with writing assertions in tests where you normally already know what
type you expect.