### PR TITLE
apollo-compiler@1.0.0-beta.12

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -39,11 +39,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `string.parse::<SchemaCoordinate>()?.lookup(&schema)` returns an enum with all the elements
     that can be looked up using schema coordinates.
 
+## Maintenance
+- **update ariadne to 0.4.0 - [pull/793]**
+  Ariadne is the diagnostic printing crate used for validation errors. v0.4.0 improves memory usage.
+
 [goto-bus-stop]: https://github.com/goto-bus-stop]
 [pull/795]: https://github.com/apollographql/apollo-rs/pull/795
 [pull/798]: https://github.com/apollographql/apollo-rs/pull/798
 [pull/801]: https://github.com/apollographql/apollo-rs/pull/801
 [pull/803]: https://github.com/apollographql/apollo-rs/pull/803
+[pull/793]: https://github.com/apollographql/apollo-rs/pull/793
 
 # [1.0.0-beta.11](https://crates.io/crates/apollo-compiler/1.0.0-beta.11) - 2023-12-19
 

--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2024-mm-dd
+# [1.0.0-beta.12](https://crates.io/crates/apollo-compiler/1.0.0-beta.12) - 2024-01-15
 
 ## BREAKING
 - **`InputValueDefinition::is_required()` returns false if it has a default value - [goto-bus-stop], [pull/798]**
@@ -29,7 +29,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Add `FieldDefinition::argument_by_name` and `DirectiveDefinition::argument_by_name` - [goto-bus-stop], [pull/801]**
   - These methods return an argument definition by name, or `None`.
 - **Add `.lookup` methods to schema coordinates - [goto-bus-stop], [pull/803]**
-  - `coord!().lookup(&schema)` returns the element at the given coordinate.
+  - `coord!(Type).lookup(&schema)` returns the type definition for `Type`.
+  - `coord!(Type.field).lookup_field(&schema)` returns the field definition for `field`.
+  - `coord!(Enum.VALUE).lookup_enum_value(&schema)` returns the enum value definition for `VALUE`.
+  - `coord!(InputType.field).lookup_input_field(&schema)` returns the input field definition for `field`.
+  - `coord!(Type.field(argument:)).lookup(&schema)` returns the argument definition for `argument`.
+  - `coord!(@directive).lookup(&schema)` returns the directive definition for `@directive`.
+  - `coord!(@directive(argument:)).lookup(&schema)` returns the argument definition for `argument`.
+  - `string.parse::<SchemaCoordinate>()?.lookup(&schema)` returns an enum with all the elements
+    that can be looked up using schema coordinates.
 
 [goto-bus-stop]: https://github.com/goto-bus-stop]
 [pull/795]: https://github.com/apollographql/apollo-rs/pull/795

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.11" # When bumping, also update README.md
+version = "1.0.0-beta.12" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.11"
+apollo-compiler = "=1.0.0-beta.12"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.11" }
+apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.12" }
 apollo-parser = { path = "../apollo-parser", version = "0.7.0" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 indexmap = "2.0.0"


### PR DESCRIPTION
It might be overly dramatic to highlight the `is_required()` as **BREAKING**, but it is technically breaking

---

## BREAKING
- **`InputValueDefinition::is_required()` returns false if it has a default value - [goto-bus-stop], [pull/798]**
  - Now `argument.is_required() == true` only if the type is non-null and there is no
    default value, meaning a value must be provided when it's used.

## Features
- **Implement `fmt::Display` for `ComponentName` - [goto-bus-stop], [pull/795]**
- **Add `FieldDefinition::argument_by_name` and `DirectiveDefinition::argument_by_name` - [goto-bus-stop], [pull/801]**
  - These methods return an argument definition by name, or `None`.
- **Add `.lookup` methods to schema coordinates - [goto-bus-stop], [pull/803]**
  - `coord!(Type).lookup(&schema)` returns the type definition for `Type`.
  - `coord!(Type.field).lookup_field(&schema)` returns the field definition for `field`.
  - `coord!(Enum.VALUE).lookup_enum_value(&schema)` returns the enum value definition for `VALUE`.
  - `coord!(InputType.field).lookup_input_field(&schema)` returns the input field definition for `field`.
  - `coord!(Type.field(argument:)).lookup(&schema)` returns the argument definition for `argument`.
  - `coord!(@directive).lookup(&schema)` returns the directive definition for `@directive`.
  - `coord!(@directive(argument:)).lookup(&schema)` returns the argument definition for `argument`.
  - `string.parse::<SchemaCoordinate>()?.lookup(&schema)` returns an enum with all the elements
    that can be looked up using schema coordinates.

## Maintenance
- **update ariadne to 0.4.0 - [pull/793]**
  Ariadne is the diagnostic printing crate used for validation errors. v0.4.0 improves memory usage.

[goto-bus-stop]: https://github.com/goto-bus-stop]
[pull/795]: https://github.com/apollographql/apollo-rs/pull/795
[pull/798]: https://github.com/apollographql/apollo-rs/pull/798
[pull/801]: https://github.com/apollographql/apollo-rs/pull/801
[pull/803]: https://github.com/apollographql/apollo-rs/pull/803
[pull/793]: https://github.com/apollographql/apollo-rs/pull/793