### PR TITLE
fix(fuzz): enable env_logger in fuzz targets

### DIFF
--- a/fuzz/fuzz_targets/coordinate.rs
+++ b/fuzz/fuzz_targets/coordinate.rs
@@ -4,6 +4,8 @@ use libfuzzer_sys::fuzz_target;
 use log::debug;
 
 fuzz_target!(|data: &str| {
+    let _ = env_logger::try_init();
+
     let coord = data.parse::<SchemaCoordinate>();
     if let Ok(coord) = &coord {
         assert_eq!(

--- a/fuzz/fuzz_targets/lexer.rs
+++ b/fuzz/fuzz_targets/lexer.rs
@@ -6,6 +6,8 @@ use log::debug;
 use std::panic;
 
 fuzz_target!(|data: &[u8]| {
+    let _ = env_logger::try_init();
+
     let doc_generated = match generate_valid_document(data) {
         Ok(d) => d,
         Err(_) => {

--- a/fuzz/fuzz_targets/parser.rs
+++ b/fuzz/fuzz_targets/parser.rs
@@ -6,6 +6,8 @@ use log::debug;
 use std::panic;
 
 fuzz_target!(|data: &[u8]| {
+    let _ = env_logger::try_init();
+
     let doc_generated = match generate_valid_document(data) {
         Ok(d) => d,
         Err(_err) => {

--- a/fuzz/fuzz_targets/strings.rs
+++ b/fuzz/fuzz_targets/strings.rs
@@ -4,6 +4,8 @@ use libfuzzer_sys::fuzz_target;
 use log::debug;
 
 fuzz_target!(|data: &str| {
+    let _ = env_logger::try_init();
+
     let mut input = Schema::new();
     let def = input.schema_definition.make_mut();
     def.description = Some(data.into());


### PR DESCRIPTION
Use `RUST_LOG=debug cargo fuzz run $target_name` to get the generated
inputs for fuzzing.
