### PR TITLE
Add constness to input value generation

### DIFF
--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -77,10 +77,10 @@ impl TryFrom<apollo_parser::cst::Argument> for Argument {
 
 impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary vector of `Argument`
-    pub fn arguments(&mut self) -> ArbitraryResult<Vec<Argument>> {
+    pub fn arguments(&mut self, constness: Constness) -> ArbitraryResult<Vec<Argument>> {
         let num_arguments = self.u.int_in_range(0..=4)?;
         let arguments = (0..num_arguments)
-            .map(|_| self.argument())
+            .map(|_| self.argument(constness))
             .collect::<ArbitraryResult<Vec<_>>>()?;
 
         Ok(arguments)
@@ -101,9 +101,9 @@ impl<'a> DocumentBuilder<'a> {
     }
 
     /// Create an arbitrary `Argument`
-    pub fn argument(&mut self) -> ArbitraryResult<Argument> {
+    pub fn argument(&mut self, constness: Constness) -> ArbitraryResult<Argument> {
         let name = self.name()?;
-        let value = self.input_value(Constness::NonConst)?;
+        let value = self.input_value(constness)?;
 
         Ok(Argument { name, value })
     }

--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -1,3 +1,4 @@
+use crate::input_value::Constness;
 use crate::{
     input_value::{InputValue, InputValueDef},
     name::Name,
@@ -102,7 +103,7 @@ impl<'a> DocumentBuilder<'a> {
     /// Create an arbitrary `Argument`
     pub fn argument(&mut self) -> ArbitraryResult<Argument> {
         let name = self.name()?;
-        let value = self.input_value()?;
+        let value = self.input_value(Constness::NonConst)?;
 
         Ok(Argument { name, value })
     }

--- a/crates/apollo-smith/src/variable.rs
+++ b/crates/apollo-smith/src/variable.rs
@@ -1,3 +1,4 @@
+use crate::input_value::Constness;
 use crate::{
     directive::{Directive, DirectiveLocation},
     input_value::InputValue,
@@ -51,7 +52,7 @@ impl<'a> DocumentBuilder<'a> {
             .u
             .arbitrary()
             .unwrap_or(false)
-            .then(|| self.input_value())
+            .then(|| self.input_value(Constness::Const))
             .transpose()?;
         let directives = self.directives(DirectiveLocation::VariableDefinition)?;
 


### PR DESCRIPTION
As per the spec: https://spec.graphql.org/October2021/#Value Values should not be variables in a const context. 

The TLDR of this is that within schema definitions variables should not be used on arguments. Within operations variables can should be used.

Fixes #810