### PR TITLE
chore(parser): optimize the most common lexer matches into lookup tables

### DIFF
--- a/crates/apollo-parser/src/lexer/lookup.rs
+++ b/crates/apollo-parser/src/lexer/lookup.rs
@@ -1,0 +1,100 @@
+use crate::TokenKind;
+
+static PUNCTUATION_CHARS: [Option<TokenKind>; 256] = punctuation_lut();
+static NAMESTART_CHARS: [bool; 256] = namestart_lut();
+
+#[inline]
+pub(crate) fn punctuation_kind(c: char) -> Option<TokenKind> {
+    if c.is_ascii() {
+        PUNCTUATION_CHARS[c as usize]
+    } else {
+        None
+    }
+}
+
+#[inline]
+pub(crate) fn is_namestart(c: char) -> bool {
+    c.is_ascii() && NAMESTART_CHARS[c as usize]
+}
+
+const fn punctuation_lut() -> [Option<TokenKind>; 256] {
+    let mut lut = [None; 256];
+    lut[b'{' as usize] = Some(TokenKind::LCurly);
+    lut[b'}' as usize] = Some(TokenKind::RCurly);
+    lut[b'!' as usize] = Some(TokenKind::Bang);
+    lut[b'$' as usize] = Some(TokenKind::Dollar);
+    lut[b'&' as usize] = Some(TokenKind::Amp);
+    lut[b'(' as usize] = Some(TokenKind::LParen);
+    lut[b')' as usize] = Some(TokenKind::RParen);
+    lut[b':' as usize] = Some(TokenKind::Colon);
+    lut[b',' as usize] = Some(TokenKind::Comma);
+    lut[b'[' as usize] = Some(TokenKind::LBracket);
+    lut[b']' as usize] = Some(TokenKind::RBracket);
+    lut[b'=' as usize] = Some(TokenKind::Eq);
+    lut[b'@' as usize] = Some(TokenKind::At);
+    lut[b'|' as usize] = Some(TokenKind::Pipe);
+
+    lut
+}
+
+/// <https://spec.graphql.org/October2021/#NameStart>
+const fn namestart_lut() -> [bool; 256] {
+    let mut lut = [false; 256];
+    lut[b'a' as usize] = true;
+    lut[b'b' as usize] = true;
+    lut[b'c' as usize] = true;
+    lut[b'd' as usize] = true;
+    lut[b'e' as usize] = true;
+    lut[b'f' as usize] = true;
+    lut[b'g' as usize] = true;
+    lut[b'h' as usize] = true;
+    lut[b'i' as usize] = true;
+    lut[b'j' as usize] = true;
+    lut[b'k' as usize] = true;
+    lut[b'l' as usize] = true;
+    lut[b'm' as usize] = true;
+    lut[b'n' as usize] = true;
+    lut[b'o' as usize] = true;
+    lut[b'p' as usize] = true;
+    lut[b'q' as usize] = true;
+    lut[b'r' as usize] = true;
+    lut[b's' as usize] = true;
+    lut[b't' as usize] = true;
+    lut[b'u' as usize] = true;
+    lut[b'v' as usize] = true;
+    lut[b'w' as usize] = true;
+    lut[b'x' as usize] = true;
+    lut[b'y' as usize] = true;
+    lut[b'z' as usize] = true;
+
+    lut[b'A' as usize] = true;
+    lut[b'B' as usize] = true;
+    lut[b'C' as usize] = true;
+    lut[b'D' as usize] = true;
+    lut[b'E' as usize] = true;
+    lut[b'F' as usize] = true;
+    lut[b'G' as usize] = true;
+    lut[b'H' as usize] = true;
+    lut[b'I' as usize] = true;
+    lut[b'J' as usize] = true;
+    lut[b'K' as usize] = true;
+    lut[b'L' as usize] = true;
+    lut[b'M' as usize] = true;
+    lut[b'N' as usize] = true;
+    lut[b'O' as usize] = true;
+    lut[b'P' as usize] = true;
+    lut[b'Q' as usize] = true;
+    lut[b'R' as usize] = true;
+    lut[b'S' as usize] = true;
+    lut[b'T' as usize] = true;
+    lut[b'U' as usize] = true;
+    lut[b'V' as usize] = true;
+    lut[b'W' as usize] = true;
+    lut[b'X' as usize] = true;
+    lut[b'Y' as usize] = true;
+    lut[b'Z' as usize] = true;
+
+    lut[b'_' as usize] = true;
+
+    lut
+}

--- a/crates/apollo-parser/src/lexer/token.rs
+++ b/crates/apollo-parser/src/lexer/token.rs
@@ -17,7 +17,7 @@ impl<'a> Token<'a> {
     }
 
     /// Get a reference to the token's data.
-    pub fn data(&self) -> &str {
+    pub fn data(&self) -> &'a str {
         self.data
     }
 


### PR DESCRIPTION
## Overview
Basically just bastardizes the good ideas in https://github.com/maciejhirsz/logos in a modest change trying to get the most value without making the code unreadable or hard to maintain. Both functions internally call `is_ascii` to prevent overflows since we're dealing with utf-8.

There's obviously more you could do but from my profiles this seems to be the most impactful paths without making the whole thing unreadable.

Feel free to close as there are obvious tradeoffs here but I opened for your consideration.

## Impact
The impact of this change really depends on the document being parsed. For small documents its negligible but for large documents, particularly schema SDLs the change speeds things up to ~18%.

```
test result: ok. 0 passed; 0 failed; 65 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/query.rs (/Users/allancalix/src/github.com/allancalix/apollo-rs/target/release/deps/query-008ff12600681735)
Benchmarking many_aliases: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.8s, enable flat sampling, or reduce sample count to 50.
many_aliases            time:   [1.9430 ms 1.9473 ms 1.9521 ms]
                        change: [-2.1904% -1.8069% -1.4314%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

query_lexer             time:   [1.1066 µs 1.1090 µs 1.1115 µs]
                        change: [-6.5579% -6.1115% -5.7380%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

query_parser            time:   [7.4054 µs 7.4149 µs 7.4241 µs]
                        change: [-13.829% -10.061% -6.8751%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

     Running benches/supergraph.rs (/Users/allancalix/src/github.com/allancalix/apollo-rs/target/release/deps/supergraph-4c8cf367fca5ad96)
supergraph_lexer        time:   [47.780 µs 47.864 µs 47.956 µs]
                        change: [-5.9375% -5.6993% -5.4348%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

supergraph_parser       time:   [201.49 µs 201.96 µs 202.47 µs]
                        change: [-1.8449% -1.4664% -1.0951%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```

The delta on the public github schema was quite sizable:
```
apollo - parse github schema
                        time:   [4.8513 ms 4.8560 ms 4.8611 ms]
                        change: [-18.862% -18.703% -18.548%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```