### PR TITLE
Fix field merging validation when multiple sub-selections partially overlap

### DIFF
--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -198,7 +198,7 @@ pub(crate) fn same_response_shape(
 
             for fields_for_name in grouped_by_name.values() {
                 // 9. Given each pair of members subfieldA and subfieldB in fieldsForName:
-                for (subfield_a, subfield_b) in pair_combinations(&fields_for_name) {
+                for (subfield_a, subfield_b) in pair_combinations(fields_for_name) {
                     // 9a. If SameResponseShape(subfieldA, subfieldB) is false, return false.
                     same_response_shape(db, file_id, *subfield_a, *subfield_b)?;
                 }

--- a/crates/apollo-compiler/test_data/diagnostics/0113_partially_overlapping_fragments.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0113_partially_overlapping_fragments.graphql
@@ -1,0 +1,29 @@
+type A {
+  unrelated: String
+  overlapping: Int
+}
+type B {
+  overlapping: Int!
+}
+type C {
+  overlapping: Int
+}
+union Union = A | B | C
+type Query {
+  root: Union
+}
+
+# There is a conflicting type due to `B.overlapping` and `C.overlapping` both being selected
+# to `root.overlapping`, but neither overlap with the initial selection set for `root`.
+
+{
+  root {
+    ... on A { unrelated }
+  }
+  root {
+    ... on B { overlapping }
+  }
+  root {
+    ... on C { overlapping }
+  }
+}

--- a/crates/apollo-compiler/test_data/diagnostics/0113_partially_overlapping_fragments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0113_partially_overlapping_fragments.txt
@@ -1,0 +1,12 @@
+Error: operation must not select different types using the same field name `overlapping`
+    ╭─[0113_partially_overlapping_fragments.graphql:27:16]
+    │
+ 24 │     ... on B { overlapping }
+    │                ─────┬─────  
+    │                     ╰─────── `overlapping` has type `Int!` here
+    │ 
+ 27 │     ... on C { overlapping }
+    │                ─────┬─────  
+    │                     ╰─────── but the same field name has type `Int` here
+────╯
+

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0113_partially_overlapping_fragments.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0113_partially_overlapping_fragments.graphql
@@ -1,0 +1,36 @@
+type A {
+  unrelated: String
+  overlapping: Int
+}
+
+type B {
+  overlapping: Int!
+}
+
+type C {
+  overlapping: Int
+}
+
+union Union = A | B | C
+
+type Query {
+  root: Union
+}
+
+query {
+  root {
+    ... on A {
+      unrelated
+    }
+  }
+  root {
+    ... on B {
+      overlapping
+    }
+  }
+  root {
+    ... on C {
+      overlapping
+    }
+  }
+}


### PR DESCRIPTION
**Current situation**
This is an offending query:

```rust
{
  root { ... on A { unrelated } }
  root { ... on B { overlapping } }
  root { ... on C { overlapping } }
}
```

Here, assume `B.overlapping` selects an `Int!`, and `C.overlapping` selects an `Int`. Clearly `root.overlapping` can either be `Int!` or `Int`, and so this must be an error. But previous versions of apollo-compiler do not report anything.

**Cause**
The validation is implemented by drilling in from the top down. The first field it encounters is `root`. `root` is selected multiple times so we need to see if its subselections can merge. In `main`, we do this by comparing every subselection to the *first* subselection (`... on A { unrelated }`). Both the `B` and `C` subselections can be merged with `A`, as they don't select any conflicting fields.

**Fix**
Comparing all selections of the same field, to the first occurrence of the same field is not enough, as other occurrences can conflict with each other but not with the first field. This PR considers all possible combinations of fields.