### PR TITLE
chore(compiler): explicitly use `IndexMap::{swap,shift}_remove`

### DIFF
--- a/crates/apollo-compiler/examples/rename.rs
+++ b/crates/apollo-compiler/examples/rename.rs
@@ -15,7 +15,7 @@ fn renamed() -> Valid<Schema> {
     let mut schema = Schema::parse(input, "schema.graphql").unwrap();
 
     // 1. Remove the definition from the `types` map, using its old name as a key
-    let mut type_def = schema.types.remove("Query").unwrap();
+    let mut type_def = schema.types.shift_remove("Query").unwrap();
 
     // 2. Set the new name in the struct
     let ExtendedType::Object(obj) = &mut type_def else {

--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -116,7 +116,7 @@ impl SchemaBuilder {
                                 &mut self.errors,
                                 $def,
                                 self.orphan_type_extensions
-                                    .remove(&$def.name)
+                                    .shift_remove(&$def.name)
                                     .unwrap_or_default(),
                             );
                             entry.insert(extended_def.into());


### PR DESCRIPTION
The indexmap crate has deprecated the `::remove` method.

I think `shift_remove()` is the correct one to use in both cases: we
want to maintain order even for orphan type extensions.

Fixes a deprecation warning that is preventing linting from passing on CI.
