### PR TITLE
apollo-parser@0.7.6

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 autotests = false # Most tests/*.rs files are modules of tests/main.rs
 
 [dependencies]
-apollo-parser = { path = "../apollo-parser", version = "0.7.4" }
+apollo-parser = { path = "../apollo-parser", version = "0.7.6" }
 ariadne = { version = "0.4.0", features = ["auto-color"] }
 indexmap = "2.0.0"
 rowan = "0.15.5"

--- a/crates/apollo-parser/CHANGELOG.md
+++ b/crates/apollo-parser/CHANGELOG.md
@@ -17,6 +17,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Documentation -->
 
+# [0.7.6](https://crates.io/crates/apollo-parser/0.7.6) - 2024-02-14
+
+## Fixes
+- **optimize the most common lexer matches into lookup tables - [allancalix], [pull/814]**
+  Parsing large schema documents can be up to 18% faster, typical documents a few percent.
+- **fix infinite loops and crashes found through fuzzing - [goto-bus-stop], [pull/828]**
+  When using a token limit, it was possible to craft a document that would cause an infinite
+  loop, eventually leading to an out of memory crash. This is addressed along with several panics.
+
+## Maintenance
+- **reduce intermediate string allocations - [goto-bus-stop], [pull/820]**
+
+[allancalix]: https://github.com/allancalix
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/814]: https://github.com/apollographql/apollo-rs/pull/814
+[pull/820]: https://github.com/apollographql/apollo-rs/pull/820
+[pull/828]: https://github.com/apollographql/apollo-rs/pull/828
+
 # [0.7.5](https://crates.io/crates/apollo-parser/0.7.5) - 2023-12-18
 
 ## Fixes
@@ -26,7 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **emit syntax errors for variables in constant values - [SimonSapin], [pull/777]**
   default values and type system directive arguments are considered constants
   and may not use `$foo` variable values.
-- **emit syntax errors for type condition without a type name [rishabh3112], [pull/781]**
+- **emit syntax errors for type condition without a type name - [rishabh3112], [pull/781]**
 
 [goto-bus-stop]: https://github.com/goto-bus-stop
 [SimonSapin]: https://github.com/SimonSapin

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-parser"
-version = "0.7.5" # When bumping, also update README.md
+version = "0.7.6" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-parser/README.md
+++ b/crates/apollo-parser/README.md
@@ -35,7 +35,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
-apollo-parser = "0.7.5"
+apollo-parser = "0.7.6"
 ```
 
 ## Rust versions


### PR DESCRIPTION

## Fixes
- **optimize the most common lexer matches into lookup tables - [allancalix], [pull/814]**
  Parsing large schema documents can be up to 18% faster, typical documents a few percent.
- **fix infinite loops and crashes found through fuzzing - [goto-bus-stop], [pull/828]**
  When using a token limit, it was possible to craft a document that would cause an infinite
  loop, eventually leading to an out of memory crash. This is addressed along with several panics.

## Maintenance
- **reduce intermediate string allocations - [goto-bus-stop], [pull/820]**

[allancalix]: https://github.com/allancalix
[goto-bus-stop]: https://github.com/goto-bus-stop
[pull/814]: https://github.com/apollographql/apollo-rs/pull/814
[pull/820]: https://github.com/apollographql/apollo-rs/pull/820
[pull/828]: https://github.com/apollographql/apollo-rs/pull/828