### PR TITLE
apollo-compiler@1.0.0-beta.13

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,20 +17,40 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2024-mm-dd
+# [1.0.0-beta.13](https://crates.io/crates/apollo-compiler/1.0.0-beta.13) - 2024-02-14
+
+> This release includes a critical fix to overflow protection in validation.
 
 ## Features
 - **New field merging validation implementation - [goto-bus-stop], [pull/816]**
-  - Uses the much more scalable [Xing algorithm].
+  - Uses the much more scalable [XING algorithm].
   - This also fixes some invalid selections that were previously accepted by apollo-compiler.
   - Selections in fragment definitions are now only validated in the context of the operations they
     are used in, reducing duplicate error reports for invalid fragments. This means invalid *unused*
     fragments do not produce field merging errors, but they will still raise a different error because
     fragments being unused is also an error according to the spec.
+- **Add owned IntoIterator for `DirectiveList` types - [SimonSapin], [pull/826]**
 
+## Fixes
+- **Actually run RecursionGuard in release mode - [SimonSapin], [pull/827]**
+  Due to a `debug_assert!()` oversight, stack overflow protection in validation did not run
+  in release mode.
+- **Accept enum values as input for custom scalars - [goto-bus-stop], [pull/835]**
+  Custom scalars accept any kind of input value. apollo-compiler used to raise a validation error when
+  an enum value was used directly for a custom scalar. However, using an enum value nested inside an
+  object or list was accepted. Now enum values are always accepted where a custom scalar is expected.
+
+## Maintenance
+- **Replace uses of deprecated `IndexMap::remove` - [goto-bus-stop], [pull/817]**
+
+[SimonSapin]: https://github.com/SimonSapin]
 [goto-bus-stop]: https://github.com/goto-bus-stop]
 [pull/816]: https://github.com/apollographql/apollo-rs/pull/816
-[Xing algorithm]: https://tech.new-work.se/graphql-overlapping-fields-can-be-merged-fast-ea6e92e0a01
+[pull/817]: https://github.com/apollographql/apollo-rs/pull/817
+[pull/826]: https://github.com/apollographql/apollo-rs/pull/826
+[pull/827]: https://github.com/apollographql/apollo-rs/pull/827
+[pull/835]: https://github.com/apollographql/apollo-rs/pull/835
+[XING algorithm]: https://tech.new-work.se/graphql-overlapping-fields-can-be-merged-fast-ea6e92e0a01
 
 # [1.0.0-beta.12](https://crates.io/crates/apollo-compiler/1.0.0-beta.12) - 2024-01-15
 

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.12" # When bumping, also update README.md
+version = "1.0.0-beta.13" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.12"
+apollo-compiler = "=1.0.0-beta.13"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.12" }
+apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.13" }
 apollo-parser = { path = "../apollo-parser", version = "0.7.0" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 indexmap = "2.0.0"


### PR DESCRIPTION
After https://github.com/apollographql/apollo-rs/pull/836


> This release includes a critical fix to overflow protection in validation.
## Features
- **New field merging validation implementation - [goto-bus-stop], [pull/816]**
  - Uses the much more scalable [XING algorithm].
  - This also fixes some invalid selections that were previously accepted by apollo-compiler.
  - Selections in fragment definitions are now only validated in the context of the operations they
    are used in, reducing duplicate error reports for invalid fragments. This means invalid *unused*
    fragments do not produce field merging errors, but they will still raise a different error because
    fragments being unused is also an error according to the spec.
- **Add owned IntoIterator for `DirectiveList` types - [SimonSapin], [pull/826]**

## Fixes
- **Actually run RecursionGuard in release mode - [SimonSapin], [pull/827]**
  - Due to a `debug_assert!()` oversight, stack overflow protection in validation did not run
  in release mode.
- **Accept enum values as input for custom scalars - [goto-bus-stop], [pull/835]**
  - Custom scalars accept any kind of input value. apollo-compiler used to raise a validation error when
  an enum value was used directly for a custom scalar. However, using an enum value nested inside an
  object or list was accepted. Now enum values are always accepted where a custom scalar is expected.

## Maintenance
- **Replace uses of deprecated `IndexMap::remove` - [goto-bus-stop], [pull/817]**

[SimonSapin]: https://github.com/SimonSapin]
[goto-bus-stop]: https://github.com/goto-bus-stop]
[pull/816]: https://github.com/apollographql/apollo-rs/pull/816
[pull/817]: https://github.com/apollographql/apollo-rs/pull/817
[pull/826]: https://github.com/apollographql/apollo-rs/pull/826
[pull/827]: https://github.com/apollographql/apollo-rs/pull/827
[pull/835]: https://github.com/apollographql/apollo-rs/pull/835
[XING algorithm]: https://tech.new-work.se/graphql-overlapping-fields-can-be-merged-fast-ea6e92e0a01