### PR TITLE
apollo-compiler@1.0.0-beta.14

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2024-mm-dd
+# [1.0.0-beta.14](https://crates.io/crates/apollo-compiler/1.0.0-beta.14) - 2024-03-13
 
 ## BREAKING
 

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.13" # When bumping, also update README.md
+version = "1.0.0-beta.14" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.13"
+apollo-compiler = "=1.0.0-beta.14"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.13" }
+apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.14" }
 apollo-parser = { path = "../apollo-parser", version = "0.7.0" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 indexmap = "2.0.0"


### PR DESCRIPTION

## BREAKING

- **Move `NodeLocation` and `FileId` from `apollo_compiler::validation` to the crate root - [SimonSapin], [pull/838]**

## Maintenance

- **Remove Salsa database for 1.2× ~ 2× validation speed - [SimonSapin], [pull/838]**
  We were not taking advantage of caching it provides.
  Additionally, validation uses `Schema` and `ExecutableDocument` directly
  rather than converting them to AST.
  ```
  $ cargo bench --bench multi-source
  supergraph parse_and_validate
                        time:   [398.09 µs 399.32 µs 400.82 µs]
                        change: [-19.966% -19.418% -18.864%] (p = 0.00 < 0.05)
                        Performance has improved.
  simple_query parse_and_validate
                        time:   [12.097 µs 12.104 µs 12.113 µs]
                        change: [-52.467% -52.282% -52.109%] (p = 0.00 < 0.05)
                        Performance has improved.
  ```

[SimonSapin]: https://github.com/SimonSapin]
[pull/838]: https://github.com/apollographql/apollo-rs/pull/838

