### PR TITLE
Implement missing schema validation - types must have one or more (fields, enum values, members, input values)

### DIFF
--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -261,6 +261,30 @@ pub(crate) enum DiagnosticData {
     },
     #[error("too much recursion")]
     RecursionError {},
+    #[error("`{type_name}` has no fields")]
+    EmptyFieldSet {
+        type_name: Name,
+        type_location: Option<NodeLocation>,
+        extensions_locations: Vec<Option<NodeLocation>>,
+    },
+    #[error("`{type_name}` has no enum values")]
+    EmptyValueSet {
+        type_name: Name,
+        type_location: Option<NodeLocation>,
+        extensions_locations: Vec<Option<NodeLocation>>,
+    },
+    #[error("`{type_name}` has no member types")]
+    EmptyMemberSet {
+        type_name: Name,
+        type_location: Option<NodeLocation>,
+        extensions_locations: Vec<Option<NodeLocation>>,
+    },
+    #[error("`{type_name}` has no input values")]
+    EmptyInputValueSet {
+        type_name: Name,
+        type_location: Option<NodeLocation>,
+        extensions_locations: Vec<Option<NodeLocation>>,
+    },
 }
 
 impl DiagnosticData {
@@ -630,7 +654,58 @@ impl DiagnosticData {
                 );
             }
             DiagnosticData::RecursionError {} => {}
+            DiagnosticData::EmptyFieldSet {
+                type_name,
+                type_location,
+                extensions_locations
+            } => {
+                Self::report_empty_type(report, type_name, type_location, extensions_locations, "fields");
+            }
+            DiagnosticData::EmptyValueSet {
+                type_name,
+                type_location,
+                extensions_locations
+            } => {
+                Self::report_empty_type(report, type_name, type_location, extensions_locations, "enum values");
+            }
+            DiagnosticData::EmptyMemberSet {
+                type_name,
+                type_location,
+                extensions_locations
+            } => {
+                Self::report_empty_type(report, type_name, type_location, extensions_locations, "union member types");
+            }
+            DiagnosticData::EmptyInputValueSet {
+                type_name,
+                type_location,
+                extensions_locations
+            } => {
+                Self::report_empty_type(report, type_name, type_location, extensions_locations, "input values");
+            }
         }
+    }
+
+    fn report_empty_type(report: &mut CliReport,
+                         type_name: &Name,
+                         type_location: &Option<NodeLocation>,
+                         extensions_locations: &[Option<NodeLocation>],
+                         describe_missing_kind: &str) {
+        report.with_label_opt(
+            *type_location,
+            format_args!("{type_name} type defined here"),
+        );
+        extensions_locations.iter().for_each(|location| {
+            report.with_label_opt(
+                *location,
+                format_args!("{type_name} extension defined here"),
+            );
+        });
+        let and_extensions_message = if !extensions_locations.is_empty() {
+            " or its type extensions"
+        } else {
+            ""
+        };
+        report.with_help(format!("Define one or more {describe_missing_kind} on `{type_name}`{and_extensions_message}."));
     }
 }
 

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -4,7 +4,7 @@ use crate::{ast, executable, schema, ExecutableDocument, Node};
 
 use super::operation::OperationValidationConfig;
 use crate::ast::Name;
-use crate::schema::Component;
+use crate::schema::{Component};
 use crate::validation::DiagnosticList;
 use indexmap::IndexMap;
 

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -119,6 +119,19 @@ pub(crate) fn validate_input_object_definition(
         &fields,
         ast::DirectiveLocation::InputFieldDefinition,
     );
+
+    // validate there is at least one input value on the input object type
+    // https://spec.graphql.org/draft/#sel-HAHhBXDBABAB5BvgD
+    if input_object.fields.is_empty() {
+        diagnostics.push(
+            input_object.location(),
+            DiagnosticData::EmptyInputValueSet {
+                type_name: input_object.name.clone(),
+                type_location: input_object.location(),
+                extensions_locations: input_object.extensions().iter().map(|ext| ext.location()).collect(),
+            },
+        );
+    }
 }
 
 pub(crate) fn validate_argument_definitions(

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -59,6 +59,19 @@ pub(crate) fn validate_interface_definition(
     // Interface Type field validation.
     validate_field_definitions(diagnostics, schema, &interface.fields);
 
+    // validate there is at least one field on the type
+    // https://spec.graphql.org/draft/#sel-HAHbnBFBABABxB4a
+    if interface.fields.is_empty() {
+        diagnostics.push(
+            interface.location(),
+            DiagnosticData::EmptyFieldSet {
+                type_name: interface.name.clone(),
+                type_location: interface.location(),
+                extensions_locations: interface.extensions().iter().map(|ext| ext.location()).collect(),
+            },
+        );
+    }
+
     // Implements Interfaceds validation.
     validate_implements_interfaces(
         diagnostics,

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -26,7 +26,7 @@ use crate::diagnostic::{CliReport, Diagnostic, ToCliReport};
 use crate::executable::BuildError as ExecutableBuildError;
 use crate::execution::{GraphQLError, Response};
 use crate::schema::BuildError as SchemaBuildError;
-use crate::SourceMap;
+use crate::{SourceMap};
 use crate::{Node, NodeLocation};
 use indexmap::IndexSet;
 use std::fmt;
@@ -252,6 +252,10 @@ impl DiagnosticData {
                     RecursiveInputObjectDefinition { .. } => "RecursiveInputObjectDefinition",
                     RecursiveFragmentDefinition { .. } => "RecursiveFragmentDefinition",
                     DeeplyNestedType { .. } => "DeeplyNestedType",
+                    EmptyFieldSet { .. } => "EmptyFieldSet",
+                    EmptyValueSet { .. } => "EmptyValueSet",
+                    EmptyMemberSet { .. } => "EmptyMemberSet",
+                    EmptyInputValueSet { .. } => "EmptyInputValueSet",
                 })
             }
             Details::ExecutableBuildError(error) => Some(match error {

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -34,6 +34,19 @@ pub(crate) fn validate_object_type_definition(
     // Object Type field validations.
     validate_field_definitions(diagnostics, schema, &object.fields);
 
+    // validate there is at least one field on the type
+    // https://spec.graphql.org/draft/#sel-FAHZhCFDBAACDA4qe
+    if object.fields.is_empty() {
+        diagnostics.push(
+            object.location(),
+            DiagnosticData::EmptyFieldSet {
+                type_name: object.name.clone(),
+                type_location: object.location(),
+                extensions_locations: object.extensions().iter().map(|ext| ext.location()).collect(),
+            },
+        );
+    }
+
     // Implements Interfaces validation.
     super::interface::validate_implements_interfaces(
         diagnostics,

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -52,4 +52,17 @@ pub(crate) fn validate_union_definition(
             }
         }
     }
+
+    // validate there is at least one union member on the union type
+    // https://spec.graphql.org/draft/#sel-HAHdfFBABAB6Bw3R
+    if union_def.members.is_empty() {
+        diagnostics.push(
+            union_def.location(),
+            DiagnosticData::EmptyMemberSet {
+                type_name: union_def.name.clone(),
+                type_location: union_def.location(),
+                extensions_locations: union_def.extensions().iter().map(|ext| ext.location()).collect(),
+            },
+        );
+    }
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.graphql
@@ -1,6 +1,8 @@
 directive @nonRepeatable on OBJECT | SCALAR | INTERFACE
 extend type TestObject @nonRepeatable
-type TestObject @nonRepeatable
+type TestObject @nonRepeatable {
+  field: String
+}
 extend type TestObject @nonRepeatable
 
 scalar Scalar @nonRepeatable
@@ -9,7 +11,7 @@ extend scalar Scalar @nonRepeatable @specifiedBy(url: "example.com")
 interface Intf @nonRepeatable {
   field: String
 }
-interface Intf @nonRepeatable
+extend interface Intf @nonRepeatable
 type Query {
   x: Int
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
@@ -4,41 +4,40 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
  2 │ extend type TestObject @nonRepeatable
    │                        ───────┬──────  
    │                               ╰──────── directive `@nonRepeatable` called again here
- 3 │ type TestObject @nonRepeatable
+ 3 │ type TestObject @nonRepeatable {
    │                 ───────┬──────  
    │                        ╰──────── directive `@nonRepeatable` first called here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0080_directive_is_unique_with_extensions.graphql:4:24]
+   ╭─[0080_directive_is_unique_with_extensions.graphql:6:24]
    │
- 3 │ type TestObject @nonRepeatable
+ 3 │ type TestObject @nonRepeatable {
    │                 ───────┬──────  
    │                        ╰──────── directive `@nonRepeatable` first called here
- 4 │ extend type TestObject @nonRepeatable
+   │ 
+ 6 │ extend type TestObject @nonRepeatable
    │                        ───────┬──────  
    │                               ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0080_directive_is_unique_with_extensions.graphql:7:22]
+   ╭─[0080_directive_is_unique_with_extensions.graphql:9:22]
    │
- 6 │ scalar Scalar @nonRepeatable
+ 8 │ scalar Scalar @nonRepeatable
    │               ───────┬──────  
    │                      ╰──────── directive `@nonRepeatable` first called here
- 7 │ extend scalar Scalar @nonRepeatable @specifiedBy(url: "example.com")
+ 9 │ extend scalar Scalar @nonRepeatable @specifiedBy(url: "example.com")
    │                      ───────┬──────  
    │                             ╰──────── directive `@nonRepeatable` called again here
 ───╯
-Error: the type `Intf` is defined multiple times in the schema
-    ╭─[0080_directive_is_unique_with_extensions.graphql:12:11]
+Error: non-repeatable directive nonRepeatable can only be used once per location
+    ╭─[0080_directive_is_unique_with_extensions.graphql:14:23]
     │
-  9 │ interface Intf @nonRepeatable {
-    │           ──┬─  
-    │             ╰─── previous definition of `Intf` here
+ 11 │ interface Intf @nonRepeatable {
+    │                ───────┬──────  
+    │                       ╰──────── directive `@nonRepeatable` first called here
     │ 
- 12 │ interface Intf @nonRepeatable
-    │           ──┬─  
-    │             ╰─── `Intf` redefined here
-    │ 
-    │ Help: remove or rename one of the definitions, or use `extend`
+ 14 │ extend interface Intf @nonRepeatable
+    │                       ───────┬──────  
+    │                              ╰──────── directive `@nonRepeatable` called again here
 ────╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
@@ -16,6 +16,15 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                                         │        
    │                                         ╰──────── directive `@nonRepeatable` called again here
 ───╯
+Error: `Dummy` has no fields
+   ╭─[0081_directive_is_unique_type_system.graphql:5:1]
+   │
+ 5 │ type Dummy @nonRepeatable @nonRepeatable
+   │ ────────────────────┬───────────────────  
+   │                     ╰───────────────────── Dummy type defined here
+   │ 
+   │ Help: Define one or more fields on `Dummy`.
+───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:5:27]
    │
@@ -24,6 +33,15 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                   ╰─────────────────────── directive `@nonRepeatable` first called here
    │                                  │        
    │                                  ╰──────── directive `@nonRepeatable` called again here
+───╯
+Error: `TestInterface` has no fields
+   ╭─[0081_directive_is_unique_type_system.graphql:6:1]
+   │
+ 6 │ interface TestInterface @nonRepeatable @nonRepeatable
+   │ ──────────────────────────┬──────────────────────────  
+   │                           ╰──────────────────────────── TestInterface type defined here
+   │ 
+   │ Help: Define one or more fields on `TestInterface`.
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:6:40]
@@ -34,6 +52,15 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                                               │        
    │                                               ╰──────── directive `@nonRepeatable` called again here
 ───╯
+Error: `TestUnion` has no member types
+   ╭─[0081_directive_is_unique_type_system.graphql:7:1]
+   │
+ 7 │ union TestUnion @nonRepeatable @nonRepeatable
+   │ ──────────────────────┬──────────────────────  
+   │                       ╰──────────────────────── TestUnion type defined here
+   │ 
+   │ Help: Define one or more union member types on `TestUnion`.
+───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:7:32]
    │
@@ -42,6 +69,15 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                        ╰─────────────────────── directive `@nonRepeatable` first called here
    │                                       │        
    │                                       ╰──────── directive `@nonRepeatable` called again here
+───╯
+Error: `TestInput` has no input values
+   ╭─[0081_directive_is_unique_type_system.graphql:8:1]
+   │
+ 8 │ input TestInput @nonRepeatable @nonRepeatable
+   │ ──────────────────────┬──────────────────────  
+   │                       ╰──────────────────────── TestInput type defined here
+   │ 
+   │ Help: Define one or more input values on `TestInput`.
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
    ╭─[0081_directive_is_unique_type_system.graphql:8:32]

--- a/crates/apollo-compiler/test_data/diagnostics/0114_interface_definition_with_missing_fields.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0114_interface_definition_with_missing_fields.graphql
@@ -1,0 +1,8 @@
+directive @foo on INTERFACE
+type Query {
+    foo: Node
+}
+
+interface Node
+
+extend interface Node @foo

--- a/crates/apollo-compiler/test_data/diagnostics/0114_interface_definition_with_missing_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0114_interface_definition_with_missing_fields.txt
@@ -1,0 +1,14 @@
+Error: `Node` has no fields
+   ╭─[0114_interface_definition_with_missing_fields.graphql:6:1]
+   │
+ 6 │ interface Node
+   │ ───────┬──────  
+   │        ╰──────── Node type defined here
+   │ 
+ 8 │ extend interface Node @foo
+   │ ─────────────┬────────────  
+   │              ╰────────────── Node extension defined here
+   │ 
+   │ Help: Define one or more fields on `Node` or its type extensions.
+───╯
+

--- a/crates/apollo-compiler/test_data/diagnostics/0115_object_definition_with_missing_fields.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0115_object_definition_with_missing_fields.graphql
@@ -1,0 +1,9 @@
+directive @foo on OBJECT
+directive @bar on OBJECT
+type Query {
+    foo: User
+}
+
+type User @foo
+
+extend type User @bar

--- a/crates/apollo-compiler/test_data/diagnostics/0115_object_definition_with_missing_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0115_object_definition_with_missing_fields.txt
@@ -1,0 +1,14 @@
+Error: `User` has no fields
+   ╭─[0115_object_definition_with_missing_fields.graphql:7:1]
+   │
+ 7 │ type User @foo
+   │ ───────┬──────  
+   │        ╰──────── User type defined here
+   │ 
+ 9 │ extend type User @bar
+   │ ──────────┬──────────  
+   │           ╰──────────── User extension defined here
+   │ 
+   │ Help: Define one or more fields on `User` or its type extensions.
+───╯
+

--- a/crates/apollo-compiler/test_data/diagnostics/0116_enum_definition_with_missing_values.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0116_enum_definition_with_missing_values.graphql
@@ -1,0 +1,8 @@
+directive @foo on ENUM
+type Query {
+    foo: WEEKDAY
+}
+
+enum WEEKDAY
+
+extend enum WEEKDAY @foo

--- a/crates/apollo-compiler/test_data/diagnostics/0116_enum_definition_with_missing_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0116_enum_definition_with_missing_values.txt
@@ -1,0 +1,14 @@
+Error: `WEEKDAY` has no enum values
+   ╭─[0116_enum_definition_with_missing_values.graphql:6:1]
+   │
+ 6 │ enum WEEKDAY
+   │ ──────┬─────  
+   │       ╰─────── WEEKDAY type defined here
+   │ 
+ 8 │ extend enum WEEKDAY @foo
+   │ ────────────┬───────────  
+   │             ╰───────────── WEEKDAY extension defined here
+   │ 
+   │ Help: Define one or more enum values on `WEEKDAY` or its type extensions.
+───╯
+

--- a/crates/apollo-compiler/test_data/diagnostics/0117_union_definition_with_missing_members.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0117_union_definition_with_missing_members.graphql
@@ -1,0 +1,8 @@
+directive @foo on UNION
+type Query {
+    foo: Search
+}
+
+union Search
+
+extend union Search @foo

--- a/crates/apollo-compiler/test_data/diagnostics/0117_union_definition_with_missing_members.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0117_union_definition_with_missing_members.txt
@@ -1,0 +1,14 @@
+Error: `Search` has no member types
+   ╭─[0117_union_definition_with_missing_members.graphql:6:1]
+   │
+ 6 │ union Search
+   │ ──────┬─────  
+   │       ╰─────── Search type defined here
+   │ 
+ 8 │ extend union Search @foo
+   │ ────────────┬───────────  
+   │             ╰───────────── Search extension defined here
+   │ 
+   │ Help: Define one or more union member types on `Search` or its type extensions.
+───╯
+

--- a/crates/apollo-compiler/test_data/diagnostics/0118_input_object_definition_with_missing_values.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0118_input_object_definition_with_missing_values.graphql
@@ -1,0 +1,8 @@
+directive @foo on INPUT_OBJECT
+type Query {
+    foo(id: In): String
+}
+
+input In
+
+extend input In @foo

--- a/crates/apollo-compiler/test_data/diagnostics/0118_input_object_definition_with_missing_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0118_input_object_definition_with_missing_values.txt
@@ -1,0 +1,14 @@
+Error: `In` has no input values
+   ╭─[0118_input_object_definition_with_missing_values.graphql:6:1]
+   │
+ 6 │ input In
+   │ ────┬───  
+   │     ╰───── In type defined here
+   │ 
+ 8 │ extend input In @foo
+   │ ──────────┬─────────  
+   │           ╰─────────── In extension defined here
+   │ 
+   │ Help: Define one or more input values on `In` or its type extensions.
+───╯
+

--- a/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.graphql
+++ b/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.graphql
@@ -1,0 +1,9 @@
+type Query {
+    foo: Node
+}
+
+interface Node
+
+extend interface Node {
+    bar: String
+}

--- a/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.txt
+++ b/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.txt
@@ -1,0 +1,110 @@
+Schema {
+    sources: {
+        -1: SourceFile {
+            path: "built_in.graphql",
+            source_text: include_str!("built_in.graphql"),
+        },
+        41: SourceFile {
+            path: "0115_interface_definition_with_extension_defines_field.graphql",
+            source_text: "type Query {\n    foo: Node\n}\n\ninterface Node\n\nextend interface Node {\n    bar: String\n}\n",
+        },
+    },
+    schema_definition: SchemaDefinition {
+        description: None,
+        directives: [],
+        query: Some(
+            ComponentName {
+                origin: Definition,
+                name: "Query",
+            },
+        ),
+        mutation: None,
+        subscription: None,
+    },
+    directive_definitions: {
+        "skip": built_in_directive!("skip"),
+        "include": built_in_directive!("include"),
+        "deprecated": built_in_directive!("deprecated"),
+        "specifiedBy": built_in_directive!("specifiedBy"),
+    },
+    types: {
+        "__Schema": built_in_type!("__Schema"),
+        "__Type": built_in_type!("__Type"),
+        "__TypeKind": built_in_type!("__TypeKind"),
+        "__Field": built_in_type!("__Field"),
+        "__InputValue": built_in_type!("__InputValue"),
+        "__EnumValue": built_in_type!("__EnumValue"),
+        "__Directive": built_in_type!("__Directive"),
+        "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
+        "Int": built_in_type!("Int"),
+        "Float": built_in_type!("Float"),
+        "String": built_in_type!("String"),
+        "Boolean": built_in_type!("Boolean"),
+        "ID": built_in_type!("ID"),
+        "Query": Object(
+            0..28 @41 ObjectType {
+                description: None,
+                name: "Query",
+                implements_interfaces: {},
+                directives: [],
+                fields: {
+                    "foo": Component {
+                        origin: Definition,
+                        node: 17..26 @41 FieldDefinition {
+                            description: None,
+                            name: "foo",
+                            arguments: [],
+                            ty: Named(
+                                "Node",
+                            ),
+                            directives: [],
+                        },
+                    },
+                },
+            },
+        ),
+        "Node": Interface(
+            30..44 @41 InterfaceType {
+                description: None,
+                name: "Node",
+                implements_interfaces: {},
+                directives: [],
+                fields: {
+                    "bar": Component {
+                        origin: Extension(
+                            ExtensionId {
+                                arc: Some(
+                                    46..87 @41,
+                                ),
+                            },
+                        ),
+                        node: 74..85 @41 FieldDefinition {
+                            description: None,
+                            name: "bar",
+                            arguments: [],
+                            ty: Named(
+                                "String",
+                            ),
+                            directives: [],
+                        },
+                    },
+                },
+            },
+        ),
+    },
+}
+ExecutableDocument {
+    sources: {
+        -1: SourceFile {
+            path: "built_in.graphql",
+            source_text: include_str!("built_in.graphql"),
+        },
+        41: SourceFile {
+            path: "0115_interface_definition_with_extension_defines_field.graphql",
+            source_text: "type Query {\n    foo: Node\n}\n\ninterface Node\n\nextend interface Node {\n    bar: String\n}\n",
+        },
+    },
+    anonymous_operation: None,
+    named_operations: {},
+    fragments: {},
+}

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0080_directive_is_unique_with_extensions.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0080_directive_is_unique_with_extensions.graphql
@@ -2,7 +2,9 @@ directive @nonRepeatable on OBJECT | SCALAR | INTERFACE
 
 extend type TestObject @nonRepeatable
 
-type TestObject @nonRepeatable
+type TestObject @nonRepeatable {
+  field: String
+}
 
 extend type TestObject @nonRepeatable
 
@@ -14,7 +16,7 @@ interface Intf @nonRepeatable {
   field: String
 }
 
-interface Intf @nonRepeatable
+extend interface Intf @nonRepeatable
 
 type Query {
   x: Int

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0114_interface_definition_with_missing_fields.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0114_interface_definition_with_missing_fields.graphql
@@ -1,0 +1,9 @@
+directive @foo on INTERFACE
+
+type Query {
+  foo: Node
+}
+
+interface Node
+
+extend interface Node @foo

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0115_object_definition_with_missing_fields.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0115_object_definition_with_missing_fields.graphql
@@ -1,0 +1,11 @@
+directive @foo on OBJECT
+
+directive @bar on OBJECT
+
+type Query {
+  foo: User
+}
+
+type User @foo
+
+extend type User @bar

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0116_enum_definition_with_missing_values.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0116_enum_definition_with_missing_values.graphql
@@ -1,0 +1,9 @@
+directive @foo on ENUM
+
+type Query {
+  foo: WEEKDAY
+}
+
+enum WEEKDAY
+
+extend enum WEEKDAY @foo

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0117_union_definition_with_missing_members.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0117_union_definition_with_missing_members.graphql
@@ -1,0 +1,9 @@
+directive @foo on UNION
+
+type Query {
+  foo: Search
+}
+
+union Search
+
+extend union Search @foo

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0118_input_object_definition_with_missing_values.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0118_input_object_definition_with_missing_values.graphql
@@ -1,0 +1,9 @@
+directive @foo on INPUT_OBJECT
+
+type Query {
+  foo(id: In): String
+}
+
+input In
+
+extend input In @foo

--- a/crates/apollo-compiler/test_data/serializer/ok/0115_interface_definition_with_extension_defines_field.graphql
+++ b/crates/apollo-compiler/test_data/serializer/ok/0115_interface_definition_with_extension_defines_field.graphql
@@ -1,0 +1,9 @@
+type Query {
+  foo: Node
+}
+
+interface Node
+
+extend interface Node {
+  bar: String
+}

--- a/crates/apollo-compiler/tests/executable.rs
+++ b/crates/apollo-compiler/tests/executable.rs
@@ -35,7 +35,7 @@ fn get_operations() {
 #[test]
 fn is_introspection_operation() {
     let query_input = r#"
-        type Query {}
+        type Query { foo: String }
         query TypeIntrospect {
           __type(name: "User") {
             name
@@ -184,7 +184,7 @@ fn is_introspection_deep() {
 #[test]
 fn is_introspection_repeated_fragment() {
     let query_input_indirect = r#"
-      type Query {}
+      type Query { foo: String }
 
       query IntrospectRepeatedIndirectFragment {
         ...A
@@ -204,7 +204,7 @@ fn is_introspection_repeated_fragment() {
     "#;
 
     let query_input_direct = r#"
-      type Query {}
+      type Query { foo: String }
 
       query IntrospectRepeatedDirectFragment {
         ...C

--- a/crates/apollo-compiler/tests/extensions.rs
+++ b/crates/apollo-compiler/tests/extensions.rs
@@ -4,7 +4,7 @@ use apollo_compiler::Schema;
 fn test_orphan_extensions() {
     let input = r#"
         extend schema @dir { query: Q }
-        extend type Obj @dir
+        extend type Obj @dir { foo: String }
         directive @dir on SCHEMA | OBJECT
         type Q { x: Int }
     "#;

--- a/crates/apollo-parser/src/parser/grammar/field.rs
+++ b/crates/apollo-parser/src/parser/grammar/field.rs
@@ -4,6 +4,7 @@ use crate::parser::grammar::value::Constness;
 use crate::parser::grammar::{argument, description, directive, name, selection, ty};
 use crate::{Parser, SyntaxKind, TokenKind, S, T};
 use std::ops::ControlFlow;
+use crate::parser::grammar::enum_::enum_value_definition;
 
 /// See: https://spec.graphql.org/October2021/#Field
 ///
@@ -41,6 +42,12 @@ pub(crate) fn field(p: &mut Parser) {
 pub(crate) fn fields_definition(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::FIELDS_DEFINITION);
     p.bump(S!['{']);
+
+    match p.peek() {
+        Some(TokenKind::Name | TokenKind::StringValue) => field_definition(p),
+        _ => p.err("expected Field Definition"),
+    }
+
     p.peek_while(|p, kind| match kind {
         TokenKind::Name | TokenKind::StringValue => {
             field_definition(p);

--- a/crates/apollo-parser/src/parser/grammar/field.rs
+++ b/crates/apollo-parser/src/parser/grammar/field.rs
@@ -4,7 +4,6 @@ use crate::parser::grammar::value::Constness;
 use crate::parser::grammar::{argument, description, directive, name, selection, ty};
 use crate::{Parser, SyntaxKind, TokenKind, S, T};
 use std::ops::ControlFlow;
-use crate::parser::grammar::enum_::enum_value_definition;
 
 /// See: https://spec.graphql.org/October2021/#Field
 ///

--- a/crates/apollo-parser/test_data/parser/err/0045_ignored_token_spans.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0045_ignored_token_spans.graphql
@@ -1,7 +1,7 @@
 cats
 # https://github.com/apollographql/apollo-rs/issues/325
 
-interface X {}
+interface X
 
 cats
 type Query {

--- a/crates/apollo-parser/test_data/parser/err/0045_ignored_token_spans.txt
+++ b/crates/apollo-parser/test_data/parser/err/0045_ignored_token_spans.txt
@@ -1,40 +1,36 @@
-- DOCUMENT@0..115
+- DOCUMENT@0..112
     - ERROR@0..4 "cats"
     - WHITESPACE@4..5 "\n"
     - COMMENT@5..60 "# https://github.com/apollographql/apollo-rs/issues/325"
     - WHITESPACE@60..62 "\n\n"
-    - INTERFACE_TYPE_DEFINITION@62..76
+    - INTERFACE_TYPE_DEFINITION@62..73
         - interface_KW@62..71 "interface"
         - WHITESPACE@71..72 " "
         - NAME@72..73
             - IDENT@72..73 "X"
-        - WHITESPACE@73..74 " "
-        - FIELDS_DEFINITION@74..76
-            - L_CURLY@74..75 "{"
-            - R_CURLY@75..76 "}"
-    - WHITESPACE@76..78 "\n\n"
-    - ERROR@78..82 "cats"
-    - WHITESPACE@82..83 "\n"
-    - OBJECT_TYPE_DEFINITION@83..114
-        - type_KW@83..87 "type"
-        - WHITESPACE@87..88 " "
-        - NAME@88..93
-            - IDENT@88..93 "Query"
-        - WHITESPACE@93..94 " "
-        - FIELDS_DEFINITION@94..114
-            - L_CURLY@94..95 "{"
-            - WHITESPACE@95..100 "\n    "
-            - FIELD_DEFINITION@100..112
-                - NAME@100..104
-                    - IDENT@100..104 "name"
-                - COLON@104..105 ":"
-                - WHITESPACE@105..106 " "
-                - NAMED_TYPE@106..112
-                    - NAME@106..112
-                        - IDENT@106..112 "String"
-            - WHITESPACE@112..113 "\n"
-            - R_CURLY@113..114 "}"
-    - WHITESPACE@114..115 "\n"
+    - WHITESPACE@73..75 "\n\n"
+    - ERROR@75..79 "cats"
+    - WHITESPACE@79..80 "\n"
+    - OBJECT_TYPE_DEFINITION@80..111
+        - type_KW@80..84 "type"
+        - WHITESPACE@84..85 " "
+        - NAME@85..90
+            - IDENT@85..90 "Query"
+        - WHITESPACE@90..91 " "
+        - FIELDS_DEFINITION@91..111
+            - L_CURLY@91..92 "{"
+            - WHITESPACE@92..97 "\n    "
+            - FIELD_DEFINITION@97..109
+                - NAME@97..101
+                    - IDENT@97..101 "name"
+                - COLON@101..102 ":"
+                - WHITESPACE@102..103 " "
+                - NAMED_TYPE@103..109
+                    - NAME@103..109
+                        - IDENT@103..109 "String"
+            - WHITESPACE@109..110 "\n"
+            - R_CURLY@110..111 "}"
+    - WHITESPACE@111..112 "\n"
 - ERROR@0:4 "expected definition" cats
-- ERROR@78:82 "expected definition" cats
+- ERROR@75:79 "expected definition" cats
 recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0055_object_definition_with_missing_name.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0055_object_definition_with_missing_name.graphql
@@ -1,0 +1,3 @@
+type  {
+  id: String
+}

--- a/crates/apollo-parser/test_data/parser/err/0055_object_definition_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0055_object_definition_with_missing_name.txt
@@ -1,0 +1,19 @@
+- DOCUMENT@0..22
+    - OBJECT_TYPE_DEFINITION@0..22
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..6 "  "
+        - FIELDS_DEFINITION@6..22
+            - L_CURLY@6..7 "{"
+            - WHITESPACE@7..10 "\n  "
+            - FIELD_DEFINITION@10..20
+                - NAME@10..12
+                    - IDENT@10..12 "id"
+                - COLON@12..13 ":"
+                - WHITESPACE@13..14 " "
+                - NAMED_TYPE@14..20
+                    - NAME@14..20
+                        - IDENT@14..20 "String"
+            - WHITESPACE@20..21 "\n"
+            - R_CURLY@21..22 "}"
+- ERROR@6:7 "expected a name" {
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0056_object_definition_with_missing_curly.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0056_object_definition_with_missing_curly.graphql
@@ -1,0 +1,1 @@
+type Person { id: String

--- a/crates/apollo-parser/test_data/parser/err/0056_object_definition_with_missing_curly.txt
+++ b/crates/apollo-parser/test_data/parser/err/0056_object_definition_with_missing_curly.txt
@@ -1,0 +1,20 @@
+- DOCUMENT@0..24
+    - OBJECT_TYPE_DEFINITION@0..24
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..5 " "
+        - NAME@5..11
+            - IDENT@5..11 "Person"
+        - WHITESPACE@11..12 " "
+        - FIELDS_DEFINITION@12..24
+            - L_CURLY@12..13 "{"
+            - WHITESPACE@13..14 " "
+            - FIELD_DEFINITION@14..24
+                - NAME@14..16
+                    - IDENT@14..16 "id"
+                - COLON@16..17 ":"
+                - WHITESPACE@17..18 " "
+                - NAMED_TYPE@18..24
+                    - NAME@18..24
+                        - IDENT@18..24 "String"
+- ERROR@24:24 "expected R_CURLY, got EOF" EOF
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0057_object_definition_with_missing_fields.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0057_object_definition_with_missing_fields.graphql
@@ -1,0 +1,2 @@
+type Person {
+}

--- a/crates/apollo-parser/test_data/parser/err/0057_object_definition_with_missing_fields.txt
+++ b/crates/apollo-parser/test_data/parser/err/0057_object_definition_with_missing_fields.txt
@@ -1,0 +1,13 @@
+- DOCUMENT@0..15
+    - OBJECT_TYPE_DEFINITION@0..15
+        - type_KW@0..4 "type"
+        - WHITESPACE@4..5 " "
+        - NAME@5..11
+            - IDENT@5..11 "Person"
+        - WHITESPACE@11..12 " "
+        - FIELDS_DEFINITION@12..15
+            - L_CURLY@12..13 "{"
+            - WHITESPACE@13..14 "\n"
+            - R_CURLY@14..15 "}"
+- ERROR@14:15 "expected Field Definition" }
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0058_interface_definition_with_missing_name.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0058_interface_definition_with_missing_name.graphql
@@ -1,0 +1,3 @@
+interface {
+  id: String
+}

--- a/crates/apollo-parser/test_data/parser/err/0058_interface_definition_with_missing_name.txt
+++ b/crates/apollo-parser/test_data/parser/err/0058_interface_definition_with_missing_name.txt
@@ -1,0 +1,19 @@
+- DOCUMENT@0..26
+    - INTERFACE_TYPE_DEFINITION@0..26
+        - interface_KW@0..9 "interface"
+        - WHITESPACE@9..10 " "
+        - FIELDS_DEFINITION@10..26
+            - L_CURLY@10..11 "{"
+            - WHITESPACE@11..14 "\n  "
+            - FIELD_DEFINITION@14..24
+                - NAME@14..16
+                    - IDENT@14..16 "id"
+                - COLON@16..17 ":"
+                - WHITESPACE@17..18 " "
+                - NAMED_TYPE@18..24
+                    - NAME@18..24
+                        - IDENT@18..24 "String"
+            - WHITESPACE@24..25 "\n"
+            - R_CURLY@25..26 "}"
+- ERROR@10:11 "expected a Name" {
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0059_interface_definition_with_missing_fields.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0059_interface_definition_with_missing_fields.graphql
@@ -1,0 +1,2 @@
+interface Person {
+}

--- a/crates/apollo-parser/test_data/parser/err/0059_interface_definition_with_missing_fields.txt
+++ b/crates/apollo-parser/test_data/parser/err/0059_interface_definition_with_missing_fields.txt
@@ -1,0 +1,13 @@
+- DOCUMENT@0..20
+    - INTERFACE_TYPE_DEFINITION@0..20
+        - interface_KW@0..9 "interface"
+        - WHITESPACE@9..10 " "
+        - NAME@10..16
+            - IDENT@10..16 "Person"
+        - WHITESPACE@16..17 " "
+        - FIELDS_DEFINITION@17..20
+            - L_CURLY@17..18 "{"
+            - WHITESPACE@18..19 "\n"
+            - R_CURLY@19..20 "}"
+- ERROR@19:20 "expected Field Definition" }
+recursion limit: 500, high: 0

--- a/crates/apollo-parser/test_data/parser/err/0060_interface_definition_with_missing_curly.graphql
+++ b/crates/apollo-parser/test_data/parser/err/0060_interface_definition_with_missing_curly.graphql
@@ -1,0 +1,1 @@
+interface Person { id: String

--- a/crates/apollo-parser/test_data/parser/err/0060_interface_definition_with_missing_curly.txt
+++ b/crates/apollo-parser/test_data/parser/err/0060_interface_definition_with_missing_curly.txt
@@ -1,0 +1,20 @@
+- DOCUMENT@0..29
+    - INTERFACE_TYPE_DEFINITION@0..29
+        - interface_KW@0..9 "interface"
+        - WHITESPACE@9..10 " "
+        - NAME@10..16
+            - IDENT@10..16 "Person"
+        - WHITESPACE@16..17 " "
+        - FIELDS_DEFINITION@17..29
+            - L_CURLY@17..18 "{"
+            - WHITESPACE@18..19 " "
+            - FIELD_DEFINITION@19..29
+                - NAME@19..21
+                    - IDENT@19..21 "id"
+                - COLON@21..22 ":"
+                - WHITESPACE@22..23 " "
+                - NAMED_TYPE@23..29
+                    - NAME@23..29
+                        - IDENT@23..29 "String"
+- ERROR@29:29 "expected R_CURLY, got EOF" EOF
+recursion limit: 500, high: 0


### PR DESCRIPTION
## Description 

Per the [GraphQL spec]( https://spec.graphql.org/draft/#sel-FAHZhCFDBAACDA4qe), object, interface, enum, union, and input types must define one or more fields, enum values, members, input values respectively across all extensions.

This PR implements the necessary validation for each of the aforementioned types.

As an example, previously, the following SDL would incorrectly pass schema validation:
```
directive @foo on OBJECT
type Query {
  foo: User
}
type User 
extend type User @foo
```
`User` does not define any fields, even across its extensions.