### PR TITLE
feat(compiler): serialize with initial indentation

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [x.x.x] (unreleased) - 2024-mm-dd
+
+## Features
+
+- **Serialize with initial indentation - [SimonSapin], [pull/848]**
+  This helps use indentation in something that is partly but not entirely GraphQL syntax,
+  such as the debugging representation of an Apollo Router query plan.
+  Example: `document.serialize().initial_indent_level(2).to_string()`
+
+[SimonSapin]: https://github.com/SimonSapin
+[pull/838]: https://github.com/apollographql/apollo-rs/pull/848
+
+
 # [1.0.0-beta.14](https://crates.io/crates/apollo-compiler/1.0.0-beta.14) - 2024-03-13
 
 ## BREAKING

--- a/crates/apollo-compiler/tests/misc.rs
+++ b/crates/apollo-compiler/tests/misc.rs
@@ -1,3 +1,4 @@
+use apollo_compiler::ast::Document;
 use apollo_compiler::executable::Selection;
 use apollo_compiler::name;
 use apollo_compiler::parse_mixed_validate;
@@ -824,4 +825,26 @@ scalar URL
     for result in results {
         assert_eq!(result.unwrap().as_deref(), Some("URL"));
     }
+}
+
+#[test]
+fn initial_indent() {
+    let ast = Document::parse("query Op { field ... @defer { otherField }}", "").unwrap();
+    let formatted = format!(
+        "Request:\n  operationName: {}\n  query:\n{}",
+        "Op",
+        ast.serialize().initial_indent_level(2)
+    );
+    let expected = expect_test::expect![[r#"
+        Request:
+          operationName: Op
+          query:
+            query Op {
+              field
+              ... @defer {
+                otherField
+              }
+            }
+    "#]];
+    expected.assert_eq(&formatted);
 }


### PR DESCRIPTION
This helps use indentation in something that is partly but not entirely GraphQL syntax, such as the debugging representation of an Apollo Router query plan. Example: `document.serialize().initial_indent_level(2).to_string()`