### PR TITLE
apollo-parser@0.7.7

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 autotests = false # Most tests/*.rs files are modules of tests/main.rs
 
 [dependencies]
-apollo-parser = { path = "../apollo-parser", version = "0.7.6" }
+apollo-parser = { path = "../apollo-parser", version = "0.7.7" }
 ariadne = { version = "0.4.0", features = ["auto-color"] }
 indexmap = "2.0.0"
 rowan = "0.15.5"

--- a/crates/apollo-parser/CHANGELOG.md
+++ b/crates/apollo-parser/CHANGELOG.md
@@ -17,6 +17,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Documentation -->
 
+# [0.7.7](https://crates.io/crates/apollo-parser/0.7.7) - 2024-04-08
+
+## Fixes
+- **raise an error for empty field sets - [tinnou], [pull/845]**
+  It's not legal to write `type Object {}` *with* braces but *without* declaring
+  any fields. In the past this was accepted by apollo-parser, now it raises an
+  error as required by the spec.
+
+[tinnou]: https://github.com/tinnou
+[pull/845]: https://github.com/apollographql/apollo-rs/pull/845
+
 # [0.7.6](https://crates.io/crates/apollo-parser/0.7.6) - 2024-02-14
 
 ## Fixes

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-parser"
-version = "0.7.6" # When bumping, also update README.md
+version = "0.7.7" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-parser/README.md
+++ b/crates/apollo-parser/README.md
@@ -35,7 +35,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
-apollo-parser = "0.7.6"
+apollo-parser = "0.7.7"
 ```
 
 ## Rust versions


### PR DESCRIPTION

## Fixes
- **raise an error for empty field sets - [tinnou], [pull/845]**
  It's not legal to write `type Object {}` *with* braces but *without* declaring
  any fields. In the past this was accepted by apollo-parser, now it raises an
  error as required by the spec.

[tinnou]: https://github.com/tinnou
[pull/845]: https://github.com/apollographql/apollo-rs/pull/845