### PR TITLE
apollo-compiler@1.0.0-beta.15

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2024-mm-dd
+# [1.0.0-beta.15](https://crates.io/crates/apollo-compiler/1.0.0-beta.14) - 2024-04-08
 
 ## Features
 
@@ -25,9 +25,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   This helps use indentation in something that is partly but not entirely GraphQL syntax,
   such as the debugging representation of an Apollo Router query plan.
   Example: `document.serialize().initial_indent_level(2).to_string()`
+- **Add validation requiring composite types declare fields - [tinnou], [pull/847]**
+  Object types, interfaces, enums, unions, and input objects must all have at least one
+  member. This is now checked in schema validation.
 
 [SimonSapin]: https://github.com/SimonSapin
-[pull/838]: https://github.com/apollographql/apollo-rs/pull/848
+[tinnou]: https://github.com/tinnou
+[pull/847]: https://github.com/apollographql/apollo-rs/pull/847
+[pull/848]: https://github.com/apollographql/apollo-rs/pull/848
 
 
 # [1.0.0-beta.14](https://crates.io/crates/apollo-compiler/1.0.0-beta.14) - 2024-03-13

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.14" # When bumping, also update README.md
+version = "1.0.0-beta.15" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.14"
+apollo-compiler = "=1.0.0-beta.15"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.14" }
+apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.15" }
 apollo-parser = { path = "../apollo-parser", version = "0.7.0" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 indexmap = "2.0.0"


### PR DESCRIPTION
For after https://github.com/apollographql/apollo-rs/pull/849

## Features

- **Serialize with initial indentation - [SimonSapin], [pull/848]**
  This helps use indentation in something that is partly but not entirely GraphQL syntax,
  such as the debugging representation of an Apollo Router query plan.
  Example: `document.serialize().initial_indent_level(2).to_string()`
- **Add validation requiring composite types declare fields - [tinnou], [pull/847]**
  Object types, interfaces, enums, unions, and input objects must all have at least one
  member. This is now checked in schema validation.

[SimonSapin]: https://github.com/SimonSapin
[tinnou]: https://github.com/tinnou
[pull/847]: https://github.com/apollographql/apollo-rs/pull/847
[pull/848]: https://github.com/apollographql/apollo-rs/pull/848