### PR TITLE
Add a graphql-js compatible-ish error serialization for Apollo Router

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [x.x.x] (unreleased) - 2024-04-12
+
+## Features
+
+- **Add GraphQL validation compatibility API for Apollo Router - [goto-bus-stop] in [pull/853]**
+  Enables large-scale production deployment of apollo-compiler's validation implementation.
+
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/853]: https://github.com/apollographql/apollo-rs/pull/853
+
 # [1.0.0-beta.15](https://crates.io/crates/apollo-compiler/1.0.0-beta.14) - 2024-04-08
 
 ## Features

--- a/crates/apollo-compiler/src/executable/from_ast.rs
+++ b/crates/apollo-compiler/src/executable/from_ast.rs
@@ -111,6 +111,7 @@ pub(crate) fn document_from_ast(
                     errors.errors.push(
                         definition.location(),
                         BuildError::TypeSystemDefinition {
+                            name: definition.name().cloned(),
                             describe: definition.describe(),
                         },
                     )

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -113,7 +113,10 @@ pub struct InlineFragment {
 #[derive(thiserror::Error, Debug, Clone)]
 pub(crate) enum BuildError {
     #[error("an executable document must not contain {describe}")]
-    TypeSystemDefinition { describe: &'static str },
+    TypeSystemDefinition {
+        name: Option<Name>,
+        describe: &'static str,
+    },
 
     #[error("anonymous operation cannot be selected when the document contains other operations")]
     AmbiguousAnonymousOperation,

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -292,6 +292,7 @@ pub(crate) fn validate_directives<'dir>(
                         dir.location(),
                         DiagnosticData::RequiredArgument {
                             name: arg_def.name.clone(),
+                            expected_type: arg_def.ty.clone(),
                             coordinate: DirectiveArgumentCoordinate {
                                 directive: directive_definition.name.clone(),
                                 argument: arg_def.name.clone(),

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -93,6 +93,7 @@ pub(crate) fn validate_field(
                     field.location(),
                     DiagnosticData::RequiredArgument {
                         name: arg_definition.name.clone(),
+                        expected_type: arg_definition.ty.clone(),
                         coordinate: FieldArgumentCoordinate {
                             ty: against_type.clone(),
                             field: field.name.clone(),

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -497,6 +497,7 @@ impl DiagnosticData {
                 } => Some(format!(r#"Unknown type "{type_name}"."#)),
                 ExecutableBuildError::SubselectionOnScalarType { type_name, path }
                 | ExecutableBuildError::SubselectionOnEnumType { type_name, path } => {
+                    #[allow(clippy::manual_map)]
                     if let Some(field) = path.nested_fields.last() {
                         Some(format!(
                             r#"Field "{field}" must not have a selection since type "{type_name}" has no subfields"#

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -14,8 +14,8 @@ fn unsupported_type(
     diagnostics.push(
         value.location(),
         DiagnosticData::UnsupportedValueType {
-            describe_value_type: value.describe(),
-            ty: declared_type.to_string(),
+            ty: declared_type.clone(),
+            value: value.clone(),
             definition_location: declared_type.location(),
         },
     )
@@ -244,6 +244,7 @@ pub(crate) fn value_of_correct_type(
                                     ty: input_obj.name.clone(),
                                     attribute: input_name.clone(),
                                 },
+                                expected_type: ty.clone(),
                                 definition_location: f.location(),
                             },
                         );

--- a/crates/apollo-compiler/src/validation/variable.rs
+++ b/crates/apollo-compiler/src/validation/variable.rs
@@ -36,8 +36,8 @@ pub(crate) fn validate_variable_definitions(
                         variable.location(),
                         DiagnosticData::VariableInputType {
                             name: variable.name.clone(),
+                            ty: ty.clone(),
                             describe_type: type_definition.describe(),
-                            type_location: ty.location(),
                         },
                     );
                 }


### PR DESCRIPTION
With some additions to the error structures to pass through the data required.

This PR adds a `.unstable_to_json_compat()` function to diagnostics that returns best-effort error messages in the graphql-js format. Some things like "Did you mean?" are omitted intentionally. There are minor differences in a handful of other messages, but much fewer than before, and hopefully it'll be obvious to users that the meaning is the same. One example difference is the `UnsupportedValueType` message, which in graphql-js is a customisable type-specific validation, but in apollo-rs is a fixed check based only on what the spec knows about builtin scalars, so the error is a bit less specific.

The new API is only meant for use in the Apollo Router, temporarily, exempt from semver, and any other users will not be supported.