### PR TITLE
apollo-compiler@1.0.0-beta.16

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2024-04-12
+# [1.0.0-beta.16](https://crates.io/crates/apollo-compiler/1.0.0-beta.16) - 2024-04-12
+
+> This release has no user-facing changes.
 
 ## Features
 
@@ -27,7 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [goto-bus-stop]: https://github.com/goto-bus-stop
 [pull/853]: https://github.com/apollographql/apollo-rs/pull/853
 
-# [1.0.0-beta.15](https://crates.io/crates/apollo-compiler/1.0.0-beta.14) - 2024-04-08
+# [1.0.0-beta.15](https://crates.io/crates/apollo-compiler/1.0.0-beta.15) - 2024-04-08
 
 ## Features
 

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.15" # When bumping, also update README.md
+version = "1.0.0-beta.16" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.15"
+apollo-compiler = "=1.0.0-beta.16"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.15" }
+apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.16" }
 apollo-parser = { path = "../apollo-parser", version = "0.7.0" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 indexmap = "2.0.0"


### PR DESCRIPTION
> This release has no user-facing changes.

## Features

- **Add GraphQL validation compatibility API for Apollo Router - [goto-bus-stop] in [pull/853]**
  Enables large-scale production deployment of apollo-compiler's validation implementation.

[goto-bus-stop]: https://github.com/goto-bus-stop
[pull/853]: https://github.com/apollographql/apollo-rs/pull/853