### PR TITLE
Remove ariadne byte/char mapping

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 - **Remove ariadne byte/char mapping - [goto-bus-stop] in [pull/855]**
-  Generating JSON or CLI reports for apollo-compiler diagnostic used a translation layer
+  Generating JSON or CLI reports for apollo-compiler diagnostics used a translation layer
   between byte offsets and character offsets, which cost some computation and memory
   proportional to the size of the source text. The latest version of [ariadne] allows us to
   remove this translation.

--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [x.x.x] (unreleased) - 2024-mm-dd
+
+## Maintenance
+
+- **Remove ariadne byte/char mapping - [goto-bus-stop] in [pull/855]**
+  Generating JSON or CLI reports for apollo-compiler diagnostic used a translation layer
+  between byte offsets and character offsets, which cost some computation and memory
+  proportional to the size of the source text. The latest version of [ariadne] allows us to
+  remove this translation.
+
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[pull/855]: https://github.com/apollographql/apollo-rs/pull/855
+[ariadne]: https://github.com/zesterer/ariadne
+
 # [1.0.0-beta.16](https://crates.io/crates/apollo-compiler/1.0.0-beta.16) - 2024-04-12
 
 > This release has no user-facing changes.

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -19,7 +19,7 @@ autotests = false # Most tests/*.rs files are modules of tests/main.rs
 
 [dependencies]
 apollo-parser = { path = "../apollo-parser", version = "0.7.7" }
-ariadne = { version = "0.4.0", features = ["auto-color"] }
+ariadne = { version = "0.4.1", features = ["auto-color"] }
 indexmap = "2.0.0"
 rowan = "0.15.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/apollo-compiler/src/diagnostic.rs
+++ b/crates/apollo-compiler/src/diagnostic.rs
@@ -168,10 +168,9 @@ type MappedSpan = (FileId, Range<usize>);
 
 /// Translate a byte-offset location into a char-offset location for use with ariadne.
 fn map_span(sources: &SourceMap, location: NodeLocation) -> Option<MappedSpan> {
-    let source = sources.get(&location.file_id)?;
-    let mapped_source = source.mapped_source();
-    let start = mapped_source.map_index(location.offset());
-    let end = mapped_source.map_index(location.end_offset());
+    let _source = sources.get(&location.file_id)?;
+    let start = location.offset();
+    let end = location.end_offset();
     Some((location.file_id, start..end))
 }
 
@@ -212,7 +211,9 @@ impl<'s> CliReport<'s> {
             // only if stderr is a terminal.
             Color::StderrIsTerminal => true,
         };
-        let config = ariadne::Config::default().with_color(enable_color);
+        let config = ariadne::Config::default()
+            .with_index_type(ariadne::IndexType::Byte)
+            .with_color(enable_color);
         Self {
             sources,
             colors: ColorGenerator::new(),

--- a/crates/apollo-compiler/src/diagnostic.rs
+++ b/crates/apollo-compiler/src/diagnostic.rs
@@ -110,7 +110,7 @@ where
 pub struct CliReport<'s> {
     sources: &'s SourceMap,
     colors: ColorGenerator,
-    report: ariadne::ReportBuilder<'static, MappedSpan>,
+    report: ariadne::ReportBuilder<'static, AriadneSpan>,
 }
 
 /// Indicate when to use ANSI colors for printing.
@@ -164,11 +164,12 @@ impl<T: ToCliReport> ToCliReport for &T {
     }
 }
 
-type MappedSpan = (FileId, Range<usize>);
+/// An ariadne span type. We avoid implementing `ariadne::Span` for `NodeLocation`
+/// so ariadne doesn't leak into the public API of apollo-compiler.
+type AriadneSpan = (FileId, Range<usize>);
 
-/// Translate a byte-offset location into a char-offset location for use with ariadne.
-fn map_span(sources: &SourceMap, location: NodeLocation) -> Option<MappedSpan> {
-    let _source = sources.get(&location.file_id)?;
+/// Translate a NodeLocation into an ariadne span type.
+fn to_span(location: NodeLocation) -> Option<AriadneSpan> {
     let start = location.offset();
     let end = location.end_offset();
     Some((location.file_id, start..end))
@@ -202,7 +203,7 @@ impl<'s> CliReport<'s> {
         color: Color,
     ) -> Self {
         let (file_id, range) = main_location
-            .and_then(|location| map_span(sources, location))
+            .and_then(to_span)
             .unwrap_or((FileId::NONE, 0..0));
         let report = ariadne::Report::build(ReportKind::Error, file_id, range.start);
         let enable_color = match color {
@@ -239,9 +240,9 @@ impl<'s> CliReport<'s> {
 
     /// Add a label at a given location. If the location is `None`, the message is discarded.
     pub fn with_label_opt(&mut self, location: Option<NodeLocation>, message: impl ToString) {
-        if let Some(mapped_span) = location.and_then(|location| map_span(self.sources, location)) {
+        if let Some(span) = location.and_then(to_span) {
             self.report.add_label(
-                ariadne::Label::new(mapped_span)
+                ariadne::Label::new(span)
                     .with_message(message)
                     .with_color(self.colors.next()),
             );


### PR DESCRIPTION
ariadne 0.4.1 supports using byte indices directly. This patch removes `MappedSource`, saving some computation but mostly memory usage when generating JSON or CLI reports for diagnostics.

We could also use `NodeLocation` as an ariadne span directly by implementing the `Span` trait for it. It's a little more convenient when creating the reports. I opted not to do that because it's user-visible if users install ariadne manually, instead I kept the internal conversion to a `(FileId, Range<u64>)` span.