### PR TITLE
fix(compiler): cache the implementers map per executable document

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -53,6 +53,11 @@ name = "fields-validation"
 path = "benches/fields_validation.rs"
 harness = false
 
+[[bench]]
+name = "fragments-validation"
+path = "benches/fragments_validation.rs"
+harness = false
+
 [[test]]
 name = "main"
 

--- a/crates/apollo-compiler/benches/fragments_validation.rs
+++ b/crates/apollo-compiler/benches/fragments_validation.rs
@@ -1,0 +1,51 @@
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use criterion::*;
+use std::fmt::Write;
+
+fn bench_big_schema_many_fragments(c: &mut Criterion) {
+    const NUM_INTERFACES: usize = 200;
+    const NUM_OBJECTS: usize = 10_000;
+
+    let mut sdl = String::new();
+    for i in 0..NUM_INTERFACES {
+        _ = writeln!(&mut sdl, r#"interface Intf{i} {{ field: Int! }}"#);
+    }
+    for o in 0..NUM_OBJECTS {
+        let i = o % NUM_INTERFACES;
+        _ = writeln!(
+            &mut sdl,
+            r#"type Ty{o} implements Intf{i} {{ field: Int! }}"#
+        );
+    }
+
+    _ = writeln!(&mut sdl, "type Query {{");
+    for i in 0..NUM_INTERFACES {
+        _ = writeln!(&mut sdl, "  intf{i}: Intf{i}");
+    }
+    _ = writeln!(&mut sdl, "}}");
+
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let mut selection = String::new();
+    let mut fragments = String::new();
+    for i in 0..NUM_INTERFACES {
+        _ = writeln!(&mut selection, "  intf{i} {{ ...frag{i} }}");
+        _ = writeln!(&mut fragments, "fragment frag{i} on Ty{i} {{ field }}");
+    }
+    let query = format!(
+        "query {{
+  {selection}}}
+{fragments}"
+    );
+
+    c.bench_function("big_schema_many_fragments", move |b| {
+        b.iter(|| {
+            let doc =
+                ExecutableDocument::parse_and_validate(&schema, &query, "query.graphql").unwrap();
+            black_box(doc);
+        });
+    });
+}
+
+criterion_group!(fragments, bench_big_schema_many_fragments,);
+criterion_main!(fragments);

--- a/crates/apollo-compiler/src/executable/validation.rs
+++ b/crates/apollo-compiler/src/executable/validation.rs
@@ -3,6 +3,7 @@ use crate::validation::fragment::validate_fragment_used;
 use crate::validation::operation::validate_operation_definitions;
 use crate::validation::selection::FieldsInSetCanMerge;
 use crate::validation::DiagnosticList;
+use crate::validation::ExecutableValidationContext;
 use crate::validation::Valid;
 use crate::ExecutableDocument;
 use crate::Schema;
@@ -40,7 +41,8 @@ pub(crate) fn validate_with_or_without_schema(
     schema: Option<&Schema>,
     document: &ExecutableDocument,
 ) {
-    validate_operation_definitions(errors, schema, document);
+    let context = ExecutableValidationContext::new(schema);
+    validate_operation_definitions(errors, document, &context);
     for def in document.fragments.values() {
         validate_fragment_used(errors, document, def);
     }
@@ -52,11 +54,12 @@ pub(crate) fn validate_field_set(
     field_set: &FieldSet,
 ) {
     let document = &ExecutableDocument::new(); // No fragment definitions
+    let context = ExecutableValidationContext::new(Some(schema));
     crate::validation::selection::validate_selection_set(
         diagnostics,
         document,
         Some((schema, &field_set.selection_set.ty)),
         &field_set.selection_set,
-        &crate::validation::operation::OperationValidationConfig::new(Some(schema), &[]),
+        context.operation_context(&[]),
     )
 }

--- a/crates/apollo-compiler/src/executable/validation.rs
+++ b/crates/apollo-compiler/src/executable/validation.rs
@@ -57,9 +57,6 @@ pub(crate) fn validate_field_set(
         document,
         Some((schema, &field_set.selection_set.ty)),
         &field_set.selection_set,
-        crate::validation::operation::OperationValidationConfig {
-            schema: Some(schema),
-            variables: &[],
-        },
+        &crate::validation::operation::OperationValidationConfig::new(Some(schema), &[]),
     )
 }

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -2,10 +2,10 @@ use crate::coordinate::{FieldArgumentCoordinate, TypeAttributeCoordinate};
 use crate::validation::diagnostics::DiagnosticData;
 use crate::{ast, executable, schema, ExecutableDocument, Node};
 
-use super::operation::OperationValidationConfig;
 use crate::ast::Name;
 use crate::schema::Component;
 use crate::validation::DiagnosticList;
+use crate::validation::OperationValidationContext;
 use indexmap::IndexMap;
 
 pub(crate) fn validate_field(
@@ -14,13 +14,13 @@ pub(crate) fn validate_field(
     // May be None if a parent selection was invalid
     against_type: Option<(&crate::Schema, &ast::NamedType)>,
     field: &Node<executable::Field>,
-    context: &OperationValidationConfig<'_>,
+    context: OperationValidationContext<'_>,
 ) {
     // First do all the validation that we can without knowing the type of the field.
 
     super::directive::validate_directives(
         diagnostics,
-        context.schema,
+        context.schema(),
         field.directives.iter(),
         ast::DirectiveLocation::Field,
         context.variables,

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -14,7 +14,7 @@ pub(crate) fn validate_field(
     // May be None if a parent selection was invalid
     against_type: Option<(&crate::Schema, &ast::NamedType)>,
     field: &Node<executable::Field>,
-    context: OperationValidationConfig<'_>,
+    context: &OperationValidationConfig<'_>,
 ) {
     // First do all the validation that we can without knowing the type of the field.
 

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -52,6 +52,7 @@ fn validate_fragment_spread_type(
     against_type: &NamedType,
     type_condition: &NamedType,
     selection: &executable::Selection,
+    context: &OperationValidationConfig<'_>,
 ) {
     // Another diagnostic will be raised if the type condition was wrong.
     // We reduce noise by silencing other issues with the fragment.
@@ -64,7 +65,7 @@ fn validate_fragment_spread_type(
         return;
     };
 
-    let implementers_map = schema.implementers_map();
+    let implementers_map = context.implementers_map();
     let concrete_parent_types = get_possible_types(against_type_definition, &implementers_map);
     let concrete_condition_types = get_possible_types(type_condition_definition, &implementers_map);
 
@@ -107,7 +108,7 @@ pub(crate) fn validate_inline_fragment(
     document: &ExecutableDocument,
     against_type: Option<(&crate::Schema, &ast::NamedType)>,
     inline: &Node<executable::InlineFragment>,
-    context: OperationValidationConfig<'_>,
+    context: &OperationValidationConfig<'_>,
 ) {
     super::directive::validate_directives(
         diagnostics,
@@ -138,6 +139,7 @@ pub(crate) fn validate_inline_fragment(
                 against_type,
                 type_condition,
                 &executable::Selection::InlineFragment(inline.clone()),
+                &context,
             );
         }
         super::selection::validate_selection_set(
@@ -159,7 +161,7 @@ pub(crate) fn validate_fragment_spread(
     document: &ExecutableDocument,
     against_type: Option<(&crate::Schema, &NamedType)>,
     spread: &Node<executable::FragmentSpread>,
-    context: OperationValidationConfig<'_>,
+    context: &OperationValidationConfig<'_>,
 ) {
     super::directive::validate_directives(
         diagnostics,
@@ -179,6 +181,7 @@ pub(crate) fn validate_fragment_spread(
                     against_type,
                     def.type_condition(),
                     &executable::Selection::FragmentSpread(spread.clone()),
+                    context,
                 );
             }
             validate_fragment_definition(diagnostics, document, def, context);
@@ -198,7 +201,7 @@ pub(crate) fn validate_fragment_definition(
     diagnostics: &mut DiagnosticList,
     document: &ExecutableDocument,
     fragment: &Node<executable::Fragment>,
-    context: OperationValidationConfig<'_>,
+    context: &OperationValidationConfig<'_>,
 ) {
     super::directive::validate_directives(
         diagnostics,

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -5,8 +5,8 @@ use crate::executable;
 use crate::schema;
 use crate::schema::Implementers;
 use crate::validation::diagnostics::DiagnosticData;
-use crate::validation::operation::OperationValidationConfig;
 use crate::validation::DiagnosticList;
+use crate::validation::OperationValidationContext;
 use crate::validation::{CycleError, NodeLocation, RecursionGuard, RecursionStack};
 use crate::ExecutableDocument;
 use crate::Node;
@@ -52,7 +52,7 @@ fn validate_fragment_spread_type(
     against_type: &NamedType,
     type_condition: &NamedType,
     selection: &executable::Selection,
-    context: &OperationValidationConfig<'_>,
+    context: OperationValidationContext<'_>,
 ) {
     // Another diagnostic will be raised if the type condition was wrong.
     // We reduce noise by silencing other issues with the fragment.
@@ -66,8 +66,8 @@ fn validate_fragment_spread_type(
     };
 
     let implementers_map = context.implementers_map();
-    let concrete_parent_types = get_possible_types(against_type_definition, &implementers_map);
-    let concrete_condition_types = get_possible_types(type_condition_definition, &implementers_map);
+    let concrete_parent_types = get_possible_types(against_type_definition, implementers_map);
+    let concrete_condition_types = get_possible_types(type_condition_definition, implementers_map);
 
     let mut applicable_types = concrete_parent_types.intersection(&concrete_condition_types);
     if applicable_types.next().is_none() {
@@ -108,18 +108,18 @@ pub(crate) fn validate_inline_fragment(
     document: &ExecutableDocument,
     against_type: Option<(&crate::Schema, &ast::NamedType)>,
     inline: &Node<executable::InlineFragment>,
-    context: &OperationValidationConfig<'_>,
+    context: OperationValidationContext<'_>,
 ) {
     super::directive::validate_directives(
         diagnostics,
-        context.schema,
+        context.schema(),
         inline.directives.iter(),
         ast::DirectiveLocation::InlineFragment,
         context.variables,
     );
 
     let previous = diagnostics.len();
-    if let Some(schema) = context.schema {
+    if let Some(schema) = context.schema() {
         if let Some(t) = &inline.type_condition {
             validate_fragment_type_condition(diagnostics, schema, None, t, inline.location())
         }
@@ -139,13 +139,13 @@ pub(crate) fn validate_inline_fragment(
                 against_type,
                 type_condition,
                 &executable::Selection::InlineFragment(inline.clone()),
-                &context,
+                context,
             );
         }
         super::selection::validate_selection_set(
             diagnostics,
             document,
-            if let (Some(schema), Some(ty)) = (&context.schema, &inline.type_condition) {
+            if let (Some(schema), Some(ty)) = (&context.schema(), &inline.type_condition) {
                 Some((schema, ty))
             } else {
                 against_type
@@ -161,11 +161,11 @@ pub(crate) fn validate_fragment_spread(
     document: &ExecutableDocument,
     against_type: Option<(&crate::Schema, &NamedType)>,
     spread: &Node<executable::FragmentSpread>,
-    context: &OperationValidationConfig<'_>,
+    context: OperationValidationContext<'_>,
 ) {
     super::directive::validate_directives(
         diagnostics,
-        context.schema,
+        context.schema(),
         spread.directives.iter(),
         ast::DirectiveLocation::FragmentSpread,
         context.variables,
@@ -201,18 +201,18 @@ pub(crate) fn validate_fragment_definition(
     diagnostics: &mut DiagnosticList,
     document: &ExecutableDocument,
     fragment: &Node<executable::Fragment>,
-    context: &OperationValidationConfig<'_>,
+    context: OperationValidationContext<'_>,
 ) {
     super::directive::validate_directives(
         diagnostics,
-        context.schema,
+        context.schema(),
         fragment.directives.iter(),
         ast::DirectiveLocation::FragmentDefinition,
         context.variables,
     );
 
     let previous = diagnostics.len();
-    if let Some(schema) = context.schema {
+    if let Some(schema) = context.schema() {
         validate_fragment_type_condition(
             diagnostics,
             schema,
@@ -231,7 +231,7 @@ pub(crate) fn validate_fragment_definition(
         // If the type does not exist, do not attempt to validate the selections against it;
         // it has either already raised an error, or we are validating an executable without
         // a schema.
-        let type_condition = context.schema.and_then(|schema| {
+        let type_condition = context.schema().and_then(|schema| {
             schema
                 .types
                 .contains_key(fragment.type_condition())

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -545,24 +545,20 @@ pub(crate) fn validate_selection_set(
     document: &ExecutableDocument,
     against_type: Option<(&crate::Schema, &NamedType)>,
     selection_set: &SelectionSet,
-    context: OperationValidationConfig<'_>,
+    context: &OperationValidationConfig<'_>,
 ) {
     for selection in &selection_set.selections {
         match selection {
-            executable::Selection::Field(field) => super::field::validate_field(
-                diagnostics,
-                document,
-                against_type,
-                field,
-                context.clone(),
-            ),
+            executable::Selection::Field(field) => {
+                super::field::validate_field(diagnostics, document, against_type, field, context)
+            }
             executable::Selection::FragmentSpread(fragment) => {
                 super::fragment::validate_fragment_spread(
                     diagnostics,
                     document,
                     against_type,
                     fragment,
-                    context.clone(),
+                    context,
                 )
             }
             executable::Selection::InlineFragment(inline) => {
@@ -571,7 +567,7 @@ pub(crate) fn validate_selection_set(
                     document,
                     against_type,
                     inline,
-                    context.clone(),
+                    context,
                 )
             }
         }

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -3,8 +3,8 @@ use crate::ast::NamedType;
 use crate::coordinate::TypeAttributeCoordinate;
 use crate::executable::BuildError;
 use crate::executable::SelectionSet;
-use crate::validation::operation::OperationValidationConfig;
 use crate::validation::DiagnosticList;
+use crate::validation::OperationValidationContext;
 use crate::ExecutableDocument;
 use crate::{ast, executable, schema, Node};
 use apollo_parser::LimitTracker;
@@ -545,7 +545,7 @@ pub(crate) fn validate_selection_set(
     document: &ExecutableDocument,
     against_type: Option<(&crate::Schema, &NamedType)>,
     selection_set: &SelectionSet,
-    context: &OperationValidationConfig<'_>,
+    context: OperationValidationContext<'_>,
 ) {
     for selection in &selection_set.selections {
         match selection {


### PR DESCRIPTION
Fixes #862.

I had proposed a different approach that would let us cache the implementers map for as long as the schema is immutable, so it could be reused for different query validations. That approach had an issue that made `Valid::assume_valid_ref` very, very subtle to use, so we are not doing that right now.

This is a less ideal version but it does solve the immediate problem. We had an `OperationValidationConfig` structure that contains contextual information about the current operation. This extends that idea to have an `ExecutableValidationContext` for the whole document, and "child" `OperationValidationContext`s for each operation.

The included benchmark goes from 200ms of validation time to 2ms.