### PR TITLE
apollo-compiler@1.0.0-beta.17

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2024-mm-dd
+# [1.0.0-beta.17](https://crates.io/crates/apollo-compiler/1.0.0-beta.17) - 2024-06-05
+
+## Fixes
+
+- **Fix validation performance bug - [goto-bus-stop] in [issue/862], [pull/863]**
+  Adds a cache in fragment spread validation, fixing a situation where validating a query
+  with many fragment spreads against a schema with many interfaces could take multiple
+  seconds to validate.
 
 ## Maintenance
 
@@ -28,7 +35,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   remove this translation.
 
 [goto-bus-stop]: https://github.com/goto-bus-stop
+[issue/862]: https://github.com/apollographql/apollo-rs/issues/862
 [pull/855]: https://github.com/apollographql/apollo-rs/pull/855
+[pull/863]: https://github.com/apollographql/apollo-rs/pull/863
 [ariadne]: https://github.com/zesterer/ariadne
 
 # [1.0.0-beta.16](https://crates.io/crates/apollo-compiler/1.0.0-beta.16) - 2024-04-12

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.16" # When bumping, also update README.md
+version = "1.0.0-beta.17" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.16"
+apollo-compiler = "=1.0.0-beta.17"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.16" }
+apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.17" }
 apollo-parser = { path = "../apollo-parser", version = "0.7.0" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 indexmap = "2.0.0"


### PR DESCRIPTION

## Fixes

- **Fix validation performance bug - [goto-bus-stop] in [issue/862], [pull/863]**
  Adds a cache in fragment spread validation, fixing a situation where validating a query
  with many fragment spreads against a schema with many interfaces could take multiple
  seconds to validate.

## Maintenance

- **Remove ariadne byte/char mapping - [goto-bus-stop] in [pull/855]**
  Generating JSON or CLI reports for apollo-compiler diagnostics used a translation layer
  between byte offsets and character offsets, which cost some computation and memory
  proportional to the size of the source text. The latest version of [ariadne] allows us to
  remove this translation.

[goto-bus-stop]: https://github.com/goto-bus-stop
[issue/862]: https://github.com/apollographql/apollo-rs/issues/862
[pull/855]: https://github.com/apollographql/apollo-rs/pull/855
[pull/863]: https://github.com/apollographql/apollo-rs/pull/863
[ariadne]: https://github.com/zesterer/ariadne