### PR TITLE
fix(compiler): fix error message for missing subselection

### DIFF
--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -192,6 +192,7 @@ pub(crate) enum DiagnosticData {
     #[error("interface, union and object types must have a subselection set")]
     MissingSubselection {
         coordinate: TypeAttributeCoordinate,
+        output_type: Name,
         describe_type: &'static str,
     },
     #[error(
@@ -598,11 +599,14 @@ impl DiagnosticData {
             }
             DiagnosticData::MissingSubselection {
                 coordinate,
+                output_type,
                 describe_type,
             } => {
                 report.with_label_opt(
                     main_location,
-                    format_args!("{coordinate} is {describe_type} and must select fields"),
+                    format_args!(
+                        "`{coordinate}` is {describe_type} `{output_type}` and must select fields"
+                    ),
                 );
             }
             DiagnosticData::InvalidFragmentTarget { name: _, ty } => {

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -106,7 +106,15 @@ pub(crate) fn validate_field(
             }
         }
 
-        if validate_leaf_field_selection(diagnostics, schema, field, &field_definition.ty).is_ok() {
+        if validate_leaf_field_selection(
+            diagnostics,
+            schema,
+            against_type,
+            field,
+            &field_definition.ty,
+        )
+        .is_ok()
+        {
             super::selection::validate_selection_set(
                 diagnostics,
                 document,
@@ -177,6 +185,7 @@ pub(crate) fn validate_field_definitions(
 pub(crate) fn validate_leaf_field_selection(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
+    parent_type: &ast::NamedType,
     field: &Node<executable::Field>,
     field_type: &ast::Type,
 ) -> Result<(), ()> {
@@ -202,9 +211,10 @@ pub(crate) fn validate_leaf_field_selection(
             field.location(),
             DiagnosticData::MissingSubselection {
                 coordinate: TypeAttributeCoordinate {
-                    ty: tname.clone(),
+                    ty: parent_type.clone(),
                     attribute: fname.clone(),
                 },
+                output_type: tname.clone(),
                 describe_type: type_def.describe(),
             },
         );

--- a/crates/apollo-compiler/test_data/diagnostics/0067_subselection_of_interface.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0067_subselection_of_interface.txt
@@ -3,41 +3,41 @@ Error: interface, union and object types must have a subselection set
    │
  2 │   pet1
    │   ──┬─  
-   │     ╰─── Pet.pet1 is an interface type and must select fields
+   │     ╰─── `Query.pet1` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0067_subselection_of_interface.graphql:3:3]
    │
  3 │   pet2
    │   ──┬─  
-   │     ╰─── Pet.pet2 is an interface type and must select fields
+   │     ╰─── `Query.pet2` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0067_subselection_of_interface.graphql:4:3]
    │
  4 │   pet3
    │   ──┬─  
-   │     ╰─── Pet.pet3 is an interface type and must select fields
+   │     ╰─── `Query.pet3` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0067_subselection_of_interface.graphql:5:3]
    │
  5 │   pet4
    │   ──┬─  
-   │     ╰─── Pet.pet4 is an interface type and must select fields
+   │     ╰─── `Query.pet4` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0067_subselection_of_interface.graphql:6:3]
    │
  6 │   pet5
    │   ──┬─  
-   │     ╰─── Pet.pet5 is an interface type and must select fields
+   │     ╰─── `Query.pet5` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0067_subselection_of_interface.graphql:7:3]
    │
  7 │   pet6
    │   ──┬─  
-   │     ╰─── Pet.pet6 is an interface type and must select fields
+   │     ╰─── `Query.pet6` is an interface type `Pet` and must select fields
 ───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0068_subselection_of_union.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0068_subselection_of_union.txt
@@ -3,41 +3,41 @@ Error: interface, union and object types must have a subselection set
    │
  2 │   pet1
    │   ──┬─  
-   │     ╰─── CatOrDog.pet1 is a union type and must select fields
+   │     ╰─── `Query.pet1` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0068_subselection_of_union.graphql:3:3]
    │
  3 │   pet2
    │   ──┬─  
-   │     ╰─── CatOrDog.pet2 is a union type and must select fields
+   │     ╰─── `Query.pet2` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0068_subselection_of_union.graphql:4:3]
    │
  4 │   pet3
    │   ──┬─  
-   │     ╰─── CatOrDog.pet3 is a union type and must select fields
+   │     ╰─── `Query.pet3` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0068_subselection_of_union.graphql:5:3]
    │
  5 │   pet4
    │   ──┬─  
-   │     ╰─── CatOrDog.pet4 is a union type and must select fields
+   │     ╰─── `Query.pet4` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0068_subselection_of_union.graphql:6:3]
    │
  6 │   pet5
    │   ──┬─  
-   │     ╰─── CatOrDog.pet5 is a union type and must select fields
+   │     ╰─── `Query.pet5` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0068_subselection_of_union.graphql:7:3]
    │
  7 │   pet6
    │   ──┬─  
-   │     ╰─── CatOrDog.pet6 is a union type and must select fields
+   │     ╰─── `Query.pet6` is a union type `CatOrDog` and must select fields
 ───╯
 

--- a/crates/apollo-compiler/test_data/diagnostics/0069_subselection_of_object.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0069_subselection_of_object.txt
@@ -3,41 +3,41 @@ Error: interface, union and object types must have a subselection set
    │
  2 │   pet1
    │   ──┬─  
-   │     ╰─── Pet.pet1 is an object type and must select fields
+   │     ╰─── `Query.pet1` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0069_subselection_of_object.graphql:3:3]
    │
  3 │   pet2
    │   ──┬─  
-   │     ╰─── Pet.pet2 is an object type and must select fields
+   │     ╰─── `Query.pet2` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0069_subselection_of_object.graphql:4:3]
    │
  4 │   pet3
    │   ──┬─  
-   │     ╰─── Pet.pet3 is an object type and must select fields
+   │     ╰─── `Query.pet3` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0069_subselection_of_object.graphql:5:3]
    │
  5 │   pet4
    │   ──┬─  
-   │     ╰─── Pet.pet4 is an object type and must select fields
+   │     ╰─── `Query.pet4` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0069_subselection_of_object.graphql:6:3]
    │
  6 │   pet5
    │   ──┬─  
-   │     ╰─── Pet.pet5 is an object type and must select fields
+   │     ╰─── `Query.pet5` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
    ╭─[0069_subselection_of_object.graphql:7:3]
    │
  7 │   pet6
    │   ──┬─  
-   │     ╰─── Pet.pet6 is an object type and must select fields
+   │     ╰─── `Query.pet6` is an object type `Pet` and must select fields
 ───╯
 

--- a/crates/apollo-compiler/tests/field_set.rs
+++ b/crates/apollo-compiler/tests/field_set.rs
@@ -51,7 +51,7 @@ fn test_invalid_field_sets() {
         "{errors}"
     );
     assert!(
-        errors.contains("Org.organization is an object type and must select fields"),
+        errors.contains("`Query.organization` is an object type `Org` and must select fields"),
         "{errors}"
     );
 


### PR DESCRIPTION
Given:

```graphql
type A { b: B }
type B { field: Int! }
```

and a selection against `A`:
```graphql
{ b }
```

The error message said `B.b` must have a subselection. But `B.b` does not exist. We confused the return type of the field `b` and its parent type.

Now you correctly get an error saying that `A.b` must have a subselection.