### PR TITLE
Remove `Hash` cache in `Node<T>`

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -19,13 +19,36 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 # [x.x.x] (unreleased) - 2024-mm-dd
 
+## BREAKING
+
+- **Feature REMOVED: `Hash` cache in `Node<T>` - [SimonSapin] in [pull/872].**
+  `Node<T>` is a reference-counted smart pointer that provides thread-safe shared ownership
+  for at `T` value together with an optional source location.
+  In previous beta version of apollo-compiler 1.0 it contained a cache in its `Hash` implementation:
+  the hash of the `T` value would be computed once and stored,
+  then `Hash for Node<T>` would hash that hash code.
+  That functionality is now removed, `Hash for Node<T>` simply forwards to `Hash for T`.
+  This reduces each `Node` heap allocation by 8 bytes, and reduces code complexity.
+
+  Now that apollo-compiler does not use [Salsa] anymore,
+  `Hash` is much less central than it used to be.
+  Many types stored in `Node<_>` don’t implement `Hash` at all
+  (because they contain an `IndexMap` which doesn’t either).
+
+  Programs that relied on this cache will still compile.
+  We still consider this change breaking
+  as they’ll need to build their own cache to maintain performance characteristics.
+
 ## Fixes
 
 - **Fix validation error message for missing subselections - [goto-bus-stop] in [pull/865]**
   It now reports the correct coordinate for the missing subselection.
 
 [goto-bus-stop]: https://github.com/goto-bus-stop
+[SimonSapin]: https://github.com/SimonSapin
 [pull/865]: https://github.com/apollographql/apollo-rs/pull/865
+[pull/872]: https://github.com/apollographql/apollo-rs/pull/872
+[Salsa]: https://crates.io/crates/salsa
 
 # [1.0.0-beta.17](https://crates.io/crates/apollo-compiler/1.0.0-beta.17) - 2024-06-05
 

--- a/crates/apollo-compiler/src/node.rs
+++ b/crates/apollo-compiler/src/node.rs
@@ -173,6 +173,12 @@ impl<T: Hash> Hash for Node<T> {
     }
 }
 
+impl<T> std::borrow::Borrow<T> for Node<T> {
+    fn borrow(&self) -> &T {
+        self
+    }
+}
+
 impl<T> AsRef<T> for Node<T> {
     fn as_ref(&self) -> &T {
         self


### PR DESCRIPTION
Hashing is much less important to apollo-compiler as it was when we were using Salsa. Many of the structs stored in `Node<_>` don’t even implement `Hash` since they contain `IndexMap` which doesn’t.

We lose: potential CPU time if repeatedly hashing nodes. `ast::Definition` implements `PartialEq` and `Hash` by traversing the whole subtree, which can be expensive. We gain: 8 fewer bytes in the heap allocation of every `Node`, and slightly less code complexity.