### PR TITLE
Prepare apollo-compiler@1.0.0-beta.18 release

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2024-mm-dd
+# [1.0.0-beta.18](https://crates.io/crates/apollo-compiler/1.0.0-beta.18) - 2024-06-27
 
 ## BREAKING
 

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.0.0-beta.17" # When bumping, also update README.md
+version = "1.0.0-beta.18" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -40,7 +40,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 # Just an example, change to the necessary package version.
 # Using an exact dependency is recommended for beta versions
 [dependencies]
-apollo-compiler = "=1.0.0-beta.17"
+apollo-compiler = "=1.0.0-beta.18"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.17" }
+apollo-compiler = { path = "../apollo-compiler", version = "=1.0.0-beta.18" }
 apollo-parser = { path = "../apollo-parser", version = "0.7.0" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 indexmap = "2.0.0"


### PR DESCRIPTION
# [1.0.0-beta.18](https://crates.io/crates/apollo-compiler/1.0.0-beta.18) - 2024-06-27

## BREAKING

- **`Name` representation change - [SimonSapin] in [pull/868].** The memory representation of GraphQL names is changed to use `Arc<str>` or `&'static str` internally, and provide corresponding cheap conversions. This may also help enable [string interning] in a future compiler version.
  * `Name` should now be imported from the crate root. The previous paths (`apollo_compiler::ast::Name`, `apollo_compiler::executable::Name`, and `apollo_compiler::schema::Name`) now emit a deprecation warning and will be removed in a later version.
  * `NodeStr` has been removed, with its functionality folded into `Name`
  * `ast::Value::String` now contains a plain `String` instead of `NodeStr`. `Value` itself is in a `Node<_>` that contains the same source span as `NodeStr` did.
  * Descriptions are now represented as `Option<Node<str>>` instead of `Option<NodeStr>`.

- **Feature REMOVED: `Hash` cache in `Node<T>` - [SimonSapin] in [pull/872].** `Node<T>` is a reference-counted smart pointer that provides thread-safe shared ownership for at `T` value together with an optional source location. In previous beta version of apollo-compiler 1.0 it contained a cache in its `Hash` implementation: the hash of the `T` value would be computed once and stored, then `Hash for Node<T>` would hash that hash code. That functionality is now removed, `Hash for Node<T>` simply forwards to `Hash for T`. This reduces each `Node` heap allocation by 8 bytes, and reduces code complexity.

  Now that apollo-compiler does not use [Salsa] anymore, `Hash` is much less central than it used to be. Many types stored in `Node<_>` don’t implement `Hash` at all (because they contain an `IndexMap` which doesn’t either).

  Programs that relied on this cache will still compile. We still consider this change breaking as they’ll need to build their own cache to maintain performance characteristics.

## Fixes

- **Fix validation error message for missing subselections - [goto-bus-stop] in [pull/865].** It now reports the correct coordinate for the missing subselection.

[goto-bus-stop]: https://github.com/goto-bus-stop
[SimonSapin]: https://github.com/SimonSapin
[pull/865]: https://github.com/apollographql/apollo-rs/pull/865
[pull/868]: https://github.com/apollographql/apollo-rs/pull/868
[pull/872]: https://github.com/apollographql/apollo-rs/pull/872
[string interning]: https://github.com/apollographql/apollo-rs/issues/385#issuecomment-2176436184
[Salsa]: https://crates.io/crates/salsa