### PR TITLE
fix(compiler): remove potential hash collision bug from `FieldsInSetCanMerge`

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -28,8 +28,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   * `apollo_compiler::executable::Name`
   These other paths emitted deprecation warnings in 1.0.0-beta.18 and are now removed.
 
+## Fixes
+
+- **Fix potential hash collision bug in validation - [goto-bus-stop] in [pull/878]**
+
 [SimonSapin]: https://github.com/SimonSapin
+[goto-bus-stop]: https://github.com/goto-bus-stop
 [pull/877]: https://github.com/apollographql/apollo-rs/pull/877
+[pull/878]: https://github.com/apollographql/apollo-rs/pull/878
 
 
 # [1.0.0-beta.18](https://crates.io/crates/apollo-compiler/1.0.0-beta.18) - 2024-06-27

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json_bytes = { version = "0.2.2", features = ["preserve_order"] }
 thiserror = "1.0.31"
 triomphe = "0.1.13"
+typed-arena = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.6", features = ["serde", "v4", "js"] }

--- a/crates/apollo-compiler/src/executable/validation.rs
+++ b/crates/apollo-compiler/src/executable/validation.rs
@@ -29,7 +29,8 @@ fn validate_with_schema(
     schema: &Schema,
     document: &ExecutableDocument,
 ) {
-    let mut fields_in_set_can_merge = FieldsInSetCanMerge::new(schema, document);
+    let alloc = typed_arena::Arena::new();
+    let mut fields_in_set_can_merge = FieldsInSetCanMerge::new(&alloc, schema, document);
     for operation in document.all_operations() {
         crate::validation::operation::validate_subscription(document, operation, errors);
         fields_in_set_can_merge.validate_operation(operation, errors);


### PR DESCRIPTION
In #816, to avoid cloning a big `Vec` for use as a hash key, I instead used the hash of the Vec as a key. I guess it's possible to get a hash collision that way and produce the wrong result.

Here I avoid the clone by allocating field selections into an arena allocator. The allocator outlives `FieldsInSetCanMerge` so we can pass around references to slices, and we can store the reference in the key and the value at the same time.

We already didn't deallocate the `Vec`s until the `FieldsInSetCanMerge` struct is dropped so the memory usage is the same.