### PR TITLE
fix(parser): add missing location information for some lexer errors

### DIFF
--- a/crates/apollo-parser/src/error.rs
+++ b/crates/apollo-parser/src/error.rs
@@ -69,15 +69,6 @@ pub struct Error {
 }
 
 impl Error {
-    /// Create a new instance of `Error`.
-    pub fn new<S: Into<String>>(message: S, data: String) -> Self {
-        Self {
-            message: message.into(),
-            data: ErrorData::Text(data),
-            index: 0,
-        }
-    }
-
     /// Create a new instance of `Error` with a `Location`.
     pub fn with_loc<S: Into<String>>(message: S, data: String, index: usize) -> Self {
         Self {

--- a/crates/apollo-parser/src/lexer/mod.rs
+++ b/crates/apollo-parser/src/lexer/mod.rs
@@ -264,7 +264,11 @@ impl<'a> Cursor<'a> {
                         return self.done(token);
                     }
                     c if !c.is_ascii_hexdigit() => {
-                        self.add_err(Error::new("invalid unicode escape sequence", c.to_string()));
+                        self.add_err(Error::with_loc(
+                            "invalid unicode escape sequence",
+                            c.to_string(),
+                            0,
+                        ));
                         state = State::StringLiteral;
 
                         continue;
@@ -283,11 +287,12 @@ impl<'a> Cursor<'a> {
                                 // changes both here and in `ast/node_ext.rs`
                                 let escape_sequence_start = hex_start - 2; // include "\u"
                                 let escape_sequence = &self.source[escape_sequence_start..hex_end];
-                                self.add_err(Error::new(
+                                self.add_err(Error::with_loc(
                                     "surrogate code point is invalid in unicode escape sequence \
                                      (paired surrogate not supported yet: \
                                      https://github.com/apollographql/apollo-rs/issues/657)",
                                     escape_sequence.to_owned(),
+                                    0,
                                 ));
                             }
                             continue;
@@ -302,7 +307,11 @@ impl<'a> Cursor<'a> {
                         return self.done(token);
                     }
                     curr if is_line_terminator(curr) => {
-                        self.add_err(Error::new("unexpected line terminator", "".to_string()));
+                        self.add_err(Error::with_loc(
+                            "unexpected line terminator",
+                            "".to_string(),
+                            0,
+                        ));
                     }
                     '\\' => {
                         state = State::StringLiteralBackslash;
@@ -338,7 +347,11 @@ impl<'a> Cursor<'a> {
                         state = State::StringLiteralEscapedUnicode(4);
                     }
                     _ => {
-                        self.add_err(Error::new("unexpected escaped character", c.to_string()));
+                        self.add_err(Error::with_loc(
+                            "unexpected escaped character",
+                            c.to_string(),
+                            0,
+                        ));
 
                         state = State::StringLiteral;
                     }

--- a/crates/apollo-parser/src/lexer/mod.rs
+++ b/crates/apollo-parser/src/lexer/mod.rs
@@ -255,11 +255,13 @@ impl<'a> Cursor<'a> {
                 },
                 State::StringLiteralEscapedUnicode(remaining) => match c {
                     '"' => {
-                        return Err(Error::with_loc(
+                        self.add_err(Error::with_loc(
                             "incomplete unicode escape sequence",
-                            self.current_str().to_string(),
+                            c.to_string(),
                             token.index,
                         ));
+                        token.data = self.current_str();
+                        return self.done(token);
                     }
                     c if !c.is_ascii_hexdigit() => {
                         self.add_err(Error::new("invalid unicode escape sequence", c.to_string()));

--- a/crates/apollo-parser/test_data/lexer/err/0014_plus_sign.txt
+++ b/crates/apollo-parser/test_data/lexer/err/0014_plus_sign.txt
@@ -2,5 +2,5 @@ ERROR@0:1 "Unexpected character \"+\"" +
 INT@1:2 "1"
 COMMA@2:3 ","
 WHITESPACE@3:4 " "
-ERROR@0:1 "Unexpected character \"+\"" +
+ERROR@4:5 "Unexpected character \"+\"" +
 EOF@5:5

--- a/crates/apollo-parser/test_data/lexer/err/0015_minus_sign.txt
+++ b/crates/apollo-parser/test_data/lexer/err/0015_minus_sign.txt
@@ -1,5 +1,5 @@
 INT@0:2 "-1"
 COMMA@2:3 ","
 WHITESPACE@3:4 " "
-ERROR@0:1 "Unexpected character \"-\"" -
+ERROR@4:5 "Unexpected character \"-\"" -
 EOF@5:5

--- a/crates/apollo-parser/test_data/lexer/err/0016_leading_zero.txt
+++ b/crates/apollo-parser/test_data/lexer/err/0016_leading_zero.txt
@@ -34,54 +34,54 @@ FLOAT@101:107 "-1e-04"
 WHITESPACE@107:108 "\n"
 COMMENT@108:117 "# Errors:"
 WHITESPACE@117:119 "\n "
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 00
+ERROR@119:121 "Numbers must not have non-significant leading zeroes" 00
 WHITESPACE@121:123 "  "
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 01
+ERROR@123:125 "Numbers must not have non-significant leading zeroes" 01
 WHITESPACE@125:127 "  "
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 04
+ERROR@127:129 "Numbers must not have non-significant leading zeroes" 04
 INT@129:130 "2"
 WHITESPACE@130:132 "  "
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 01
+ERROR@132:134 "Numbers must not have non-significant leading zeroes" 01
 ERROR@134:136 "Unterminated spread operator" .1
 WHITESPACE@136:138 "  "
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 00
+ERROR@138:140 "Numbers must not have non-significant leading zeroes" 00
 ERROR@140:142 "Unterminated spread operator" .2
 WHITESPACE@142:144 "  "
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 01
+ERROR@144:146 "Numbers must not have non-significant leading zeroes" 01
 NAME@146:149 "e04"
 WHITESPACE@149:151 "  "
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 01
+ERROR@151:153 "Numbers must not have non-significant leading zeroes" 01
 NAME@153:154 "e"
-ERROR@0:1 "Unexpected character \"+\"" +
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 04
+ERROR@154:155 "Unexpected character \"+\"" +
+ERROR@155:157 "Numbers must not have non-significant leading zeroes" 04
 WHITESPACE@157:159 "  "
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 01
+ERROR@159:161 "Numbers must not have non-significant leading zeroes" 01
 NAME@161:162 "e"
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -04
+ERROR@162:165 "Numbers must not have non-significant leading zeroes" -04
 WHITESPACE@165:166 "\n"
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -00
+ERROR@166:169 "Numbers must not have non-significant leading zeroes" -00
 WHITESPACE@169:170 " "
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -01
+ERROR@170:173 "Numbers must not have non-significant leading zeroes" -01
 WHITESPACE@173:174 " "
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -04
+ERROR@174:177 "Numbers must not have non-significant leading zeroes" -04
 INT@177:178 "2"
 WHITESPACE@178:179 " "
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -01
+ERROR@179:182 "Numbers must not have non-significant leading zeroes" -01
 ERROR@182:184 "Unterminated spread operator" .1
 WHITESPACE@184:185 " "
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -00
+ERROR@185:188 "Numbers must not have non-significant leading zeroes" -00
 ERROR@188:190 "Unterminated spread operator" .2
 WHITESPACE@190:191 " "
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -01
+ERROR@191:194 "Numbers must not have non-significant leading zeroes" -01
 NAME@194:197 "e04"
 WHITESPACE@197:198 " "
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -01
+ERROR@198:201 "Numbers must not have non-significant leading zeroes" -01
 NAME@201:202 "e"
-ERROR@0:1 "Unexpected character \"+\"" +
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 04
+ERROR@202:203 "Unexpected character \"+\"" +
+ERROR@203:205 "Numbers must not have non-significant leading zeroes" 04
 WHITESPACE@205:206 " "
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -01
+ERROR@206:209 "Numbers must not have non-significant leading zeroes" -01
 NAME@209:210 "e"
-ERROR@0:3 "Numbers must not have non-significant leading zeroes" -04
+ERROR@210:213 "Numbers must not have non-significant leading zeroes" -04
 WHITESPACE@213:214 "\n"
 EOF@214:214

--- a/crates/apollo-parser/test_data/lexer/err/0017_number_lookahead.txt
+++ b/crates/apollo-parser/test_data/lexer/err/0017_number_lookahead.txt
@@ -1,42 +1,42 @@
 COMMENT@0:88 "# Both IntValue and FloatValue are specified with [lookahead != {Digit, `.`, NameStart}]"
 WHITESPACE@88:89 "\n"
-ERROR@0:2 "Numbers must not have non-significant leading zeroes" 00
+ERROR@89:91 "Numbers must not have non-significant leading zeroes" 00
 WHITESPACE@91:92 "\n"
-ERROR@0:3 "Unexpected character `\n`, expected fractional digit" 2.
+ERROR@92:95 "Unexpected character `\n`, expected fractional digit" 2.
 
-ERROR@0:4 "Unexpected character `.` as float suffix" 2.2.
+ERROR@95:99 "Unexpected character `.` as float suffix" 2.2.
 WHITESPACE@99:100 "\n"
-ERROR@0:4 "Unexpected character `.` as float suffix" 2.2.
+ERROR@100:104 "Unexpected character `.` as float suffix" 2.2.
 INT@104:105 "2"
 WHITESPACE@105:106 "\n"
-ERROR@0:4 "Unexpected character `.` as float suffix" 2e2.
+ERROR@106:110 "Unexpected character `.` as float suffix" 2e2.
 WHITESPACE@110:111 "\n"
-ERROR@0:4 "Unexpected character `.` as float suffix" 2e2.
+ERROR@111:115 "Unexpected character `.` as float suffix" 2e2.
 INT@115:116 "2"
 WHITESPACE@116:117 "\n"
-ERROR@0:6 "Unexpected character `.` as float suffix" 2.2e2.
+ERROR@117:123 "Unexpected character `.` as float suffix" 2.2e2.
 WHITESPACE@123:124 "\n"
-ERROR@0:6 "Unexpected character `.` as float suffix" 2.2e2.
+ERROR@124:130 "Unexpected character `.` as float suffix" 2.2e2.
 INT@130:131 "2"
 WHITESPACE@131:132 "\n"
-ERROR@0:2 "Unexpected character `_` as integer suffix" 2_
+ERROR@132:134 "Unexpected character `_` as integer suffix" 2_
 WHITESPACE@134:135 "\n"
-ERROR@0:4 "Unexpected character `_` as float suffix" 2.2_
+ERROR@135:139 "Unexpected character `_` as float suffix" 2.2_
 WHITESPACE@139:140 "\n"
-ERROR@0:4 "Unexpected character `_` as float suffix" 2e2_
+ERROR@140:144 "Unexpected character `_` as float suffix" 2e2_
 WHITESPACE@144:145 "\n"
-ERROR@0:6 "Unexpected character `_` as float suffix" 2.2e2_
+ERROR@145:151 "Unexpected character `_` as float suffix" 2.2e2_
 WHITESPACE@151:152 "\n"
-ERROR@0:2 "Unexpected character `x` as integer suffix" 2x
+ERROR@152:154 "Unexpected character `x` as integer suffix" 2x
 WHITESPACE@154:155 "\n"
-ERROR@0:4 "Unexpected character `x` as float suffix" 2.2x
+ERROR@155:159 "Unexpected character `x` as float suffix" 2.2x
 WHITESPACE@159:160 "\n"
-ERROR@0:4 "Unexpected character `x` as float suffix" 2e2x
+ERROR@160:164 "Unexpected character `x` as float suffix" 2e2x
 WHITESPACE@164:165 "\n"
-ERROR@0:6 "Unexpected character `x` as float suffix" 2.2e2x
+ERROR@165:171 "Unexpected character `x` as float suffix" 2.2e2x
 WHITESPACE@171:172 "\n"
-ERROR@0:4 "Unexpected character `e` as float suffix" 2e2e
+ERROR@172:176 "Unexpected character `e` as float suffix" 2e2e
 WHITESPACE@176:177 "\n"
-ERROR@0:4 "Unexpected character `e` as float suffix" 2e2e
+ERROR@177:181 "Unexpected character `e` as float suffix" 2e2e
 INT@181:182 "2"
 EOF@182:182

--- a/crates/apollo-parser/test_data/lexer/err/0029_not_whitespace.txt
+++ b/crates/apollo-parser/test_data/lexer/err/0029_not_whitespace.txt
@@ -1,28 +1,28 @@
 WHITESPACE@0:3 "\u{feff}"
 COMMENT@3:11 "# U+FEFF"
 WHITESPACE@11:12 "\n"
-ERROR@0:1 "Unexpected character \"\u{b}\"" 
+ERROR@12:13 "Unexpected character \"\u{b}\"" 
 COMMENT@13:21 "# U+000B"
 WHITESPACE@21:22 "\n"
-ERROR@0:1 "Unexpected character \"\u{c}\"" 
+ERROR@22:23 "Unexpected character \"\u{c}\"" 
 COMMENT@23:31 "# U+000C"
 WHITESPACE@31:32 "\n"
-ERROR@0:2 "Unexpected character \"\u{85}\"" 
+ERROR@32:34 "Unexpected character \"\u{85}\"" 
 COMMENT@34:42 "# U+0085"
 WHITESPACE@42:43 "\n"
-ERROR@0:2 "Unexpected character \"\u{a0}\""  
+ERROR@43:45 "Unexpected character \"\u{a0}\""  
 COMMENT@45:53 "# U+00A0"
 WHITESPACE@53:54 "\n"
-ERROR@0:3 "Unexpected character \"\u{200e}\"" ‎
+ERROR@54:57 "Unexpected character \"\u{200e}\"" ‎
 COMMENT@57:65 "# U+200E"
 WHITESPACE@65:66 "\n"
-ERROR@0:3 "Unexpected character \"\u{200f}\"" ‏
+ERROR@66:69 "Unexpected character \"\u{200f}\"" ‏
 COMMENT@69:77 "# U+200F"
 WHITESPACE@77:78 "\n"
-ERROR@0:3 "Unexpected character \"\u{2028}\""  
+ERROR@78:81 "Unexpected character \"\u{2028}\""  
 COMMENT@81:89 "# U+2028"
 WHITESPACE@89:90 "\n"
-ERROR@0:3 "Unexpected character \"\u{2029}\""  
+ERROR@90:93 "Unexpected character \"\u{2029}\""  
 COMMENT@93:101 "# U+2029"
 WHITESPACE@101:102 "\n"
 EOF@102:102


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-rs/issues/731

I _think_ these are all the missing locations, but there are a few more places that do `Error::new` - as far as I can tell though these errors are getting location information filled in at a later stage (via `self.done()`).

I saw the original issue proposed removing `Error::new` completely - I'm happy to do it, but it would be a break, and I'm not sure what the policy on those is in this repo.