### PR TITLE
Fixes and additions to schema introspection, for comparative fuzzing

### DIFF
--- a/crates/apollo-compiler/src/built_in_types.graphql
+++ b/crates/apollo-compiler/src/built_in_types.graphql
@@ -1,12 +1,19 @@
+"A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."
 type __Schema {
   description: String
+  "A list of all types supported by this server."
   types: [__Type!]!
+  "The type that query operations will be rooted at."
   queryType: __Type!
+  "If this server supports mutation, the type that mutation operations will be rooted at."
   mutationType: __Type
+  "If this server support subscription, the type that subscription operations will be rooted at."
   subscriptionType: __Type
+  "A list of all directives supported by this server."
   directives: [__Directive!]!
 }
 
+"The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types."
 type __Type {
   kind: __TypeKind!
   name: String
@@ -27,17 +34,27 @@ type __Type {
   specifiedByURL: String
 }
 
+"An enum describing what kind of type a given `__Type` is."
 enum __TypeKind {
+  "Indicates this type is a scalar."
   SCALAR
+  "Indicates this type is an object. `fields` and `interfaces` are valid fields."
   OBJECT
+  "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields."
   INTERFACE
+  "Indicates this type is a union. `possibleTypes` is a valid field."
   UNION
+  "Indicates this type is an enum. `enumValues` is a valid field."
   ENUM
+  "Indicates this type is an input object. `inputFields` is a valid field."
   INPUT_OBJECT
+  "Indicates this type is a list. `ofType` is a valid field."
   LIST
+  "Indicates this type is a non-null. `ofType` is a valid field."
   NON_NULL
 }
 
+"Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type."
 type __Field {
   name: String!
   description: String
@@ -47,15 +64,18 @@ type __Field {
   deprecationReason: String
 }
 
+"Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value."
 type __InputValue {
   name: String!
   description: String
   type: __Type!
+  "A GraphQL-formatted string representing the default value for this input value."
   defaultValue: String
   isDeprecated: Boolean!
   deprecationReason: String
 }
 
+"One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string."
 type __EnumValue {
   name: String!
   description: String
@@ -63,6 +83,7 @@ type __EnumValue {
   deprecationReason: String
 }
 
+"A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor."
 type __Directive {
   name: String!
   description: String
@@ -71,25 +92,45 @@ type __Directive {
   isRepeatable: Boolean!
 }
 
+"A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies."
 enum __DirectiveLocation {
+  "Location adjacent to a query operation."
   QUERY
+  "Location adjacent to a mutation operation."
   MUTATION
+  "Location adjacent to a subscription operation."
   SUBSCRIPTION
+  "Location adjacent to a field."
   FIELD
+  "Location adjacent to a fragment definition."
   FRAGMENT_DEFINITION
+  "Location adjacent to a fragment spread."
   FRAGMENT_SPREAD
+  "Location adjacent to an inline fragment."
   INLINE_FRAGMENT
+  "Location adjacent to a variable definition."
   VARIABLE_DEFINITION
+  "Location adjacent to a schema definition."
   SCHEMA
+  "Location adjacent to a scalar definition."
   SCALAR
+  "Location adjacent to an object type definition."
   OBJECT
+  "Location adjacent to a field definition."
   FIELD_DEFINITION
+  "Location adjacent to an argument definition."
   ARGUMENT_DEFINITION
+  "Location adjacent to an interface definition."
   INTERFACE
+  "Location adjacent to a union definition."
   UNION
+  "Location adjacent to an enum definition."
   ENUM
+  "Location adjacent to an enum value definition."
   ENUM_VALUE
+  "Location adjacent to an input object type definition."
   INPUT_OBJECT
+  "Location adjacent to an input object field definition."
   INPUT_FIELD_DEFINITION
 }
 
@@ -108,36 +149,29 @@ directive @include(
 "Marks an element of a GraphQL schema as no longer supported."
 directive @deprecated(
   """
-  Explains why this element was deprecated, usually also including a
-  suggestion for how to access supported similar data. Formatted using
-  the Markdown syntax, as specified by
-  [CommonMark](https://commonmark.org/).
+  Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).
   """
   reason: String = "No longer supported"
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
-"Exposes a URL that specifies the behaviour of this scalar."
+"Exposes a URL that specifies the behavior of this scalar."
 directive @specifiedBy(
-    "The URL that specifies the behaviour of this scalar."
+    "The URL that specifies the behavior of this scalar."
     url: String!
 ) on SCALAR
 
 """
-The `Int` scalar type represents non-fractional signed whole numeric values. Int
-can represent values between -(2^31) and 2^31 - 1.
+The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.
 """
 scalar Int
 
 """
-The `Float` scalar type represents signed double-precision fractional values as
-specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
+The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
 """
 scalar Float
 
 """
-The `String` scalar type represents textual data, represented as UTF-8 character
-sequences. The String type is most often used by GraphQL to represent free-form
-human-readable text.
+The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
 """
 scalar String
 
@@ -145,10 +179,6 @@ scalar String
 scalar Boolean
 
 """
-The `ID` scalar type represents a unique identifier, often used to refetch an
-object or as key for a cache. The ID type appears in a JSON response as a
-String; however, it is not intended to be human-readable. When expected as an
-input type, any string (such as `\"4\"`) or integer (such as `4`) input value
-will be accepted as an ID.
+The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
 """
 scalar ID

--- a/crates/apollo-compiler/src/execution/introspection_execute.rs
+++ b/crates/apollo-compiler/src/execution/introspection_execute.rs
@@ -22,6 +22,7 @@ use std::sync::OnceLock;
 /// Obtained from [`SchemaIntrospectionSplit::split`].
 ///
 /// [schema introspection]: https://spec.graphql.org/October2021/#sec-Schema-Introspection
+#[derive(Clone, Debug)]
 pub struct SchemaIntrospectionQuery(pub(crate) Valid<ExecutableDocument>);
 
 impl std::ops::Deref for SchemaIntrospectionQuery {

--- a/crates/apollo-compiler/src/execution/introspection_execute.rs
+++ b/crates/apollo-compiler/src/execution/introspection_execute.rs
@@ -135,7 +135,7 @@ impl<'a> SchemaWithCache<'a> {
             .get_or_init(|| self.schema.implementers_map())
             .get(interface_name)
             .into_iter()
-            .flat_map(Implementers::iter)
+            .flat_map(|implementers| &implementers.objects)
     }
 }
 

--- a/crates/apollo-compiler/src/execution/introspection_execute.rs
+++ b/crates/apollo-compiler/src/execution/introspection_execute.rs
@@ -433,7 +433,7 @@ impl_resolver! {
     fn possibleTypes() { Ok(ResolvedValue::null()) }
     fn enumValues() { Ok(ResolvedValue::null()) }
     fn inputFields() { Ok(ResolvedValue::null()) }
-    fn specifiedBy() { Ok(ResolvedValue::null()) }
+    fn specifiedByURL() { Ok(ResolvedValue::null()) }
 }
 
 impl_resolver! {

--- a/crates/apollo-compiler/src/execution/introspection_execute.rs
+++ b/crates/apollo-compiler/src/execution/introspection_execute.rs
@@ -556,7 +556,9 @@ impl_resolver! {
     }
 
     fn defaultValue(&self_) {
-        Ok(ResolvedValue::leaf(self_.def.default_value.as_ref().map(|val| val.to_string())))
+        Ok(ResolvedValue::leaf(self_.def.default_value.as_ref().map(|val| {
+            val.serialize().no_indent().to_string()
+        })))
     }
 
     fn isDeprecated(&self_) {

--- a/crates/apollo-compiler/src/execution/introspection_execute.rs
+++ b/crates/apollo-compiler/src/execution/introspection_execute.rs
@@ -301,7 +301,7 @@ impl_resolver! {
             schema::ExtendedType::Enum(_) |
             schema::ExtendedType::InputObject(_) => return Ok(ResolvedValue::null()),
         };
-        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        let include_deprecated = include_deprecated(args);
         Ok(ResolvedValue::list(fields
             .values()
             .filter(move |def| {
@@ -353,7 +353,7 @@ impl_resolver! {
         let schema::ExtendedType::Enum(def) = self_.def else {
             return Ok(ResolvedValue::null());
         };
-        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        let include_deprecated = include_deprecated(args);
         Ok(ResolvedValue::list(def
             .values
             .values()
@@ -370,7 +370,7 @@ impl_resolver! {
         let schema::ExtendedType::InputObject(def) = self_.def else {
             return Ok(ResolvedValue::null());
         };
-        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        let include_deprecated = include_deprecated(args);
         Ok(ResolvedValue::list(def
             .fields
             .values()
@@ -450,7 +450,7 @@ impl_resolver! {
     }
 
     fn args(&self_, args) {
-        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        let include_deprecated = include_deprecated(args);
         Ok(ResolvedValue::list(self_
             .def
             .arguments
@@ -489,7 +489,7 @@ impl_resolver! {
     }
 
     fn args(&self_, args) {
-        let include_deprecated = args["includeDeprecated"].as_bool().unwrap();
+        let include_deprecated = include_deprecated(args);
         Ok(ResolvedValue::list(self_
             .def
             .arguments
@@ -565,5 +565,14 @@ impl_resolver! {
 
     fn deprecationReason(&self_) {
         Ok(deprecation_reason(self_.def.directives.get("deprecated")))
+    }
+}
+
+/// Although it should be non-null, the `includeDeprecated: Boolean = false` argument is nullable
+fn include_deprecated(args: &JsonMap) -> bool {
+    match &args["includeDeprecated"] {
+        serde_json_bytes::Value::Bool(b) => *b,
+        serde_json_bytes::Value::Null => false,
+        _ => unreachable!(),
     }
 }

--- a/crates/apollo-compiler/src/execution/introspection_split.rs
+++ b/crates/apollo-compiler/src/execution/introspection_split.rs
@@ -26,6 +26,7 @@ use indexmap::map::Entry;
 /// Result of [`split`][Self::split]ting [schema introspection] fields from an operation.
 ///
 /// [schema introspection]: https://spec.graphql.org/October2021/#sec-Schema-Introspection
+#[derive(Clone, Debug)]
 pub enum SchemaIntrospectionSplit {
     /// The selected operation does *not* use [schema introspection] fields.
     /// It should be executed unchanged.
@@ -61,6 +62,7 @@ pub enum SchemaIntrospectionSplit {
     },
 }
 
+#[derive(Debug)]
 pub enum SchemaIntrospectionError {
     SuspectedValidationBug(SuspectedValidationBug),
     Unsupported {

--- a/crates/apollo-compiler/src/execution/introspection_split.rs
+++ b/crates/apollo-compiler/src/execution/introspection_split.rs
@@ -239,13 +239,9 @@ fn make_single_operation_document(
         fragments,
     };
     new_document.operations.insert(new_operation);
-    if cfg!(debug_assertions) {
-        new_document
-            .validate(schema)
-            .expect("filtering a valid document should result in a valid document")
-    } else {
-        Valid::assume_valid(new_document)
-    }
+    new_document
+        .validate(schema)
+        .expect("filtering a valid document should result in a valid document")
 }
 
 fn get_fragment<'doc>(

--- a/crates/apollo-compiler/src/execution/resolver.rs
+++ b/crates/apollo-compiler/src/execution/resolver.rs
@@ -79,7 +79,10 @@ macro_rules! impl_resolver {
                         },
                     )*
                     _ => Err(crate::execution::resolver::ResolverError {
-                        message: format!("unexpected field name: {field_name}")
+                        message: format!(
+                            "unexpected field name: {field_name} in type {}",
+                            self.type_name()
+                        )
                     }),
                 }
             }

--- a/crates/apollo-compiler/src/execution/response.rs
+++ b/crates/apollo-compiler/src/execution/response.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 /// A [GraphQL response](https://spec.graphql.org/October2021/#sec-Response-Format)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Response {
     // <https://spec.graphql.org/October2021/#note-6f005> suggests serializing this first
@@ -26,7 +26,7 @@ pub struct Response {
 }
 
 /// The `data` entry of a [`Response`]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(from = "Option<JsonMap>")]
 pub enum ResponseData {
     /// Execution returned an object.
@@ -143,7 +143,7 @@ impl GraphQLError {
 
 impl ResponseData {
     /// For serde `skip_serializing_if`
-    fn is_absent(&self) -> bool {
+    pub fn is_absent(&self) -> bool {
         matches!(self, Self::Absent)
     }
 

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -360,6 +360,7 @@ impl DiagnosticData {
                 ExecutableBuildError::ConflictingFieldName(_) => "ConflictingFieldName",
                 ExecutableBuildError::ConflictingFieldArgument(_) => "ConflictingFieldArgument",
             }),
+            Details::RecursionLimitError => Some("RecursionLimitError"),
             _ => None,
         }
     }

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
@@ -5,11 +5,11 @@ Error: skip directive is not supported for VARIABLE_DEFINITION location
      │                              ───────┬───────  
      │                                     ╰───────── directive cannot be used on VARIABLE_DEFINITION
      │
-     ├─[built_in.graphql:96:1]
+     ├─[built_in.graphql:137:1]
      │
-  96 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
+ 137 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
      ┆ ┆   
- 100 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+ 141 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
      │ │                                                    
      │ ╰──────────────────────────────────────────────────── directive defined here
      │     
@@ -22,11 +22,11 @@ Error: skip directive is not supported for QUERY location
      │                                               ────────┬───────  
      │                                                       ╰───────── directive cannot be used on QUERY
      │
-     ├─[built_in.graphql:96:1]
+     ├─[built_in.graphql:137:1]
      │
-  96 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
+ 137 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
      ┆ ┆   
- 100 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+ 141 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
      │ │                                                    
      │ ╰──────────────────────────────────────────────────── directive defined here
      │     
@@ -39,11 +39,11 @@ Error: deprecated directive is not supported for FIELD location
      │                             ─────┬─────  
      │                                  ╰─────── directive cannot be used on FIELD
      │
-     ├─[built_in.graphql:108:1]
+     ├─[built_in.graphql:149:1]
      │
- 108 │ ╭─▶ "Marks an element of a GraphQL schema as no longer supported."
+ 149 │ ╭─▶ "Marks an element of a GraphQL schema as no longer supported."
      ┆ ┆   
- 117 │ ├─▶ ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+ 155 │ ├─▶ ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
      │ │                                                                                       
      │ ╰─────────────────────────────────────────────────────────────────────────────────────── directive defined here
      │     
@@ -108,11 +108,11 @@ Error: skip directive is not supported for MUTATION location
      │                     ───────┬───────  
      │                            ╰───────── directive cannot be used on MUTATION
      │
-     ├─[built_in.graphql:96:1]
+     ├─[built_in.graphql:137:1]
      │
-  96 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
+ 137 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
      ┆ ┆   
- 100 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+ 141 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
      │ │                                                    
      │ ╰──────────────────────────────────────────────────── directive defined here
      │     
@@ -125,11 +125,11 @@ Error: skip directive is not supported for INTERFACE location
      │               ───────┬───────  
      │                      ╰───────── directive cannot be used on INTERFACE
      │
-     ├─[built_in.graphql:96:1]
+     ├─[built_in.graphql:137:1]
      │
-  96 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
+ 137 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
      ┆ ┆   
- 100 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+ 141 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
      │ │                                                    
      │ ╰──────────────────────────────────────────────────── directive defined here
      │     
@@ -155,11 +155,11 @@ Error: include directive is not supported for INPUT_OBJECT location
      │               ─────────┬────────  
      │                        ╰────────── directive cannot be used on INPUT_OBJECT
      │
-     ├─[built_in.graphql:102:1]
+     ├─[built_in.graphql:143:1]
      │
- 102 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
+ 143 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
      ┆ ┆   
- 106 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+ 147 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
      │ │                                                    
      │ ╰──────────────────────────────────────────────────── directive defined here
      │     
@@ -172,11 +172,11 @@ Error: include directive is not supported for INPUT_FIELD_DEFINITION location
      │                 ─────────┬────────  
      │                          ╰────────── directive cannot be used on INPUT_FIELD_DEFINITION
      │
-     ├─[built_in.graphql:102:1]
+     ├─[built_in.graphql:143:1]
      │
- 102 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
+ 143 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
      ┆ ┆   
- 106 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+ 147 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
      │ │                                                    
      │ ╰──────────────────────────────────────────────────── directive defined here
      │     
@@ -228,11 +228,11 @@ Error: deprecated directive is not supported for OBJECT location
      │            ─────┬─────  
      │                 ╰─────── directive cannot be used on OBJECT
      │
-     ├─[built_in.graphql:108:1]
+     ├─[built_in.graphql:149:1]
      │
- 108 │ ╭─▶ "Marks an element of a GraphQL schema as no longer supported."
+ 149 │ ╭─▶ "Marks an element of a GraphQL schema as no longer supported."
      ┆ ┆   
- 117 │ ├─▶ ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+ 155 │ ├─▶ ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
      │ │                                                                                       
      │ ╰─────────────────────────────────────────────────────────────────────────────────────── directive defined here
      │     
@@ -245,11 +245,11 @@ Error: specifiedBy directive is not supported for ARGUMENT_DEFINITION location
      │                           ────────────────────────────┬───────────────────────────  
      │                                                       ╰───────────────────────────── directive cannot be used on ARGUMENT_DEFINITION
      │
-     ├─[built_in.graphql:119:1]
+     ├─[built_in.graphql:157:1]
      │
- 119 │ ╭─▶ "Exposes a URL that specifies the behaviour of this scalar."
+ 157 │ ╭─▶ "Exposes a URL that specifies the behavior of this scalar."
      ┆ ┆   
- 123 │ ├─▶ ) on SCALAR
+ 161 │ ├─▶ ) on SCALAR
      │ │                 
      │ ╰───────────────── directive defined here
      │     
@@ -262,11 +262,11 @@ Error: include directive is not supported for SCHEMA location
      │        ─────────┬────────  
      │                 ╰────────── directive cannot be used on SCHEMA
      │
-     ├─[built_in.graphql:102:1]
+     ├─[built_in.graphql:143:1]
      │
- 102 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
+ 143 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
      ┆ ┆   
- 106 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+ 147 │ ├─▶ ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
      │ │                                                    
      │ ╰──────────────────────────────────────────────────── directive defined here
      │     

--- a/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
@@ -32,19 +32,19 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provid
     │                     ╰────────────────── missing value for argument `req1`
 ────╯
 Error: the required argument `@skip(if:)` is not provided
-    ╭─[0054_argument_not_provided.graphql:21:9]
-    │
- 21 │   basic @skip @include(wrong: false) {
-    │         ──┬──  
-    │           ╰──── missing value for argument `if`
-    │
-    ├─[built_in.graphql:98:3]
-    │
- 98 │ ╭─▶   "Skipped when true."
- 99 │ ├─▶   if: Boolean!
-    │ │                    
-    │ ╰──────────────────── argument defined here
-────╯
+     ╭─[0054_argument_not_provided.graphql:21:9]
+     │
+  21 │   basic @skip @include(wrong: false) {
+     │         ──┬──  
+     │           ╰──── missing value for argument `if`
+     │
+     ├─[built_in.graphql:139:3]
+     │
+ 139 │ ╭─▶   "Skipped when true."
+ 140 │ ├─▶   if: Boolean!
+     │ │                    
+     │ ╰──────────────────── argument defined here
+─────╯
 Error: the required argument `@include(if:)` is not provided
      ╭─[0054_argument_not_provided.graphql:21:15]
      │
@@ -52,10 +52,10 @@ Error: the required argument `@include(if:)` is not provided
      │               ───────────┬──────────  
      │                          ╰──────────── missing value for argument `if`
      │
-     ├─[built_in.graphql:104:3]
+     ├─[built_in.graphql:145:3]
      │
- 104 │ ╭─▶   "Included when true."
- 105 │ ├─▶   if: Boolean!
+ 145 │ ╭─▶   "Included when true."
+ 146 │ ├─▶   if: Boolean!
      │ │                    
      │ ╰──────────────────── argument defined here
 ─────╯

--- a/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
@@ -25,9 +25,9 @@ Error: type `Int` does not have a field `name`
      │       ──┬─  
      │         ╰─── field `name` selected here
      │
-     ├─[built_in.graphql:129:8]
+     ├─[built_in.graphql:166:8]
      │
- 129 │ scalar Int
+ 166 │ scalar Int
      │        ─┬─  
      │         ╰─── type `Int` defined here
      │ 
@@ -51,9 +51,9 @@ Error: type `Int` does not have a field `name`
      │   ──┬─  
      │     ╰─── field `name` selected here
      │
-     ├─[built_in.graphql:129:8]
+     ├─[built_in.graphql:166:8]
      │
- 129 │ scalar Int
+ 166 │ scalar Int
      │        ─┬─  
      │         ╰─── type `Int` defined here
      │ 
@@ -77,9 +77,9 @@ Error: type `Int` does not have a field `name`
      │     ──┬─  
      │       ╰─── field `name` selected here
      │
-     ├─[built_in.graphql:129:8]
+     ├─[built_in.graphql:166:8]
      │
- 129 │ scalar Int
+ 166 │ scalar Int
      │        ─┬─  
      │         ╰─── type `Int` defined here
      │ 

--- a/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
@@ -425,9 +425,9 @@ Error: expected value of type Boolean!, found a string
      │                    ──┬──  
      │                      ╰──── provided value is a string
      │
-     ├─[built_in.graphql:105:7]
+     ├─[built_in.graphql:146:7]
      │
- 105 │   if: Boolean!
+ 146 │   if: Boolean!
      │       ────┬───  
      │           ╰───── expected type declared here as Boolean!
 ─────╯
@@ -438,9 +438,9 @@ Error: expected value of type Boolean!, found an enum
      │                    ──┬─  
      │                      ╰─── provided value is an enum
      │
-     ├─[built_in.graphql:99:7]
+     ├─[built_in.graphql:140:7]
      │
-  99 │   if: Boolean!
+ 140 │   if: Boolean!
      │       ────┬───  
      │           ╰───── expected type declared here as Boolean!
 ─────╯

--- a/crates/apollo-compiler/test_data/introspection/response_full.json
+++ b/crates/apollo-compiler/test_data/introspection/response_full.json
@@ -10,7 +10,7 @@
         {
           "kind": "OBJECT",
           "name": "__Schema",
-          "description": null,
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
           "fields": [
             {
               "name": "description",
@@ -26,7 +26,7 @@
             },
             {
               "name": "types",
-              "description": null,
+              "description": "A list of all types supported by this server.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -50,7 +50,7 @@
             },
             {
               "name": "queryType",
-              "description": null,
+              "description": "The type that query operations will be rooted at.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -66,7 +66,7 @@
             },
             {
               "name": "mutationType",
-              "description": null,
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
@@ -78,7 +78,7 @@
             },
             {
               "name": "subscriptionType",
-              "description": null,
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
@@ -90,7 +90,7 @@
             },
             {
               "name": "directives",
-              "description": null,
+              "description": "A list of all directives supported by this server.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -121,7 +121,7 @@
         {
           "kind": "OBJECT",
           "name": "__Type",
-          "description": null,
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
           "fields": [
             {
               "name": "kind",
@@ -335,56 +335,56 @@
         {
           "kind": "ENUM",
           "name": "__TypeKind",
-          "description": null,
+          "description": "An enum describing what kind of type a given `__Type` is.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
               "name": "SCALAR",
-              "description": null,
+              "description": "Indicates this type is a scalar.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "OBJECT",
-              "description": null,
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INTERFACE",
-              "description": null,
+              "description": "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UNION",
-              "description": null,
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ENUM",
-              "description": null,
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INPUT_OBJECT",
-              "description": null,
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "LIST",
-              "description": null,
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "NON_NULL",
-              "description": null,
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -394,7 +394,7 @@
         {
           "kind": "OBJECT",
           "name": "__Field",
-          "description": null,
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
           "fields": [
             {
               "name": "name",
@@ -514,7 +514,7 @@
         {
           "kind": "OBJECT",
           "name": "__InputValue",
-          "description": null,
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
           "fields": [
             {
               "name": "name",
@@ -562,7 +562,7 @@
             },
             {
               "name": "defaultValue",
-              "description": null,
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -609,7 +609,7 @@
         {
           "kind": "OBJECT",
           "name": "__EnumValue",
-          "description": null,
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
           "fields": [
             {
               "name": "name",
@@ -676,7 +676,7 @@
         {
           "kind": "OBJECT",
           "name": "__Directive",
-          "description": null,
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
           "fields": [
             {
               "name": "name",
@@ -792,122 +792,122 @@
         {
           "kind": "ENUM",
           "name": "__DirectiveLocation",
-          "description": null,
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
               "name": "QUERY",
-              "description": null,
+              "description": "Location adjacent to a query operation.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "MUTATION",
-              "description": null,
+              "description": "Location adjacent to a mutation operation.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SUBSCRIPTION",
-              "description": null,
+              "description": "Location adjacent to a subscription operation.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "FIELD",
-              "description": null,
+              "description": "Location adjacent to a field.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "FRAGMENT_DEFINITION",
-              "description": null,
+              "description": "Location adjacent to a fragment definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "FRAGMENT_SPREAD",
-              "description": null,
+              "description": "Location adjacent to a fragment spread.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INLINE_FRAGMENT",
-              "description": null,
+              "description": "Location adjacent to an inline fragment.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "VARIABLE_DEFINITION",
-              "description": null,
+              "description": "Location adjacent to a variable definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SCHEMA",
-              "description": null,
+              "description": "Location adjacent to a schema definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "SCALAR",
-              "description": null,
+              "description": "Location adjacent to a scalar definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "OBJECT",
-              "description": null,
+              "description": "Location adjacent to an object type definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "FIELD_DEFINITION",
-              "description": null,
+              "description": "Location adjacent to a field definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ARGUMENT_DEFINITION",
-              "description": null,
+              "description": "Location adjacent to an argument definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INTERFACE",
-              "description": null,
+              "description": "Location adjacent to an interface definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UNION",
-              "description": null,
+              "description": "Location adjacent to a union definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ENUM",
-              "description": null,
+              "description": "Location adjacent to an enum definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ENUM_VALUE",
-              "description": null,
+              "description": "Location adjacent to an enum value definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INPUT_OBJECT",
-              "description": null,
+              "description": "Location adjacent to an input object type definition.",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "INPUT_FIELD_DEFINITION",
-              "description": null,
+              "description": "Location adjacent to an input object field definition.",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -917,7 +917,7 @@
         {
           "kind": "SCALAR",
           "name": "Int",
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int\ncan represent values between -(2^31) and 2^31 - 1.",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -927,7 +927,7 @@
         {
           "kind": "SCALAR",
           "name": "Float",
-          "description": "The `Float` scalar type represents signed double-precision fractional values as\nspecified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -937,7 +937,7 @@
         {
           "kind": "SCALAR",
           "name": "String",
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character\nsequences. The String type is most often used by GraphQL to represent free-form\nhuman-readable text.",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -957,7 +957,7 @@
         {
           "kind": "SCALAR",
           "name": "ID",
-          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an\nobject or as key for a cache. The ID type appears in a JSON response as a\nString; however, it is not intended to be human-readable. When expected as an\ninput type, any string (such as `\\\"4\\\"`) or integer (such as `4`) input value\nwill be accepted as an ID.",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -1136,7 +1136,7 @@
           "args": [
             {
               "name": "reason",
-              "description": "Explains why this element was deprecated, usually also including a\nsuggestion for how to access supported similar data. Formatted using\nthe Markdown syntax, as specified by\n[CommonMark](https://commonmark.org/).",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1150,14 +1150,14 @@
         },
         {
           "name": "specifiedBy",
-          "description": "Exposes a URL that specifies the behaviour of this scalar.",
+          "description": "Exposes a URL that specifies the behavior of this scalar.",
           "locations": [
             "SCALAR"
           ],
           "args": [
             {
               "name": "url",
-              "description": "The URL that specifies the behaviour of this scalar.",
+              "description": "The URL that specifies the behavior of this scalar.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
+++ b/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
@@ -109,8 +109,10 @@ ExecutableDocument {
                                     selections: [
                                         Field(
                                             44..62 @14 Field {
-                                                definition: 60..78 @1 FieldDefinition {
-                                                    description: None,
+                                                definition: 314..386 @1 FieldDefinition {
+                                                    description: Some(
+                                                        314..365 @1 "The type that query operations will be rooted at.",
+                                                    ),
                                                     name: "queryType",
                                                     arguments: [],
                                                     ty: NonNullNamed(
@@ -127,7 +129,7 @@ ExecutableDocument {
                                                     selections: [
                                                         Field(
                                                             56..60 @14 Field {
-                                                                definition: 198..210 @1 FieldDefinition {
+                                                                definition: 1300..1312 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "name",
                                                                     arguments: [],
@@ -152,8 +154,10 @@ ExecutableDocument {
                                         ),
                                         Field(
                                             67..88 @14 Field {
-                                                definition: 81..101 @1 FieldDefinition {
-                                                    description: None,
+                                                definition: 389..500 @1 FieldDefinition {
+                                                    description: Some(
+                                                        389..477 @1 "If this server supports mutation, the type that mutation operations will be rooted at.",
+                                                    ),
                                                     name: "mutationType",
                                                     arguments: [],
                                                     ty: Named(
@@ -170,7 +174,7 @@ ExecutableDocument {
                                                     selections: [
                                                         Field(
                                                             82..86 @14 Field {
-                                                                definition: 198..210 @1 FieldDefinition {
+                                                                definition: 1300..1312 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "name",
                                                                     arguments: [],
@@ -195,8 +199,10 @@ ExecutableDocument {
                                         ),
                                         Field(
                                             93..118 @14 Field {
-                                                definition: 104..128 @1 FieldDefinition {
-                                                    description: None,
+                                                definition: 503..625 @1 FieldDefinition {
+                                                    description: Some(
+                                                        503..598 @1 "If this server support subscription, the type that subscription operations will be rooted at.",
+                                                    ),
                                                     name: "subscriptionType",
                                                     arguments: [],
                                                     ty: Named(
@@ -213,7 +219,7 @@ ExecutableDocument {
                                                     selections: [
                                                         Field(
                                                             112..116 @14 Field {
-                                                                definition: 198..210 @1 FieldDefinition {
+                                                                definition: 1300..1312 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "name",
                                                                     arguments: [],
@@ -238,8 +244,10 @@ ExecutableDocument {
                                         ),
                                         Field(
                                             123..154 @14 Field {
-                                                definition: 40..57 @1 FieldDefinition {
-                                                    description: None,
+                                                definition: 244..311 @1 FieldDefinition {
+                                                    description: Some(
+                                                        244..291 @1 "A list of all types supported by this server.",
+                                                    ),
                                                     name: "types",
                                                     arguments: [],
                                                     ty: NonNullList(
@@ -268,8 +276,10 @@ ExecutableDocument {
                                         ),
                                         Field(
                                             159..265 @14 Field {
-                                                definition: 131..158 @1 FieldDefinition {
-                                                    description: None,
+                                                definition: 628..710 @1 FieldDefinition {
+                                                    description: Some(
+                                                        628..680 @1 "A list of all directives supported by this server.",
+                                                    ),
                                                     name: "directives",
                                                     arguments: [],
                                                     ty: NonNullList(
@@ -288,7 +298,7 @@ ExecutableDocument {
                                                     selections: [
                                                         Field(
                                                             178..182 @14 Field {
-                                                                definition: 1495..1508 @1 FieldDefinition {
+                                                                definition: 4183..4196 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "name",
                                                                     arguments: [],
@@ -309,7 +319,7 @@ ExecutableDocument {
                                                         ),
                                                         Field(
                                                             189..200 @14 Field {
-                                                                definition: 1511..1530 @1 FieldDefinition {
+                                                                definition: 4199..4218 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "description",
                                                                     arguments: [],
@@ -330,7 +340,7 @@ ExecutableDocument {
                                                         ),
                                                         Field(
                                                             207..216 @14 Field {
-                                                                definition: 1533..1567 @1 FieldDefinition {
+                                                                definition: 4221..4255 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "locations",
                                                                     arguments: [],
@@ -353,18 +363,18 @@ ExecutableDocument {
                                                         ),
                                                         Field(
                                                             223..259 @14 Field {
-                                                                definition: 1570..1628 @1 FieldDefinition {
+                                                                definition: 4258..4316 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "args",
                                                                     arguments: [
-                                                                        1575..1609 @1 InputValueDefinition {
+                                                                        4263..4297 @1 InputValueDefinition {
                                                                             description: None,
                                                                             name: "includeDeprecated",
-                                                                            ty: 1594..1601 @1 Named(
+                                                                            ty: 4282..4289 @1 Named(
                                                                                 "Boolean",
                                                                             ),
                                                                             default_value: Some(
-                                                                                1604..1609 @1 Boolean(
+                                                                                4292..4297 @1 Boolean(
                                                                                     false,
                                                                                 ),
                                                                             ),
@@ -417,7 +427,7 @@ ExecutableDocument {
                 selections: [
                     Field(
                         304..308 @14 Field {
-                            definition: 178..195 @1 FieldDefinition {
+                            definition: 1280..1297 @1 FieldDefinition {
                                 description: None,
                                 name: "kind",
                                 arguments: [],
@@ -438,7 +448,7 @@ ExecutableDocument {
                     ),
                     Field(
                         311..315 @14 Field {
-                            definition: 198..210 @1 FieldDefinition {
+                            definition: 1300..1312 @1 FieldDefinition {
                                 description: None,
                                 name: "name",
                                 arguments: [],
@@ -459,7 +469,7 @@ ExecutableDocument {
                     ),
                     Field(
                         318..329 @14 Field {
-                            definition: 213..232 @1 FieldDefinition {
+                            definition: 1315..1334 @1 FieldDefinition {
                                 description: None,
                                 name: "description",
                                 arguments: [],
@@ -480,18 +490,18 @@ ExecutableDocument {
                     ),
                     Field(
                         332..504 @14 Field {
-                            definition: 298..352 @1 FieldDefinition {
+                            definition: 1400..1454 @1 FieldDefinition {
                                 description: None,
                                 name: "fields",
                                 arguments: [
-                                    305..339 @1 InputValueDefinition {
+                                    1407..1441 @1 InputValueDefinition {
                                         description: None,
                                         name: "includeDeprecated",
-                                        ty: 324..331 @1 Named(
+                                        ty: 1426..1433 @1 Named(
                                             "Boolean",
                                         ),
                                         default_value: Some(
-                                            334..339 @1 Boolean(
+                                            1436..1441 @1 Boolean(
                                                 false,
                                             ),
                                         ),
@@ -521,7 +531,7 @@ ExecutableDocument {
                                 selections: [
                                     Field(
                                         370..374 @14 Field {
-                                            definition: 1039..1052 @1 FieldDefinition {
+                                            definition: 2906..2919 @1 FieldDefinition {
                                                 description: None,
                                                 name: "name",
                                                 arguments: [],
@@ -542,7 +552,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         379..390 @14 Field {
-                                            definition: 1055..1074 @1 FieldDefinition {
+                                            definition: 2922..2941 @1 FieldDefinition {
                                                 description: None,
                                                 name: "description",
                                                 arguments: [],
@@ -563,18 +573,18 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         395..427 @14 Field {
-                                            definition: 1077..1135 @1 FieldDefinition {
+                                            definition: 2944..3002 @1 FieldDefinition {
                                                 description: None,
                                                 name: "args",
                                                 arguments: [
-                                                    1082..1116 @1 InputValueDefinition {
+                                                    2949..2983 @1 InputValueDefinition {
                                                         description: None,
                                                         name: "includeDeprecated",
-                                                        ty: 1101..1108 @1 Named(
+                                                        ty: 2968..2975 @1 Named(
                                                             "Boolean",
                                                         ),
                                                         default_value: Some(
-                                                            1111..1116 @1 Boolean(
+                                                            2978..2983 @1 Boolean(
                                                                 false,
                                                             ),
                                                         ),
@@ -607,7 +617,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         432..461 @14 Field {
-                                            definition: 1138..1151 @1 FieldDefinition {
+                                            definition: 3005..3018 @1 FieldDefinition {
                                                 description: None,
                                                 name: "type",
                                                 arguments: [],
@@ -635,7 +645,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         466..478 @14 Field {
-                                            definition: 1154..1176 @1 FieldDefinition {
+                                            definition: 3021..3043 @1 FieldDefinition {
                                                 description: None,
                                                 name: "isDeprecated",
                                                 arguments: [],
@@ -656,7 +666,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         483..500 @14 Field {
-                                            definition: 1179..1204 @1 FieldDefinition {
+                                            definition: 3046..3071 @1 FieldDefinition {
                                                 description: None,
                                                 name: "deprecationReason",
                                                 arguments: [],
@@ -681,18 +691,18 @@ ExecutableDocument {
                     ),
                     Field(
                         507..542 @14 Field {
-                            definition: 698..762 @1 FieldDefinition {
+                            definition: 1800..1864 @1 FieldDefinition {
                                 description: None,
                                 name: "inputFields",
                                 arguments: [
-                                    710..744 @1 InputValueDefinition {
+                                    1812..1846 @1 InputValueDefinition {
                                         description: None,
                                         name: "includeDeprecated",
-                                        ty: 729..736 @1 Named(
+                                        ty: 1831..1838 @1 Named(
                                             "Boolean",
                                         ),
                                         default_value: Some(
-                                            739..744 @1 Boolean(
+                                            1841..1846 @1 Boolean(
                                                 false,
                                             ),
                                         ),
@@ -725,7 +735,7 @@ ExecutableDocument {
                     ),
                     Field(
                         545..576 @14 Field {
-                            definition: 418..439 @1 FieldDefinition {
+                            definition: 1520..1541 @1 FieldDefinition {
                                 description: None,
                                 name: "interfaces",
                                 arguments: [],
@@ -755,18 +765,18 @@ ExecutableDocument {
                     ),
                     Field(
                         579..684 @14 Field {
-                            definition: 578..640 @1 FieldDefinition {
+                            definition: 1680..1742 @1 FieldDefinition {
                                 description: None,
                                 name: "enumValues",
                                 arguments: [
-                                    589..623 @1 InputValueDefinition {
+                                    1691..1725 @1 InputValueDefinition {
                                         description: None,
                                         name: "includeDeprecated",
-                                        ty: 608..615 @1 Named(
+                                        ty: 1710..1717 @1 Named(
                                             "Boolean",
                                         ),
                                         default_value: Some(
-                                            618..623 @1 Boolean(
+                                            1720..1725 @1 Boolean(
                                                 false,
                                             ),
                                         ),
@@ -796,7 +806,7 @@ ExecutableDocument {
                                 selections: [
                                     Field(
                                         621..625 @14 Field {
-                                            definition: 1382..1395 @1 FieldDefinition {
+                                            definition: 3692..3705 @1 FieldDefinition {
                                                 description: None,
                                                 name: "name",
                                                 arguments: [],
@@ -817,7 +827,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         630..641 @14 Field {
-                                            definition: 1398..1417 @1 FieldDefinition {
+                                            definition: 3708..3727 @1 FieldDefinition {
                                                 description: None,
                                                 name: "description",
                                                 arguments: [],
@@ -838,7 +848,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         646..658 @14 Field {
-                                            definition: 1420..1442 @1 FieldDefinition {
+                                            definition: 3730..3752 @1 FieldDefinition {
                                                 description: None,
                                                 name: "isDeprecated",
                                                 arguments: [],
@@ -859,7 +869,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         663..680 @14 Field {
-                                            definition: 1445..1470 @1 FieldDefinition {
+                                            definition: 3755..3780 @1 FieldDefinition {
                                                 description: None,
                                                 name: "deprecationReason",
                                                 arguments: [],
@@ -884,7 +894,7 @@ ExecutableDocument {
                     ),
                     Field(
                         687..721 @14 Field {
-                            definition: 504..528 @1 FieldDefinition {
+                            definition: 1606..1630 @1 FieldDefinition {
                                 description: None,
                                 name: "possibleTypes",
                                 arguments: [],
@@ -923,7 +933,7 @@ ExecutableDocument {
                 selections: [
                     Field(
                         764..768 @14 Field {
-                            definition: 1230..1243 @1 FieldDefinition {
+                            definition: 3271..3284 @1 FieldDefinition {
                                 description: None,
                                 name: "name",
                                 arguments: [],
@@ -944,7 +954,7 @@ ExecutableDocument {
                     ),
                     Field(
                         771..782 @14 Field {
-                            definition: 1246..1265 @1 FieldDefinition {
+                            definition: 3287..3306 @1 FieldDefinition {
                                 description: None,
                                 name: "description",
                                 arguments: [],
@@ -965,7 +975,7 @@ ExecutableDocument {
                     ),
                     Field(
                         785..804 @14 Field {
-                            definition: 1268..1281 @1 FieldDefinition {
+                            definition: 3309..3322 @1 FieldDefinition {
                                 description: None,
                                 name: "type",
                                 arguments: [],
@@ -993,8 +1003,10 @@ ExecutableDocument {
                     ),
                     Field(
                         807..819 @14 Field {
-                            definition: 1284..1304 @1 FieldDefinition {
-                                description: None,
+                            definition: 3325..3429 @1 FieldDefinition {
+                                description: Some(
+                                    3325..3406 @1 "A GraphQL-formatted string representing the default value for this input value.",
+                                ),
                                 name: "defaultValue",
                                 arguments: [],
                                 ty: Named(
@@ -1023,7 +1035,7 @@ ExecutableDocument {
                 selections: [
                     Field(
                         853..857 @14 Field {
-                            definition: 178..195 @1 FieldDefinition {
+                            definition: 1280..1297 @1 FieldDefinition {
                                 description: None,
                                 name: "kind",
                                 arguments: [],
@@ -1044,7 +1056,7 @@ ExecutableDocument {
                     ),
                     Field(
                         860..864 @14 Field {
-                            definition: 198..210 @1 FieldDefinition {
+                            definition: 1300..1312 @1 FieldDefinition {
                                 description: None,
                                 name: "name",
                                 arguments: [],
@@ -1065,7 +1077,7 @@ ExecutableDocument {
                     ),
                     Field(
                         867..1263 @14 Field {
-                            definition: 825..839 @1 FieldDefinition {
+                            definition: 1927..1941 @1 FieldDefinition {
                                 description: None,
                                 name: "ofType",
                                 arguments: [],
@@ -1083,7 +1095,7 @@ ExecutableDocument {
                                 selections: [
                                     Field(
                                         880..884 @14 Field {
-                                            definition: 178..195 @1 FieldDefinition {
+                                            definition: 1280..1297 @1 FieldDefinition {
                                                 description: None,
                                                 name: "kind",
                                                 arguments: [],
@@ -1104,7 +1116,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         889..893 @14 Field {
-                                            definition: 198..210 @1 FieldDefinition {
+                                            definition: 1300..1312 @1 FieldDefinition {
                                                 description: None,
                                                 name: "name",
                                                 arguments: [],
@@ -1125,7 +1137,7 @@ ExecutableDocument {
                                     ),
                                     Field(
                                         898..1259 @14 Field {
-                                            definition: 825..839 @1 FieldDefinition {
+                                            definition: 1927..1941 @1 FieldDefinition {
                                                 description: None,
                                                 name: "ofType",
                                                 arguments: [],
@@ -1143,7 +1155,7 @@ ExecutableDocument {
                                                 selections: [
                                                     Field(
                                                         913..917 @14 Field {
-                                                            definition: 178..195 @1 FieldDefinition {
+                                                            definition: 1280..1297 @1 FieldDefinition {
                                                                 description: None,
                                                                 name: "kind",
                                                                 arguments: [],
@@ -1164,7 +1176,7 @@ ExecutableDocument {
                                                     ),
                                                     Field(
                                                         924..928 @14 Field {
-                                                            definition: 198..210 @1 FieldDefinition {
+                                                            definition: 1300..1312 @1 FieldDefinition {
                                                                 description: None,
                                                                 name: "name",
                                                                 arguments: [],
@@ -1185,7 +1197,7 @@ ExecutableDocument {
                                                     ),
                                                     Field(
                                                         935..1253 @14 Field {
-                                                            definition: 825..839 @1 FieldDefinition {
+                                                            definition: 1927..1941 @1 FieldDefinition {
                                                                 description: None,
                                                                 name: "ofType",
                                                                 arguments: [],
@@ -1203,7 +1215,7 @@ ExecutableDocument {
                                                                 selections: [
                                                                     Field(
                                                                         952..956 @14 Field {
-                                                                            definition: 178..195 @1 FieldDefinition {
+                                                                            definition: 1280..1297 @1 FieldDefinition {
                                                                                 description: None,
                                                                                 name: "kind",
                                                                                 arguments: [],
@@ -1224,7 +1236,7 @@ ExecutableDocument {
                                                                     ),
                                                                     Field(
                                                                         965..969 @14 Field {
-                                                                            definition: 198..210 @1 FieldDefinition {
+                                                                            definition: 1300..1312 @1 FieldDefinition {
                                                                                 description: None,
                                                                                 name: "name",
                                                                                 arguments: [],
@@ -1245,7 +1257,7 @@ ExecutableDocument {
                                                                     ),
                                                                     Field(
                                                                         978..1245 @14 Field {
-                                                                            definition: 825..839 @1 FieldDefinition {
+                                                                            definition: 1927..1941 @1 FieldDefinition {
                                                                                 description: None,
                                                                                 name: "ofType",
                                                                                 arguments: [],
@@ -1263,7 +1275,7 @@ ExecutableDocument {
                                                                                 selections: [
                                                                                     Field(
                                                                                         997..1001 @14 Field {
-                                                                                            definition: 178..195 @1 FieldDefinition {
+                                                                                            definition: 1280..1297 @1 FieldDefinition {
                                                                                                 description: None,
                                                                                                 name: "kind",
                                                                                                 arguments: [],
@@ -1284,7 +1296,7 @@ ExecutableDocument {
                                                                                     ),
                                                                                     Field(
                                                                                         1012..1016 @14 Field {
-                                                                                            definition: 198..210 @1 FieldDefinition {
+                                                                                            definition: 1300..1312 @1 FieldDefinition {
                                                                                                 description: None,
                                                                                                 name: "name",
                                                                                                 arguments: [],
@@ -1305,7 +1317,7 @@ ExecutableDocument {
                                                                                     ),
                                                                                     Field(
                                                                                         1027..1235 @14 Field {
-                                                                                            definition: 825..839 @1 FieldDefinition {
+                                                                                            definition: 1927..1941 @1 FieldDefinition {
                                                                                                 description: None,
                                                                                                 name: "ofType",
                                                                                                 arguments: [],
@@ -1323,7 +1335,7 @@ ExecutableDocument {
                                                                                                 selections: [
                                                                                                     Field(
                                                                                                         1048..1052 @14 Field {
-                                                                                                            definition: 178..195 @1 FieldDefinition {
+                                                                                                            definition: 1280..1297 @1 FieldDefinition {
                                                                                                                 description: None,
                                                                                                                 name: "kind",
                                                                                                                 arguments: [],
@@ -1344,7 +1356,7 @@ ExecutableDocument {
                                                                                                     ),
                                                                                                     Field(
                                                                                                         1065..1069 @14 Field {
-                                                                                                            definition: 198..210 @1 FieldDefinition {
+                                                                                                            definition: 1300..1312 @1 FieldDefinition {
                                                                                                                 description: None,
                                                                                                                 name: "name",
                                                                                                                 arguments: [],
@@ -1365,7 +1377,7 @@ ExecutableDocument {
                                                                                                     ),
                                                                                                     Field(
                                                                                                         1082..1223 @14 Field {
-                                                                                                            definition: 825..839 @1 FieldDefinition {
+                                                                                                            definition: 1927..1941 @1 FieldDefinition {
                                                                                                                 description: None,
                                                                                                                 name: "ofType",
                                                                                                                 arguments: [],
@@ -1383,7 +1395,7 @@ ExecutableDocument {
                                                                                                                 selections: [
                                                                                                                     Field(
                                                                                                                         1105..1109 @14 Field {
-                                                                                                                            definition: 178..195 @1 FieldDefinition {
+                                                                                                                            definition: 1280..1297 @1 FieldDefinition {
                                                                                                                                 description: None,
                                                                                                                                 name: "kind",
                                                                                                                                 arguments: [],
@@ -1404,7 +1416,7 @@ ExecutableDocument {
                                                                                                                     ),
                                                                                                                     Field(
                                                                                                                         1124..1128 @14 Field {
-                                                                                                                            definition: 198..210 @1 FieldDefinition {
+                                                                                                                            definition: 1300..1312 @1 FieldDefinition {
                                                                                                                                 description: None,
                                                                                                                                 name: "name",
                                                                                                                                 arguments: [],
@@ -1425,7 +1437,7 @@ ExecutableDocument {
                                                                                                                     ),
                                                                                                                     Field(
                                                                                                                         1143..1209 @14 Field {
-                                                                                                                            definition: 825..839 @1 FieldDefinition {
+                                                                                                                            definition: 1927..1941 @1 FieldDefinition {
                                                                                                                                 description: None,
                                                                                                                                 name: "ofType",
                                                                                                                                 arguments: [],
@@ -1443,7 +1455,7 @@ ExecutableDocument {
                                                                                                                                 selections: [
                                                                                                                                     Field(
                                                                                                                                         1168..1172 @14 Field {
-                                                                                                                                            definition: 178..195 @1 FieldDefinition {
+                                                                                                                                            definition: 1280..1297 @1 FieldDefinition {
                                                                                                                                                 description: None,
                                                                                                                                                 name: "kind",
                                                                                                                                                 arguments: [],
@@ -1464,7 +1476,7 @@ ExecutableDocument {
                                                                                                                                     ),
                                                                                                                                     Field(
                                                                                                                                         1189..1193 @14 Field {
-                                                                                                                                            definition: 198..210 @1 FieldDefinition {
+                                                                                                                                            definition: 1300..1312 @1 FieldDefinition {
                                                                                                                                                 description: None,
                                                                                                                                                 name: "name",
                                                                                                                                                 arguments: [],

--- a/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
+++ b/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
@@ -169,7 +169,7 @@ ExecutableDocument {
                                     selections: [
                                         Field(
                                             139..143 @27 Field {
-                                                definition: 198..210 @1 FieldDefinition {
+                                                definition: 1300..1312 @1 FieldDefinition {
                                                     description: None,
                                                     name: "name",
                                                     arguments: [],
@@ -190,18 +190,18 @@ ExecutableDocument {
                                         ),
                                         Field(
                                             148..207 @27 Field {
-                                                definition: 298..352 @1 FieldDefinition {
+                                                definition: 1400..1454 @1 FieldDefinition {
                                                     description: None,
                                                     name: "fields",
                                                     arguments: [
-                                                        305..339 @1 InputValueDefinition {
+                                                        1407..1441 @1 InputValueDefinition {
                                                             description: None,
                                                             name: "includeDeprecated",
-                                                            ty: 324..331 @1 Named(
+                                                            ty: 1426..1433 @1 Named(
                                                                 "Boolean",
                                                             ),
                                                             default_value: Some(
-                                                                334..339 @1 Boolean(
+                                                                1436..1441 @1 Boolean(
                                                                     false,
                                                                 ),
                                                             ),
@@ -224,7 +224,7 @@ ExecutableDocument {
                                                     selections: [
                                                         Field(
                                                             163..167 @27 Field {
-                                                                definition: 1039..1052 @1 FieldDefinition {
+                                                                definition: 2906..2919 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "name",
                                                                     arguments: [],
@@ -245,7 +245,7 @@ ExecutableDocument {
                                                         ),
                                                         Field(
                                                             174..201 @27 Field {
-                                                                definition: 1138..1151 @1 FieldDefinition {
+                                                                definition: 3005..3018 @1 FieldDefinition {
                                                                     description: None,
                                                                     name: "type",
                                                                     arguments: [],
@@ -263,7 +263,7 @@ ExecutableDocument {
                                                                     selections: [
                                                                         Field(
                                                                             189..193 @27 Field {
-                                                                                definition: 198..210 @1 FieldDefinition {
+                                                                                definition: 1300..1312 @1 FieldDefinition {
                                                                                     description: None,
                                                                                     name: "name",
                                                                                     arguments: [],

--- a/crates/apollo-compiler/tests/validation/types.rs
+++ b/crates/apollo-compiler/tests/validation/types.rs
@@ -1738,25 +1738,25 @@ mod directive_arguments {
                      │                    ──┬──  
                      │                      ╰──── provided value is a string
                      │
-                     ├─[built_in.graphql:105:7]
+                     ├─[built_in.graphql:146:7]
                      │
-                 105 │   if: Boolean!
+                 146 │   if: Boolean!
                      │       ────┬───  
                      │           ╰───── expected type declared here as Boolean!
                 ─────╯
                 Error: expected value of type Boolean!, found an enum
-                    ╭─[query.graphql:3:20]
-                    │
-                  3 │     name @skip(if: ENUM)
-                    │                    ──┬─  
-                    │                      ╰─── provided value is an enum
-                    │
-                    ├─[built_in.graphql:99:7]
-                    │
-                 99 │   if: Boolean!
-                    │       ────┬───  
-                    │           ╰───── expected type declared here as Boolean!
-                ────╯
+                     ╭─[query.graphql:3:20]
+                     │
+                   3 │     name @skip(if: ENUM)
+                     │                    ──┬─  
+                     │                      ╰─── provided value is an enum
+                     │
+                     ├─[built_in.graphql:140:7]
+                     │
+                 140 │   if: Boolean!
+                     │       ────┬───  
+                     │           ╰───── expected type declared here as Boolean!
+                ─────╯
             "#]],
         );
     }


### PR DESCRIPTION
We fuzz many introspection queries then expect apollo-compiler and graphql-js to return equivalent responses. Some of these changes help writing the fuzz targets, others fix bugs found by fuzzing.