### PR TITLE
refactor(parser): Use peek_token() to streamline peek operations

### DIFF
--- a/crates/apollo-parser/src/parser/grammar/document.rs
+++ b/crates/apollo-parser/src/parser/grammar/document.rs
@@ -36,12 +36,18 @@ pub(crate) fn document(p: &mut Parser) {
                 }
             }
             TokenKind::Name => {
-                let def = p.peek_data().unwrap();
-                select_definition(def, p);
+                if let Some(def) = p.peek_data() {
+                    select_definition(def, p);
+                } else {
+                    p.err_and_pop("expected a definition after this Name");
+                }
             }
             TokenKind::LCurly => {
-                let def = p.peek_data().unwrap();
-                select_definition(def, p);
+                if let Some(def) = p.peek_data() {
+                    select_definition(def, p);
+                } else {
+                    p.err_and_pop("expected a definition");
+                }
             }
             TokenKind::Eof => return ControlFlow::Break(()),
             _ => p.err_and_pop("expected a StringValue, Name or OperationDefinition"),

--- a/crates/apollo-parser/src/parser/grammar/fragment.rs
+++ b/crates/apollo-parser/src/parser/grammar/fragment.rs
@@ -36,15 +36,17 @@ pub(crate) fn fragment_definition(p: &mut Parser) {
 ///     Name *but not* **on**
 pub(crate) fn fragment_name(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::FRAGMENT_NAME);
-    match p.peek() {
-        Some(TokenKind::Name) => {
-            if p.peek_data().unwrap() == "on" {
-                return p.err("Fragment Name cannot be 'on'");
+    if let Some(token) = p.peek_token() {
+        if token.kind() == TokenKind::Name {
+            if token.data() != "on" {
+                name::name(p);
+            } else {
+                p.err("Fragment Name cannot be 'on'");
             }
-            name::name(p)
+            return;
         }
-        _ => p.err("expected Fragment Name"),
     }
+    p.err("expected Fragment Name");
 }
 
 /// See: https://spec.graphql.org/October2021/#TypeCondition
@@ -53,21 +55,20 @@ pub(crate) fn fragment_name(p: &mut Parser) {
 ///     **on** NamedType
 pub(crate) fn type_condition(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::TYPE_CONDITION);
-    match p.peek() {
-        Some(TokenKind::Name) => {
-            if p.peek_data().unwrap() == "on" {
-                p.bump(SyntaxKind::on_KW);
-            } else {
-                p.err("expected 'on'");
-            }
-
-            if let Some(TokenKind::Name) = p.peek() {
-                ty::named_type(p)
-            } else {
-                p.err("expected a Name in Type Condition")
-            }
+    if let Some(token) = p.peek_token() {
+        if token.kind() == TokenKind::Name && token.data() == "on" {
+            p.bump(SyntaxKind::on_KW);
+        } else {
+            p.err("expected 'on'");
         }
-        _ => p.err("expected Type Condition"),
+
+        if let Some(TokenKind::Name) = p.peek() {
+            ty::named_type(p)
+        } else {
+            p.err("expected a Name in Type Condition")
+        }
+    } else {
+        p.err("expected Type Condition")
     }
 }
 

--- a/crates/apollo-parser/src/parser/grammar/name.rs
+++ b/crates/apollo-parser/src/parser/grammar/name.rs
@@ -8,14 +8,16 @@ use crate::S;
 /// *Name*:
 ///     [_A-Za-z][_0-9A-Za-z]
 pub(crate) fn name(p: &mut Parser) {
-    match p.peek() {
-        Some(TokenKind::Name) => {
+    if let Some(token) = p.peek_token() {
+        if token.kind() == TokenKind::Name {
+            let name_data = token.data();
             let _g = p.start_node(SyntaxKind::NAME);
-            validate_name(p.peek_data().unwrap(), p);
+            validate_name(name_data, p);
             p.bump(SyntaxKind::IDENT);
+            return;
         }
-        _ => p.err("expected a Name"),
     }
+    p.err("expected a Name");
 }
 
 pub(crate) fn validate_name(name: &str, p: &mut Parser) {

--- a/crates/apollo-parser/src/parser/grammar/object.rs
+++ b/crates/apollo-parser/src/parser/grammar/object.rs
@@ -19,31 +19,45 @@ use crate::T;
 pub(crate) fn object_type_definition(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::OBJECT_TYPE_DEFINITION);
 
-    if let Some(TokenKind::StringValue) = p.peek() {
-        description::description(p);
-    }
-
-    if let Some("type") = p.peek_data() {
-        p.bump(SyntaxKind::type_KW);
-    }
-
-    match p.peek() {
-        Some(TokenKind::Name) => name::name(p),
-        _ => p.err("expected a name"),
-    }
-
-    if let Some(TokenKind::Name) = p.peek() {
-        if p.peek_data().unwrap() == "implements" {
-            implements_interfaces(p);
+    if let Some(token) = p.peek_token() {
+        if token.kind() == TokenKind::StringValue {
+            description::description(p);
         }
     }
 
-    if let Some(T![@]) = p.peek() {
-        directive::directives(p, Constness::Const);
+    if let Some(token) = p.peek_token() {
+        if token.data() == "type" {
+            p.bump(SyntaxKind::type_KW);
+        }
     }
 
-    if let Some(T!['{']) = p.peek() {
-        field::fields_definition(p);
+    if let Some(token) = p.peek_token() {
+        match token.kind() {
+            TokenKind::Name => name::name(p),
+            _ => p.err("expected a name"),
+        }
+    }
+
+    if let Some(token) = p.peek_token() {
+        if token.kind() == TokenKind::Name {
+            if token.data() == "implements" {
+                implements_interfaces(p);
+            } else {
+                p.err("unexpected Name");
+            }
+        }
+    }
+
+    if let Some(token) = p.peek_token() {
+        if token.kind() == T![@] {
+            directive::directives(p, Constness::Const);
+        }
+    }
+
+    if let Some(token) = p.peek_token() {
+        if token.kind() == T!['{'] {
+            field::fields_definition(p);
+        }
     }
 }
 
@@ -62,24 +76,32 @@ pub(crate) fn object_type_extension(p: &mut Parser) {
     // FieldsDefinitions is provided. If none are present, we push an error.
     let mut meets_requirements = false;
 
-    match p.peek() {
-        Some(TokenKind::Name) => name::name(p),
-        _ => p.err("expected a Name"),
+    if let Some(token) = p.peek_token() {
+        match token.kind() {
+            TokenKind::Name => name::name(p),
+            _ => p.err("expected a Name"),
+        }
     }
 
-    if let Some("implements") = p.peek_data() {
-        meets_requirements = true;
-        implements_interfaces(p);
+    if let Some(token) = p.peek_token() {
+        if token.data() == "implements" {
+            meets_requirements = true;
+            implements_interfaces(p);
+        }
     }
 
-    if let Some(T![@]) = p.peek() {
-        meets_requirements = true;
-        directive::directives(p, Constness::Const)
+    if let Some(token) = p.peek_token() {
+        if token.kind() == T![@] {
+            meets_requirements = true;
+            directive::directives(p, Constness::Const);
+        }
     }
 
-    if let Some(T!['{']) = p.peek() {
-        meets_requirements = true;
-        field::fields_definition(p)
+    if let Some(token) = p.peek_token() {
+        if token.kind() == T!['{'] {
+            meets_requirements = true;
+            field::fields_definition(p);
+        }
     }
 
     if !meets_requirements {
@@ -97,10 +119,12 @@ pub(crate) fn implements_interfaces(p: &mut Parser) {
     p.bump(SyntaxKind::implements_KW);
 
     p.parse_separated_list(T![&], S![&], |p| {
-        if let Some(TokenKind::Name) = p.peek() {
-            ty::named_type(p);
-        } else {
-            p.err("expected an Interface name");
+        if let Some(token) = p.peek_token() {
+            if token.kind() == TokenKind::Name {
+                ty::named_type(p);
+            } else {
+                p.err("expected an Interface name");
+            }
         }
     });
 }

--- a/crates/apollo-parser/src/parser/grammar/object.rs
+++ b/crates/apollo-parser/src/parser/grammar/object.rs
@@ -19,45 +19,31 @@ use crate::T;
 pub(crate) fn object_type_definition(p: &mut Parser) {
     let _g = p.start_node(SyntaxKind::OBJECT_TYPE_DEFINITION);
 
-    if let Some(token) = p.peek_token() {
-        if token.kind() == TokenKind::StringValue {
-            description::description(p);
-        }
+    if let Some(TokenKind::StringValue) = p.peek() {
+        description::description(p);
+    }
+
+    if let Some("type") = p.peek_data() {
+        p.bump(SyntaxKind::type_KW);
+    }
+
+    match p.peek() {
+        Some(TokenKind::Name) => name::name(p),
+        _ => p.err("expected a name"),
     }
 
     if let Some(token) = p.peek_token() {
-        if token.data() == "type" {
-            p.bump(SyntaxKind::type_KW);
+        if token.kind() == TokenKind::Name && token.data() == "implements" {
+            implements_interfaces(p);
         }
     }
 
-    if let Some(token) = p.peek_token() {
-        match token.kind() {
-            TokenKind::Name => name::name(p),
-            _ => p.err("expected a name"),
-        }
+    if let Some(T![@]) = p.peek() {
+        directive::directives(p, Constness::Const);
     }
 
-    if let Some(token) = p.peek_token() {
-        if token.kind() == TokenKind::Name {
-            if token.data() == "implements" {
-                implements_interfaces(p);
-            } else {
-                p.err("unexpected Name");
-            }
-        }
-    }
-
-    if let Some(token) = p.peek_token() {
-        if token.kind() == T![@] {
-            directive::directives(p, Constness::Const);
-        }
-    }
-
-    if let Some(token) = p.peek_token() {
-        if token.kind() == T!['{'] {
-            field::fields_definition(p);
-        }
+    if let Some(T!['{']) = p.peek() {
+        field::fields_definition(p);
     }
 }
 
@@ -72,36 +58,28 @@ pub(crate) fn object_type_extension(p: &mut Parser) {
     p.bump(SyntaxKind::extend_KW);
     p.bump(SyntaxKind::type_KW);
 
-    // Use this variable to see if any of ImplementsInterfacs, Directives or
+    // Use this variable to see if any of ImplementsInterfaces, Directives or
     // FieldsDefinitions is provided. If none are present, we push an error.
     let mut meets_requirements = false;
 
-    if let Some(token) = p.peek_token() {
-        match token.kind() {
-            TokenKind::Name => name::name(p),
-            _ => p.err("expected a Name"),
-        }
+    match p.peek() {
+        Some(TokenKind::Name) => name::name(p),
+        _ => p.err("expected a Name"),
     }
 
-    if let Some(token) = p.peek_token() {
-        if token.data() == "implements" {
-            meets_requirements = true;
-            implements_interfaces(p);
-        }
+    if let Some("implements") = p.peek_data() {
+        meets_requirements = true;
+        implements_interfaces(p);
     }
 
-    if let Some(token) = p.peek_token() {
-        if token.kind() == T![@] {
-            meets_requirements = true;
-            directive::directives(p, Constness::Const);
-        }
+    if let Some(T![@]) = p.peek() {
+        meets_requirements = true;
+        directive::directives(p, Constness::Const)
     }
 
-    if let Some(token) = p.peek_token() {
-        if token.kind() == T!['{'] {
-            meets_requirements = true;
-            field::fields_definition(p);
-        }
+    if let Some(T!['{']) = p.peek() {
+        meets_requirements = true;
+        field::fields_definition(p)
     }
 
     if !meets_requirements {
@@ -119,12 +97,10 @@ pub(crate) fn implements_interfaces(p: &mut Parser) {
     p.bump(SyntaxKind::implements_KW);
 
     p.parse_separated_list(T![&], S![&], |p| {
-        if let Some(token) = p.peek_token() {
-            if token.kind() == TokenKind::Name {
-                ty::named_type(p);
-            } else {
-                p.err("expected an Interface name");
-            }
+        if let Some(TokenKind::Name) = p.peek() {
+            ty::named_type(p);
+        } else {
+            p.err("expected an Interface name");
         }
     });
 }

--- a/crates/apollo-parser/src/parser/grammar/value.rs
+++ b/crates/apollo-parser/src/parser/grammar/value.rs
@@ -52,21 +52,22 @@ pub(crate) fn value(p: &mut Parser, constness: Constness, pop_on_error: bool) {
             p.bump(SyntaxKind::STRING);
         }
         Some(TokenKind::Name) => {
-            let node = p.peek_data().unwrap();
-            match node {
-                "true" => {
-                    let _g = p.start_node(SyntaxKind::BOOLEAN_VALUE);
-                    p.bump(SyntaxKind::true_KW);
+            if let Some(token) = p.peek_token() {
+                match token.data() {
+                    "true" => {
+                        let _g = p.start_node(SyntaxKind::BOOLEAN_VALUE);
+                        p.bump(SyntaxKind::true_KW);
+                    }
+                    "false" => {
+                        let _g = p.start_node(SyntaxKind::BOOLEAN_VALUE);
+                        p.bump(SyntaxKind::false_KW);
+                    }
+                    "null" => {
+                        let _g = p.start_node(SyntaxKind::NULL_VALUE);
+                        p.bump(SyntaxKind::null_KW)
+                    }
+                    _ => enum_value(p),
                 }
-                "false" => {
-                    let _g = p.start_node(SyntaxKind::BOOLEAN_VALUE);
-                    p.bump(SyntaxKind::false_KW);
-                }
-                "null" => {
-                    let _g = p.start_node(SyntaxKind::NULL_VALUE);
-                    p.bump(SyntaxKind::null_KW)
-                }
-                _ => enum_value(p),
             }
         }
         Some(T!['[']) => list_value(p, constness),


### PR DESCRIPTION
Closes #830 

This PR `refactors` parser to use `peek_token()` instead of separate `peek()` and `peek_data()` calls.

_Changes:_

- Replaced instances of `peek()` / `peek_data()` call pairs.
- Removed `unwrap()` by working directly with the `peek_token()`. This ensures that the `token's kind` and `data` are always in `sync` and that no intermediate changes can occur between the checks.