### PR TITLE
Port MaxIntrospectionDepthRule from graphql-js

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -28,8 +28,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   and matches their definition order in the schema.
   This helps fuzzing, where the same entropy source should generate the same test case.
 
+## Features
+
+- **Port MaxIntrospectionDepthRule from graphql-js - [SimonSapin] in [pull/904].**
+  This limits list nesting in introspection query which can cause very large responses.
+
 [SimonSapin]: https://github.com/SimonSapin
 [pull/898]: https://github.com/apollographql/apollo-rs/pull/898
+[pull/904]: https://github.com/apollographql/apollo-rs/pull/904
 
 
 # [1.0.0-beta.20](https://crates.io/crates/apollo-compiler/1.0.0-beta.20) - 2024-07-30

--- a/crates/apollo-compiler/src/execution/introspection_max_depth.rs
+++ b/crates/apollo-compiler/src/execution/introspection_max_depth.rs
@@ -1,0 +1,53 @@
+use crate::executable::Selection;
+use crate::executable::SelectionSet;
+use crate::execution::introspection_split::get_fragment;
+use crate::execution::SchemaIntrospectionError;
+use crate::validation::Valid;
+use crate::ExecutableDocument;
+
+const MAX_LISTS_DEPTH: u32 = 3;
+
+pub(crate) fn check_document(
+    document: &Valid<ExecutableDocument>,
+) -> Result<(), SchemaIntrospectionError> {
+    for operation in document.operations.iter() {
+        let initial_depth = 0;
+        check_selection_set(document, initial_depth, &operation.selection_set)?;
+    }
+    Ok(())
+}
+
+fn check_selection_set(
+    document: &Valid<ExecutableDocument>,
+    depth_so_far: u32,
+    selection_set: &SelectionSet,
+) -> Result<(), SchemaIntrospectionError> {
+    for selection in &selection_set.selections {
+        match selection {
+            Selection::InlineFragment(inline) => {
+                check_selection_set(document, depth_so_far, &inline.selection_set)?
+            }
+            Selection::FragmentSpread(spread) => {
+                // Validation ensures that `Valid<ExecutableDocument>` does not contain fragment cycles
+                let def = get_fragment(document, &spread.fragment_name)?;
+                check_selection_set(document, depth_so_far, &def.selection_set)?
+            }
+            Selection::Field(field) => {
+                let mut depth = depth_so_far;
+                if matches!(
+                    field.name.as_str(),
+                    "fields" | "interfaces" | "possibleTypes" | "inputFields"
+                ) {
+                    depth += 1;
+                    if depth >= MAX_LISTS_DEPTH {
+                        return Err(SchemaIntrospectionError::DeeplyNestedIntrospectionList(
+                            field.name.location(),
+                        ));
+                    }
+                }
+                check_selection_set(document, depth, &field.selection_set)?
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/apollo-compiler/src/execution/mod.rs
+++ b/crates/apollo-compiler/src/execution/mod.rs
@@ -9,6 +9,7 @@ mod resolver;
 mod engine;
 mod input_coercion;
 mod introspection_execute;
+mod introspection_max_depth;
 mod introspection_split;
 mod response;
 mod result_coercion;

--- a/crates/apollo-compiler/tests/introspection_max_depth.rs
+++ b/crates/apollo-compiler/tests/introspection_max_depth.rs
@@ -1,0 +1,393 @@
+use apollo_compiler::execution::SchemaIntrospectionSplit;
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use expect_test::expect;
+
+#[test]
+fn test_3_sibling_fields_list() {
+    let doc = r#"
+      {
+        __type(name: "Query") {
+          trueFields: fields(includeDeprecated: true) {
+            name
+          }
+          falseFields: fields(includeDeprecated: false) {
+            name
+          }
+          omittedFields: fields {
+            name
+          }
+        }
+      }
+    "#;
+    let expected = expect!["Ok"];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_2_nested_fields_lists() {
+    let doc = r#"
+      {
+        __type(name: "Query") {
+          fields {
+            type {
+              fields {
+                name
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect!["Ok"];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_3_nested_fields_lists() {
+    let doc = r#"
+      {
+        __type(name: "Query") {
+          fields {
+            type {
+              fields {
+                type {
+                  fields {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect![[r#"
+        GraphQLError {
+            message: "Maximum introspection depth exceeded",
+            locations: [
+                LineColumn {
+                    line: 8,
+                    column: 19,
+                },
+            ],
+            path: [],
+            extensions: {},
+        }
+    "#]];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_2_nested_input_fields_lists() {
+    let doc = r#"
+      {
+        __type(name: "Query") {
+          inputFields {
+            type {
+              inputFields {
+                name
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect!["Ok"];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_3_nested_input_fields_lists() {
+    let doc = r#"
+      {
+        __type(name: "Query") {
+          inputFields {
+            type {
+              inputFields {
+                type {
+                  inputFields {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect![[r#"
+        GraphQLError {
+            message: "Maximum introspection depth exceeded",
+            locations: [
+                LineColumn {
+                    line: 8,
+                    column: 19,
+                },
+            ],
+            path: [],
+            extensions: {},
+        }
+    "#]];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_2_nested_interfaces_lists() {
+    let doc = r#"
+      {
+        __schema {
+          types {
+            interfaces {
+              interfaces {
+                name
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect!["Ok"];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_3_nested_interfaces_lists() {
+    let doc = r#"
+      {
+        __schema {
+          types {
+            interfaces {
+              interfaces {
+                interfaces {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect![[r#"
+        GraphQLError {
+            message: "Maximum introspection depth exceeded",
+            locations: [
+                LineColumn {
+                    line: 7,
+                    column: 17,
+                },
+            ],
+            path: [],
+            extensions: {},
+        }
+    "#]];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_2_nested_possible_types_lists() {
+    let doc = r#"
+      {
+        __schema {
+          types {
+            possibleTypes {
+              possibleTypes {
+                name
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect!["Ok"];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_3_nested_possible_types_lists() {
+    let doc = r#"
+      {
+        __schema {
+          types {
+            possibleTypes {
+              possibleTypes {
+                possibleTypes {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect![[r#"
+        GraphQLError {
+            message: "Maximum introspection depth exceeded",
+            locations: [
+                LineColumn {
+                    line: 7,
+                    column: 17,
+                },
+            ],
+            path: [],
+            extensions: {},
+        }
+    "#]];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_2_nested_possible_types_lists_with_inline_fragments() {
+    let doc = r#"
+      {
+        ... on Query {
+          __schema {
+            types {
+              ... on __Type {
+                possibleTypes {
+                  ... on __Type {
+                    possibleTypes {
+                      ... on __Type {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect!["Ok"];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_3_nested_possible_types_lists_with_inline_fragments() {
+    let doc = r#"
+      {
+        ... on Query {
+          __schema {
+            types {
+              ... on __Type {
+                possibleTypes {
+                  ... on __Type {
+                    possibleTypes {
+                      ... on __Type {
+                        possibleTypes {
+                          ... on __Type {
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    "#;
+    let expected = expect![[r#"
+        GraphQLError {
+            message: "Maximum introspection depth exceeded",
+            locations: [
+                LineColumn {
+                    line: 11,
+                    column: 25,
+                },
+            ],
+            path: [],
+            extensions: {},
+        }
+    "#]];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_2_nested_possible_types_lists_with_named_fragments() {
+    let doc = r#"
+      {
+        __schema {
+          types {
+            ...One
+          }
+        }
+      }
+      fragment One on __Type {
+        possibleTypes {
+          ...Two
+        }
+      }
+      fragment Two on __Type {
+        possibleTypes {
+          ...Three
+        }
+      }
+      fragment Three on __Type {
+        name
+      }
+    "#;
+    let expected = expect!["Ok"];
+    assert_split(doc, expected);
+}
+
+#[test]
+fn test_3_nested_possible_types_lists_with_named_fragments() {
+    let doc = r#"
+      {
+        __schema {
+          types {
+            ...One
+          }
+        }
+      }
+      fragment One on __Type {
+        possibleTypes {
+          ...Two
+        }
+      }
+      fragment Two on __Type {
+        possibleTypes {
+          ...Three
+        }
+      }
+      fragment Three on __Type {
+        possibleTypes {
+          ...Four
+        }
+      }
+      fragment Four on __Type {
+        name
+      }
+    "#;
+    let expected = expect![[r#"
+        GraphQLError {
+            message: "Maximum introspection depth exceeded",
+            locations: [
+                LineColumn {
+                    line: 20,
+                    column: 9,
+                },
+            ],
+            path: [],
+            extensions: {},
+        }
+    "#]];
+    assert_split(doc, expected);
+}
+
+#[track_caller]
+fn assert_split(doc: &str, expected: expect_test::Expect) {
+    let schema = "type Query { f: Int }";
+    let schema = Schema::parse_and_validate(schema, "schema.graphql").unwrap();
+    let doc = ExecutableDocument::parse_and_validate(&schema, doc, "doc.graphql").unwrap();
+    let operation = doc.operations.get(None).unwrap();
+
+    match SchemaIntrospectionSplit::split(&schema, &doc, operation) {
+        Ok(_) => expected.assert_eq("Ok"),
+        Err(err) => expected.assert_debug_eq(&err.into_graphql_error(&doc.sources)),
+    }
+}

--- a/crates/apollo-compiler/tests/main.rs
+++ b/crates/apollo-compiler/tests/main.rs
@@ -3,6 +3,7 @@ mod extensions;
 mod field_set;
 mod field_type;
 mod introspection;
+mod introspection_max_depth;
 mod introspection_split;
 mod merge_schemas;
 /// Formerly in src/lib.rs


### PR DESCRIPTION
* https://github.com/graphql/graphql-js/blob/v17.0.0-alpha.7/src/validation/rules/MaxIntrospectionDepthRule.ts
* https://github.com/graphql/graphql-js/blob/v17.0.0-alpha.7/src/validation/__tests__/MaxIntrospectionDepthRule-test.ts

Without this rule, a malicious client could cause huge introspection responses that grow exponentially with the list nesting level in the query.

Instead of a validation rule, this check is performed as part of `SchemaIntrospectionSplit::split`. graphql-js allows users to disable or enable specific validation rules, with max introspection depth being part of "recommended" rules. apollo-compiler does not have this mechanism, so `document.validate()` always performs validation as per the GraphQL spec.

The depth limit is hard-coded to 3, and applied to specific intropsection fields that matches graphql-js. graphql-js code has a comment about counting all list fields. When I tried that, a "normal" introspection query was rejected because `__schema.types[list].field[list].args[list]` reaches depth 3.