### PR TITLE
Add convenience APIs on operations

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -28,8 +28,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   and matches their definition order in the schema.
   This helps fuzzing, where the same entropy source should generate the same test case.
 
+## Features
+
+- **Add convenience APIs on operations - [SimonSapin] in [pull/905]**
+  * `OperationMap::len` and `OperationMap::is_empty`, making it more like a collection type
+  * `Operation::all_fields` and `Operation::root_fields` iterators
+
+
 [SimonSapin]: https://github.com/SimonSapin
 [pull/898]: https://github.com/apollographql/apollo-rs/pull/898
+[pull/905]: https://github.com/apollographql/apollo-rs/pull/905
 
 
 # [1.0.0-beta.20](https://crates.io/crates/apollo-compiler/1.0.0-beta.20) - 2024-07-30


### PR DESCRIPTION
* `OperationMap::len` and `OperationMap::is_empty`, making it more like a collection type
* `Operation::all_fields` and `Operation::root_fields` iterators