### PR TITLE
fix: `adopt_orphan_extensions` + schema extensions + implicit root operation interaction

### DIFF
--- a/crates/apollo-compiler/tests/extensions.rs
+++ b/crates/apollo-compiler/tests/extensions.rs
@@ -35,6 +35,22 @@ fn test_orphan_extensions() {
 }
 
 #[test]
+fn test_orphan_extensions_schema_with_default_query_name() {
+    let input = r#"
+        extend schema { query: Query }
+        type Query { x: Int }
+    "#;
+
+    let schema = Schema::builder()
+        .adopt_orphan_extensions()
+        .parse(input, "schema.graphql")
+        .build()
+        .unwrap();
+
+    schema.validate().unwrap();
+}
+
+#[test]
 fn test_orphan_extensions_kind_mismatch() {
     let input = r#"
     extend type T @dir

--- a/crates/apollo-compiler/tests/extensions.rs
+++ b/crates/apollo-compiler/tests/extensions.rs
@@ -71,6 +71,28 @@ fn test_orphan_extensions_schema_def_with_extensions() {
 }
 
 #[test]
+fn test_invalid_orphan_extensions_schema_def_with_duplicate_root_operation() {
+    let input = r#"
+        extend schema { query: Query }
+        extend schema { subscription: S }
+        schema { mutation: Mutation, query: AnotherQuery }
+        type Query { x: Int }
+        type Mutation { y: Int }
+        type S { z: Int }
+        type AnotherQuery { a: String }
+    "#;
+
+    let invalid = Schema::builder()
+        .adopt_orphan_extensions()
+        .parse(input, "schema.graphql")
+        .build()
+        .unwrap_err();
+
+    let err = invalid.errors.to_string();
+    assert!(err.contains("duplicate definitions for the `query` root operation type"));
+}
+
+#[test]
 fn test_orphan_extensions_kind_mismatch() {
     let input = r#"
     extend type T @dir

--- a/crates/apollo-compiler/tests/extensions.rs
+++ b/crates/apollo-compiler/tests/extensions.rs
@@ -51,6 +51,26 @@ fn test_orphan_extensions_schema_with_default_query_name() {
 }
 
 #[test]
+fn test_orphan_extensions_schema_def_with_extensions() {
+    let input = r#"
+        extend schema { query: Query }
+        extend schema { subscription: S }
+        schema { mutation: Mutation }
+        type Query { x: Int }
+        type Mutation { y: Int }
+        type S { z: Int }
+    "#;
+
+    let schema = Schema::builder()
+        .adopt_orphan_extensions()
+        .parse(input, "schema.graphql")
+        .build()
+        .unwrap();
+
+    schema.validate().unwrap();
+}
+
+#[test]
 fn test_orphan_extensions_kind_mismatch() {
     let input = r#"
     extend type T @dir


### PR DESCRIPTION
Building a schema with the `adopt_orphan_extensions` option enabled yields an error in the following simple case:
```graphql
extend schema { query: Query }

type Query { x: Int }
```

```
Error: duplicate definitions for the `query` root operation type
   ╭─[schema.graphql:2:25]
   │
 2 │         extend schema { query: Query }
   │                         ──────┬─────  
   │                               ╰─────── `query` redefined here
───╯
```

Currently, it accidentally makes the assumption that a schema extension's root operations do not use a default name, which explains why [this test](https://github.com/apollographql/apollo-rs/blob/caf820d86a03db3650149cefe6157442c73d7e50/crates/apollo-compiler/tests/extensions.rs#L5-L10) currently passes but the failing test from [f3f95b8](https://github.com/apollographql/apollo-rs/pull/907/commits/f3f95b8e65b4f4988843fd9151a7ffbfa70d9125) did not. This results in the `query` root operation type being added twice - once at the implicit step, and again when the orphan extensions are applied.

In the case that `adopt_orphan_extensions` is enabled, we need to scan the orphan schema extensions for root operations that match the default name and _skip_ the implicit addition step if so, since the extensions will be applied in a subsequent step.
