### PR TITLE
feat(compiler): add compact Debug impl for LineColumn

### DIFF
--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -68,7 +68,7 @@ pub struct SourceSpan {
 }
 
 /// A line number and column number within a GraphQL document.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct LineColumn {
     /// The line number for this location, starting at 1 for the first line.
@@ -76,6 +76,12 @@ pub struct LineColumn {
     /// The column number for this location, starting at 1 and counting characters (Unicode Scalar
     /// Values) like [`str::chars`].
     pub column: usize,
+}
+
+impl std::fmt::Debug for LineColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.line, self.column)
+    }
 }
 
 /// Parse a schema and executable document from the given source text

--- a/crates/apollo-compiler/tests/introspection_max_depth.rs
+++ b/crates/apollo-compiler/tests/introspection_max_depth.rs
@@ -66,10 +66,7 @@ fn test_3_nested_fields_lists() {
         GraphQLError {
             message: "Maximum introspection depth exceeded",
             locations: [
-                LineColumn {
-                    line: 8,
-                    column: 19,
-                },
+                8:19,
             ],
             path: [],
             extensions: {},
@@ -120,10 +117,7 @@ fn test_3_nested_input_fields_lists() {
         GraphQLError {
             message: "Maximum introspection depth exceeded",
             locations: [
-                LineColumn {
-                    line: 8,
-                    column: 19,
-                },
+                8:19,
             ],
             path: [],
             extensions: {},
@@ -172,10 +166,7 @@ fn test_3_nested_interfaces_lists() {
         GraphQLError {
             message: "Maximum introspection depth exceeded",
             locations: [
-                LineColumn {
-                    line: 7,
-                    column: 17,
-                },
+                7:17,
             ],
             path: [],
             extensions: {},
@@ -224,10 +215,7 @@ fn test_3_nested_possible_types_lists() {
         GraphQLError {
             message: "Maximum introspection depth exceeded",
             locations: [
-                LineColumn {
-                    line: 7,
-                    column: 17,
-                },
+                7:17,
             ],
             path: [],
             extensions: {},
@@ -294,10 +282,7 @@ fn test_3_nested_possible_types_lists_with_inline_fragments() {
         GraphQLError {
             message: "Maximum introspection depth exceeded",
             locations: [
-                LineColumn {
-                    line: 11,
-                    column: 25,
-                },
+                11:25,
             ],
             path: [],
             extensions: {},
@@ -367,10 +352,7 @@ fn test_3_nested_possible_types_lists_with_named_fragments() {
         GraphQLError {
             message: "Maximum introspection depth exceeded",
             locations: [
-                LineColumn {
-                    line: 20,
-                    column: 9,
-                },
+                20:9,
             ],
             path: [],
             extensions: {},

--- a/crates/apollo-compiler/tests/introspection_split.rs
+++ b/crates/apollo-compiler/tests/introspection_split.rs
@@ -78,10 +78,7 @@ fn test_nested() {
         GraphQLError {
             message: "Schema introspection field __schema is not supported nested in other fields",
             locations: [
-                LineColumn {
-                    line: 2,
-                    column: 43,
-                },
+                2:43,
             ],
             path: [],
             extensions: {},
@@ -100,10 +97,7 @@ fn test_nested_in_fragment() {
         GraphQLError {
             message: "Schema introspection field __schema is not supported nested in other fields",
             locations: [
-                LineColumn {
-                    line: 3,
-                    column: 41,
-                },
+                3:41,
             ],
             path: [],
             extensions: {},
@@ -121,10 +115,7 @@ fn test_mutation() {
         GraphQLError {
             message: "Schema introspection field __schema is not supported in a mutation operation",
             locations: [
-                LineColumn {
-                    line: 2,
-                    column: 33,
-                },
+                2:33,
             ],
             path: [],
             extensions: {},
@@ -142,10 +133,7 @@ fn test_mutation_nested() {
         GraphQLError {
             message: "Schema introspection field __schema is not supported in a mutation operation",
             locations: [
-                LineColumn {
-                    line: 2,
-                    column: 46,
-                },
+                2:46,
             ],
             path: [],
             extensions: {},


### PR DESCRIPTION
This felt nicer in a case like the below:

https://github.com/apollographql/router/blob/e9dc61255e87294f624a0ecc68ac7c83fab5a7f0/apollo-federation/src/sources/connect/validation/snapshots/validation_tests%40rest.graphql.snap#L10-L25

It's not a big deal though. If anyone isn't that enthusiastic about it
we can just not :)
