### PR TITLE
Validation adds/removes built-in scalar defs based on usage

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [x.x.x] (unreleased) - 2024-mm-dd
+
+## Fixes
+- **Validation adds/removes built-in scalar definitions based on usage - [SimonSapin], [pull/911].**
+
+[SimonSapin]: https://github.com/SimonSapin
+[pull/911]: https://github.com/apollographql/apollo-rs/pull/911
+
+
 # [1.0.0-beta.22](https://crates.io/crates/apollo-compiler/1.0.0-beta.21) - 2024-09-09
 
 ## Fixes

--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -64,8 +64,8 @@ impl Document {
         let mut builder = Schema::builder();
         let executable_definitions_are_errors = true;
         builder.add_ast_document(self, executable_definitions_are_errors);
-        let (schema, mut errors) = builder.build_inner();
-        crate::schema::validation::validate_schema(&mut errors, &schema);
+        let (mut schema, mut errors) = builder.build_inner();
+        crate::schema::validation::validate_schema(&mut errors, &mut schema);
         errors.into_valid_result(schema)
     }
 
@@ -114,14 +114,14 @@ impl Document {
         let executable_definitions_are_errors = false;
         let type_system_definitions_are_errors = false;
         builder.add_ast_document(self, executable_definitions_are_errors);
-        let (schema, mut errors) = builder.build_inner();
+        let (mut schema, mut errors) = builder.build_inner();
         let executable = crate::executable::from_ast::document_from_ast(
             Some(&schema),
             self,
             &mut errors,
             type_system_definitions_are_errors,
         );
-        crate::schema::validation::validate_schema(&mut errors, &schema);
+        crate::schema::validation::validate_schema(&mut errors, &mut schema);
         crate::executable::validation::validate_executable_document(
             &mut errors,
             &schema,

--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -274,14 +274,14 @@ impl Parser {
         let executable_definitions_are_errors = false;
         let type_system_definitions_are_errors = false;
         builder.add_ast_document_not_adding_sources(&ast, executable_definitions_are_errors);
-        let (schema, mut errors) = builder.build_inner();
+        let (mut schema, mut errors) = builder.build_inner();
         let executable = crate::executable::from_ast::document_from_ast(
             Some(&schema),
             &ast,
             &mut errors,
             type_system_definitions_are_errors,
         );
-        crate::schema::validation::validate_schema(&mut errors, &schema);
+        crate::schema::validation::validate_schema(&mut errors, &mut schema);
         crate::executable::validation::validate_executable_document(
             &mut errors,
             &schema,

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -51,8 +51,18 @@ pub struct Schema {
     /// Built-in and explicit directive definitions
     pub directive_definitions: IndexMap<Name, Node<DirectiveDefinition>>,
 
-    /// Definitions and extensions of built-in scalars, introspection types,
-    /// and explicit types
+    /// Definitions and extensions of all types relevant to a schema:
+    ///
+    /// * Explict types in parsed input files or added programatically.
+    ///
+    /// * [Schema-introspection](https://spec.graphql.org/draft/#sec-Schema-Introspection)
+    ///   types such as `__Schema`, `__Field`, etc.
+    ///
+    /// * When a `Schema` is initially created or parsed,
+    ///   all [Built-in scalars](https://spec.graphql.org/draft/#sec-Scalars.Built-in-Scalars).
+    ///   After validation, the Rust `types` map in a `Valid<Schema>` only contains
+    ///   built-in scalar definitions for scalars that are used in the schema.
+    ///   We reflect in this Rust API the behavior of `__Schema.types` in GraphQL introspection.
     pub types: IndexMap<NamedType, ExtendedType>,
 }
 

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -329,8 +329,8 @@ impl Schema {
     ) -> Result<Valid<Self>, WithErrors<Self>> {
         let mut builder = Schema::builder();
         Parser::default().parse_into_schema_builder(source_text, path, &mut builder);
-        let (schema, mut errors) = builder.build_inner();
-        validation::validate_schema(&mut errors, &schema);
+        let (mut schema, mut errors) = builder.build_inner();
+        validation::validate_schema(&mut errors, &mut schema);
         errors.into_valid_result(schema)
     }
 
@@ -346,9 +346,9 @@ impl Schema {
         SchemaBuilder::new()
     }
 
-    pub fn validate(self) -> Result<Valid<Self>, WithErrors<Self>> {
+    pub fn validate(mut self) -> Result<Valid<Self>, WithErrors<Self>> {
         let mut errors = DiagnosticList::new(self.sources.clone());
-        validation::validate_schema(&mut errors, &self);
+        validation::validate_schema(&mut errors, &mut self);
         errors.into_valid_result(self)
     }
 

--- a/crates/apollo-compiler/src/schema/validation.rs
+++ b/crates/apollo-compiler/src/schema/validation.rs
@@ -1,21 +1,26 @@
+use super::ExtendedType;
 use crate::validation::directive::validate_directive_definitions;
-use crate::validation::enum_::validate_enum_definitions;
-use crate::validation::input_object::validate_input_object_definitions;
-use crate::validation::interface::validate_interface_definitions;
-use crate::validation::object::validate_object_type_definitions;
-use crate::validation::scalar::validate_scalar_definitions;
+use crate::validation::enum_::validate_enum_definition;
+use crate::validation::input_object::validate_input_object_definition;
+use crate::validation::interface::validate_interface_definition;
+use crate::validation::object::validate_object_type_definition;
+use crate::validation::scalar::validate_scalar_definition;
 use crate::validation::schema::validate_schema_definition;
-use crate::validation::union_::validate_union_definitions;
+use crate::validation::union_::validate_union_definition;
 use crate::validation::DiagnosticList;
 use crate::Schema;
 
-pub(crate) fn validate_schema(errors: &mut DiagnosticList, schema: &Schema) {
+pub(crate) fn validate_schema(errors: &mut DiagnosticList, schema: &mut Schema) {
     validate_schema_definition(errors, schema);
-    validate_scalar_definitions(errors, schema);
-    validate_enum_definitions(errors, schema);
-    validate_union_definitions(errors, schema);
-    validate_interface_definitions(errors, schema);
     validate_directive_definitions(errors, schema);
-    validate_input_object_definitions(errors, schema);
-    validate_object_type_definitions(errors, schema);
+    for def in schema.types.values() {
+        match def {
+            ExtendedType::Scalar(def) => validate_scalar_definition(errors, schema, def),
+            ExtendedType::Object(def) => validate_object_type_definition(errors, schema, def),
+            ExtendedType::Interface(def) => validate_interface_definition(errors, schema, def),
+            ExtendedType::Union(def) => validate_union_definition(errors, schema, def),
+            ExtendedType::Enum(def) => validate_enum_definition(errors, schema, def),
+            ExtendedType::InputObject(def) => validate_input_object_definition(errors, schema, def),
+        }
+    }
 }

--- a/crates/apollo-compiler/src/schema/validation.rs
+++ b/crates/apollo-compiler/src/schema/validation.rs
@@ -1,4 +1,7 @@
 use super::ExtendedType;
+use crate::collections::HashMap;
+use crate::collections::HashSet;
+use crate::schema::ScalarType;
 use crate::validation::directive::validate_directive_definitions;
 use crate::validation::enum_::validate_enum_definition;
 use crate::validation::input_object::validate_input_object_definition;
@@ -8,19 +11,119 @@ use crate::validation::scalar::validate_scalar_definition;
 use crate::validation::schema::validate_schema_definition;
 use crate::validation::union_::validate_union_definition;
 use crate::validation::DiagnosticList;
+use crate::Name;
+use crate::Node;
 use crate::Schema;
+use std::sync::OnceLock;
 
 pub(crate) fn validate_schema(errors: &mut DiagnosticList, schema: &mut Schema) {
+    let mut builtin_scalars = BuiltInScalars::new();
     validate_schema_definition(errors, schema);
-    validate_directive_definitions(errors, schema);
+    validate_directive_definitions(errors, schema, &mut builtin_scalars);
     for def in schema.types.values() {
         match def {
             ExtendedType::Scalar(def) => validate_scalar_definition(errors, schema, def),
-            ExtendedType::Object(def) => validate_object_type_definition(errors, schema, def),
-            ExtendedType::Interface(def) => validate_interface_definition(errors, schema, def),
+            ExtendedType::Object(def) => {
+                validate_object_type_definition(errors, schema, &mut builtin_scalars, def)
+            }
+            ExtendedType::Interface(def) => {
+                validate_interface_definition(errors, schema, &mut builtin_scalars, def)
+            }
             ExtendedType::Union(def) => validate_union_definition(errors, schema, def),
             ExtendedType::Enum(def) => validate_enum_definition(errors, schema, def),
-            ExtendedType::InputObject(def) => validate_input_object_definition(errors, schema, def),
+            ExtendedType::InputObject(def) => {
+                validate_input_object_definition(errors, schema, &mut builtin_scalars, def)
+            }
         }
+    }
+    // Remove definitions of unused built-in scalars
+    if !builtin_scalars.all_used() {
+        schema.types.retain(|name, def| {
+            // Keep all custom (not built-in) definitions
+            if !def.is_built_in() {
+                return true;
+            }
+
+            // Keep built-in non-scalars (such as schema-introspection types)
+            if !builtin_scalars.all.contains_key(name) {
+                return true;
+            }
+
+            // Keep used definitions
+            if builtin_scalars.used_and_defined.contains(name) {
+                return true;
+            }
+
+            // Reached only for unused built-in scalars: remove
+            false
+        })
+    }
+    // Insert missing definitions
+    for name in builtin_scalars.used_and_undefined {
+        let def = &builtin_scalars.all[&name];
+        schema
+            .types
+            .insert(def.name.clone(), ExtendedType::Scalar(def.clone()));
+    }
+}
+
+/// Keeps track of usage of [built-in scalars] in a schema to determine which definitions
+/// should be removed or added.
+///
+/// > When returning the set of types from the `__Schema` introspection type,
+/// > all referenced built-in scalars must be included.
+/// > If a built-in scalar type is not referenced anywhere in a schema
+/// > (there is no field, argument, or input field of that type) then it must not be included.
+///
+/// We reflect this behavior of introspection in the `types` map of a `Valid<Schema>`.
+///
+/// [built-in scalars]: https://spec.graphql.org/draft/#sec-Scalars.Built-in-Scalars
+pub(crate) struct BuiltInScalars {
+    all: &'static HashMap<Name, Node<ScalarType>>,
+    used_and_defined: HashSet<Name>,
+    used_and_undefined: HashSet<Name>,
+}
+
+impl BuiltInScalars {
+    fn new() -> Self {
+        static ALL: OnceLock<HashMap<Name, Node<ScalarType>>> = OnceLock::new();
+        let all = ALL.get_or_init(|| {
+            super::SchemaBuilder::built_in()
+                .schema
+                .types
+                .iter()
+                .filter_map(|(name, def)| {
+                    if let ExtendedType::Scalar(def) = def {
+                        Some((name.clone(), def.clone()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        });
+        Self {
+            all,
+            used_and_defined: HashSet::default(),
+            used_and_undefined: HashSet::default(),
+        }
+    }
+
+    /// Records a type reference to keep track of which built-in scalars are used in a schema,
+    /// and returns whether this type name is for a built-in scalar
+    pub(crate) fn record_type_ref(&mut self, schema: &Schema, name: &Name) -> bool {
+        let is_built_in_scalar = self.all.contains_key(name);
+        if is_built_in_scalar {
+            if schema.types.contains_key(name) {
+                self.used_and_defined.insert(name.clone());
+            } else {
+                self.used_and_undefined.insert(name.clone());
+            }
+        }
+        is_built_in_scalar
+    }
+
+    fn all_used(&self) -> bool {
+        let used_count = self.used_and_defined.len() + self.used_and_undefined.len();
+        used_count == self.all.len()
     }
 }

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -5,6 +5,7 @@ use crate::collections::HashSet;
 use crate::coordinate::DirectiveArgumentCoordinate;
 use crate::coordinate::DirectiveCoordinate;
 use crate::schema;
+use crate::schema::validation::BuiltInScalars;
 use crate::validation::diagnostics::DiagnosticData;
 use crate::validation::DiagnosticList;
 use crate::validation::RecursionGuard;
@@ -140,11 +141,13 @@ impl FindRecursiveDirective<'_> {
 pub(crate) fn validate_directive_definition(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
+    built_in_scalars: &mut BuiltInScalars,
     def: &Node<ast::DirectiveDefinition>,
 ) {
     super::input_object::validate_argument_definitions(
         diagnostics,
         schema,
+        built_in_scalars,
         &def.arguments,
         ast::DirectiveLocation::ArgumentDefinition,
     );
@@ -179,9 +182,10 @@ pub(crate) fn validate_directive_definition(
 pub(crate) fn validate_directive_definitions(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
+    built_in_scalars: &mut BuiltInScalars,
 ) {
     for directive_definition in schema.directive_definitions.values() {
-        validate_directive_definition(diagnostics, schema, directive_definition);
+        validate_directive_definition(diagnostics, schema, built_in_scalars, directive_definition);
     }
 }
 

--- a/crates/apollo-compiler/src/validation/enum_.rs
+++ b/crates/apollo-compiler/src/validation/enum_.rs
@@ -1,17 +1,8 @@
 use crate::ast;
 use crate::schema::EnumType;
-use crate::schema::ExtendedType;
 use crate::validation::diagnostics::DiagnosticData;
 use crate::validation::DiagnosticList;
 use crate::Node;
-
-pub(crate) fn validate_enum_definitions(diagnostics: &mut DiagnosticList, schema: &crate::Schema) {
-    for ty in schema.types.values() {
-        if let ExtendedType::Enum(enum_) = ty {
-            validate_enum_definition(diagnostics, schema, enum_);
-        }
-    }
-}
 
 pub(crate) fn validate_enum_definition(
     diagnostics: &mut DiagnosticList,

--- a/crates/apollo-compiler/src/validation/input_object.rs
+++ b/crates/apollo-compiler/src/validation/input_object.rs
@@ -1,6 +1,5 @@
 use crate::ast;
 use crate::collections::HashMap;
-use crate::schema::ExtendedType;
 use crate::schema::InputObjectType;
 use crate::validation::diagnostics::DiagnosticData;
 use crate::validation::CycleError;
@@ -62,17 +61,6 @@ impl FindRecursiveInputValue<'_> {
         let mut recursion_stack = RecursionStack::with_root(input_object.name.clone());
         FindRecursiveInputValue { schema }
             .input_object_definition(recursion_stack.guard(), input_object)
-    }
-}
-
-pub(crate) fn validate_input_object_definitions(
-    diagnostics: &mut DiagnosticList,
-    schema: &crate::Schema,
-) {
-    for ty in schema.types.values() {
-        if let ExtendedType::InputObject(input_object) = ty {
-            validate_input_object_definition(diagnostics, schema, input_object);
-        }
     }
 }
 

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -2,24 +2,12 @@ use crate::ast;
 use crate::collections::IndexSet;
 use crate::parser::SourceSpan;
 use crate::schema::ComponentName;
-use crate::schema::ExtendedType;
 use crate::schema::InterfaceType;
 use crate::schema::Name;
 use crate::validation::diagnostics::DiagnosticData;
 use crate::validation::field::validate_field_definitions;
 use crate::validation::DiagnosticList;
 use crate::Node;
-
-pub(crate) fn validate_interface_definitions(
-    diagnostics: &mut DiagnosticList,
-    schema: &crate::Schema,
-) {
-    for ty in schema.types.values() {
-        if let ExtendedType::Interface(interface) = ty {
-            validate_interface_definition(diagnostics, schema, interface);
-        }
-    }
-}
 
 pub(crate) fn validate_interface_definition(
     diagnostics: &mut DiagnosticList,

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -1,6 +1,7 @@
 use crate::ast;
 use crate::collections::IndexSet;
 use crate::parser::SourceSpan;
+use crate::schema::validation::BuiltInScalars;
 use crate::schema::ComponentName;
 use crate::schema::InterfaceType;
 use crate::schema::Name;
@@ -12,6 +13,7 @@ use crate::Node;
 pub(crate) fn validate_interface_definition(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
+    built_in_scalars: &mut BuiltInScalars,
     interface: &Node<InterfaceType>,
 ) {
     super::directive::validate_directives(
@@ -50,7 +52,7 @@ pub(crate) fn validate_interface_definition(
     }
 
     // Interface Type field validation.
-    validate_field_definitions(diagnostics, schema, &interface.fields);
+    validate_field_definitions(diagnostics, schema, built_in_scalars, &interface.fields);
 
     // validate there is at least one field on the type
     // https://spec.graphql.org/draft/#sel-HAHbnBFBABABxB4a

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -1,21 +1,9 @@
 use crate::ast;
-use crate::schema::ExtendedType;
 use crate::schema::ObjectType;
 use crate::validation::diagnostics::DiagnosticData;
 use crate::validation::field::validate_field_definitions;
 use crate::validation::DiagnosticList;
 use crate::Node;
-
-pub(crate) fn validate_object_type_definitions(
-    diagnostics: &mut DiagnosticList,
-    schema: &crate::Schema,
-) {
-    for ty in schema.types.values() {
-        if let ExtendedType::Object(object) = ty {
-            validate_object_type_definition(diagnostics, schema, object)
-        }
-    }
-}
 
 pub(crate) fn validate_object_type_definition(
     diagnostics: &mut DiagnosticList,

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -1,4 +1,5 @@
 use crate::ast;
+use crate::schema::validation::BuiltInScalars;
 use crate::schema::ObjectType;
 use crate::validation::diagnostics::DiagnosticData;
 use crate::validation::field::validate_field_definitions;
@@ -8,6 +9,7 @@ use crate::Node;
 pub(crate) fn validate_object_type_definition(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
+    built_in_scalars: &mut BuiltInScalars,
     object: &Node<ObjectType>,
 ) {
     super::directive::validate_directives(
@@ -20,7 +22,7 @@ pub(crate) fn validate_object_type_definition(
     );
 
     // Object Type field validations.
-    validate_field_definitions(diagnostics, schema, &object.fields);
+    validate_field_definitions(diagnostics, schema, built_in_scalars, &object.fields);
 
     // validate there is at least one field on the type
     // https://spec.graphql.org/draft/#sel-FAHZhCFDBAACDA4qe

--- a/crates/apollo-compiler/src/validation/scalar.rs
+++ b/crates/apollo-compiler/src/validation/scalar.rs
@@ -3,17 +3,6 @@ use crate::schema;
 use crate::validation::DiagnosticList;
 use crate::Node;
 
-pub(crate) fn validate_scalar_definitions(
-    diagnostics: &mut DiagnosticList,
-    schema: &crate::Schema,
-) {
-    for def in schema.types.values() {
-        if let schema::ExtendedType::Scalar(scalar) = def {
-            validate_scalar_definition(diagnostics, schema, scalar);
-        }
-    }
-}
-
 pub(crate) fn validate_scalar_definition(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -1,18 +1,9 @@
 use crate::ast;
 use crate::schema;
-use crate::schema::ExtendedType;
 use crate::schema::UnionType;
 use crate::validation::diagnostics::DiagnosticData;
 use crate::validation::DiagnosticList;
 use crate::Node;
-
-pub(crate) fn validate_union_definitions(diagnostics: &mut DiagnosticList, schema: &crate::Schema) {
-    for ty in schema.types.values() {
-        if let ExtendedType::Union(def) = ty {
-            validate_union_definition(diagnostics, schema, def);
-        }
-    }
-}
 
 pub(crate) fn validate_union_definition(
     diagnostics: &mut DiagnosticList,

--- a/crates/apollo-compiler/test_data/introspection/response_full.json
+++ b/crates/apollo-compiler/test_data/introspection/response_full.json
@@ -926,16 +926,6 @@
         },
         {
           "kind": "SCALAR",
-          "name": "Float",
-          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
           "name": "String",
           "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
           "fields": null,

--- a/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             33..58 @3 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             109..134 @4 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
@@ -47,10 +47,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "PetType": Enum(
             105..135 @5 EnumType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
+++ b/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..44 @6 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..43 @7 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "SearchResult": Union(
             33..68 @8 UnionType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
@@ -37,7 +37,6 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
         "ID": built_in_type!("ID"),

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
@@ -56,8 +56,6 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
         "ID": built_in_type!("ID"),

--- a/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
@@ -40,7 +40,6 @@ Schema {
         "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..44 @11 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -56,10 +56,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             70..134 @12 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
@@ -36,8 +36,6 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
         "ID": built_in_type!("ID"),

--- a/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
+++ b/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             1266..1293 @14 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             165..233 @15 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0014_float_values.txt
+++ b/crates/apollo-compiler/test_data/ok/0014_float_values.txt
@@ -36,11 +36,9 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
         "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..56 @16 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
@@ -232,7 +232,6 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
         "ID": built_in_type!("ID"),

--- a/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
+++ b/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             230..255 @18 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Dog": Object(
             314..429 @19 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
+++ b/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
@@ -46,10 +46,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "A": Object(
             78..100 @20 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0019_extensions.txt
+++ b/crates/apollo-compiler/test_data/ok/0019_extensions.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Scalar": Scalar(
             0..13 @21 ScalarType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..25 @22 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
+++ b/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "DogCommand": Enum(
             0..32 @23 EnumType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
+++ b/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Pet": Interface(
             0..33 @24 InterfaceType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..77 @25 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
@@ -55,10 +55,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             70..97 @26 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
+++ b/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..59 @27 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..59 @28 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "SearchResult": Union(
             0..35 @29 UnionType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
+++ b/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Product": Object(
             0..65 @30 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
+++ b/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..60 @31 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
+++ b/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
@@ -37,7 +37,6 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
         "ID": built_in_type!("ID"),

--- a/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
+++ b/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             298..337 @34 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
+++ b/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
@@ -78,10 +78,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             200..235 @35 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0035_implicit_schema_definition_with_query_type.txt
+++ b/crates/apollo-compiler/test_data/ok/0035_implicit_schema_definition_with_query_type.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..31 @36 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0036_implicit_schema_definition_with_several_default_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0036_implicit_schema_definition_with_several_default_types.txt
@@ -41,11 +41,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..31 @37 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
@@ -59,11 +59,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..31 @38 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
+++ b/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
@@ -70,10 +70,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             96..147 @39 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0039_string_literals.txt
+++ b/crates/apollo-compiler/test_data/ok/0039_string_literals.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..947 @40 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0040_field_merging_issue_755.txt
+++ b/crates/apollo-compiler/test_data/ok/0040_field_merging_issue_755.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Subselection": Object(
             174..213 @41 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0041_unquoted_string_for_custom_scalar.txt
+++ b/crates/apollo-compiler/test_data/ok/0041_unquoted_string_for_custom_scalar.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Currency": Scalar(
             0..15 @42 ScalarType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0042_used_variable_in_operation_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0042_used_variable_in_operation_directive.txt
@@ -87,10 +87,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             106..135 @43 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.txt
+++ b/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.txt
@@ -36,11 +36,8 @@ Schema {
         "__EnumValue": built_in_type!("__EnumValue"),
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
-        "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..28 @44 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/test_data/ok/0116_interface_without_implementations.txt
+++ b/crates/apollo-compiler/test_data/ok/0116_interface_without_implementations.txt
@@ -37,10 +37,8 @@ Schema {
         "__Directive": built_in_type!("__Directive"),
         "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
         "Int": built_in_type!("Int"),
-        "Float": built_in_type!("Float"),
         "String": built_in_type!("String"),
         "Boolean": built_in_type!("Boolean"),
-        "ID": built_in_type!("ID"),
         "Query": Object(
             0..27 @45 ObjectType {
                 description: None,

--- a/crates/apollo-compiler/tests/introspection.rs
+++ b/crates/apollo-compiler/tests/introspection.rs
@@ -1,7 +1,12 @@
+use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::ast::InputValueDefinition;
 use apollo_compiler::execution::coerce_variable_values;
 use apollo_compiler::execution::JsonMap;
 use apollo_compiler::execution::Response;
 use apollo_compiler::execution::SchemaIntrospectionQuery;
+use apollo_compiler::name;
+use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::ty;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Schema;
 use expect_test::expect;
@@ -133,4 +138,75 @@ fn test() {
         Default::default(),
     );
     expect_file!("../test_data/introspection/response_full.json").assert_eq(&response);
+}
+
+#[test]
+fn built_in_scalars() {
+    // Initially a `Schema` contains all built-in types
+    let schema = Schema::new();
+    assert!(schema.types.contains_key("ID"));
+    assert!(schema.types.contains_key("Int"));
+    assert!(schema.types.contains_key("Float"));
+    assert!(schema.types.contains_key("String"));
+    assert!(schema.types.contains_key("Boolean"));
+
+    // Same when parsing
+    let input = r"
+      type Query { some: Thing }
+      scalar Thing
+    ";
+    let schema = Schema::parse(input, "").unwrap();
+    assert!(schema.types.contains_key("ID"));
+    assert!(schema.types.contains_key("Int"));
+    assert!(schema.types.contains_key("Float"));
+    assert!(schema.types.contains_key("String"));
+    assert!(schema.types.contains_key("Boolean"));
+
+    // https://spec.graphql.org/draft/#sec-Scalars.Built-in-Scalars
+    // > When returning the set of types from the `__Schema` introspection type,
+    // > all referenced built-in scalars must be included.
+    // > If a built-in scalar type is not referenced anywhere in a schema
+    // > (there is no field, argument, or input field of that type) then it must not be included.
+    //
+    // We reflect this behavior in the Rust API for `Valid<Schema>`:
+    // validation removes unused definitions
+    let valid_schema = schema.validate().unwrap();
+    assert!(!valid_schema.types.contains_key("ID"));
+    assert!(!valid_schema.types.contains_key("Int"));
+    assert!(!valid_schema.types.contains_key("Float"));
+    // String and Boolean are still used in built-in directives and schema-introspection types
+    assert!(valid_schema.types.contains_key("String"));
+    assert!(valid_schema.types.contains_key("Boolean"));
+
+    // The `Valid<_>` wrapper makes its contents immutable, but it can be unwraped
+    let mut mutable_again = valid_schema.into_inner();
+    let ExtendedType::Object(query) = &mut mutable_again.types["Query"] else {
+        panic!("expected object")
+    };
+    query.make_mut().fields.insert(
+        name!(sensor),
+        FieldDefinition {
+            description: None,
+            name: name!(sensor),
+            arguments: vec![InputValueDefinition {
+                description: None,
+                name: name!(sensorId),
+                ty: ty!(ID).into(),
+                default_value: None,
+                directives: Default::default(),
+            }
+            .into()],
+            ty: ty!(Float),
+            directives: Default::default(),
+        }
+        .into(),
+    );
+    let valid_after_mutation = mutable_again.validate().unwrap();
+
+    // Validation also adds/restores definitions as needed:
+    assert!(valid_after_mutation.types.contains_key("ID"));
+    assert!(!valid_after_mutation.types.contains_key("Int"));
+    assert!(valid_after_mutation.types.contains_key("Float"));
+    assert!(valid_after_mutation.types.contains_key("String"));
+    assert!(valid_after_mutation.types.contains_key("Boolean"));
 }


### PR DESCRIPTION
We choose to reflect in the Rust API the behavior expected of introspection:

https://spec.graphql.org/draft/#sec-Scalars.Built-in-Scalars
> When returning the set of types from the `__Schema` introspection type, all referenced built-in scalars must be included. If a built-in scalar type is not referenced anywhere in a schema (there is no field, argument, or input field of that type) then it must not be included.

Because our public API allows arbitrary mutation of a Rust `Schema`, we need a full schema scan at some point to determine usage. Validation is a good fit as it already does this scan.

In [the full GraphQL grammar](https://spec.graphql.org/draft/#sec-Document-Syntax)
the `NamedType` rule is used in:

* `TypeCondition`: not in a schema
* `RootOperationDefinition`, `UnionMemberTypes`: must refer to an object type
* `ImplementsInterfaces`: must refer to an interface type, not a scalar
* `Type` / `NonNullType`:
  * … in `VariableDefinition`: not in a schema
  * … in `FieldDefinition`: object/interface field "return" type, **can be a scalar**
  * … in `InputValueDefinition`: **can be a scalar**
    * … in `InputFieldsDefinition` (fields of input types)
    * … in `ArgumentsDefinition` for directive arguments or object/interface field arguments

Based on this, I think `validate_input_value_definitions` and `validate_field_definitions` are the only two places where validation code needs to record potential references to built-in scalar types.