### PR TITLE
Add failing test for #916

### DIFF
--- a/crates/apollo-compiler/test_data/diagnostics/0119_nested_subselection_issue_916.graphql
+++ b/crates/apollo-compiler/test_data/diagnostics/0119_nested_subselection_issue_916.graphql
@@ -1,0 +1,8 @@
+type Query {
+  me: User
+}
+type User {
+  name: String
+}
+
+query Invalid { me { name { reviews { body } } } }

--- a/crates/apollo-compiler/test_data/diagnostics/0119_nested_subselection_issue_916.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0119_nested_subselection_issue_916.txt
@@ -1,0 +1,10 @@
+Error: field selection of scalar type `String` must not have subselections
+   ╭─[0119_nested_subselection_issue_916.graphql:8:22]
+   │
+ 8 │ query Invalid { me { name { reviews { body } } } }
+   │                      ────────────┬────────────  
+   │                                  ╰────────────── remove subselections here
+   │ 
+   │ Note: path to the field: `query Invalid → me → name`
+───╯
+

--- a/crates/apollo-compiler/test_data/serializer/diagnostics/0119_nested_subselection_issue_916.graphql
+++ b/crates/apollo-compiler/test_data/serializer/diagnostics/0119_nested_subselection_issue_916.graphql
@@ -1,0 +1,17 @@
+type Query {
+  me: User
+}
+
+type User {
+  name: String
+}
+
+query Invalid {
+  me {
+    name {
+      reviews {
+        body
+      }
+    }
+  }
+}


### PR DESCRIPTION
It also reports this, which doesn't make sense:
```
Error: interface, union and object types must have a subselection set
   ╭─[0119_nested_subselection_issue_916.graphql:8:17]
   │
 8 │ query Invalid { me { name { reviews { body } } } }
   │                 ────────────────┬───────────────
   │                                 ╰───────────────── `Query.me` is an object type `User` and must select fields
───╯
```