### PR TITLE
chore(compiler): add some benchmarks with many duplicate directives

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -48,6 +48,11 @@ path = "benches/multi_source.rs"
 harness = false
 
 [[bench]]
+name = "directives-validation"
+path = "benches/directives_validation.rs"
+harness = false
+
+[[bench]]
 name = "fields-validation"
 path = "benches/fields_validation.rs"
 harness = false

--- a/crates/apollo-compiler/benches/directives_validation.rs
+++ b/crates/apollo-compiler/benches/directives_validation.rs
@@ -1,0 +1,79 @@
+use apollo_compiler::{ExecutableDocument, Schema};
+use criterion::*;
+
+fn bench_many_identical_directives(c: &mut Criterion) {
+    let schema = format!(
+        r#"
+        directive @nothing repeatable on OBJECT
+        type Query {} {{ hello: String! }}
+        "#,
+        "@nothing ".repeat(10_000),
+    );
+
+    c.bench_function("many_same_directive", move |b| {
+        b.iter(|| {
+            let result = Schema::parse_and_validate(&schema, "schema.graphqls").unwrap();
+            black_box(result);
+        });
+    });
+}
+
+fn bench_many_identical_directives_query(c: &mut Criterion) {
+    let schema = Schema::parse_and_validate(
+        r#"
+        directive @nothing repeatable on FIELD
+        type Query { hello: String! }
+        "#,
+        "schema.graphql",
+    ).unwrap();
+
+    let query = format!(
+        r#"
+        {{
+          hello {}
+        }}
+        "#,
+        "@nothing ".repeat(10_000),
+    );
+
+    c.bench_function("many_same_directive_query", move |b| {
+        b.iter(|| {
+            let result = ExecutableDocument::parse_and_validate(&schema, &query, "query.graphql").unwrap();
+            black_box(result);
+        });
+    });
+}
+
+fn bench_many_invalid_directives_query(c: &mut Criterion) {
+    let schema = Schema::parse_and_validate(
+        r#"
+        type Query { hello: String! }
+        "#,
+        "schema.graphql",
+    ).unwrap();
+
+    let query = format!(
+        r#"
+        {{
+          hello {}
+        }}
+        "#,
+        "@nothing ".repeat(10_000),
+    );
+
+    c.bench_function("many_invalid_directive", move |b| {
+        b.iter(|| {
+            let result = ExecutableDocument::parse_and_validate(&schema, &query, "query.graphql")
+                .expect_err("should have produced diagnostics");
+            black_box(result);
+        });
+    });
+}
+
+criterion_group!(
+    directives,
+    bench_many_identical_directives,
+    bench_many_identical_directives_query,
+    bench_many_invalid_directives_query,
+);
+criterion_main!(directives);

--- a/crates/apollo-compiler/benches/directives_validation.rs
+++ b/crates/apollo-compiler/benches/directives_validation.rs
@@ -1,4 +1,5 @@
-use apollo_compiler::{ExecutableDocument, Schema};
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
 use criterion::*;
 
 fn bench_many_identical_directives(c: &mut Criterion) {
@@ -25,7 +26,8 @@ fn bench_many_identical_directives_query(c: &mut Criterion) {
         type Query { hello: String! }
         "#,
         "schema.graphql",
-    ).unwrap();
+    )
+    .unwrap();
 
     let query = format!(
         r#"
@@ -38,7 +40,8 @@ fn bench_many_identical_directives_query(c: &mut Criterion) {
 
     c.bench_function("many_same_directive_query", move |b| {
         b.iter(|| {
-            let result = ExecutableDocument::parse_and_validate(&schema, &query, "query.graphql").unwrap();
+            let result =
+                ExecutableDocument::parse_and_validate(&schema, &query, "query.graphql").unwrap();
             black_box(result);
         });
     });
@@ -50,7 +53,8 @@ fn bench_many_invalid_directives_query(c: &mut Criterion) {
         type Query { hello: String! }
         "#,
         "schema.graphql",
-    ).unwrap();
+    )
+    .unwrap();
 
     let query = format!(
         r#"


### PR DESCRIPTION
It could be risky if these are slow to parse or validate, as it's easy
to produce a malicious document with many directives.

Parsing + validation of a document with 10K directives seems to take
about 3 ms on my laptop, which seems acceptable.

```
many_same_directive     time:   [3.0178 ms 3.0297 ms 3.0423 ms]
                        change: [-0.4138% +0.3025% +0.9324%] (p = 0.41 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

many_same_directive_query
                        time:   [3.0302 ms 3.0358 ms 3.0419 ms]
                        change: [-0.7244% -0.4807% -0.2229%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

many_invalid_directive  time:   [2.8780 ms 2.8877 ms 2.8980 ms]
                        change: [-0.7915% -0.3865% +0.0358%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```