### PR TITLE
Silence clippy::result_large_err warning

### DIFF
--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -54,6 +54,7 @@ impl Document {
     }
 
     /// Build a schema with this AST document as its sole input.
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn to_schema(&self) -> Result<Schema, WithErrors<Schema>> {
         let mut builder = Schema::builder();
         let executable_definitions_are_errors = true;
@@ -62,6 +63,7 @@ impl Document {
     }
 
     /// Build and validate a schema with this AST document as its sole input.
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn to_schema_validate(&self) -> Result<Valid<Schema>, WithErrors<Schema>> {
         let mut builder = Schema::builder();
         let executable_definitions_are_errors = true;
@@ -72,6 +74,7 @@ impl Document {
     }
 
     /// Build an executable document from this AST, with the given schema
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn to_executable(
         &self,
         schema: &Valid<Schema>,
@@ -82,6 +85,7 @@ impl Document {
     }
 
     /// Build and validate an executable document from this AST, with the given schema
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn to_executable_validate(
         &self,
         schema: &Valid<Schema>,

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -295,6 +295,7 @@ impl ExecutableDocument {
     /// to identify this source file to users.
     ///
     /// Create a [`Parser`] to use different parser configuration.
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn parse(
         schema: &Valid<Schema>,
         source_text: impl Into<String>,
@@ -305,6 +306,7 @@ impl ExecutableDocument {
 
     /// [`parse`][Self::parse] then [`validate`][Self::validate],
     /// to get a `Valid<ExecutableDocument>` when mutating it isn’t needed.
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn parse_and_validate(
         schema: &Valid<Schema>,
         source_text: impl Into<String>,
@@ -317,6 +319,7 @@ impl ExecutableDocument {
         errors.into_valid_result(doc)
     }
 
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn validate(self, schema: &Valid<Schema>) -> Result<Valid<Self>, WithErrors<Self>> {
         let mut sources = IndexMap::clone(&schema.sources);
         sources.extend(self.sources.iter().map(|(k, v)| (*k, v.clone())));

--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -208,6 +208,7 @@ impl Parser {
     ///
     /// To have multiple files contribute to a schema,
     /// use [`Schema::builder`] and [`Parser::parse_into_schema_builder`].
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn parse_schema(
         &mut self,
         source_text: impl Into<String>,
@@ -241,6 +242,7 @@ impl Parser {
     ///
     /// `path` is the filesystem path (or arbitrary string) used in diagnostics
     /// to identify this source file to users.
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn parse_executable(
         &mut self,
         schema: &Valid<Schema>,

--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -255,6 +255,7 @@ impl SchemaBuilder {
     }
 
     /// Returns the schema built from all added documents
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn build(self) -> Result<Schema, WithErrors<Schema>> {
         let (schema, errors) = self.build_inner();
         errors.into_result_with(schema)

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -335,6 +335,7 @@ impl Schema {
     ///
     /// Create a [`Parser`] to use different parser configuration.
     /// Use [`builder()`][Self::builder] to build a schema from multiple parsed files.
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn parse(
         source_text: impl Into<String>,
         path: impl AsRef<Path>,
@@ -344,6 +345,7 @@ impl Schema {
 
     /// [`parse`][Self::parse] then [`validate`][Self::validate],
     /// to get a `Valid<Schema>` when mutating it isn’t needed.
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn parse_and_validate(
         source_text: impl Into<String>,
         path: impl AsRef<Path>,
@@ -367,6 +369,7 @@ impl Schema {
         SchemaBuilder::new()
     }
 
+    #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn validate(mut self) -> Result<Valid<Self>, WithErrors<Self>> {
         let mut errors = DiagnosticList::new(self.sources.clone());
         validation::validate_schema(&mut errors, &mut self);


### PR DESCRIPTION
This lint seems to be more aggressive in Rust 1.82 than in previous versions as it now warns about functions returning `Result<Schema, WithErrors<Schema>>` or `Result<ExecutableDocument, WithErrors<ExecutableDocument>>`.

The lint is correct that a return value of e.g. 224 bytes has some cost, but parsing and validation functions are typically not called very often so we accept this cost rather than make the API more awkward by boxing schemas and documents.