### PR TITLE
remove CCI-based security scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ version: 2.1
 orbs:
   rust: circleci/rust@1.6.1
   gh: circleci/github-cli@2.6.0
-  secops: apollo/circleci-secops-orb@2.0.7
 
 # We run jobs on the following platforms: linux, macos and windows.
 # These are their specifications:
@@ -66,20 +65,6 @@ workflows:
           matrix:
             parameters:
               platform: [linux]
-  security-scans:
-    jobs:
-      - secops/gitleaks:
-          context:
-            - platform-docker-ro
-            - github-orb
-            - secops-oidc
-          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
-          git-revision: << pipeline.git.revision >>
-      - secops/semgrep:
-          context:
-            - secops-oidc
-            - github-orb
-          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
 
 # Details of the three jobs: lint, test and wasm
 jobs:


### PR DESCRIPTION
## Motivation / Implements

[SECOPS-4142](https://apollographql.atlassian.net/browse/SECOPS-4142)

Removes the security scans running on this repo in CircleCI in favor of our Github App-based implementation of the same scans. After this PR merges, I'll update the branch protection rules on the repo to require the Github App-based jobs.

The Github app implementation improves both the time it takes to run these tests and better supports pull requests from forks.

## Changed 
- Removed the `gitleaks` and `semgrep` jobs that were running in CircleCI. 


[SECOPS-4142]: https://apollographql.atlassian.net/browse/SECOPS-4142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ