### PR TITLE
chore: remove rust 1.76.0 MSRV, and unpin rowan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,7 @@ workflows:
           matrix:
             parameters:
               platform: [linux, macos, windows]
-              # The Apollo Router is stuck on 1.76.0
-              rust_channel: [1.76.0, stable, nightly]
+              rust_channel: [stable, nightly]
   miri:
     jobs:
       - miri:

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -22,7 +22,7 @@ ahash = "0.8.11"
 apollo-parser = { path = "../apollo-parser", version = "0.8.0" }
 ariadne = { version = "0.5.0", features = ["auto-color"] }
 indexmap = "2.0.0"
-rowan = "=0.15.15"
+rowan = "0.15.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json_bytes = { version = "0.2.2", features = ["preserve_order"] }
 thiserror = "1.0.31"

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 
 [dependencies]
 memchr = "2.6.1"
-rowan = "=0.15.15"
+rowan = "0.15.15"
 thiserror = "1.0.30"
 
 [dev-dependencies]


### PR DESCRIPTION
This essentially reverts #933.

Apollo Router is no longer stuck on rustc 1.76.0, so we don't have a reason to stay on that old version.

We could consider using the same rustc version as Router (so 1.83.0 at the time of writing), in case some other constraint forces us to pin it again. I think it's much less likely now without Deno, and it's more work to update both repositories if we are pinning a version in both, so I am not doing it here.