### PR TITLE
Avoid reprocessing named fragments

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -30,6 +30,7 @@ triomphe = "0.1.13"
 typed-arena = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 uuid = { version = "1.6", features = ["serde", "v4", "js"] }
 
 [dev-dependencies]

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -804,7 +804,7 @@ impl Field {
     }
 
     pub fn with_opt_alias(mut self, alias: Option<Name>) -> Self {
-        self.alias = alias.map(Into::into);
+        self.alias = alias;
         self
     }
 

--- a/crates/apollo-compiler/src/executable/validation.rs
+++ b/crates/apollo-compiler/src/executable/validation.rs
@@ -61,6 +61,6 @@ pub(crate) fn validate_field_set(
         document,
         Some((schema, &field_set.selection_set.ty)),
         &field_set.selection_set,
-        context.operation_context(&[]),
+        &mut context.operation_context(&[]),
     )
 }

--- a/crates/apollo-compiler/src/introspection/max_depth.rs
+++ b/crates/apollo-compiler/src/introspection/max_depth.rs
@@ -1,4 +1,4 @@
-use crate::collections::HashSet;
+use crate::collections::HashMap;
 use crate::executable::Selection;
 use crate::executable::SelectionSet;
 use crate::request::RequestError;
@@ -10,29 +10,48 @@ const MAX_LISTS_DEPTH: u32 = 3;
 
 pub(super) fn check_selection_set<'doc>(
     document: &'doc Valid<ExecutableDocument>,
-    fragments_visited: &mut HashSet<&'doc Name>,
+    fragment_depths: &mut HashMap<&'doc Name, u32>,
     depth_so_far: u32,
     selection_set: &'doc SelectionSet,
-) -> Result<(), RequestError> {
+) -> Result<u32, RequestError> {
+    let mut max_depth = depth_so_far;
     for selection in &selection_set.selections {
         match selection {
-            Selection::InlineFragment(inline) => check_selection_set(
-                document,
-                fragments_visited,
-                depth_so_far,
-                &inline.selection_set,
-            )?,
+            Selection::InlineFragment(inline) => {
+                max_depth = max_depth.max(check_selection_set(
+                    document,
+                    fragment_depths,
+                    depth_so_far,
+                    &inline.selection_set,
+                )?)
+            }
             Selection::FragmentSpread(spread) => {
-                if let Some(def) = document.fragments.get(&spread.fragment_name) {
-                    let new = fragments_visited.insert(&spread.fragment_name);
-                    if new {
-                        check_selection_set(
-                            document,
-                            fragments_visited,
-                            depth_so_far,
-                            &def.selection_set,
-                        )?
+                let Some(def) = document.fragments.get(&spread.fragment_name) else {
+                    continue;
+                };
+                // Avoiding the entry API because we may have to modify the map in-between this `.get()`
+                // and the `.insert()`.
+                if let Some(fragment_depth) = fragment_depths.get(&spread.fragment_name) {
+                    if depth_so_far + *fragment_depth > MAX_LISTS_DEPTH {
+                        return Err(RequestError {
+                            message: "Maximum introspection depth exceeded".into(),
+                            location: spread.location(),
+                            is_suspected_validation_bug: false,
+                        });
                     }
+                } else {
+                    // Recursing without marking our fragment spread as used is fine,
+                    // because validation guarantees that we do not have a self-referential
+                    // fragment chain.
+                    let post_fragment_depth = check_selection_set(
+                        document,
+                        fragment_depths,
+                        depth_so_far,
+                        &def.selection_set,
+                    )?;
+                    fragment_depths
+                        .insert(&spread.fragment_name, post_fragment_depth - depth_so_far);
+                    max_depth = max_depth.max(post_fragment_depth);
                 }
             }
             Selection::Field(field) => {
@@ -50,9 +69,14 @@ pub(super) fn check_selection_set<'doc>(
                         });
                     }
                 }
-                check_selection_set(document, fragments_visited, depth, &field.selection_set)?
+                max_depth = max_depth.max(check_selection_set(
+                    document,
+                    fragment_depths,
+                    depth,
+                    &field.selection_set,
+                )?)
             }
         }
     }
-    Ok(())
+    Ok(max_depth)
 }

--- a/crates/apollo-compiler/src/introspection/mod.rs
+++ b/crates/apollo-compiler/src/introspection/mod.rs
@@ -5,6 +5,7 @@
 //! The main entry point is [`partial_execute`].
 
 use crate::collections::HashMap;
+use crate::collections::HashSet;
 use crate::executable::Operation;
 #[cfg(doc)]
 use crate::executable::OperationMap;
@@ -42,7 +43,12 @@ pub fn check_max_depth(
     operation: &Operation,
 ) -> Result<(), RequestError> {
     let initial_depth = 0;
-    max_depth::check_selection_set(document, initial_depth, &operation.selection_set)
+    max_depth::check_selection_set(
+        document,
+        &mut HashSet::default(),
+        initial_depth,
+        &operation.selection_set,
+    )
 }
 
 /// Excecutes the [schema introspection](https://spec.graphql.org/draft/#sec-Schema-Introspection)

--- a/crates/apollo-compiler/src/introspection/mod.rs
+++ b/crates/apollo-compiler/src/introspection/mod.rs
@@ -5,7 +5,6 @@
 //! The main entry point is [`partial_execute`].
 
 use crate::collections::HashMap;
-use crate::collections::HashSet;
 use crate::executable::Operation;
 #[cfg(doc)]
 use crate::executable::OperationMap;
@@ -45,10 +44,11 @@ pub fn check_max_depth(
     let initial_depth = 0;
     max_depth::check_selection_set(
         document,
-        &mut HashSet::default(),
+        &mut HashMap::default(),
         initial_depth,
         &operation.selection_set,
     )
+    .map(drop)
 }
 
 /// Excecutes the [schema introspection](https://spec.graphql.org/draft/#sec-Schema-Introspection)

--- a/crates/apollo-compiler/src/validation/field.rs
+++ b/crates/apollo-compiler/src/validation/field.rs
@@ -19,7 +19,7 @@ pub(crate) fn validate_field(
     // May be None if a parent selection was invalid
     against_type: Option<(&crate::Schema, &ast::NamedType)>,
     field: &Node<executable::Field>,
-    context: OperationValidationContext<'_>,
+    context: &mut OperationValidationContext<'_>,
 ) {
     // First do all the validation that we can without knowing the type of the field.
 

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod value;
 pub(crate) mod variable;
 
 use crate::collections::HashMap;
+use crate::collections::HashSet;
 use crate::collections::IndexSet;
 use crate::diagnostic::CliReport;
 use crate::diagnostic::Diagnostic;
@@ -160,18 +161,20 @@ impl<'a> ExecutableValidationContext<'a> {
         OperationValidationContext {
             executable: self,
             variables,
+            validated_fragments: HashSet::default(),
         }
     }
 }
 
 /// Shared context when validating things inside an operation.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub(crate) struct OperationValidationContext<'a> {
     /// Parent context. Using a reference so the `OnceLock` is shared between all operation
     /// contexts.
     executable: &'a ExecutableValidationContext<'a>,
     /// The variables defined for this operation.
-    pub variables: &'a [Node<VariableDefinition>],
+    pub(crate) variables: &'a [Node<VariableDefinition>],
+    pub(crate) validated_fragments: HashSet<Name>,
 }
 
 impl<'a> OperationValidationContext<'a> {

--- a/crates/apollo-compiler/src/validation/operation.rs
+++ b/crates/apollo-compiler/src/validation/operation.rs
@@ -82,7 +82,7 @@ pub(crate) fn validate_operation(
         document,
         against_type,
         &operation.selection_set,
-        context.operation_context(&operation.variables),
+        &mut context.operation_context(&operation.variables),
     );
 }
 

--- a/crates/apollo-compiler/src/validation/selection.rs
+++ b/crates/apollo-compiler/src/validation/selection.rs
@@ -581,7 +581,7 @@ pub(crate) fn validate_selection_set(
     document: &ExecutableDocument,
     against_type: Option<(&crate::Schema, &NamedType)>,
     selection_set: &SelectionSet,
-    context: OperationValidationContext<'_>,
+    context: &mut OperationValidationContext<'_>,
 ) {
     for selection in &selection_set.selections {
         match selection {

--- a/crates/apollo-compiler/tests/executable.rs
+++ b/crates/apollo-compiler/tests/executable.rs
@@ -272,7 +272,7 @@ fn iter_root_fields() {
         op.root_fields(&doc)
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>(),
-        ["f1", "f2", "f3", "f3"]
+        ["f1", "f2", "f3"]
     );
 }
 
@@ -299,6 +299,6 @@ fn iter_all_fields() {
         op.all_fields(&doc)
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>(),
-        ["f1", "inner", "f2", "f3", "f3"]
+        ["f1", "inner", "f2", "f3"]
     );
 }

--- a/crates/apollo-compiler/tests/validation/recursion.rs
+++ b/crates/apollo-compiler/tests/validation/recursion.rs
@@ -120,7 +120,6 @@ fn long_fragment_chains_do_not_overflow_stack() {
 
     let expected = expect_test::expect![[r#"
         Error: too much recursion
-        Error: too much recursion
         Error: `typeFragment1` contains too much nesting
             ╭─[overflow.graphql:11:11]
             │


### PR DESCRIPTION
Due to named fragments being processed more than once, some error messages were getting duplicated. This PR fixes the relevant functions, and also avoids reprocessing named fragments in other parts of the codebase.