### PR TITLE
Add WebAssembly demo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,11 @@ jobs:
           rust_channel: << parameters.rust_channel >>
           platform: << parameters.platform >>
       - run:
-          name: Build to wasm target
-          command: rustup target add wasm32-unknown-unknown && cargo build --package apollo-parser --package apollo-compiler --target wasm32-unknown-unknown
+          name: Install wasm-pack
+          command: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - run:
+          name: Build wasm demo
+          command: wasm-pack build --target web examples/validation-wasm-demo
 
   test:
     parameters:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "crates/apollo-parser",
     "crates/apollo-compiler",
     "crates/apollo-smith",
-    "fuzz",
+    "fuzz", 
+    "examples/validation-wasm-demo",
 ]

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -29,9 +29,6 @@ thiserror = "1.0.31"
 triomphe = "0.1.13"
 typed-arena = "2.0"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-uuid = { version = "1.6", features = ["serde", "v4", "js"] }
-
 [dev-dependencies]
 anyhow = "1.0"
 criterion = "0.5.1"

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -794,7 +794,7 @@ impl Field {
     }
 
     pub fn with_opt_alias(mut self, alias: Option<Name>) -> Self {
-        self.alias = alias.map(Into::into);
+        self.alias = alias;
         self
     }
 

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -1028,7 +1028,7 @@ impl DiagnosticList {
     }
 }
 
-/// Use Debug formatting to output with colors: `format!("{diagnostics:?}")`
+/// Use Display formatting to output without colors: `format!("{diagnostics}")`
 impl fmt::Display for DiagnosticList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for diagnostic in self.iter() {
@@ -1038,7 +1038,7 @@ impl fmt::Display for DiagnosticList {
     }
 }
 
-/// Use Display formatting to output without colors: `format!("{diagnostics}")`
+/// Use Debug formatting to output with colors: `format!("{diagnostics:?}")`
 impl fmt::Debug for DiagnosticList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for diagnostic in self.iter() {

--- a/examples/validation-wasm-demo/Cargo.toml
+++ b/examples/validation-wasm-demo/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "validation-wasm-demo"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+apollo-compiler.path = "../../crates/apollo-compiler"
+# https://docs.rs/getrandom/0.2.15/getrandom/index.html#webassembly-support
+getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen = "0.2.100"

--- a/examples/validation-wasm-demo/README.md
+++ b/examples/validation-wasm-demo/README.md
@@ -1,0 +1,9 @@
+# WebAssembly demo of GraphQL validation
+
+1. [Install wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
+2. Install either [miniserve](https://crates.io/crates/miniserve) with `cargo install miniserve`,
+   or Python
+3. Move to this directory if needed: `cd examples/validation-wasm-demo`
+3. Build with `wasm-pack build --target web`
+4. Start an HTTP server with `miniserve --index index.html` or `python3 -m http.server`
+5. Navigate to [http://127.0.0.1:8080/](http://127.0.0.1:8080/)

--- a/examples/validation-wasm-demo/index.html
+++ b/examples/validation-wasm-demo/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset=utf-8>
+  <title>GraphQL validation in Wasm demo</title>
+  <style>
+    html {
+      margin: 0;
+      padding: 0;
+      color: #222;
+    }
+
+    body {
+      margin: 0 auto;
+      padding: 1em;
+      max-width: 120ch;
+      font-family: sans-serif;
+    }
+
+    h1 {
+      border-bottom: 1px solid;
+    }
+
+    body>div {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1em;
+    }
+
+    body>div>div {
+      flex: 1;
+      min-width: 40ch;
+    }
+
+    textarea {
+      width: 100%;
+      height: 15em;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>GraphQL validation in Wasm demo</h1>
+  <div>
+    <div>
+      <h2>Schema</h2>
+      <textarea id=schema>
+type Query {
+  field1: Int64
+}
+</textarea>
+    </div>
+    <div>
+      <h2>Executable Document</h2>
+      <textarea id=executable>
+{ field2 }
+</textarea>
+    </div>
+  </div>
+  <h2>Diagnostics</h2>
+  <button id=validate>Validate</button>
+  <pre id=diagnostics></pre>
+
+  <script type="module">
+    import init, { validate } from './pkg/validation_wasm_demo.js';
+    async function run() {
+      await init();
+      document.getElementById("validate").addEventListener("click", function (e) {
+        let result = validate(
+          document.getElementById("schema").value,
+          document.getElementById("executable").value,
+        );
+        document.getElementById("diagnostics").textContent = result || "No error!";
+      });
+    }
+    run();
+  </script>
+</body>
+
+</html>

--- a/examples/validation-wasm-demo/src/lib.rs
+++ b/examples/validation-wasm-demo/src/lib.rs
@@ -1,0 +1,29 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn validate(schema_sdl: &str, executable_document: &str) -> Option<String> {
+    let schema_result = apollo_compiler::Schema::parse_and_validate(schema_sdl, "schema.graphql");
+    if executable_document.trim().is_empty() {
+        return schema_result.err().map(|e| e.to_string());
+    }
+    let schema = match &schema_result {
+        Ok(s) => s,
+        Err(with_errors) => {
+            apollo_compiler::validation::Valid::assume_valid_ref(&with_errors.partial)
+        }
+    };
+    let executable_result = apollo_compiler::ExecutableDocument::parse_and_validate(
+        schema,
+        executable_document,
+        "executable.graphql",
+    );
+    match (schema_result, executable_result) {
+        (Ok(_), Ok(_)) => None,
+        (Ok(_), Err(e)) => Some(e.to_string()),
+        (Err(e), Ok(_)) => Some(e.to_string()),
+        (Err(mut e1), Err(e2)) => {
+            e1.errors.merge(e2.errors);
+            Some(e1.to_string())
+        }
+    }
+}

--- a/examples/validation-wasm-demo/src/lib.rs
+++ b/examples/validation-wasm-demo/src/lib.rs
@@ -1,5 +1,13 @@
 use wasm_bindgen::prelude::*;
 
+/// Returns diagnostics formatted to a string,
+/// or `None` / `null` if the schema and documents are valid together.
+///
+/// The format is intitially intended for terminal output and contains symbol-based
+/// underlyning and arrows that require a monospace font to display properly.
+///
+/// This interface is just enough for a demo.
+/// In a real application you may want something more structured.
 #[wasm_bindgen]
 pub fn validate(schema_sdl: &str, executable_document: &str) -> Option<String> {
     let schema_result = apollo_compiler::Schema::parse_and_validate(schema_sdl, "schema.graphql");


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ee56747a-632b-418d-9797-e21ee2024178)

This replace compiling the library with wasm target on CI, which recently started failing with:

```
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /home/circleci/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.15/src/lib.rs:342:9
    |
342 | /         compile_error!("the wasm*-unknown-unknown targets are not supported by \
343 | |                         default, you may need to enable the \"js\" feature. \
344 | |                         For more information see: \
345 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /home/circleci/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.15/src/lib.rs:398:9
    |
398 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of undeclared crate or module `imp`
```

The only available fix is to enable the `js` feature when compiling getrandom to wasm, but https://docs.rs/getrandom/0.2.15/getrandom/index.html#webassembly-support recommends specifically _against_ doing so in a library crate. The new demo therefore serves as a non-library crate to enable it, as well as a more end-to-end test (if manual) than just compiling the library.

Randomness is used by the `ahash` crate as a DoS mitigation.