### PR TITLE
change type signature for impl ariadne::Cache

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [1.2x.x] (unreleased) - 2025-mm-dd
+## Fixes
+
+- **Update `ariadne` trait implementations - [lrlna], [pull/960]**
+`ariadne@0.5.1` release changed their type signature for `ariadne::Cache` trait, which required an update to `apollo-compiler`'s implementation of `ariadne::Cache<FileId>`. 
+
+This release also had a slight change to path formatting, so if you had any snapshots in your tests, you can expect a change from this:
+```
+Error: `typeFragment1` contains too much nesting
+    ╭─[overflow.graphql:11:11]
+```
+
+to this (notice the extra white space around the file path):
+```
+Error: `typeFragment1` contains too much nesting
+    ╭─[ overflow.graphql:11:11 ]
+```
+
+[lrlna]: https://github.com/lrlna
+
 # [1.27.0](https://crates.io/crates/apollo-compiler/1.26.0) - 2025-03-04
 
 ## Features

--- a/crates/apollo-compiler/src/diagnostic.rs
+++ b/crates/apollo-compiler/src/diagnostic.rs
@@ -296,7 +296,7 @@ impl ariadne::Cache<FileId> for Cache<'_> {
             static EMPTY: OnceLock<ariadne::Source> = OnceLock::new();
             Ok(EMPTY.get_or_init(|| ariadne::Source::from(String::new())))
         } else {
-            Err(Box::new(NotFound(*file_id)))
+            Err(NotFound(*file_id))
         }
     }
 
@@ -316,9 +316,9 @@ impl ariadne::Cache<FileId> for Cache<'_> {
 
         if *file_id != FileId::NONE {
             let source_file = self.0.get(file_id)?;
-            Some(Box::new(Path::SourceFile(source_file.clone())))
+            Some(Path::SourceFile(source_file.clone()))
         } else {
-            Some(Box::new(Path::NoSourceFile))
+            Some(Path::NoSourceFile)
         }
     }
 }

--- a/crates/apollo-compiler/test_data/diagnostics/0001_duplicate_operatoin_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0001_duplicate_operatoin_names.txt
@@ -1,5 +1,5 @@
 Error: the operation `getName` is defined multiple times in the document
-   ╭─[0001_duplicate_operatoin_names.graphql:5:7]
+   ╭─[ 0001_duplicate_operatoin_names.graphql:5:7 ]
    │
  1 │ query getName {
    │       ───┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0002_multiple_anonymous_operations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0002_multiple_anonymous_operations.txt
@@ -1,5 +1,5 @@
 Error: anonymous operation cannot be selected when the document contains other operations
-   ╭─[0002_multiple_anonymous_operations.graphql:1:1]
+   ╭─[ 0002_multiple_anonymous_operations.graphql:1:1 ]
    │
  1 │ ╭─▶ query {
    ┆ ┆   
@@ -10,7 +10,7 @@ Error: anonymous operation cannot be selected when the document contains other o
    │     Help: GraphQL requires operations to be named if the document has more than one
 ───╯
 Error: anonymous operation cannot be selected when the document contains other operations
-   ╭─[0002_multiple_anonymous_operations.graphql:5:1]
+   ╭─[ 0002_multiple_anonymous_operations.graphql:5:1 ]
    │
  5 │ ╭─▶ mutation {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0003_anonymous_and_named_operation.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0003_anonymous_and_named_operation.txt
@@ -1,5 +1,5 @@
 Error: anonymous operation cannot be selected when the document contains other operations
-   ╭─[0003_anonymous_and_named_operation.graphql:1:1]
+   ╭─[ 0003_anonymous_and_named_operation.graphql:1:1 ]
    │
  1 │ ╭─▶ query {
    ┆ ┆   
@@ -10,7 +10,7 @@ Error: anonymous operation cannot be selected when the document contains other o
    │     Help: GraphQL requires operations to be named if the document has more than one
 ───╯
 Error: the required argument `Mutation.addPet(name:)` is not provided
-    ╭─[0003_anonymous_and_named_operation.graphql:6:3]
+    ╭─[ 0003_anonymous_and_named_operation.graphql:6:3 ]
     │
   6 │ ╭─▶   addPet {
     ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0004_subscription_with_multiple_root_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0004_subscription_with_multiple_root_fields.txt
@@ -1,5 +1,5 @@
 Error: subscription `sub` can only have one root field
-   ╭─[0004_subscription_with_multiple_root_fields.graphql:1:1]
+   ╭─[ 0004_subscription_with_multiple_root_fields.graphql:1:1 ]
    │
  1 │ ╭─▶ subscription sub {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0005_subscription_with_multiple_root_fields_in_fragment_spreads.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0005_subscription_with_multiple_root_fields_in_fragment_spreads.txt
@@ -1,5 +1,5 @@
 Error: subscription `sub` can only have one root field
-   ╭─[0005_subscription_with_multiple_root_fields_in_fragment_spreads.graphql:1:1]
+   ╭─[ 0005_subscription_with_multiple_root_fields_in_fragment_spreads.graphql:1:1 ]
    │
  1 │ ╭─▶ subscription sub {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0006_subscription_with_multiple_root_fields_in_inline_fragments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0006_subscription_with_multiple_root_fields_in_inline_fragments.txt
@@ -1,5 +1,5 @@
 Error: subscription `sub` can only have one root field
-   ╭─[0006_subscription_with_multiple_root_fields_in_inline_fragments.graphql:1:1]
+   ╭─[ 0006_subscription_with_multiple_root_fields_in_inline_fragments.graphql:1:1 ]
    │
  1 │ ╭─▶ subscription sub {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0007_operation_with_undefined_variables.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0007_operation_with_undefined_variables.txt
@@ -1,19 +1,19 @@
 Error: variable `$undefinedVariable` is not defined
-   ╭─[0007_operation_with_undefined_variables.graphql:3:12]
+   ╭─[ 0007_operation_with_undefined_variables.graphql:3:12 ]
    │
  3 │     first: $undefinedVariable
    │            ─────────┬────────  
    │                     ╰────────── not found in this scope
 ───╯
 Error: variable `$offset` is not defined
-   ╭─[0007_operation_with_undefined_variables.graphql:5:15]
+   ╭─[ 0007_operation_with_undefined_variables.graphql:5:15 ]
    │
  5 │       offset: $offset
    │               ───┬───  
    │                  ╰───── not found in this scope
 ───╯
 Error: variable `$keyword` is not defined
-   ╭─[0007_operation_with_undefined_variables.graphql:6:23]
+   ╭─[ 0007_operation_with_undefined_variables.graphql:6:23 ]
    │
  6 │       keywords: ["a", $keyword]
    │                       ────┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0008_operation_with_undefined_variables_in_inline_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0008_operation_with_undefined_variables_in_inline_fragment.txt
@@ -1,5 +1,5 @@
 Error: variable `$value` is not defined
-   ╭─[0008_operation_with_undefined_variables_in_inline_fragment.graphql:5:25]
+   ╭─[ 0008_operation_with_undefined_variables_in_inline_fragment.graphql:5:25 ]
    │
  5 │         price(setPrice: $value)
    │                         ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0009_operation_with_undefined_variables_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0009_operation_with_undefined_variables_in_fragment.txt
@@ -1,19 +1,19 @@
 Error: variable `$queryLabel` is not defined
-   ╭─[0009_operation_with_undefined_variables_in_fragment.graphql:4:51]
+   ╭─[ 0009_operation_with_undefined_variables_in_fragment.graphql:4:51 ]
    │
  4 │ query ExampleQuery($variable: Int) @report(label: $queryLabel) {
    │                                                   ─────┬─────  
    │                                                        ╰─────── not found in this scope
 ───╯
 Error: variable `$productsLabel` is not defined
-    ╭─[0009_operation_with_undefined_variables_in_fragment.graphql:11:41]
+    ╭─[ 0009_operation_with_undefined_variables_in_fragment.graphql:11:41 ]
     │
  11 │ fragment subFrag on Query @track(label: $productsLabel) {
     │                                         ───────┬──────  
     │                                                ╰──────── not found in this scope
 ────╯
 Error: variable `$value` is not defined
-    ╭─[0009_operation_with_undefined_variables_in_fragment.graphql:13:21]
+    ╭─[ 0009_operation_with_undefined_variables_in_fragment.graphql:13:21 ]
     │
  13 │     price(setPrice: $value)
     │                     ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0010_operation_with_unused_variable.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0010_operation_with_unused_variable.txt
@@ -1,5 +1,5 @@
 Error: unused variable: `$unusedVariable`
-   ╭─[0010_operation_with_unused_variable.graphql:1:20]
+   ╭─[ 0010_operation_with_unused_variable.graphql:1:20 ]
    │
  1 │ query ExampleQuery($unusedVariable: Int) {
    │                    ───────┬───────  

--- a/crates/apollo-compiler/test_data/diagnostics/0011_syntactic_errors_from_parser.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0011_syntactic_errors_from_parser.txt
@@ -1,5 +1,5 @@
 Error: syntax error: expected at least one Selection in Selection Set
-   ╭─[0011_syntactic_errors_from_parser.graphql:1:16]
+   ╭─[ 0011_syntactic_errors_from_parser.graphql:1:16 ]
    │
  1 │ query getName {}
    │                ┬  

--- a/crates/apollo-compiler/test_data/diagnostics/0012_schema_definition_with_missing_query_operation_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0012_schema_definition_with_missing_query_operation_type.txt
@@ -1,5 +1,5 @@
 Error: missing query root operation type in schema definition
-   ╭─[0012_schema_definition_with_missing_query_operation_type.graphql:1:1]
+   ╭─[ 0012_schema_definition_with_missing_query_operation_type.graphql:1:1 ]
    │
  1 │ ╭─▶ schema {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0013_schema_definition_with_duplicate_root_type_operations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0013_schema_definition_with_duplicate_root_type_operations.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `query` root operation type
-   ╭─[0013_schema_definition_with_duplicate_root_type_operations.graphql:3:3]
+   ╭─[ 0013_schema_definition_with_duplicate_root_type_operations.graphql:3:3 ]
    │
  2 │   query: customPetQuery
    │          ───────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0014_subscription_operation_without_subscription_schema_operation_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0014_subscription_operation_without_subscription_schema_operation_type.txt
@@ -1,5 +1,5 @@
 Error: `subscription` root operation type is not defined
-   ╭─[0014_subscription_operation_without_subscription_schema_operation_type.graphql:1:1]
+   ╭─[ 0014_subscription_operation_without_subscription_schema_operation_type.graphql:1:1 ]
    │
  1 │ ╭─▶ subscription messageSubscription {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0015_mutation_operation_without_mutation_schema_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0015_mutation_operation_without_mutation_schema_definition.txt
@@ -1,5 +1,5 @@
 Error: `mutation` root operation type is not defined
-   ╭─[0015_mutation_operation_without_mutation_schema_definition.graphql:1:1]
+   ╭─[ 0015_mutation_operation_without_mutation_schema_definition.graphql:1:1 ]
    │
  1 │ ╭─▶ mutation adoptAPetMutation {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0016_schema_with_built_in_scalar_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0016_schema_with_built_in_scalar_definition.txt
@@ -1,5 +1,5 @@
 Error: built-in scalar definitions must be omitted
-   ╭─[0016_schema_with_built_in_scalar_definition.graphql:5:1]
+   ╭─[ 0016_schema_with_built_in_scalar_definition.graphql:5:1 ]
    │
  5 │ scalar Int
    │ ─────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0017_schema_with_unspecified_scalar.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0017_schema_with_unspecified_scalar.txt
@@ -1,6 +1,6 @@
 Error: missing query root operation type in schema definition
 Error: syntax error: Unexpected <EOF>.
-   ╭─[0017_schema_with_unspecified_scalar.graphql:1:54]
+   ╭─[ 0017_schema_with_unspecified_scalar.graphql:1:54 ]
    │
  1 │ # Placeholder for removed test, to avoid renumbering
    │                                                      │ 

--- a/crates/apollo-compiler/test_data/diagnostics/0018_schema_with_specified_scalar_missing_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0018_schema_with_specified_scalar_missing_values.txt
@@ -1,6 +1,6 @@
 Error: missing query root operation type in schema definition
 Error: syntax error: Unexpected <EOF>.
-   ╭─[0018_schema_with_specified_scalar_missing_values.graphql:1:54]
+   ╭─[ 0018_schema_with_specified_scalar_missing_values.graphql:1:54 ]
    │
  1 │ # Placeholder for removed test, to avoid renumbering
    │                                                      │ 

--- a/crates/apollo-compiler/test_data/diagnostics/0019_enum_definition_with_duplicate_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0019_enum_definition_with_duplicate_values.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `CAT` value of enum type `Pet`
-    ╭─[0019_enum_definition_with_duplicate_values.graphql:10:5]
+    ╭─[ 0019_enum_definition_with_duplicate_values.graphql:10:5 ]
     │
   7 │     CAT
     │     ─┬─  
@@ -10,7 +10,7 @@ Error: duplicate definitions for the `CAT` value of enum type `Pet`
     │      ╰─── `CAT` redefined here
 ────╯
 Error: duplicate definitions for the `THRIVE_PET_FOODS` value of enum type `Snack`
-    ╭─[0019_enum_definition_with_duplicate_values.graphql:17:5]
+    ╭─[ 0019_enum_definition_with_duplicate_values.graphql:17:5 ]
     │
  14 │     THRIVE_PET_FOODS
     │     ────────┬───────  

--- a/crates/apollo-compiler/test_data/diagnostics/0020_enum_values_with_uncapitalised_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0020_enum_values_with_uncapitalised_values.txt
@@ -1,6 +1,6 @@
 Error: missing query root operation type in schema definition
 Error: syntax error: Unexpected <EOF>.
-   ╭─[0020_enum_values_with_uncapitalised_values.graphql:1:54]
+   ╭─[ 0020_enum_values_with_uncapitalised_values.graphql:1:54 ]
    │
  1 │ # Placeholder for removed test, to avoid renumbering
    │                                                      │ 

--- a/crates/apollo-compiler/test_data/diagnostics/0021_union_definition_with_duplicate_members.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0021_union_definition_with_duplicate_members.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `Photo` member of union type `SearchResult`
-   ╭─[0021_union_definition_with_duplicate_members.graphql:5:30]
+   ╭─[ 0021_union_definition_with_duplicate_members.graphql:5:30 ]
    │
  5 │ union SearchResult = Photo | Photo
    │                      ──┬──   ──┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0022_duplicate_interface_definitions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0022_duplicate_interface_definitions.txt
@@ -1,5 +1,5 @@
 Error: the type `NamedEntity` is defined multiple times in the schema
-   ╭─[0022_duplicate_interface_definitions.graphql:9:11]
+   ╭─[ 0022_duplicate_interface_definitions.graphql:9:11 ]
    │
  5 │ interface NamedEntity {
    │           ─────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0023_interface_definition_with_cyclic_implements_interfaces.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0023_interface_definition_with_cyclic_implements_interfaces.txt
@@ -1,5 +1,5 @@
 Error: interface NamedEntity cannot implement itself
-   ╭─[0023_interface_definition_with_cyclic_implements_interfaces.graphql:5:34]
+   ╭─[ 0023_interface_definition_with_cyclic_implements_interfaces.graphql:5:34 ]
    │
  5 │ interface NamedEntity implements NamedEntity {
    │                                  ─────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0024_interface_definition_with_duplicate_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0024_interface_definition_with_duplicate_fields.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `name` field of interface type `NamedEntity`
-   ╭─[0024_interface_definition_with_duplicate_fields.graphql:7:3]
+   ╭─[ 0024_interface_definition_with_duplicate_fields.graphql:7:3 ]
    │
  6 │   name: String
    │   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0025_interface_definition_with_missing_transitive_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0025_interface_definition_with_missing_transitive_fields.txt
@@ -1,5 +1,5 @@
 Error: type `Image` does not satisfy interface `Resource`: missing field `width`
-    ╭─[0025_interface_definition_with_missing_transitive_fields.graphql:14:1]
+    ╭─[ 0025_interface_definition_with_missing_transitive_fields.graphql:14:1 ]
     │
  11 │       width: Int
     │       ─────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0026_interface_definition_with_missing_implemetns_interface.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0026_interface_definition_with_missing_implemetns_interface.txt
@@ -1,5 +1,5 @@
 Error: interface `Image` declares that it implements `Resource`, but to do so it must also implement `Node`
-    ╭─[0026_interface_definition_with_missing_implemetns_interface.graphql:15:1]
+    ╭─[ 0026_interface_definition_with_missing_implemetns_interface.graphql:15:1 ]
     │
   9 │     interface Resource implements Node {
     │                                   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0027_interface_definition_with_undefined_implements_interface.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0027_interface_definition_with_undefined_implements_interface.txt
@@ -1,5 +1,5 @@
 Error: cannot find type `Url` in this document
-    ╭─[0027_interface_definition_with_undefined_implements_interface.graphql:11:39]
+    ╭─[ 0027_interface_definition_with_undefined_implements_interface.graphql:11:39 ]
     │
  11 │ interface Image implements Resource & Url {
     │                                       ─┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.txt
@@ -1,5 +1,5 @@
 Error: interface `Image` declares that it implements `Resource`, but to do so it must also implement `Node`
-    ╭─[0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:1]
+    ╭─[ 0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:1 ]
     │
   9 │     interface Resource implements Node {
     │                                   ──┬─  
@@ -12,7 +12,7 @@ Error: interface `Image` declares that it implements `Resource`, but to do so it
     │ ╰────── Node must also be implemented here
 ────╯
 Error: type `Image` does not satisfy interface `Resource`: missing field `width`
-    ╭─[0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:1]
+    ╭─[ 0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:1 ]
     │
  11 │       width: Int
     │       ─────┬────  
@@ -29,7 +29,7 @@ Error: type `Image` does not satisfy interface `Resource`: missing field `width`
     │     Help: An object or interface must declare all fields required by the interfaces it implements
 ────╯
 Error: cannot find type `Url` in this document
-    ╭─[0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:39]
+    ╭─[ 0028_interface_definition_with_missing_fields_implements_intrefaces_undefined_interfaces.graphql:14:39 ]
     │
  14 │ interface Image implements Resource & Url{
     │                                       ─┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0029_directive_definitions_with_duplicate_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0029_directive_definitions_with_duplicate_names.txt
@@ -1,5 +1,5 @@
 Error: the directive `@foo` is defined multiple times in the schema
-    ╭─[0029_directive_definitions_with_duplicate_names.graphql:11:12]
+    ╭─[ 0029_directive_definitions_with_duplicate_names.graphql:11:12 ]
     │
  10 │ directive @foo on SCHEMA
     │            ─┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0030_schema_with_duplicate_input_objects.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0030_schema_with_duplicate_input_objects.txt
@@ -1,5 +1,5 @@
 Error: the type `Point2D` is defined multiple times in the schema
-    ╭─[0030_schema_with_duplicate_input_objects.graphql:13:7]
+    ╭─[ 0030_schema_with_duplicate_input_objects.graphql:13:7 ]
     │
   8 │ input Point2D {
     │       ───┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0031_input_object_with_duplicate_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0031_input_object_with_duplicate_fields.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `x` field of input object type `Point2D`
-    ╭─[0031_input_object_with_duplicate_fields.graphql:10:3]
+    ╭─[ 0031_input_object_with_duplicate_fields.graphql:10:3 ]
     │
   9 │   x: Float
     │   ┬  

--- a/crates/apollo-compiler/test_data/diagnostics/0032_duplicate_object_type_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0032_duplicate_object_type_definition.txt
@@ -1,5 +1,5 @@
 Error: the type `Query` is defined multiple times in the schema
-   ╭─[0032_duplicate_object_type_definition.graphql:5:6]
+   ╭─[ 0032_duplicate_object_type_definition.graphql:5:6 ]
    │
  1 │ type Query {
    │      ──┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0033_object_type_definition_with_duplicate_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0033_object_type_definition_with_duplicate_fields.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `name` field of object type `Query`
-   ╭─[0033_object_type_definition_with_duplicate_fields.graphql:3:3]
+   ╭─[ 0033_object_type_definition_with_duplicate_fields.graphql:3:3 ]
    │
  2 │   name: String
    │   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0034_object_type_definition_with_missing_transitive_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0034_object_type_definition_with_missing_transitive_fields.txt
@@ -1,5 +1,5 @@
 Error: type `Query` does not satisfy interface `Node`: missing field `id`
-   ╭─[0034_object_type_definition_with_missing_transitive_fields.graphql:1:1]
+   ╭─[ 0034_object_type_definition_with_missing_transitive_fields.graphql:1:1 ]
    │
  1 │ ╭─▶ type Query implements Node & Resource {
    │ │                         ──┬─  
@@ -16,7 +16,7 @@ Error: type `Query` does not satisfy interface `Node`: missing field `id`
    │     Help: An object or interface must declare all fields required by the interfaces it implements
 ───╯
 Error: type `Query` does not satisfy interface `Resource`: missing field `width`
-    ╭─[0034_object_type_definition_with_missing_transitive_fields.graphql:1:1]
+    ╭─[ 0034_object_type_definition_with_missing_transitive_fields.graphql:1:1 ]
     │
   1 │ ╭─▶ type Query implements Node & Resource {
     │ │                                ────┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0035_object_type_definition_with_missing_implements_interfaces_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0035_object_type_definition_with_missing_implements_interfaces_definition.txt
@@ -1,5 +1,5 @@
 Error: interface `Query` declares that it implements `Image`, but to do so it must also implement `Resource`
-    ╭─[0035_object_type_definition_with_missing_implements_interfaces_definition.graphql:1:1]
+    ╭─[ 0035_object_type_definition_with_missing_implements_interfaces_definition.graphql:1:1 ]
     │
   1 │ ╭─▶ type Query implements Image {
     ┆ ┆   
@@ -12,7 +12,7 @@ Error: interface `Query` declares that it implements `Image`, but to do so it mu
     │                                    ╰───── implementation of Resource declared by Image here
 ────╯
 Error: interface `Image` declares that it implements `Resource`, but to do so it must also implement `Node`
-    ╭─[0035_object_type_definition_with_missing_implements_interfaces_definition.graphql:19:1]
+    ╭─[ 0035_object_type_definition_with_missing_implements_interfaces_definition.graphql:19:1 ]
     │
  13 │     interface Resource implements Node {
     │                                   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0036_object_type_with_non_output_field_types.txt
@@ -1,12 +1,12 @@
 Error: cannot find type `Auth` in this document
-    ╭─[0036_object_type_with_non_output_field_types.graphql:20:16]
+    ╭─[ 0036_object_type_with_non_output_field_types.graphql:20:16 ]
     │
  20 │   permissions: Auth
     │                ──┬─  
     │                  ╰─── not found in this scope
 ────╯
 Error: `coordinates` field must return an output type
-    ╭─[0036_object_type_with_non_output_field_types.graphql:21:3]
+    ╭─[ 0036_object_type_with_non_output_field_types.graphql:21:3 ]
     │
  21 │   coordinates: Point2D
     │                ───┬───  
@@ -15,14 +15,14 @@ Error: `coordinates` field must return an output type
     │ Help: Scalars, Objects, Interfaces, Unions and Enums are output types. Change `coordinates` field to return one of these output types.
 ────╯
 Error: cannot find type `mainPage` in this document
-    ╭─[0036_object_type_with_non_output_field_types.graphql:22:9]
+    ╭─[ 0036_object_type_with_non_output_field_types.graphql:22:9 ]
     │
  22 │   main: mainPage
     │         ────┬───  
     │             ╰───── not found in this scope
 ────╯
 Error: cannot find type `Photo` in this document
-    ╭─[0036_object_type_with_non_output_field_types.graphql:39:22]
+    ╭─[ 0036_object_type_with_non_output_field_types.graphql:39:22 ]
     │
  39 │ union SearchResult = Photo | Person
     │                      ──┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0037_interface_with_non_output_fields.txt
@@ -1,12 +1,12 @@
 Error: cannot find type `Auth` in this document
-    ╭─[0037_interface_with_non_output_fields.graphql:18:16]
+    ╭─[ 0037_interface_with_non_output_fields.graphql:18:16 ]
     │
  18 │   permissions: Auth
     │                ──┬─  
     │                  ╰─── not found in this scope
 ────╯
 Error: `coordinates` field must return an output type
-    ╭─[0037_interface_with_non_output_fields.graphql:19:3]
+    ╭─[ 0037_interface_with_non_output_fields.graphql:19:3 ]
     │
  19 │   coordinates: Point2D
     │                ───┬───  
@@ -15,14 +15,14 @@ Error: `coordinates` field must return an output type
     │ Help: Scalars, Objects, Interfaces, Unions and Enums are output types. Change `coordinates` field to return one of these output types.
 ────╯
 Error: cannot find type `mainPage` in this document
-    ╭─[0037_interface_with_non_output_fields.graphql:20:9]
+    ╭─[ 0037_interface_with_non_output_fields.graphql:20:9 ]
     │
  20 │   main: mainPage
     │         ────┬───  
     │             ╰───── not found in this scope
 ────╯
 Error: cannot find type `Photo` in this document
-    ╭─[0037_interface_with_non_output_fields.graphql:37:22]
+    ╭─[ 0037_interface_with_non_output_fields.graphql:37:22 ]
     │
  37 │ union SearchResult = Photo | Person
     │                      ──┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0038_object_type_with_undefined_field_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0038_object_type_with_undefined_field_type.txt
@@ -1,12 +1,12 @@
 Error: cannot find type `Url` in this document
-   ╭─[0038_object_type_with_undefined_field_type.graphql:3:8]
+   ╭─[ 0038_object_type_with_undefined_field_type.graphql:3:8 ]
    │
  3 │   img: Url
    │        ─┬─  
    │         ╰─── not found in this scope
 ───╯
 Error: cannot find type `Person` in this document
-   ╭─[0038_object_type_with_undefined_field_type.graphql:4:17]
+   ╭─[ 0038_object_type_with_undefined_field_type.graphql:4:17 ]
    │
  4 │   relationship: Person
    │                 ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0039_interface_with_undefined_field_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0039_interface_with_undefined_field_type.txt
@@ -1,12 +1,12 @@
 Error: cannot find type `Url` in this document
-   ╭─[0039_interface_with_undefined_field_type.graphql:3:8]
+   ╭─[ 0039_interface_with_undefined_field_type.graphql:3:8 ]
    │
  3 │   img: Url
    │        ─┬─  
    │         ╰─── not found in this scope
 ───╯
 Error: cannot find type `Person` in this document
-   ╭─[0039_interface_with_undefined_field_type.graphql:7:17]
+   ╭─[ 0039_interface_with_undefined_field_type.graphql:7:17 ]
    │
  7 │   relationship: Person
    │                 ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0040_operation_with_undefined_fields_on_reference_type.txt
@@ -1,5 +1,5 @@
 Error: type `Query` does not have a field `size`
-   ╭─[0040_operation_with_undefined_fields_on_reference_type.graphql:2:3]
+   ╭─[ 0040_operation_with_undefined_fields_on_reference_type.graphql:2:3 ]
    │
  2 │   size
    │   ──┬─  
@@ -12,7 +12,7 @@ Error: type `Query` does not have a field `size`
    │ Note: path to the field: `query getProduct → size`
 ───╯
 Error: type `Query` does not have a field `weight`
-   ╭─[0040_operation_with_undefined_fields_on_reference_type.graphql:3:3]
+   ╭─[ 0040_operation_with_undefined_fields_on_reference_type.graphql:3:3 ]
    │
  3 │   weight
    │   ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0041_subscription_operation_with_undefined_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0041_subscription_operation_with_undefined_fields.txt
@@ -1,5 +1,5 @@
 Error: type `Subscription` does not have a field `undefinedSubscriptionField`
-   ╭─[0041_subscription_operation_with_undefined_fields.graphql:2:3]
+   ╭─[ 0041_subscription_operation_with_undefined_fields.graphql:2:3 ]
    │
  2 │   undefinedSubscriptionField
    │   ─────────────┬────────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0042_mutation_operation_with_undefined_fields.txt
@@ -1,5 +1,5 @@
 Error: type `Mutation` does not have a field `undefinedMutationField`
-    ╭─[0042_mutation_operation_with_undefined_fields.graphql:2:3]
+    ╭─[ 0042_mutation_operation_with_undefined_fields.graphql:2:3 ]
     │
   2 │   undefinedMutationField
     │   ───────────┬──────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0043_undefined_union_member.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0043_undefined_union_member.txt
@@ -1,5 +1,5 @@
 Error: cannot find type `Cat` in this document
-    ╭─[0043_undefined_union_member.graphql:11:18]
+    ╭─[ 0043_undefined_union_member.graphql:11:18 ]
     │
  11 │ union CatOrDog = Cat | Dog
     │                  ─┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0044_union_member_not_of_object_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0044_union_member_not_of_object_type.txt
@@ -1,5 +1,5 @@
 Error: union member `Pet` must be an object type
-    ╭─[0044_union_member_not_of_object_type.graphql:17:24]
+    ╭─[ 0044_union_member_not_of_object_type.graphql:17:24 ]
     │
  17 │ union CatOrDog = Cat | Pet
     │                        ─┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0045_operation_with_unused_variable_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0045_operation_with_unused_variable_in_fragment.txt
@@ -1,12 +1,12 @@
 Error: unused variable: `$variable`
-   ╭─[0045_operation_with_unused_variable_in_fragment.graphql:1:20]
+   ╭─[ 0045_operation_with_unused_variable_in_fragment.graphql:1:20 ]
    │
  1 │ query ExampleQuery($variable: Int) {
    │                    ────┬────  
    │                        ╰────── variable is never used
 ───╯
 Error: fragment `unusedFrag` must be used in an operation
-    ╭─[0045_operation_with_unused_variable_in_fragment.graphql:7:1]
+    ╭─[ 0045_operation_with_unused_variable_in_fragment.graphql:7:1 ]
     │
   7 │ ╭─▶ fragment unusedFrag on Query {
     ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0046_duplicate_directive_arguments.txt
@@ -1,5 +1,5 @@
 Error: the argument `url` is provided multiple times
-   ╭─[0046_duplicate_directive_arguments.graphql:1:75]
+   ╭─[ 0046_duplicate_directive_arguments.graphql:1:75 ]
    │
  1 │ scalar newScalar @specifiedBy(url: "https://tools.ietf.org/html/rfc4122", url: "https://tools.ietf.org/html/rfc4125")
    │                               ─────────────────────┬────────────────────  ─────────────────────┬────────────────────  
@@ -10,7 +10,7 @@ Error: the argument `url` is provided multiple times
    │ Help: `url` argument must only be provided once.
 ───╯
 Error: the argument `if` is provided multiple times
-   ╭─[0046_duplicate_directive_arguments.graphql:5:40]
+   ╭─[ 0046_duplicate_directive_arguments.graphql:5:40 ]
    │
  5 │   response: String @example(if: false, if: true)
    │                             ────┬────  ────┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0047_duplicate_field_arguments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0047_duplicate_field_arguments.txt
@@ -1,5 +1,5 @@
 Error: the argument `arg` is provided multiple times
-   ╭─[0047_duplicate_field_arguments.graphql:5:21]
+   ╭─[ 0047_duplicate_field_arguments.graphql:5:21 ]
    │
  5 │   single(arg: true, arg: false)
    │          ────┬────  ─────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0048_duplicate_field_argument_definition_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0048_duplicate_field_argument_definition_names.txt
@@ -1,5 +1,5 @@
 Error: the value `arg` is defined multiple times
-   ╭─[0048_duplicate_field_argument_definition_names.graphql:2:13]
+   ╭─[ 0048_duplicate_field_argument_definition_names.graphql:2:13 ]
    │
  2 │   duplicate(arg: Boolean, arg: Boolean): Int
    │             ──────┬─────  ──────┬─────  
@@ -10,7 +10,7 @@ Error: the value `arg` is defined multiple times
    │ Help: `arg` must only be defined once in this argument list or input object definition.
 ───╯
 Error: the value `arg` is defined multiple times
-   ╭─[0048_duplicate_field_argument_definition_names.graphql:7:13]
+   ╭─[ 0048_duplicate_field_argument_definition_names.graphql:7:13 ]
    │
  7 │   duplicate(arg: Boolean, arg: Boolean): Int
    │             ──────┬─────  ──────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0049_duplicate_directive_argument_definition_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0049_duplicate_directive_argument_definition_names.txt
@@ -1,5 +1,5 @@
 Error: the value `arg` is defined multiple times
-   ╭─[0049_duplicate_directive_argument_definition_names.graphql:1:20]
+   ╭─[ 0049_duplicate_directive_argument_definition_names.graphql:1:20 ]
    │
  1 │ directive @example(arg: Boolean, arg: Boolean) on FIELD
    │                    ──────┬─────  ──────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0050_directives_in_invalid_locations.txt
@@ -1,11 +1,11 @@
 Error: skip directive is not supported for VARIABLE_DEFINITION location
-     ╭─[0050_directives_in_invalid_locations.graphql:1:30]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:1:30 ]
      │
    1 │ query queryA($status: String @skip(if: true)) @skip(if: false){
      │                              ───────┬───────  
      │                                     ╰───────── directive cannot be used on VARIABLE_DEFINITION
      │
-     ├─[built_in.graphql:137:1]
+     ├─[ built_in.graphql:137:1 ]
      │
  137 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
      ┆ ┆   
@@ -16,13 +16,13 @@ Error: skip directive is not supported for VARIABLE_DEFINITION location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
 ─────╯
 Error: skip directive is not supported for QUERY location
-     ╭─[0050_directives_in_invalid_locations.graphql:1:47]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:1:47 ]
      │
    1 │ query queryA($status: String @skip(if: true)) @skip(if: false){
      │                                               ────────┬───────  
      │                                                       ╰───────── directive cannot be used on QUERY
      │
-     ├─[built_in.graphql:137:1]
+     ├─[ built_in.graphql:137:1 ]
      │
  137 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
      ┆ ┆   
@@ -33,13 +33,13 @@ Error: skip directive is not supported for QUERY location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
 ─────╯
 Error: deprecated directive is not supported for FIELD location
-     ╭─[0050_directives_in_invalid_locations.graphql:3:29]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:3:29 ]
      │
    3 │   response(status: $status) @deprecated
      │                             ─────┬─────  
      │                                  ╰─────── directive cannot be used on FIELD
      │
-     ├─[built_in.graphql:149:1]
+     ├─[ built_in.graphql:149:1 ]
      │
  149 │ ╭─▶ "Marks an element of a GraphQL schema as no longer supported."
      ┆ ┆   
@@ -50,7 +50,7 @@ Error: deprecated directive is not supported for FIELD location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD_DEFINITION, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION, ENUM_VALUE
 ─────╯
 Error: directiveB directive is not supported for FRAGMENT_SPREAD location
-    ╭─[0050_directives_in_invalid_locations.graphql:5:20]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:5:20 ]
     │
   5 │     pets { ... pet @directiveB }
     │                    ─────┬─────  
@@ -63,7 +63,7 @@ Error: directiveB directive is not supported for FRAGMENT_SPREAD location
     │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 Error: directiveB directive is not supported for FRAGMENT_DEFINITION location
-    ╭─[0050_directives_in_invalid_locations.graphql:9:21]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:9:21 ]
     │
   9 │ fragment pet on Cat @directiveB {
     │                     ─────┬─────  
@@ -76,7 +76,7 @@ Error: directiveB directive is not supported for FRAGMENT_DEFINITION location
     │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 Error: directiveA directive is not supported for INLINE_FRAGMENT location
-    ╭─[0050_directives_in_invalid_locations.graphql:11:14]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:11:14 ]
     │
  11 │   ... on Pet @directiveA {
     │              ─────┬─────  
@@ -89,7 +89,7 @@ Error: directiveA directive is not supported for INLINE_FRAGMENT location
     │ Help: the directive must be used in a location that the service has declared support for: UNION
 ────╯
 Error: directiveA directive is not supported for SUBSCRIPTION location
-    ╭─[0050_directives_in_invalid_locations.graphql:16:28]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:16:28 ]
     │
  16 │ subscription subscriptionA @directiveA {
     │                            ─────┬─────  
@@ -102,13 +102,13 @@ Error: directiveA directive is not supported for SUBSCRIPTION location
     │ Help: the directive must be used in a location that the service has declared support for: UNION
 ────╯
 Error: skip directive is not supported for MUTATION location
-     ╭─[0050_directives_in_invalid_locations.graphql:23:21]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:23:21 ]
      │
   23 │ mutation myMutation @skip(if: true) {
      │                     ───────┬───────  
      │                            ╰───────── directive cannot be used on MUTATION
      │
-     ├─[built_in.graphql:137:1]
+     ├─[ built_in.graphql:137:1 ]
      │
  137 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
      ┆ ┆   
@@ -119,13 +119,13 @@ Error: skip directive is not supported for MUTATION location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
 ─────╯
 Error: skip directive is not supported for INTERFACE location
-     ╭─[0050_directives_in_invalid_locations.graphql:27:15]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:27:15 ]
      │
   27 │ interface Pet @skip(if: true) {
      │               ───────┬───────  
      │                      ╰───────── directive cannot be used on INTERFACE
      │
-     ├─[built_in.graphql:137:1]
+     ├─[ built_in.graphql:137:1 ]
      │
  137 │ ╭─▶ "Directs the executor to skip this field or fragment when the `if` argument is true."
      ┆ ┆   
@@ -136,7 +136,7 @@ Error: skip directive is not supported for INTERFACE location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
 ─────╯
 Error: directiveB directive is not supported for FIELD_DEFINITION location
-    ╭─[0050_directives_in_invalid_locations.graphql:32:16]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:32:16 ]
     │
  32 │   name: String @directiveB
     │                ─────┬─────  
@@ -149,13 +149,13 @@ Error: directiveB directive is not supported for FIELD_DEFINITION location
     │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 Error: include directive is not supported for INPUT_OBJECT location
-     ╭─[0050_directives_in_invalid_locations.graphql:43:15]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:43:15 ]
      │
   43 │ input Example @include(if: true) {
      │               ─────────┬────────  
      │                        ╰────────── directive cannot be used on INPUT_OBJECT
      │
-     ├─[built_in.graphql:143:1]
+     ├─[ built_in.graphql:143:1 ]
      │
  143 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
      ┆ ┆   
@@ -166,13 +166,13 @@ Error: include directive is not supported for INPUT_OBJECT location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
 ─────╯
 Error: include directive is not supported for INPUT_FIELD_DEFINITION location
-     ╭─[0050_directives_in_invalid_locations.graphql:44:17]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:44:17 ]
      │
   44 │   self: Example @include(if: true)
      │                 ─────────┬────────  
      │                          ╰────────── directive cannot be used on INPUT_FIELD_DEFINITION
      │
-     ├─[built_in.graphql:143:1]
+     ├─[ built_in.graphql:143:1 ]
      │
  143 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
      ┆ ┆   
@@ -183,7 +183,7 @@ Error: include directive is not supported for INPUT_FIELD_DEFINITION location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
 ─────╯
 Error: directiveB directive is not supported for UNION location
-    ╭─[0050_directives_in_invalid_locations.graphql:48:16]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:48:16 ]
     │
  48 │ union CatOrDog @directiveB = Cat | Dog
     │                ─────┬─────  
@@ -196,7 +196,7 @@ Error: directiveB directive is not supported for UNION location
     │ Help: the directive must be used in a location that the service has declared support for: ENUM
 ────╯
 Error: directiveA directive is not supported for ENUM location
-    ╭─[0050_directives_in_invalid_locations.graphql:55:13]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:55:13 ]
     │
  55 │ enum Status @directiveA {
     │             ─────┬─────  
@@ -209,7 +209,7 @@ Error: directiveA directive is not supported for ENUM location
     │ Help: the directive must be used in a location that the service has declared support for: UNION
 ────╯
 Error: directiveA directive is not supported for ENUM_VALUE location
-    ╭─[0050_directives_in_invalid_locations.graphql:56:9]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:56:9 ]
     │
  56 │   GREEN @directiveA,
     │         ─────┬─────  
@@ -222,13 +222,13 @@ Error: directiveA directive is not supported for ENUM_VALUE location
     │ Help: the directive must be used in a location that the service has declared support for: UNION
 ────╯
 Error: deprecated directive is not supported for OBJECT location
-     ╭─[0050_directives_in_invalid_locations.graphql:61:12]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:61:12 ]
      │
   61 │ type Query @deprecated {
      │            ─────┬─────  
      │                 ╰─────── directive cannot be used on OBJECT
      │
-     ├─[built_in.graphql:149:1]
+     ├─[ built_in.graphql:149:1 ]
      │
  149 │ ╭─▶ "Marks an element of a GraphQL schema as no longer supported."
      ┆ ┆   
@@ -239,13 +239,13 @@ Error: deprecated directive is not supported for OBJECT location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD_DEFINITION, ARGUMENT_DEFINITION, INPUT_FIELD_DEFINITION, ENUM_VALUE
 ─────╯
 Error: specifiedBy directive is not supported for ARGUMENT_DEFINITION location
-     ╭─[0050_directives_in_invalid_locations.graphql:64:27]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:64:27 ]
      │
   64 │   response(status: String @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")): Status
      │                           ────────────────────────────┬───────────────────────────  
      │                                                       ╰───────────────────────────── directive cannot be used on ARGUMENT_DEFINITION
      │
-     ├─[built_in.graphql:157:1]
+     ├─[ built_in.graphql:157:1 ]
      │
  157 │ ╭─▶ "Exposes a URL that specifies the behavior of this scalar."
      ┆ ┆   
@@ -256,13 +256,13 @@ Error: specifiedBy directive is not supported for ARGUMENT_DEFINITION location
      │     Help: the directive must be used in a location that the service has declared support for: SCALAR
 ─────╯
 Error: include directive is not supported for SCHEMA location
-     ╭─[0050_directives_in_invalid_locations.graphql:75:8]
+     ╭─[ 0050_directives_in_invalid_locations.graphql:75:8 ]
      │
   75 │ schema @include(if: true) {
      │        ─────────┬────────  
      │                 ╰────────── directive cannot be used on SCHEMA
      │
-     ├─[built_in.graphql:143:1]
+     ├─[ built_in.graphql:143:1 ]
      │
  143 │ ╭─▶ "Directs the executor to include this field or fragment only when the `if` argument is true."
      ┆ ┆   
@@ -273,7 +273,7 @@ Error: include directive is not supported for SCHEMA location
      │     Help: the directive must be used in a location that the service has declared support for: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
 ─────╯
 Error: directiveB directive is not supported for SCALAR location
-    ╭─[0050_directives_in_invalid_locations.graphql:86:13]
+    ╭─[ 0050_directives_in_invalid_locations.graphql:86:13 ]
     │
  86 │ scalar spec @directiveB @specifiedBy(url: "https://spec.graphql.org/")
     │             ─────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0051_subscription_operation_with_root_introspection_field.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0051_subscription_operation_with_root_introspection_field.txt
@@ -1,12 +1,12 @@
 Error: subscription `sub` can not have an introspection field as a root field
-   ╭─[0051_subscription_operation_with_root_introspection_field.graphql:2:3]
+   ╭─[ 0051_subscription_operation_with_root_introspection_field.graphql:2:3 ]
    │
  2 │   __typename
    │   ─────┬────  
    │        ╰────── __typename is an introspection field
 ───╯
 Error: a field cannot be named `__typename` as names starting with two underscores are reserved
-   ╭─[0051_subscription_operation_with_root_introspection_field.graphql:6:3]
+   ╭─[ 0051_subscription_operation_with_root_introspection_field.graphql:6:3 ]
    │
  6 │   __typename: String
    │   ─────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0052_undefined_directive.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0052_undefined_directive.txt
@@ -1,5 +1,5 @@
 Error: cannot find directive `@directiveA` in this document
-   ╭─[0052_undefined_directive.graphql:3:17]
+   ╭─[ 0052_undefined_directive.graphql:3:17 ]
    │
  3 │     status: Int @directiveA
    │                 ─────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0053_argument_name_is_not_defined.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0053_argument_name_is_not_defined.txt
@@ -1,5 +1,5 @@
 Error: the argument `arg2` is not supported by `Field.field`
-    ╭─[0053_argument_name_is_not_defined.graphql:11:18]
+    ╭─[ 0053_argument_name_is_not_defined.graphql:11:18 ]
     │
   7 │   field(arg4: Int): Int
     │   ──────────┬──────────  
@@ -10,7 +10,7 @@ Error: the argument `arg2` is not supported by `Field.field`
     │                     ╰───── argument by this name not found
 ────╯
 Error: the argument `arg3` is not supported by `Field.field`
-    ╭─[0053_argument_name_is_not_defined.graphql:11:27]
+    ╭─[ 0053_argument_name_is_not_defined.graphql:11:27 ]
     │
   7 │   field(arg4: Int): Int
     │   ──────────┬──────────  
@@ -21,7 +21,7 @@ Error: the argument `arg3` is not supported by `Field.field`
     │                              ╰───── argument by this name not found
 ────╯
 Error: the argument `arg2` is not supported by `Query.field`
-    ╭─[0053_argument_name_is_not_defined.graphql:15:9]
+    ╭─[ 0053_argument_name_is_not_defined.graphql:15:9 ]
     │
   2 │   field(arg1: Int): Int
     │   ──────────┬──────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0054_argument_not_provided.txt
@@ -1,5 +1,5 @@
 Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
-    ╭─[0054_argument_not_provided.graphql:14:5]
+    ╭─[ 0054_argument_not_provided.graphql:14:5 ]
     │
   2 │   multipleReqs(req1: Int!, req2: Int!): String
     │                ─────┬────  
@@ -10,7 +10,7 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provid
     │           ╰─────── missing value for argument `req1`
 ────╯
 Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
-    ╭─[0054_argument_not_provided.graphql:14:5]
+    ╭─[ 0054_argument_not_provided.graphql:14:5 ]
     │
   2 │   multipleReqs(req1: Int!, req2: Int!): String
     │                            ─────┬────  
@@ -21,7 +21,7 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provid
     │           ╰─────── missing value for argument `req2`
 ────╯
 Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
-    ╭─[0054_argument_not_provided.graphql:17:5]
+    ╭─[ 0054_argument_not_provided.graphql:17:5 ]
     │
   2 │   multipleReqs(req1: Int!, req2: Int!): String
     │                ─────┬────  
@@ -32,13 +32,13 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provid
     │                     ╰────────────────── missing value for argument `req1`
 ────╯
 Error: the required argument `@skip(if:)` is not provided
-     ╭─[0054_argument_not_provided.graphql:21:9]
+     ╭─[ 0054_argument_not_provided.graphql:21:9 ]
      │
   21 │   basic @skip @include(wrong: false) {
      │         ──┬──  
      │           ╰──── missing value for argument `if`
      │
-     ├─[built_in.graphql:139:3]
+     ├─[ built_in.graphql:139:3 ]
      │
  139 │ ╭─▶   "Skipped when true."
  140 │ ├─▶   if: Boolean!
@@ -46,13 +46,13 @@ Error: the required argument `@skip(if:)` is not provided
      │ ╰──────────────────── argument defined here
 ─────╯
 Error: the required argument `@include(if:)` is not provided
-     ╭─[0054_argument_not_provided.graphql:21:15]
+     ╭─[ 0054_argument_not_provided.graphql:21:15 ]
      │
   21 │   basic @skip @include(wrong: false) {
      │               ───────────┬──────────  
      │                          ╰──────────── missing value for argument `if`
      │
-     ├─[built_in.graphql:145:3]
+     ├─[ built_in.graphql:145:3 ]
      │
  145 │ ╭─▶   "Included when true."
  146 │ ├─▶   if: Boolean!
@@ -60,7 +60,7 @@ Error: the required argument `@include(if:)` is not provided
      │ ╰──────────────────── argument defined here
 ─────╯
 Error: the argument `wrong` is not supported by `@include`
-    ╭─[0054_argument_not_provided.graphql:21:24]
+    ╭─[ 0054_argument_not_provided.graphql:21:24 ]
     │
  21 │   basic @skip @include(wrong: false) {
     │               ───────────┬───┬──────  
@@ -69,7 +69,7 @@ Error: the argument `wrong` is not supported by `@include`
     │                              ╰──────── argument by this name not found
 ────╯
 Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
-    ╭─[0054_argument_not_provided.graphql:26:5]
+    ╭─[ 0054_argument_not_provided.graphql:26:5 ]
     │
   2 │   multipleReqs(req1: Int!, req2: Int!): String
     │                ─────┬────  
@@ -80,7 +80,7 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provid
     │                 ╰───────────── missing value for argument `req1`
 ────╯
 Error: the required argument `ComplicatedArgs.multipleOptAndReq(req2:)` is not provided
-    ╭─[0054_argument_not_provided.graphql:27:5]
+    ╭─[ 0054_argument_not_provided.graphql:27:5 ]
     │
   3 │   multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String
     │                                 ─────┬────  
@@ -91,7 +91,7 @@ Error: the required argument `ComplicatedArgs.multipleOptAndReq(req2:)` is not p
     │                   ╰──────────────── missing value for argument `req2`
 ────╯
 Error: the required argument `ComplicatedArgs.multipleOptAndReq(req2:)` is not provided
-    ╭─[0054_argument_not_provided.graphql:28:5]
+    ╭─[ 0054_argument_not_provided.graphql:28:5 ]
     │
   3 │   multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String
     │                                 ─────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0055_duplicate_variable_definitions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0055_duplicate_variable_definitions.txt
@@ -1,5 +1,5 @@
 Error: the variable `$atOtherHomes` is declared multiple times
-   ╭─[0055_duplicate_variable_definitions.graphql:1:49]
+   ╭─[ 0055_duplicate_variable_definitions.graphql:1:49 ]
    │
  1 │ query houseTrainedQuery($atOtherHomes: Boolean, $atOtherHomes: Boolean) {
    │                         ───────────┬──────────  ───────────┬──────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0056_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0056_variables_are_input_types.txt
@@ -1,5 +1,5 @@
 Error: `$cat` variable must be of an input type
-   ╭─[0056_variables_are_input_types.graphql:1:16]
+   ╭─[ 0056_variables_are_input_types.graphql:1:16 ]
    │
  1 │ query takesCat($cat: Cat) {
    │                      ─┬─  
@@ -8,7 +8,7 @@ Error: `$cat` variable must be of an input type
    │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ───╯
 Error: variable `$cat` of type `Cat` cannot be used for argument `atOtherHomes` of type `Boolean`
-   ╭─[0056_variables_are_input_types.graphql:3:20]
+   ╭─[ 0056_variables_are_input_types.graphql:3:20 ]
    │
  1 │ query takesCat($cat: Cat) {
    │                ────┬────  
@@ -19,7 +19,7 @@ Error: variable `$cat` of type `Cat` cannot be used for argument `atOtherHomes` 
    │                             ╰────────── variable `$cat` used here
 ───╯
 Error: `$dog` variable must be of an input type
-   ╭─[0056_variables_are_input_types.graphql:7:20]
+   ╭─[ 0056_variables_are_input_types.graphql:7:20 ]
    │
  7 │ query takesDogBang($dog: Dog!) {
    │                          ──┬─  
@@ -28,7 +28,7 @@ Error: `$dog` variable must be of an input type
    │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ───╯
 Error: variable `$dog` of type `Dog!` cannot be used for argument `atOtherHomes` of type `Boolean`
-   ╭─[0056_variables_are_input_types.graphql:9:20]
+   ╭─[ 0056_variables_are_input_types.graphql:9:20 ]
    │
  7 │ query takesDogBang($dog: Dog!) {
    │                    ─────┬────  
@@ -39,7 +39,7 @@ Error: variable `$dog` of type `Dog!` cannot be used for argument `atOtherHomes`
    │                             ╰────────── variable `$dog` used here
 ───╯
 Error: `$pets` variable must be of an input type
-    ╭─[0056_variables_are_input_types.graphql:13:22]
+    ╭─[ 0056_variables_are_input_types.graphql:13:22 ]
     │
  13 │ query takesListOfPet($pets: [Pet]) {
     │                             ──┬──  
@@ -48,7 +48,7 @@ Error: `$pets` variable must be of an input type
     │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ────╯
 Error: variable `$pets` of type `[Pet]` cannot be used for argument `booleanListArg` of type `[Boolean!]`
-    ╭─[0056_variables_are_input_types.graphql:14:15]
+    ╭─[ 0056_variables_are_input_types.graphql:14:15 ]
     │
  13 │ query takesListOfPet($pets: [Pet]) {
     │                      ──────┬─────  
@@ -58,7 +58,7 @@ Error: variable `$pets` of type `[Pet]` cannot be used for argument `booleanList
     │                         ╰──────────── variable `$pets` used here
 ────╯
 Error: `$catOrDog` variable must be of an input type
-    ╭─[0056_variables_are_input_types.graphql:17:21]
+    ╭─[ 0056_variables_are_input_types.graphql:17:21 ]
     │
  17 │ query takesCatOrDog($catOrDog: CatOrDog) {
     │                                ────┬───  
@@ -67,7 +67,7 @@ Error: `$catOrDog` variable must be of an input type
     │ Help: objects, unions, and interfaces cannot be used because variables can only be of input type
 ────╯
 Error: variable `$catOrDog` of type `CatOrDog` cannot be used for argument `atOtherHomes` of type `Boolean`
-    ╭─[0056_variables_are_input_types.graphql:19:20]
+    ╭─[ 0056_variables_are_input_types.graphql:19:20 ]
     │
  17 │ query takesCatOrDog($catOrDog: CatOrDog) {
     │                     ─────────┬─────────  
@@ -78,14 +78,14 @@ Error: variable `$catOrDog` of type `CatOrDog` cannot be used for argument `atOt
     │                               ╰───────────── variable `$catOrDog` used here
 ────╯
 Error: cannot find type `Dragon` in this document
-    ╭─[0056_variables_are_input_types.graphql:23:22]
+    ╭─[ 0056_variables_are_input_types.graphql:23:22 ]
     │
  23 │ query takesCatOrDog2($catOrDog: Dragon) {
     │                      ────────┬────────  
     │                              ╰────────── not found in this scope
 ────╯
 Error: variable `$catOrDog` of type `Dragon` cannot be used for argument `atOtherHomes` of type `Boolean`
-    ╭─[0056_variables_are_input_types.graphql:25:20]
+    ╭─[ 0056_variables_are_input_types.graphql:25:20 ]
     │
  23 │ query takesCatOrDog2($catOrDog: Dragon) {
     │                      ────────┬────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0057_duplicate_type_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0057_duplicate_type_names.txt
@@ -1,5 +1,5 @@
 Error: the type `World` is defined multiple times in the schema
-   ╭─[0057_duplicate_type_names.graphql:9:6]
+   ╭─[ 0057_duplicate_type_names.graphql:9:6 ]
    │
  1 │ interface World {
    │           ──┬──  
@@ -12,7 +12,7 @@ Error: the type `World` is defined multiple times in the schema
    │ Help: remove or rename one of the definitions, or use `extend`
 ───╯
 Error: the type `X` is defined multiple times in the schema
-    ╭─[0057_duplicate_type_names.graphql:16:7]
+    ╭─[ 0057_duplicate_type_names.graphql:16:7 ]
     │
  14 │ scalar X @specifiedBy(url: "https://apollographql.com")
     │        ┬  
@@ -25,7 +25,7 @@ Error: the type `X` is defined multiple times in the schema
     │ Help: remove or rename one of the definitions, or use `extend`
 ────╯
 Error: the type `X` is defined multiple times in the schema
-    ╭─[0057_duplicate_type_names.graphql:18:6]
+    ╭─[ 0057_duplicate_type_names.graphql:18:6 ]
     │
  14 │ scalar X @specifiedBy(url: "https://apollographql.com")
     │        ┬  
@@ -38,7 +38,7 @@ Error: the type `X` is defined multiple times in the schema
     │ Help: remove or rename one of the definitions, or use `extend`
 ────╯
 Error: the type `X` is defined multiple times in the schema
-    ╭─[0057_duplicate_type_names.graphql:20:6]
+    ╭─[ 0057_duplicate_type_names.graphql:20:6 ]
     │
  14 │ scalar X @specifiedBy(url: "https://apollographql.com")
     │        ┬  

--- a/crates/apollo-compiler/test_data/diagnostics/0058_fragment_definitions_with_duplicate_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0058_fragment_definitions_with_duplicate_names.txt
@@ -1,5 +1,5 @@
 Error: the fragment `petFragment` is defined multiple times in the document
-    ╭─[0058_fragment_definitions_with_duplicate_names.graphql:22:10]
+    ╭─[ 0058_fragment_definitions_with_duplicate_names.graphql:22:10 ]
     │
  17 │ fragment petFragment on Pet {
     │          ─────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0059_root_operation_object_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0059_root_operation_object_type.txt
@@ -1,5 +1,5 @@
 Error: `SomeInterface` field must return an object type
-   ╭─[0059_root_operation_object_type.graphql:2:12]
+   ╭─[ 0059_root_operation_object_type.graphql:2:12 ]
    │
  2 │     query: SomeInterface
    │            ──────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0060_root_operation_definition_undefined_operation_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0060_root_operation_definition_undefined_operation_type.txt
@@ -1,5 +1,5 @@
 Error: cannot find type `SomeQuery` in this document
-   ╭─[0060_root_operation_definition_undefined_operation_type.graphql:2:12]
+   ╭─[ 0060_root_operation_definition_undefined_operation_type.graphql:2:12 ]
    │
  2 │     query: SomeQuery
    │            ────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0061_root_operation_with_default_undefined_query.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0061_root_operation_with_default_undefined_query.txt
@@ -1,5 +1,5 @@
 Error: cannot find type `Query` in this document
-   ╭─[0061_root_operation_with_default_undefined_query.graphql:2:12]
+   ╭─[ 0061_root_operation_with_default_undefined_query.graphql:2:12 ]
    │
  2 │     query: Query
    │            ──┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0062_root_operation_with_list.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0062_root_operation_with_list.txt
@@ -1,5 +1,5 @@
 Error: missing query root operation type in schema definition
-   ╭─[0062_root_operation_with_list.graphql:1:1]
+   ╭─[ 0062_root_operation_with_list.graphql:1:1 ]
    │
  1 │ ╭─▶ schema {
  2 │ ├─▶   query: [Object]
@@ -7,35 +7,35 @@ Error: missing query root operation type in schema definition
    │ ╰─────────────────────── `query` root operation type must be defined here
 ───╯
 Error: syntax error: expected R_CURLY, got [
-   ╭─[0062_root_operation_with_list.graphql:2:10]
+   ╭─[ 0062_root_operation_with_list.graphql:2:10 ]
    │
  2 │   query: [Object]
    │          ┬  
    │          ╰── expected R_CURLY, got [
 ───╯
 Error: syntax error: expected a StringValue, Name or OperationDefinition
-   ╭─[0062_root_operation_with_list.graphql:2:10]
+   ╭─[ 0062_root_operation_with_list.graphql:2:10 ]
    │
  2 │   query: [Object]
    │          ┬  
    │          ╰── expected a StringValue, Name or OperationDefinition
 ───╯
 Error: syntax error: expected definition
-   ╭─[0062_root_operation_with_list.graphql:2:11]
+   ╭─[ 0062_root_operation_with_list.graphql:2:11 ]
    │
  2 │   query: [Object]
    │           ───┬──  
    │              ╰──── expected definition
 ───╯
 Error: syntax error: expected a StringValue, Name or OperationDefinition
-   ╭─[0062_root_operation_with_list.graphql:2:17]
+   ╭─[ 0062_root_operation_with_list.graphql:2:17 ]
    │
  2 │   query: [Object]
    │                 ┬  
    │                 ╰── expected a StringValue, Name or OperationDefinition
 ───╯
 Error: syntax error: expected a StringValue, Name or OperationDefinition
-   ╭─[0062_root_operation_with_list.graphql:3:1]
+   ╭─[ 0062_root_operation_with_list.graphql:3:1 ]
    │
  3 │ }
    │ ┬  

--- a/crates/apollo-compiler/test_data/diagnostics/0063_extension_orphan.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0063_extension_orphan.txt
@@ -1,47 +1,47 @@
 Error: type extension for undefined type `A`
-   ╭─[0063_extension_orphan.graphql:5:15]
+   ╭─[ 0063_extension_orphan.graphql:5:15 ]
    │
  5 │ extend scalar A @deprecated(reason: "Use B instead")
    │               ┬  
    │               ╰── extension here
 ───╯
 Error: type extension for undefined type `B`
-   ╭─[0063_extension_orphan.graphql:6:13]
+   ╭─[ 0063_extension_orphan.graphql:6:13 ]
    │
  6 │ extend type B { field: Int! }
    │             ┬  
    │             ╰── extension here
 ───╯
 Error: duplicate definitions for the `query` root operation type
-   ╭─[0063_extension_orphan.graphql:8:3]
+   ╭─[ 0063_extension_orphan.graphql:8:3 ]
    │
  8 │   query: Query
    │   ──────┬─────  
    │         ╰─────── `query` redefined here
 ───╯
 Error: type extension for undefined type `C`
-    ╭─[0063_extension_orphan.graphql:10:14]
+    ╭─[ 0063_extension_orphan.graphql:10:14 ]
     │
  10 │ extend union C = String
     │              ┬  
     │              ╰── extension here
 ────╯
 Error: type extension for undefined type `D`
-    ╭─[0063_extension_orphan.graphql:11:18]
+    ╭─[ 0063_extension_orphan.graphql:11:18 ]
     │
  11 │ extend interface D {
     │                  ┬  
     │                  ╰── extension here
 ────╯
 Error: type extension for undefined type `E`
-    ╭─[0063_extension_orphan.graphql:14:14]
+    ╭─[ 0063_extension_orphan.graphql:14:14 ]
     │
  14 │ extend input E {
     │              ┬  
     │              ╰── extension here
 ────╯
 Error: type extension for undefined type `F`
-    ╭─[0063_extension_orphan.graphql:17:13]
+    ╭─[ 0063_extension_orphan.graphql:17:13 ]
     │
  17 │ extend enum F {
     │             ┬  

--- a/crates/apollo-compiler/test_data/diagnostics/0064_extension_wrong_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0064_extension_wrong_type.txt
@@ -1,5 +1,5 @@
 Error: union member `Scalar` must be an object type
-   ╭─[0064_extension_wrong_type.graphql:8:15]
+   ╭─[ 0064_extension_wrong_type.graphql:8:15 ]
    │
  8 │ union Union = Scalar | Object
    │               ───┬──  
@@ -8,7 +8,7 @@ Error: union member `Scalar` must be an object type
    │ Help: Union members must be object types.
 ───╯
 Error: adding a union type extension, but `Scalar` is a scalar type
-    ╭─[0064_extension_wrong_type.graphql:16:14]
+    ╭─[ 0064_extension_wrong_type.graphql:16:14 ]
     │
   1 │ scalar Scalar @specifiedBy(url: "https://apollographql.com")
     │        ───┬──  
@@ -19,7 +19,7 @@ Error: adding a union type extension, but `Scalar` is a scalar type
     │                 ╰──── extension here
 ────╯
 Error: adding an interface type extension, but `Object` is an object type
-    ╭─[0064_extension_wrong_type.graphql:17:18]
+    ╭─[ 0064_extension_wrong_type.graphql:17:18 ]
     │
   5 │ type Object {
     │      ───┬──  
@@ -30,7 +30,7 @@ Error: adding an interface type extension, but `Object` is an object type
     │                     ╰──── extension here
 ────╯
 Error: adding an enum type extension, but `Intf` is an interface type
-    ╭─[0064_extension_wrong_type.graphql:20:13]
+    ╭─[ 0064_extension_wrong_type.graphql:20:13 ]
     │
   2 │ interface Intf {
     │           ──┬─  
@@ -41,7 +41,7 @@ Error: adding an enum type extension, but `Intf` is an interface type
     │               ╰─── extension here
 ────╯
 Error: adding an object type extension, but `Input` is an input object type
-    ╭─[0064_extension_wrong_type.graphql:23:13]
+    ╭─[ 0064_extension_wrong_type.graphql:23:13 ]
     │
   9 │ input Input {
     │       ──┬──  
@@ -52,7 +52,7 @@ Error: adding an object type extension, but `Input` is an input object type
     │               ╰──── extension here
 ────╯
 Error: adding an input object type extension, but `Enum` is an enum type
-    ╭─[0064_extension_wrong_type.graphql:26:14]
+    ╭─[ 0064_extension_wrong_type.graphql:26:14 ]
     │
  12 │ enum Enum {
     │      ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0065_subselection_of_enum.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0065_subselection_of_enum.txt
@@ -1,5 +1,5 @@
 Error: field selection of enum type `Pet` must not have subselections
-   ╭─[0065_subselection_of_enum.graphql:2:3]
+   ╭─[ 0065_subselection_of_enum.graphql:2:3 ]
    │
  2 │   pet1 { name }
    │   ──────┬──────  
@@ -8,7 +8,7 @@ Error: field selection of enum type `Pet` must not have subselections
    │ Note: path to the field: `query SelectionOfEnum → pet1`
 ───╯
 Error: field selection of enum type `Pet` must not have subselections
-   ╭─[0065_subselection_of_enum.graphql:3:3]
+   ╭─[ 0065_subselection_of_enum.graphql:3:3 ]
    │
  3 │   pet2 { name }
    │   ──────┬──────  
@@ -17,7 +17,7 @@ Error: field selection of enum type `Pet` must not have subselections
    │ Note: path to the field: `query SelectionOfEnum → pet2`
 ───╯
 Error: field selection of enum type `Pet` must not have subselections
-   ╭─[0065_subselection_of_enum.graphql:4:3]
+   ╭─[ 0065_subselection_of_enum.graphql:4:3 ]
    │
  4 │   pet3 { name }
    │   ──────┬──────  
@@ -26,7 +26,7 @@ Error: field selection of enum type `Pet` must not have subselections
    │ Note: path to the field: `query SelectionOfEnum → pet3`
 ───╯
 Error: field selection of enum type `Pet` must not have subselections
-   ╭─[0065_subselection_of_enum.graphql:5:3]
+   ╭─[ 0065_subselection_of_enum.graphql:5:3 ]
    │
  5 │   pet4 { name }
    │   ──────┬──────  
@@ -35,7 +35,7 @@ Error: field selection of enum type `Pet` must not have subselections
    │ Note: path to the field: `query SelectionOfEnum → pet4`
 ───╯
 Error: field selection of enum type `Pet` must not have subselections
-   ╭─[0065_subselection_of_enum.graphql:6:3]
+   ╭─[ 0065_subselection_of_enum.graphql:6:3 ]
    │
  6 │   pet5 { name }
    │   ──────┬──────  
@@ -44,7 +44,7 @@ Error: field selection of enum type `Pet` must not have subselections
    │ Note: path to the field: `query SelectionOfEnum → pet5`
 ───╯
 Error: field selection of enum type `Pet` must not have subselections
-   ╭─[0065_subselection_of_enum.graphql:7:3]
+   ╭─[ 0065_subselection_of_enum.graphql:7:3 ]
    │
  7 │   pet6 { name }
    │   ──────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0066_subselection_of_scalar.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0066_subselection_of_scalar.txt
@@ -1,5 +1,5 @@
 Error: field selection of scalar type `URL` must not have subselections
-   ╭─[0066_subselection_of_scalar.graphql:2:3]
+   ╭─[ 0066_subselection_of_scalar.graphql:2:3 ]
    │
  2 │   url1 { name }
    │   ──────┬──────  
@@ -8,7 +8,7 @@ Error: field selection of scalar type `URL` must not have subselections
    │ Note: path to the field: `query SelectionOfScalar → url1`
 ───╯
 Error: field selection of scalar type `URL` must not have subselections
-   ╭─[0066_subselection_of_scalar.graphql:3:3]
+   ╭─[ 0066_subselection_of_scalar.graphql:3:3 ]
    │
  3 │   url2 { name }
    │   ──────┬──────  
@@ -17,7 +17,7 @@ Error: field selection of scalar type `URL` must not have subselections
    │ Note: path to the field: `query SelectionOfScalar → url2`
 ───╯
 Error: field selection of scalar type `URL` must not have subselections
-   ╭─[0066_subselection_of_scalar.graphql:4:3]
+   ╭─[ 0066_subselection_of_scalar.graphql:4:3 ]
    │
  4 │   url3 { name }
    │   ──────┬──────  
@@ -26,7 +26,7 @@ Error: field selection of scalar type `URL` must not have subselections
    │ Note: path to the field: `query SelectionOfScalar → url3`
 ───╯
 Error: field selection of scalar type `URL` must not have subselections
-   ╭─[0066_subselection_of_scalar.graphql:5:3]
+   ╭─[ 0066_subselection_of_scalar.graphql:5:3 ]
    │
  5 │   url4 { name }
    │   ──────┬──────  
@@ -35,7 +35,7 @@ Error: field selection of scalar type `URL` must not have subselections
    │ Note: path to the field: `query SelectionOfScalar → url4`
 ───╯
 Error: field selection of scalar type `URL` must not have subselections
-   ╭─[0066_subselection_of_scalar.graphql:6:3]
+   ╭─[ 0066_subselection_of_scalar.graphql:6:3 ]
    │
  6 │   url5 { name }
    │   ──────┬──────  
@@ -44,7 +44,7 @@ Error: field selection of scalar type `URL` must not have subselections
    │ Note: path to the field: `query SelectionOfScalar → url5`
 ───╯
 Error: field selection of scalar type `URL` must not have subselections
-   ╭─[0066_subselection_of_scalar.graphql:7:3]
+   ╭─[ 0066_subselection_of_scalar.graphql:7:3 ]
    │
  7 │   url6 { name }
    │   ──────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0067_subselection_of_interface.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0067_subselection_of_interface.txt
@@ -1,40 +1,40 @@
 Error: interface, union and object types must have a subselection set
-   ╭─[0067_subselection_of_interface.graphql:2:3]
+   ╭─[ 0067_subselection_of_interface.graphql:2:3 ]
    │
  2 │   pet1
    │   ──┬─  
    │     ╰─── `Query.pet1` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0067_subselection_of_interface.graphql:3:3]
+   ╭─[ 0067_subselection_of_interface.graphql:3:3 ]
    │
  3 │   pet2
    │   ──┬─  
    │     ╰─── `Query.pet2` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0067_subselection_of_interface.graphql:4:3]
+   ╭─[ 0067_subselection_of_interface.graphql:4:3 ]
    │
  4 │   pet3
    │   ──┬─  
    │     ╰─── `Query.pet3` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0067_subselection_of_interface.graphql:5:3]
+   ╭─[ 0067_subselection_of_interface.graphql:5:3 ]
    │
  5 │   pet4
    │   ──┬─  
    │     ╰─── `Query.pet4` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0067_subselection_of_interface.graphql:6:3]
+   ╭─[ 0067_subselection_of_interface.graphql:6:3 ]
    │
  6 │   pet5
    │   ──┬─  
    │     ╰─── `Query.pet5` is an interface type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0067_subselection_of_interface.graphql:7:3]
+   ╭─[ 0067_subselection_of_interface.graphql:7:3 ]
    │
  7 │   pet6
    │   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0068_subselection_of_union.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0068_subselection_of_union.txt
@@ -1,40 +1,40 @@
 Error: interface, union and object types must have a subselection set
-   ╭─[0068_subselection_of_union.graphql:2:3]
+   ╭─[ 0068_subselection_of_union.graphql:2:3 ]
    │
  2 │   pet1
    │   ──┬─  
    │     ╰─── `Query.pet1` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0068_subselection_of_union.graphql:3:3]
+   ╭─[ 0068_subselection_of_union.graphql:3:3 ]
    │
  3 │   pet2
    │   ──┬─  
    │     ╰─── `Query.pet2` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0068_subselection_of_union.graphql:4:3]
+   ╭─[ 0068_subselection_of_union.graphql:4:3 ]
    │
  4 │   pet3
    │   ──┬─  
    │     ╰─── `Query.pet3` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0068_subselection_of_union.graphql:5:3]
+   ╭─[ 0068_subselection_of_union.graphql:5:3 ]
    │
  5 │   pet4
    │   ──┬─  
    │     ╰─── `Query.pet4` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0068_subselection_of_union.graphql:6:3]
+   ╭─[ 0068_subselection_of_union.graphql:6:3 ]
    │
  6 │   pet5
    │   ──┬─  
    │     ╰─── `Query.pet5` is a union type `CatOrDog` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0068_subselection_of_union.graphql:7:3]
+   ╭─[ 0068_subselection_of_union.graphql:7:3 ]
    │
  7 │   pet6
    │   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0069_subselection_of_object.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0069_subselection_of_object.txt
@@ -1,40 +1,40 @@
 Error: interface, union and object types must have a subselection set
-   ╭─[0069_subselection_of_object.graphql:2:3]
+   ╭─[ 0069_subselection_of_object.graphql:2:3 ]
    │
  2 │   pet1
    │   ──┬─  
    │     ╰─── `Query.pet1` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0069_subselection_of_object.graphql:3:3]
+   ╭─[ 0069_subselection_of_object.graphql:3:3 ]
    │
  3 │   pet2
    │   ──┬─  
    │     ╰─── `Query.pet2` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0069_subselection_of_object.graphql:4:3]
+   ╭─[ 0069_subselection_of_object.graphql:4:3 ]
    │
  4 │   pet3
    │   ──┬─  
    │     ╰─── `Query.pet3` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0069_subselection_of_object.graphql:5:3]
+   ╭─[ 0069_subselection_of_object.graphql:5:3 ]
    │
  5 │   pet4
    │   ──┬─  
    │     ╰─── `Query.pet4` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0069_subselection_of_object.graphql:6:3]
+   ╭─[ 0069_subselection_of_object.graphql:6:3 ]
    │
  6 │   pet5
    │   ──┬─  
    │     ╰─── `Query.pet5` is an object type `Pet` and must select fields
 ───╯
 Error: interface, union and object types must have a subselection set
-   ╭─[0069_subselection_of_object.graphql:7:3]
+   ╭─[ 0069_subselection_of_object.graphql:7:3 ]
    │
  7 │   pet6
    │   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0070_self_referential_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0070_self_referential_directive_definition.txt
@@ -1,5 +1,5 @@
 Error: `invalidExample` directive definition cannot reference itself
-   ╭─[0070_self_referential_directive_definition.graphql:7:1]
+   ╭─[ 0070_self_referential_directive_definition.graphql:7:1 ]
    │
  7 │ directive @invalidExample(arg: String @invalidExample) on ARGUMENT_DEFINITION
    │ ────────────┬────────────             ───────┬───────  
@@ -8,7 +8,7 @@ Error: `invalidExample` directive definition cannot reference itself
    │                                              ╰───────── `invalidExample` circularly references `invalidExample` here
 ───╯
 Error: `deprecatedType` directive definition cannot reference itself
-    ╭─[0070_self_referential_directive_definition.graphql:11:1]
+    ╭─[ 0070_self_referential_directive_definition.graphql:11:1 ]
     │
  10 │ extend scalar String @deprecatedType(reason: "use OurCustomString instead")
     │                      ───────────────────────────┬──────────────────────────  
@@ -18,7 +18,7 @@ Error: `deprecatedType` directive definition cannot reference itself
     │             ╰────────────── recursive directive definition
 ────╯
 Error: `loopA` directive definition cannot reference itself
-    ╭─[0070_self_referential_directive_definition.graphql:13:1]
+    ╭─[ 0070_self_referential_directive_definition.graphql:13:1 ]
     │
  13 │ directive @loopA(arg: Boolean @loopB) on ARGUMENT_DEFINITION
     │ ────────┬───────              ───┬──  
@@ -33,7 +33,7 @@ Error: `loopA` directive definition cannot reference itself
     │                                  ╰──── `loopC` circularly references `loopA` here
 ────╯
 Error: `loopB` directive definition cannot reference itself
-    ╭─[0070_self_referential_directive_definition.graphql:14:1]
+    ╭─[ 0070_self_referential_directive_definition.graphql:14:1 ]
     │
  13 │ directive @loopA(arg: Boolean @loopB) on ARGUMENT_DEFINITION
     │                               ───┬──  
@@ -48,7 +48,7 @@ Error: `loopB` directive definition cannot reference itself
     │                                  ╰──── `loopC` references `loopA` here...
 ────╯
 Error: `loopC` directive definition cannot reference itself
-    ╭─[0070_self_referential_directive_definition.graphql:15:1]
+    ╭─[ 0070_self_referential_directive_definition.graphql:15:1 ]
     │
  13 │ directive @loopA(arg: Boolean @loopB) on ARGUMENT_DEFINITION
     │                               ───┬──  
@@ -63,7 +63,7 @@ Error: `loopC` directive definition cannot reference itself
     │                                  ╰──── `loopC` references `loopA` here...
 ────╯
 Error: `wrong` directive definition cannot reference itself
-    ╭─[0070_self_referential_directive_definition.graphql:21:1]
+    ╭─[ 0070_self_referential_directive_definition.graphql:21:1 ]
     │
  18 │ extend enum Enum { RECURSIVE @wrong }
     │                              ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0074_merge_identical_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0074_merge_identical_fields.txt
@@ -1,5 +1,5 @@
 Error: operation must not select different types using the same name `name`
-    ╭─[0074_merge_identical_fields.graphql:19:3]
+    ╭─[ 0074_merge_identical_fields.graphql:19:3 ]
     │
  18 │   name: nickname
     │   ───────┬──────  
@@ -9,7 +9,7 @@ Error: operation must not select different types using the same name `name`
     │     ╰─── `name` is selected from `Dog.name: String!` here
 ────╯
 Error: cannot select different fields into the same alias `name`
-    ╭─[0074_merge_identical_fields.graphql:19:3]
+    ╭─[ 0074_merge_identical_fields.graphql:19:3 ]
     │
  18 │   name: nickname
     │   ───────┬──────  
@@ -21,7 +21,7 @@ Error: cannot select different fields into the same alias `name`
     │ Help: Both fields may be present on the schema type, so it's not clear which one should be used to fill the response
 ────╯
 Error: operation must not select different types using the same name `fido`
-    ╭─[0074_merge_identical_fields.graphql:24:3]
+    ╭─[ 0074_merge_identical_fields.graphql:24:3 ]
     │
  23 │   fido: name
     │   ─────┬────  
@@ -31,7 +31,7 @@ Error: operation must not select different types using the same name `fido`
     │          ╰──────── `fido` is selected from `Dog.nickname: String` here
 ────╯
 Error: cannot select different fields into the same alias `fido`
-    ╭─[0074_merge_identical_fields.graphql:24:3]
+    ╭─[ 0074_merge_identical_fields.graphql:24:3 ]
     │
  23 │   fido: name
     │   ─────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0075_merge_conflicting_args.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0075_merge_conflicting_args.txt
@@ -1,5 +1,5 @@
 Error: operation must not provide conflicting field arguments for the same name `doesKnowCommand`
-    ╭─[0075_merge_conflicting_args.graphql:47:3]
+    ╭─[ 0075_merge_conflicting_args.graphql:47:3 ]
     │
  46 │   doesKnowCommand(dogCommand: SIT)
     │   ────────────────┬───────────────  
@@ -11,7 +11,7 @@ Error: operation must not provide conflicting field arguments for the same name 
     │ Help: The same name cannot be selected multiple times with different arguments, because it's not clear which set of arguments should be used to fill the response. If you intend to use diverging arguments, consider adding an alias to differentiate
 ────╯
 Error: operation must not provide conflicting field arguments for the same name `doesKnowCommand`
-    ╭─[0075_merge_conflicting_args.graphql:52:3]
+    ╭─[ 0075_merge_conflicting_args.graphql:52:3 ]
     │
  51 │   doesKnowCommand(dogCommand: SIT)
     │   ────────────────┬───────────────  
@@ -23,7 +23,7 @@ Error: operation must not provide conflicting field arguments for the same name 
     │ Help: The same name cannot be selected multiple times with different arguments, because it's not clear which set of arguments should be used to fill the response. If you intend to use diverging arguments, consider adding an alias to differentiate
 ────╯
 Error: operation must not provide conflicting field arguments for the same name `doesKnowCommand`
-    ╭─[0075_merge_conflicting_args.graphql:57:3]
+    ╭─[ 0075_merge_conflicting_args.graphql:57:3 ]
     │
  56 │   doesKnowCommand(dogCommand: $varOne)
     │   ──────────────────┬─────────────────  
@@ -35,7 +35,7 @@ Error: operation must not provide conflicting field arguments for the same name 
     │ Help: The same name cannot be selected multiple times with different arguments, because it's not clear which set of arguments should be used to fill the response. If you intend to use diverging arguments, consider adding an alias to differentiate
 ────╯
 Error: operation must not provide conflicting field arguments for the same name `doesKnowCommand`
-    ╭─[0075_merge_conflicting_args.graphql:62:3]
+    ╭─[ 0075_merge_conflicting_args.graphql:62:3 ]
     │
  61 │   doesKnowCommand(dogCommand: SIT)
     │   ────────────────┬───────────────  
@@ -47,7 +47,7 @@ Error: operation must not provide conflicting field arguments for the same name 
     │ Help: The same name cannot be selected multiple times with different arguments, because it's not clear which set of arguments should be used to fill the response. If you intend to use diverging arguments, consider adding an alias to differentiate
 ────╯
 Error: operation must not provide conflicting field arguments for the same name `isAtLocation`
-    ╭─[0075_merge_conflicting_args.graphql:67:3]
+    ╭─[ 0075_merge_conflicting_args.graphql:67:3 ]
     │
  66 │   isAtLocation(x: 0)
     │   ─────────┬────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0076_merge_differing_responses.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0076_merge_differing_responses.txt
@@ -1,5 +1,5 @@
 Error: operation must not select different types using the same name `someValue`
-    ╭─[0076_merge_differing_responses.graphql:42:5]
+    ╭─[ 0076_merge_differing_responses.graphql:42:5 ]
     │
  39 │     someValue: nickname
     │     ─────────┬─────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0077_merge_conflict_deep.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0077_merge_conflict_deep.txt
@@ -1,5 +1,5 @@
 Error: cannot select different fields into the same alias `x`
-    ╭─[0077_merge_conflict_deep.graphql:14:5]
+    ╭─[ 0077_merge_conflict_deep.graphql:14:5 ]
     │
  11 │     x: a
     │     ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0078_merge_conflict_nested_fragments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0078_merge_conflict_nested_fragments.txt
@@ -1,5 +1,5 @@
 Error: cannot select different fields into the same alias `y`
-    ╭─[0078_merge_conflict_nested_fragments.graphql:25:3]
+    ╭─[ 0078_merge_conflict_nested_fragments.graphql:25:3 ]
     │
  25 │   y: c
     │   ──┬─  
@@ -12,7 +12,7 @@ Error: cannot select different fields into the same alias `y`
     │ Help: Both fields may be present on the schema type, so it's not clear which one should be used to fill the response
 ────╯
 Error: cannot select different fields into the same alias `x`
-    ╭─[0078_merge_conflict_nested_fragments.graphql:32:3]
+    ╭─[ 0078_merge_conflict_nested_fragments.graphql:32:3 ]
     │
  21 │   x: a
     │   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0079_directive_is_unique.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0079_directive_is_unique.txt
@@ -1,5 +1,5 @@
 Error: non-repeatable directive unique can only be used once per location
-    ╭─[0079_directive_is_unique.graphql:11:18]
+    ╭─[ 0079_directive_is_unique.graphql:11:18 ]
     │
  11 │   fieldB @unique @unique
     │          ───┬─── ───┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0080_directive_is_unique_with_extensions.txt
@@ -1,5 +1,5 @@
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0080_directive_is_unique_with_extensions.graphql:2:24]
+   ╭─[ 0080_directive_is_unique_with_extensions.graphql:2:24 ]
    │
  2 │ extend type TestObject @nonRepeatable
    │                        ───────┬──────  
@@ -9,7 +9,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                        ╰──────── directive `@nonRepeatable` first called here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0080_directive_is_unique_with_extensions.graphql:6:24]
+   ╭─[ 0080_directive_is_unique_with_extensions.graphql:6:24 ]
    │
  3 │ type TestObject @nonRepeatable {
    │                 ───────┬──────  
@@ -20,7 +20,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                               ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0080_directive_is_unique_with_extensions.graphql:9:22]
+   ╭─[ 0080_directive_is_unique_with_extensions.graphql:9:22 ]
    │
  8 │ scalar Scalar @nonRepeatable
    │               ───────┬──────  
@@ -30,7 +30,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                             ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-    ╭─[0080_directive_is_unique_with_extensions.graphql:14:23]
+    ╭─[ 0080_directive_is_unique_with_extensions.graphql:14:23 ]
     │
  11 │ interface Intf @nonRepeatable {
     │                ───────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0081_directive_is_unique_type_system.txt
@@ -1,5 +1,5 @@
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0081_directive_is_unique_type_system.graphql:3:23]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:3:23 ]
    │
  3 │ schema @nonRepeatable @nonRepeatable { query: Dummy }
    │        ───────┬────── ───────┬──────  
@@ -8,7 +8,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                              ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0081_directive_is_unique_type_system.graphql:4:34]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:4:34 ]
    │
  4 │ scalar TestScalar @nonRepeatable @nonRepeatable @specifiedBy(url: "example.com")
    │                   ───────┬────── ───────┬──────  
@@ -17,7 +17,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                                         ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: `Dummy` has no fields
-   ╭─[0081_directive_is_unique_type_system.graphql:5:1]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:5:1 ]
    │
  5 │ type Dummy @nonRepeatable @nonRepeatable
    │ ────────────────────┬───────────────────  
@@ -26,7 +26,7 @@ Error: `Dummy` has no fields
    │ Help: Define one or more fields on `Dummy`.
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0081_directive_is_unique_type_system.graphql:5:27]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:5:27 ]
    │
  5 │ type Dummy @nonRepeatable @nonRepeatable
    │            ───────┬────── ───────┬──────  
@@ -35,7 +35,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                                  ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: `TestInterface` has no fields
-   ╭─[0081_directive_is_unique_type_system.graphql:6:1]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:6:1 ]
    │
  6 │ interface TestInterface @nonRepeatable @nonRepeatable
    │ ──────────────────────────┬──────────────────────────  
@@ -44,7 +44,7 @@ Error: `TestInterface` has no fields
    │ Help: Define one or more fields on `TestInterface`.
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0081_directive_is_unique_type_system.graphql:6:40]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:6:40 ]
    │
  6 │ interface TestInterface @nonRepeatable @nonRepeatable
    │                         ───────┬────── ───────┬──────  
@@ -53,7 +53,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                                               ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: `TestUnion` has no member types
-   ╭─[0081_directive_is_unique_type_system.graphql:7:1]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:7:1 ]
    │
  7 │ union TestUnion @nonRepeatable @nonRepeatable
    │ ──────────────────────┬──────────────────────  
@@ -62,7 +62,7 @@ Error: `TestUnion` has no member types
    │ Help: Define one or more union member types on `TestUnion`.
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0081_directive_is_unique_type_system.graphql:7:32]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:7:32 ]
    │
  7 │ union TestUnion @nonRepeatable @nonRepeatable
    │                 ───────┬────── ───────┬──────  
@@ -71,7 +71,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
    │                                       ╰──────── directive `@nonRepeatable` called again here
 ───╯
 Error: `TestInput` has no input values
-   ╭─[0081_directive_is_unique_type_system.graphql:8:1]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:8:1 ]
    │
  8 │ input TestInput @nonRepeatable @nonRepeatable
    │ ──────────────────────┬──────────────────────  
@@ -80,7 +80,7 @@ Error: `TestInput` has no input values
    │ Help: Define one or more input values on `TestInput`.
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-   ╭─[0081_directive_is_unique_type_system.graphql:8:32]
+   ╭─[ 0081_directive_is_unique_type_system.graphql:8:32 ]
    │
  8 │ input TestInput @nonRepeatable @nonRepeatable
    │                 ───────┬────── ───────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0082_introspection_types_in_mutation.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0082_introspection_types_in_mutation.txt
@@ -1,5 +1,5 @@
 Error: type `MyMutationRootType` does not have a field `__type`
-    ╭─[0082_introspection_types_in_mutation.graphql:15:3]
+    ╭─[ 0082_introspection_types_in_mutation.graphql:15:3 ]
     │
  10 │ type MyMutationRootType {
     │      ─────────┬────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0083_type_introspection_from_disallowed_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0083_type_introspection_from_disallowed_type.txt
@@ -1,5 +1,5 @@
 Error: type `Product` does not have a field `__type`
-    ╭─[0083_type_introspection_from_disallowed_type.graphql:4:5]
+    ╭─[ 0083_type_introspection_from_disallowed_type.graphql:4:5 ]
     │
   4 │     __type(name: "User") {
     │     ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0084_circular_non_nullable_input_objects.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0084_circular_non_nullable_input_objects.txt
@@ -1,5 +1,5 @@
 Error: `First` input object cannot reference itself
-    ╭─[0084_circular_non_nullable_input_objects.graphql:6:1]
+    ╭─[ 0084_circular_non_nullable_input_objects.graphql:6:1 ]
     │
   6 │ ╭─▶ input First {
   7 │ │     second: Second!
@@ -23,7 +23,7 @@ Error: `First` input object cannot reference itself
     │             ╰──────── `fourth` circularly references `First` here
 ────╯
 Error: `Second` input object cannot reference itself
-    ╭─[0084_circular_non_nullable_input_objects.graphql:11:1]
+    ╭─[ 0084_circular_non_nullable_input_objects.graphql:11:1 ]
     │
   7 │       second: Second!
     │       ───────┬───────  
@@ -47,7 +47,7 @@ Error: `Second` input object cannot reference itself
     │             ╰──────── `fourth` references `first` here...
 ────╯
 Error: `Third` input object cannot reference itself
-    ╭─[0084_circular_non_nullable_input_objects.graphql:16:1]
+    ╭─[ 0084_circular_non_nullable_input_objects.graphql:16:1 ]
     │
   7 │       second: Second!
     │       ───────┬───────  
@@ -71,7 +71,7 @@ Error: `Third` input object cannot reference itself
     │             ╰──────── `fourth` references `first` here...
 ────╯
 Error: `Fourth` input object cannot reference itself
-    ╭─[0084_circular_non_nullable_input_objects.graphql:21:1]
+    ╭─[ 0084_circular_non_nullable_input_objects.graphql:21:1 ]
     │
   7 │       second: Second!
     │       ───────┬───────  

--- a/crates/apollo-compiler/test_data/diagnostics/0085_fragment_spread_target_defined.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0085_fragment_spread_target_defined.txt
@@ -1,5 +1,5 @@
 Error: cannot find fragment `undefinedFragment` in this document
-    ╭─[0085_fragment_spread_target_defined.graphql:10:5]
+    ╭─[ 0085_fragment_spread_target_defined.graphql:10:5 ]
     │
  10 │     ...undefinedFragment
     │     ──────────┬─────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0086_unused_fragment.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0086_unused_fragment.txt
@@ -1,5 +1,5 @@
 Error: fragment `nameFragment` must be used in an operation
-    ╭─[0086_unused_fragment.graphql:17:1]
+    ╭─[ 0086_unused_fragment.graphql:17:1 ]
     │
  17 │ ╭─▶ fragment nameFragment on Product {
     ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0087_fragment_type_condition_on_composite_types.txt
@@ -1,5 +1,5 @@
 Error: field selection of scalar type `Int` must not have subselections
-   ╭─[0087_fragment_type_condition_on_composite_types.graphql:5:5]
+   ╭─[ 0087_fragment_type_condition_on_composite_types.graphql:5:5 ]
    │
  5 │     price { ...fragOnScalar }
    │     ────────────┬────────────  
@@ -8,7 +8,7 @@ Error: field selection of scalar type `Int` must not have subselections
    │ Note: path to the field: `query Query → products → price`
 ───╯
 Error: inline fragment must have a composite type in its type condition
-   ╭─[0087_fragment_type_condition_on_composite_types.graphql:7:5]
+   ╭─[ 0087_fragment_type_condition_on_composite_types.graphql:7:5 ]
    │
  7 │ ╭─▶     ... on Int {
    ┆ ┆   
@@ -19,13 +19,13 @@ Error: inline fragment must have a composite type in its type condition
    │     Help: fragments cannot be defined on enums, scalars and input objects
 ───╯
 Error: type `Int` does not have a field `name`
-     ╭─[0087_fragment_type_condition_on_composite_types.graphql:8:7]
+     ╭─[ 0087_fragment_type_condition_on_composite_types.graphql:8:7 ]
      │
    8 │       name
      │       ──┬─  
      │         ╰─── field `name` selected here
      │
-     ├─[built_in.graphql:166:8]
+     ├─[ built_in.graphql:166:8 ]
      │
  166 │ scalar Int
      │        ─┬─  
@@ -34,7 +34,7 @@ Error: type `Int` does not have a field `name`
      │ Note: path to the field: `query Query → products → name`
 ─────╯
 Error: fragment `fragOnScalar` must be used in an operation
-    ╭─[0087_fragment_type_condition_on_composite_types.graphql:21:1]
+    ╭─[ 0087_fragment_type_condition_on_composite_types.graphql:21:1 ]
     │
  21 │ ╭─▶ fragment fragOnScalar on Int {
     ┆ ┆   
@@ -45,13 +45,13 @@ Error: fragment `fragOnScalar` must be used in an operation
     │     Help: fragment `fragOnScalar` must be used in an operation
 ────╯
 Error: type `Int` does not have a field `name`
-     ╭─[0087_fragment_type_condition_on_composite_types.graphql:22:3]
+     ╭─[ 0087_fragment_type_condition_on_composite_types.graphql:22:3 ]
      │
   22 │   name
      │   ──┬─  
      │     ╰─── field `name` selected here
      │
-     ├─[built_in.graphql:166:8]
+     ├─[ built_in.graphql:166:8 ]
      │
  166 │ scalar Int
      │        ─┬─  
@@ -60,7 +60,7 @@ Error: type `Int` does not have a field `name`
      │ Note: path to the field: `fragment fragOnScalar → name`
 ─────╯
 Error: inline fragment must have a composite type in its type condition
-    ╭─[0087_fragment_type_condition_on_composite_types.graphql:26:3]
+    ╭─[ 0087_fragment_type_condition_on_composite_types.graphql:26:3 ]
     │
  26 │ ╭─▶   ... on Int {
     ┆ ┆   
@@ -71,13 +71,13 @@ Error: inline fragment must have a composite type in its type condition
     │     Help: fragments cannot be defined on enums, scalars and input objects
 ────╯
 Error: type `Int` does not have a field `name`
-     ╭─[0087_fragment_type_condition_on_composite_types.graphql:27:5]
+     ╭─[ 0087_fragment_type_condition_on_composite_types.graphql:27:5 ]
      │
   27 │     name
      │     ──┬─  
      │       ╰─── field `name` selected here
      │
-     ├─[built_in.graphql:166:8]
+     ├─[ built_in.graphql:166:8 ]
      │
  166 │ scalar Int
      │        ─┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0088_fragment_selection_set.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0088_fragment_selection_set.txt
@@ -1,5 +1,5 @@
 Error: type `Query` does not have a field `topProduct`
-    ╭─[0088_fragment_selection_set.graphql:13:5]
+    ╭─[ 0088_fragment_selection_set.graphql:13:5 ]
     │
   1 │ type Query {
     │      ──┬──  
@@ -12,7 +12,7 @@ Error: type `Query` does not have a field `topProduct`
     │ Note: path to the field: `query getProduct → topProduct`
 ────╯
 Error: type `Product` does not have a field `notExistingField`
-    ╭─[0088_fragment_selection_set.graphql:22:3]
+    ╭─[ 0088_fragment_selection_set.graphql:22:3 ]
     │
   6 │ type Product {
     │      ───┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0089_fragment_type_condition_on_non_existent_types.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0089_fragment_type_condition_on_non_existent_types.txt
@@ -1,12 +1,12 @@
 Error: cannot find fragment `invalidFragmentCondition` in this document
-   ╭─[0089_fragment_type_condition_on_non_existent_types.graphql:3:5]
+   ╭─[ 0089_fragment_type_condition_on_non_existent_types.graphql:3:5 ]
    │
  3 │     ...invalidFragmentCondition
    │     ─────────────┬─────────────  
    │                  ╰─────────────── fragment `invalidFragmentCondition` is not defined
 ───╯
 Error: type condition `MissingSecondType` of inline fragment is not a type defined in the schema
-   ╭─[0089_fragment_type_condition_on_non_existent_types.graphql:5:12]
+   ╭─[ 0089_fragment_type_condition_on_non_existent_types.graphql:5:12 ]
    │
  5 │     ... on MissingSecondType {
    │            ────────┬────────  
@@ -15,7 +15,7 @@ Error: type condition `MissingSecondType` of inline fragment is not a type defin
    │ Note: path to the inline fragment: `query Query → interface → ...`
 ───╯
 Error: type condition `MissingType` of inline fragment is not a type defined in the schema
-    ╭─[0089_fragment_type_condition_on_non_existent_types.graphql:23:10]
+    ╭─[ 0089_fragment_type_condition_on_non_existent_types.graphql:23:10 ]
     │
  23 │   ... on MissingType {
     │          ─────┬─────  
@@ -24,7 +24,7 @@ Error: type condition `MissingType` of inline fragment is not a type defined in 
     │ Note: path to the inline fragment: `fragment invalidInlineFragment → ...`
 ────╯
 Error: type condition `Interface2` of fragment `invalidFragmentCondition` is not a type defined in the schema
-    ╭─[0089_fragment_type_condition_on_non_existent_types.graphql:28:38]
+    ╭─[ 0089_fragment_type_condition_on_non_existent_types.graphql:28:38 ]
     │
  28 │ fragment invalidFragmentCondition on Interface2 {
     │                                      ─────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0090_fragment_spread_impossible.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0090_fragment_spread_impossible.txt
@@ -1,5 +1,5 @@
 Error: fragment `catInDogFragmentInvalid` with type condition `Dog` cannot be applied to `Human`
-    ╭─[0090_fragment_spread_impossible.graphql:39:9]
+    ╭─[ 0090_fragment_spread_impossible.graphql:39:9 ]
     │
  25 │   ╭─▶ type Human implements Sentient {
     ┆   ┆   
@@ -18,7 +18,7 @@ Error: fragment `catInDogFragmentInvalid` with type condition `Dog` cannot be ap
     │ ╰───────── fragment declared with type condition `Dog` here
 ────╯
 Error: fragment `nonIntersectingInterfaces` with type condition `Pet` cannot be applied to `Human`
-    ╭─[0090_fragment_spread_impossible.graphql:42:9]
+    ╭─[ 0090_fragment_spread_impossible.graphql:42:9 ]
     │
  25 │   ╭─▶ type Human implements Sentient {
     ┆   ┆   
@@ -37,7 +37,7 @@ Error: fragment `nonIntersectingInterfaces` with type condition `Pet` cannot be 
     │ ╰───────── fragment declared with type condition `Pet` here
 ────╯
 Error: inline fragment with type condition `Cat` cannot be applied to `Dog`
-    ╭─[0090_fragment_spread_impossible.graphql:48:3]
+    ╭─[ 0090_fragment_spread_impossible.graphql:48:3 ]
     │
  13 │ ╭───▶ type Dog implements Pet {
     ┆ ┆     
@@ -52,7 +52,7 @@ Error: inline fragment with type condition `Cat` cannot be applied to `Dog`
     │   ╰───────── inline fragment cannot be applied
 ────╯
 Error: inline fragment with type condition `Dog` cannot be applied to `Sentient`
-    ╭─[0090_fragment_spread_impossible.graphql:54:3]
+    ╭─[ 0090_fragment_spread_impossible.graphql:54:3 ]
     │
   5 │ ╭───▶ interface Sentient {
     ┆ ┆     
@@ -67,7 +67,7 @@ Error: inline fragment with type condition `Dog` cannot be applied to `Sentient`
     │   ╰───────── inline fragment cannot be applied
 ────╯
 Error: inline fragment with type condition `Cat` cannot be applied to `HumanOrAlien`
-    ╭─[0090_fragment_spread_impossible.graphql:60:3]
+    ╭─[ 0090_fragment_spread_impossible.graphql:60:3 ]
     │
  35 │     union HumanOrAlien = Human | Alien
     │     ─────────────────┬────────────────  
@@ -80,7 +80,7 @@ Error: inline fragment with type condition `Cat` cannot be applied to `HumanOrAl
     │ ╰───────── inline fragment cannot be applied
 ────╯
 Error: fragment `sentientFragment2` with type condition `Sentient` cannot be applied to `Pet`
-    ╭─[0090_fragment_spread_impossible.graphql:66:3]
+    ╭─[ 0090_fragment_spread_impossible.graphql:66:3 ]
     │
   9 │   ╭─▶ interface Pet {
     ┆   ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0091_recursive_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0091_recursive_interface_definition.txt
@@ -1,5 +1,5 @@
 Error: interface `A` declares that it implements `B`, but to do so it must also implement `A`
-   ╭─[0091_recursive_interface_definition.graphql:1:1]
+   ╭─[ 0091_recursive_interface_definition.graphql:1:1 ]
    │
  1 │ ╭─▶ interface A implements B {
    ┆ ┆   
@@ -11,7 +11,7 @@ Error: interface `A` declares that it implements `B`, but to do so it must also 
    │                            ╰── implementation of A declared by B here
 ───╯
 Error: interface `B` declares that it implements `A`, but to do so it must also implement `B`
-   ╭─[0091_recursive_interface_definition.graphql:4:1]
+   ╭─[ 0091_recursive_interface_definition.graphql:4:1 ]
    │
  1 │     interface A implements B {
    │                            ┬  

--- a/crates/apollo-compiler/test_data/diagnostics/0092_recursive_fragment_spread.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0092_recursive_fragment_spread.txt
@@ -1,5 +1,5 @@
 Error: `fragA` fragment cannot reference itself
-    ╭─[0092_recursive_fragment_spread.graphql:14:1]
+    ╭─[ 0092_recursive_fragment_spread.graphql:14:1 ]
     │
  14 │ fragment fragA on Human { name, ...fragB }
     │ ───────┬──────                  ────┬───  
@@ -14,7 +14,7 @@ Error: `fragA` fragment cannot reference itself
     │                                     ╰───── `fragC` circularly references `fragA` here
 ────╯
 Error: `cycle1` fragment cannot reference itself
-    ╭─[0092_recursive_fragment_spread.graphql:19:1]
+    ╭─[ 0092_recursive_fragment_spread.graphql:19:1 ]
     │
  19 │ fragment cycle1 on __Type { kind, ...cycle2 }
     │ ───────┬───────                   ────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0093_fragment_validation_with_recursive_type_system.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0093_fragment_validation_with_recursive_type_system.txt
@@ -1,5 +1,5 @@
 Error: interface `A` declares that it implements `B`, but to do so it must also implement `A`
-   ╭─[0093_fragment_validation_with_recursive_type_system.graphql:2:1]
+   ╭─[ 0093_fragment_validation_with_recursive_type_system.graphql:2:1 ]
    │
  2 │ ╭─▶ interface A implements B {
    ┆ ┆   
@@ -11,7 +11,7 @@ Error: interface `A` declares that it implements `B`, but to do so it must also 
    │                            ╰── implementation of A declared by B here
 ───╯
 Error: interface `B` declares that it implements `A`, but to do so it must also implement `B`
-   ╭─[0093_fragment_validation_with_recursive_type_system.graphql:6:1]
+   ╭─[ 0093_fragment_validation_with_recursive_type_system.graphql:6:1 ]
    │
  2 │     interface A implements B {
    │                            ┬  

--- a/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0094_object_type_extensions.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `age` field of object type `UniqueNames`
-   ╭─[0094_object_type_extensions.graphql:6:3]
+   ╭─[ 0094_object_type_extensions.graphql:6:3 ]
    │
  5 │   age: Int
    │   ─┬─  
@@ -9,7 +9,7 @@ Error: duplicate definitions for the `age` field of object type `UniqueNames`
    │       ╰───── `age` redefined here
 ───╯
 Error: duplicate definitions for the `name` field of object type `ConflictingNames`
-    ╭─[0094_object_type_extensions.graphql:13:3]
+    ╭─[ 0094_object_type_extensions.graphql:13:3 ]
     │
  10 │   name: String
     │   ──┬─  
@@ -20,7 +20,7 @@ Error: duplicate definitions for the `name` field of object type `ConflictingNam
     │         ╰─────── `name` redefined here
 ────╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-    ╭─[0094_object_type_extensions.graphql:20:29]
+    ╭─[ 0094_object_type_extensions.graphql:20:29 ]
     │
  17 │ type UniqueDirective @nonRepeatable {
     │                      ───────┬──────  
@@ -31,7 +31,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │                                    ╰──────── directive `@nonRepeatable` called again here
 ────╯
 Error: object type `UniqueInterfaces` implements interface `Base` more than once
-    ╭─[0094_object_type_extensions.graphql:31:41]
+    ╭─[ 0094_object_type_extensions.graphql:31:41 ]
     │
  27 │ type UniqueInterfaces implements Base {
     │                                  ──┬─  
@@ -42,7 +42,7 @@ Error: object type `UniqueInterfaces` implements interface `Base` more than once
     │                                           ╰─── `Base` implemented again here
 ────╯
 Error: type `ImplementsBaseButNotExtension` does not satisfy interface `ExtendedInterface`: missing field `fail`
-    ╭─[0094_object_type_extensions.graphql:38:1]
+    ╭─[ 0094_object_type_extensions.graphql:38:1 ]
     │
  38 │ ╭─▶ type ImplementsBaseButNotExtension implements ExtendedInterface {
     │ │                                                 ────────┬────────  

--- a/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0095_interface_implementation_declared_once.txt
@@ -1,5 +1,5 @@
 Error: object type `Object` implements interface `Intf` more than once
-   ╭─[0095_interface_implementation_declared_once.graphql:5:31]
+   ╭─[ 0095_interface_implementation_declared_once.graphql:5:31 ]
    │
  5 │ type Object implements Intf & Intf {
    │                        ──┬─   ──┬─  
@@ -8,7 +8,7 @@ Error: object type `Object` implements interface `Intf` more than once
    │                                 ╰─── `Intf` implemented again here
 ───╯
 Error: object type `Extended` implements interface `Intf` more than once
-    ╭─[0095_interface_implementation_declared_once.graphql:12:33]
+    ╭─[ 0095_interface_implementation_declared_once.graphql:12:33 ]
     │
   9 │ type Extended implements Intf {
     │                          ──┬─  
@@ -19,7 +19,7 @@ Error: object type `Extended` implements interface `Intf` more than once
     │                                   ╰─── `Intf` implemented again here
 ────╯
 Error: interface type `SubIntf` implements interface `Intf` more than once
-    ╭─[0095_interface_implementation_declared_once.graphql:14:37]
+    ╭─[ 0095_interface_implementation_declared_once.graphql:14:37 ]
     │
  14 │ interface SubIntf implements Intf & Intf {
     │                              ──┬─   ──┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0096_schema_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0096_schema_extensions.txt
@@ -1,5 +1,5 @@
 Error: non-repeatable directive nonRepeatable can only be used once per location
-    ╭─[0096_schema_extensions.graphql:11:15]
+    ╭─[ 0096_schema_extensions.graphql:11:15 ]
     │
   8 │ schema @nonRepeatable {
     │        ───────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0097_enum_extensions.txt
@@ -1,5 +1,5 @@
 Error: non-repeatable directive nonRepeatable can only be used once per location
-    ╭─[0097_enum_extensions.graphql:13:15]
+    ╭─[ 0097_enum_extensions.graphql:13:15 ]
     │
   8 │ extend enum E @nonRepeatable {
     │               ───────┬──────  
@@ -10,7 +10,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │                      ╰──────── directive `@nonRepeatable` called again here
 ────╯
 Error: duplicate definitions for the `MEMBER_2` value of enum type `E`
-    ╭─[0097_enum_extensions.graphql:14:3]
+    ╭─[ 0097_enum_extensions.graphql:14:3 ]
     │
   5 │   MEMBER_2
     │   ────┬───  
@@ -21,7 +21,7 @@ Error: duplicate definitions for the `MEMBER_2` value of enum type `E`
     │       ╰───── `MEMBER_2` redefined here
 ────╯
 Error: duplicate definitions for the `MEMBER_4` value of enum type `E`
-    ╭─[0097_enum_extensions.graphql:15:3]
+    ╭─[ 0097_enum_extensions.graphql:15:3 ]
     │
  10 │   MEMBER_4
     │   ────┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0098_interface_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0098_interface_extensions.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `name` field of interface type `UniqueNames`
-   ╭─[0098_interface_extensions.graphql:5:3]
+   ╭─[ 0098_interface_extensions.graphql:5:3 ]
    │
  2 │   name: String
    │   ──┬─  
@@ -10,7 +10,7 @@ Error: duplicate definitions for the `name` field of interface type `UniqueNames
    │         ╰─────── `name` redefined here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-    ╭─[0098_interface_extensions.graphql:14:29]
+    ╭─[ 0098_interface_extensions.graphql:14:29 ]
     │
  10 │ interface Directives @nonRepeatable {
     │                      ───────┬──────  
@@ -21,7 +21,7 @@ Error: non-repeatable directive nonRepeatable can only be used once per location
     │                                    ╰──────── directive `@nonRepeatable` called again here
 ────╯
 Error: type `Derived` does not satisfy interface `Base`: missing field `b`
-    ╭─[0098_interface_extensions.graphql:21:1]
+    ╭─[ 0098_interface_extensions.graphql:21:1 ]
     │
  18 │       b: Int
     │       ───┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0099_input_object_extensions.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `field` field of input object type `UniqueNames`
-   ╭─[0099_input_object_extensions.graphql:5:3]
+   ╭─[ 0099_input_object_extensions.graphql:5:3 ]
    │
  2 │   field: String
    │   ──┬──  
@@ -10,7 +10,7 @@ Error: duplicate definitions for the `field` field of input object type `UniqueN
    │         ╰──────── `field` redefined here
 ───╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-    ╭─[0099_input_object_extensions.graphql:12:30]
+    ╭─[ 0099_input_object_extensions.graphql:12:30 ]
     │
   9 │ input UniqueDirective @nonRepeatable {
     │                       ───────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0100_union_extensions.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0100_union_extensions.txt
@@ -1,5 +1,5 @@
 Error: union member `ThisIsAScalar` must be an object type
-   ╭─[0100_union_extensions.graphql:8:30]
+   ╭─[ 0100_union_extensions.graphql:8:30 ]
    │
  8 │ extend union NonObjectType = ThisIsAScalar
    │                              ──────┬──────  
@@ -8,7 +8,7 @@ Error: union member `ThisIsAScalar` must be an object type
    │ Help: Union members must be object types.
 ───╯
 Error: duplicate definitions for the `WithFieldA` member of union type `DuplicateMembers`
-    ╭─[0100_union_extensions.graphql:12:33]
+    ╭─[ 0100_union_extensions.graphql:12:33 ]
     │
  11 │ union DuplicateMembers = WithFieldA
     │                          ─────┬────  
@@ -18,7 +18,7 @@ Error: duplicate definitions for the `WithFieldA` member of union type `Duplicat
     │                                      ╰────── `WithFieldA` redefined here
 ────╯
 Error: non-repeatable directive nonRepeatable can only be used once per location
-    ╭─[0100_union_extensions.graphql:17:33]
+    ╭─[ 0100_union_extensions.graphql:17:33 ]
     │
  16 │ union DuplicateDirective @nonRepeatable = WithFieldA
     │                          ───────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0101_mismatched_variable_usage.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0101_mismatched_variable_usage.txt
@@ -1,5 +1,5 @@
 Error: variable `$intArg` of type `Int` cannot be used for argument `booleanArg` of type `Boolean`
-   ╭─[0101_mismatched_variable_usage.graphql:3:21]
+   ╭─[ 0101_mismatched_variable_usage.graphql:3:21 ]
    │
  1 │ query intCannotGoIntoBoolean($intArg: Int) {
    │                              ──────┬─────  
@@ -10,7 +10,7 @@ Error: variable `$intArg` of type `Int` cannot be used for argument `booleanArg`
    │                              ╰─────────── variable `$intArg` used here
 ───╯
 Error: variable `$booleanListArg` of type `[Boolean]` cannot be used for argument `booleanArg` of type `Boolean`
-   ╭─[0101_mismatched_variable_usage.graphql:9:21]
+   ╭─[ 0101_mismatched_variable_usage.graphql:9:21 ]
    │
  7 │ query booleanListCannotGoIntoBoolean($booleanListArg: [Boolean]) {
    │                                      ─────────────┬────────────  
@@ -21,7 +21,7 @@ Error: variable `$booleanListArg` of type `[Boolean]` cannot be used for argumen
    │                                  ╰─────────────── variable `$booleanListArg` used here
 ───╯
 Error: variable `$booleanArg` of type `Boolean` cannot be used for argument `nonNullBooleanArg` of type `Boolean!`
-    ╭─[0101_mismatched_variable_usage.graphql:15:28]
+    ╭─[ 0101_mismatched_variable_usage.graphql:15:28 ]
     │
  13 │ query booleanArgQuery($booleanArg: Boolean) {
     │                       ──────────┬─────────  
@@ -32,7 +32,7 @@ Error: variable `$booleanArg` of type `Boolean` cannot be used for argument `non
     │                                           ╰──────────────── variable `$booleanArg` used here
 ────╯
 Error: variable `$booleanList` of type `[Boolean]` cannot be used for argument `nonNullBooleanListArg` of type `[Boolean]!`
-    ╭─[0101_mismatched_variable_usage.graphql:21:29]
+    ╭─[ 0101_mismatched_variable_usage.graphql:21:29 ]
     │
  19 │ query listToNonNullList($booleanList: [Boolean]) {
     │                         ───────────┬───────────  
@@ -43,7 +43,7 @@ Error: variable `$booleanList` of type `[Boolean]` cannot be used for argument `
     │                                              ╰─────────────────── variable `$booleanList` used here
 ────╯
 Error: variable `$intArg` of type `Int` cannot be used for argument `nonNullIntArg` of type `Int!`
-    ╭─[0101_mismatched_variable_usage.graphql:26:24]
+    ╭─[ 0101_mismatched_variable_usage.graphql:26:24 ]
     │
  26 │     nonNullIntArgField(nonNullIntArg: $intArg)
     │                        ───────────┬──────────  
@@ -54,7 +54,7 @@ Error: variable `$intArg` of type `Int` cannot be used for argument `nonNullIntA
     │                                        ╰─────── variable `$intArg` of type `Int` is declared here
 ────╯
 Error: variable `$intArg` of type `Int` cannot be used for argument `nonNullIntArg` of type `Int!`
-    ╭─[0101_mismatched_variable_usage.graphql:40:24]
+    ╭─[ 0101_mismatched_variable_usage.graphql:40:24 ]
     │
  40 │     nonNullIntArgField(nonNullIntArg: $intArg)
     │                        ───────────┬──────────  
@@ -65,7 +65,7 @@ Error: variable `$intArg` of type `Int` cannot be used for argument `nonNullIntA
     │                                                    ╰─────── variable `$intArg` of type `Int` is declared here
 ────╯
 Error: expected value of type Boolean, found a variable
-    ╭─[0101_mismatched_variable_usage.graphql:51:50]
+    ╭─[ 0101_mismatched_variable_usage.graphql:51:50 ]
     │
  51 │     nonNullBooleanListField(nonNullBooleanListArg: [$intArg])
     │                                                     ───┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0102_invalid_string_values.txt
@@ -1,5 +1,5 @@
 Error: expected value of type String, found an integer
-    ╭─[0102_invalid_string_values.graphql:71:31]
+    ╭─[ 0102_invalid_string_values.graphql:71:31 ]
     │
   8 │   stringArgField(stringArg: String): String
     │                             ───┬──  
@@ -10,7 +10,7 @@ Error: expected value of type String, found an integer
     │                               ╰── provided value is an integer
 ────╯
 Error: expected value of type String, found a float
-    ╭─[0102_invalid_string_values.graphql:77:31]
+    ╭─[ 0102_invalid_string_values.graphql:77:31 ]
     │
   8 │   stringArgField(stringArg: String): String
     │                             ───┬──  
@@ -21,7 +21,7 @@ Error: expected value of type String, found a float
     │                                ╰─── provided value is a float
 ────╯
 Error: expected value of type String, found a boolean
-    ╭─[0102_invalid_string_values.graphql:83:31]
+    ╭─[ 0102_invalid_string_values.graphql:83:31 ]
     │
   8 │   stringArgField(stringArg: String): String
     │                             ───┬──  
@@ -32,7 +32,7 @@ Error: expected value of type String, found a boolean
     │                                 ╰─── provided value is a boolean
 ────╯
 Error: expected value of type String, found an enum
-    ╭─[0102_invalid_string_values.graphql:89:31]
+    ╭─[ 0102_invalid_string_values.graphql:89:31 ]
     │
   8 │   stringArgField(stringArg: String): String
     │                             ───┬──  
@@ -43,7 +43,7 @@ Error: expected value of type String, found an enum
     │                                ╰─── provided value is an enum
 ────╯
 Error: expected value of type Int, found a string
-    ╭─[0102_invalid_string_values.graphql:95:25]
+    ╭─[ 0102_invalid_string_values.graphql:95:25 ]
     │
   6 │   intArgField(intArg: Int): String
     │                       ─┬─  
@@ -54,14 +54,14 @@ Error: expected value of type Int, found a string
     │                          ╰─── provided value is a string
 ────╯
 Error: int cannot represent non 32-bit signed integer value
-     ╭─[0102_invalid_string_values.graphql:101:25]
+     ╭─[ 0102_invalid_string_values.graphql:101:25 ]
      │
  101 │     intArgField(intArg: 829384293849283498239482938)
      │                         ─────────────┬─────────────  
      │                                      ╰─────────────── cannot be coerced to a 32-bit integer
 ─────╯
 Error: expected value of type Int, found an enum
-     ╭─[0102_invalid_string_values.graphql:107:25]
+     ╭─[ 0102_invalid_string_values.graphql:107:25 ]
      │
    6 │   intArgField(intArg: Int): String
      │                       ─┬─  
@@ -72,7 +72,7 @@ Error: expected value of type Int, found an enum
      │                          ╰─── provided value is an enum
 ─────╯
 Error: expected value of type Int, found a float
-     ╭─[0102_invalid_string_values.graphql:113:25]
+     ╭─[ 0102_invalid_string_values.graphql:113:25 ]
      │
    6 │   intArgField(intArg: Int): String
      │                       ─┬─  
@@ -83,7 +83,7 @@ Error: expected value of type Int, found a float
      │                          ╰─── provided value is a float
 ─────╯
 Error: expected value of type Int, found a float
-     ╭─[0102_invalid_string_values.graphql:119:25]
+     ╭─[ 0102_invalid_string_values.graphql:119:25 ]
      │
    6 │   intArgField(intArg: Int): String
      │                       ─┬─  
@@ -94,7 +94,7 @@ Error: expected value of type Int, found a float
      │                           ╰──── provided value is a float
 ─────╯
 Error: expected value of type Float, found a string
-     ╭─[0102_invalid_string_values.graphql:125:29]
+     ╭─[ 0102_invalid_string_values.graphql:125:29 ]
      │
   11 │   floatArgField(floatArg: Float): String
      │                           ──┬──  
@@ -105,7 +105,7 @@ Error: expected value of type Float, found a string
      │                                ╰───── provided value is a string
 ─────╯
 Error: expected value of type Float, found a boolean
-     ╭─[0102_invalid_string_values.graphql:131:29]
+     ╭─[ 0102_invalid_string_values.graphql:131:29 ]
      │
   11 │   floatArgField(floatArg: Float): String
      │                           ──┬──  
@@ -116,7 +116,7 @@ Error: expected value of type Float, found a boolean
      │                               ╰─── provided value is a boolean
 ─────╯
 Error: expected value of type Float, found an enum
-     ╭─[0102_invalid_string_values.graphql:137:29]
+     ╭─[ 0102_invalid_string_values.graphql:137:29 ]
      │
   11 │   floatArgField(floatArg: Float): String
      │                           ──┬──  
@@ -127,7 +127,7 @@ Error: expected value of type Float, found an enum
      │                              ╰─── provided value is an enum
 ─────╯
 Error: expected value of type Boolean, found an integer
-     ╭─[0102_invalid_string_values.graphql:143:33]
+     ╭─[ 0102_invalid_string_values.graphql:143:33 ]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
      │                               ───┬───  
@@ -138,7 +138,7 @@ Error: expected value of type Boolean, found an integer
      │                                 ╰── provided value is an integer
 ─────╯
 Error: expected value of type Boolean, found a float
-     ╭─[0102_invalid_string_values.graphql:149:33]
+     ╭─[ 0102_invalid_string_values.graphql:149:33 ]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
      │                               ───┬───  
@@ -149,7 +149,7 @@ Error: expected value of type Boolean, found a float
      │                                  ╰─── provided value is a float
 ─────╯
 Error: expected value of type Boolean, found a string
-     ╭─[0102_invalid_string_values.graphql:155:33]
+     ╭─[ 0102_invalid_string_values.graphql:155:33 ]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
      │                               ───┬───  
@@ -160,7 +160,7 @@ Error: expected value of type Boolean, found a string
      │                                    ╰──── provided value is a string
 ─────╯
 Error: expected value of type Boolean, found an enum
-     ╭─[0102_invalid_string_values.graphql:161:33]
+     ╭─[ 0102_invalid_string_values.graphql:161:33 ]
      │
    9 │   booleanArgField(booleanArg: Boolean): String
      │                               ───┬───  
@@ -171,7 +171,7 @@ Error: expected value of type Boolean, found an enum
      │                                   ╰─── provided value is an enum
 ─────╯
 Error: expected value of type ID, found a float
-     ╭─[0102_invalid_string_values.graphql:167:23]
+     ╭─[ 0102_invalid_string_values.graphql:167:23 ]
      │
   12 │   idArgField(idArg: ID): String
      │                     ─┬  
@@ -182,7 +182,7 @@ Error: expected value of type ID, found a float
      │                        ╰─── provided value is a float
 ─────╯
 Error: expected value of type ID, found a boolean
-     ╭─[0102_invalid_string_values.graphql:173:23]
+     ╭─[ 0102_invalid_string_values.graphql:173:23 ]
      │
   12 │   idArgField(idArg: ID): String
      │                     ─┬  
@@ -193,7 +193,7 @@ Error: expected value of type ID, found a boolean
      │                         ╰─── provided value is a boolean
 ─────╯
 Error: expected value of type ID, found an enum
-     ╭─[0102_invalid_string_values.graphql:179:23]
+     ╭─[ 0102_invalid_string_values.graphql:179:23 ]
      │
   12 │   idArgField(idArg: ID): String
      │                     ─┬  
@@ -204,7 +204,7 @@ Error: expected value of type ID, found an enum
      │                           ╰────── provided value is an enum
 ─────╯
 Error: expected value of type DogCommand, found an integer
-     ╭─[0102_invalid_string_values.graphql:186:33]
+     ╭─[ 0102_invalid_string_values.graphql:186:33 ]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
      │                               ─────┬────  
@@ -215,7 +215,7 @@ Error: expected value of type DogCommand, found an integer
      │                                 ╰── provided value is an integer
 ─────╯
 Error: expected value of type DogCommand, found a float
-     ╭─[0102_invalid_string_values.graphql:192:33]
+     ╭─[ 0102_invalid_string_values.graphql:192:33 ]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
      │                               ─────┬────  
@@ -226,7 +226,7 @@ Error: expected value of type DogCommand, found a float
      │                                  ╰─── provided value is a float
 ─────╯
 Error: expected value of type DogCommand, found a string
-     ╭─[0102_invalid_string_values.graphql:198:33]
+     ╭─[ 0102_invalid_string_values.graphql:198:33 ]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
      │                               ─────┬────  
@@ -237,7 +237,7 @@ Error: expected value of type DogCommand, found a string
      │                                   ╰──── provided value is a string
 ─────╯
 Error: expected value of type DogCommand, found a boolean
-     ╭─[0102_invalid_string_values.graphql:204:33]
+     ╭─[ 0102_invalid_string_values.graphql:204:33 ]
      │
   47 │   doesKnowCommand(dogCommand: DogCommand): Boolean
      │                               ─────┬────  
@@ -248,7 +248,7 @@ Error: expected value of type DogCommand, found a boolean
      │                                   ╰─── provided value is a boolean
 ─────╯
 Error: value `JUGGLE` does not exist on `DogCommand`
-     ╭─[0102_invalid_string_values.graphql:210:33]
+     ╭─[ 0102_invalid_string_values.graphql:210:33 ]
      │
   40 │ ╭─▶ enum DogCommand {
      ┆ ┆   
@@ -261,7 +261,7 @@ Error: value `JUGGLE` does not exist on `DogCommand`
      │                                        ╰──── value does not exist on `DogCommand` enum
 ─────╯
 Error: value `sit` does not exist on `DogCommand`
-     ╭─[0102_invalid_string_values.graphql:216:33]
+     ╭─[ 0102_invalid_string_values.graphql:216:33 ]
      │
   40 │ ╭─▶ enum DogCommand {
      ┆ ┆   
@@ -274,7 +274,7 @@ Error: value `sit` does not exist on `DogCommand`
      │                                      ╰─── value does not exist on `DogCommand` enum
 ─────╯
 Error: expected value of type String, found an integer
-     ╭─[0102_invalid_string_values.graphql:222:47]
+     ╭─[ 0102_invalid_string_values.graphql:222:47 ]
      │
   13 │   stringListArgField(stringListArg: [String]): String
      │                                     ────┬───  
@@ -285,7 +285,7 @@ Error: expected value of type String, found an integer
      │                                               ╰── provided value is an integer
 ─────╯
 Error: expected value of type [String], found an integer
-     ╭─[0102_invalid_string_values.graphql:228:39]
+     ╭─[ 0102_invalid_string_values.graphql:228:39 ]
      │
   13 │   stringListArgField(stringListArg: [String]): String
      │                                     ────┬───  
@@ -296,7 +296,7 @@ Error: expected value of type [String], found an integer
      │                                       ╰── provided value is an integer
 ─────╯
 Error: expected value of type Int!, found a string
-     ╭─[0102_invalid_string_values.graphql:235:24]
+     ╭─[ 0102_invalid_string_values.graphql:235:24 ]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                                  ──┬─  
@@ -307,7 +307,7 @@ Error: expected value of type Int!, found a string
      │                          ╰──── provided value is a string
 ─────╯
 Error: expected value of type Int!, found a string
-     ╭─[0102_invalid_string_values.graphql:235:37]
+     ╭─[ 0102_invalid_string_values.graphql:235:37 ]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                      ──┬─  
@@ -318,7 +318,7 @@ Error: expected value of type Int!, found a string
      │                                       ╰──── provided value is a string
 ─────╯
 Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
-     ╭─[0102_invalid_string_values.graphql:241:5]
+     ╭─[ 0102_invalid_string_values.graphql:241:5 ]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                            ─────┬────  
@@ -329,7 +329,7 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provid
      │                 ╰────────────── missing value for argument `req2`
 ─────╯
 Error: expected value of type Int!, found a string
-     ╭─[0102_invalid_string_values.graphql:241:24]
+     ╭─[ 0102_invalid_string_values.graphql:241:24 ]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                      ──┬─  
@@ -340,7 +340,7 @@ Error: expected value of type Int!, found a string
      │                          ╰──── provided value is a string
 ─────╯
 Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
-     ╭─[0102_invalid_string_values.graphql:247:5]
+     ╭─[ 0102_invalid_string_values.graphql:247:5 ]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                ─────┬────  
@@ -351,7 +351,7 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provid
      │                 ╰───────────── missing value for argument `req1`
 ─────╯
 Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
-     ╭─[0102_invalid_string_values.graphql:247:5]
+     ╭─[ 0102_invalid_string_values.graphql:247:5 ]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                            ─────┬────  
@@ -362,7 +362,7 @@ Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provid
      │                 ╰───────────── missing value for argument `req2`
 ─────╯
 Error: expected value of type Int!, found null
-     ╭─[0102_invalid_string_values.graphql:247:24]
+     ╭─[ 0102_invalid_string_values.graphql:247:24 ]
      │
   16 │   multipleReqs(req1: Int!, req2: Int!): String
      │                      ──┬─  
@@ -373,7 +373,7 @@ Error: expected value of type Int!, found null
      │                          ╰─── provided value is null
 ─────╯
 Error: the required field `ComplexInput.requiredField` is not provided
-     ╭─[0102_invalid_string_values.graphql:254:33]
+     ╭─[ 0102_invalid_string_values.graphql:254:33 ]
      │
   32 │   requiredField: Boolean!
      │   ───────────┬───────────  
@@ -384,7 +384,7 @@ Error: the required field `ComplexInput.requiredField` is not provided
      │                                        ╰───────── missing value for field `requiredField`
 ─────╯
 Error: expected value of type String, found an integer
-     ╭─[0102_invalid_string_values.graphql:261:32]
+     ╭─[ 0102_invalid_string_values.graphql:261:32 ]
      │
   37 │   stringListField: [String]
      │                    ────┬───  
@@ -395,7 +395,7 @@ Error: expected value of type String, found an integer
      │                                ╰── provided value is an integer
 ─────╯
 Error: expected value of type Boolean!, found null
-     ╭─[0102_invalid_string_values.graphql:271:21]
+     ╭─[ 0102_invalid_string_values.graphql:271:21 ]
      │
   33 │   nonNullField: Boolean! = false
      │                 ────┬───  
@@ -406,7 +406,7 @@ Error: expected value of type Boolean!, found null
      │                       ╰─── provided value is null
 ─────╯
 Error: field `invalidField` does not exist on `ComplexInput`
-     ╭─[0102_invalid_string_values.graphql:280:21]
+     ╭─[ 0102_invalid_string_values.graphql:280:21 ]
      │
   31 │ ╭─▶ input ComplexInput {
      ┆ ┆   
@@ -419,33 +419,33 @@ Error: field `invalidField` does not exist on `ComplexInput`
      │                            ╰───── value does not exist on `ComplexInput` input object
 ─────╯
 Error: expected value of type Boolean!, found a string
-     ╭─[0102_invalid_string_values.graphql:287:20]
+     ╭─[ 0102_invalid_string_values.graphql:287:20 ]
      │
  287 │   dog @include(if: "yes") {
      │                    ──┬──  
      │                      ╰──── provided value is a string
      │
-     ├─[built_in.graphql:146:7]
+     ├─[ built_in.graphql:146:7 ]
      │
  146 │   if: Boolean!
      │       ────┬───  
      │           ╰───── expected type declared here as Boolean!
 ─────╯
 Error: expected value of type Boolean!, found an enum
-     ╭─[0102_invalid_string_values.graphql:288:20]
+     ╭─[ 0102_invalid_string_values.graphql:288:20 ]
      │
  288 │     name @skip(if: ENUM)
      │                    ──┬─  
      │                      ╰─── provided value is an enum
      │
-     ├─[built_in.graphql:140:7]
+     ├─[ built_in.graphql:140:7 ]
      │
  140 │   if: Boolean!
      │       ────┬───  
      │           ╰───── expected type declared here as Boolean!
 ─────╯
 Error: expected value of type Int!, found null
-     ╭─[0102_invalid_string_values.graphql:294:14]
+     ╭─[ 0102_invalid_string_values.graphql:294:14 ]
      │
  294 │   $a: Int! = null,
      │       ──┬─   ──┬─  
@@ -454,7 +454,7 @@ Error: expected value of type Int!, found null
      │                ╰─── provided value is null
 ─────╯
 Error: expected value of type String!, found null
-     ╭─[0102_invalid_string_values.graphql:295:17]
+     ╭─[ 0102_invalid_string_values.graphql:295:17 ]
      │
  295 │   $b: String! = null,
      │       ───┬───   ──┬─  
@@ -463,7 +463,7 @@ Error: expected value of type String!, found null
      │                   ╰─── provided value is null
 ─────╯
 Error: the required field `ComplexInput.requiredField` is not provided
-     ╭─[0102_invalid_string_values.graphql:296:22]
+     ╭─[ 0102_invalid_string_values.graphql:296:22 ]
      │
   32 │   requiredField: Boolean!
      │   ───────────┬───────────  
@@ -474,7 +474,7 @@ Error: the required field `ComplexInput.requiredField` is not provided
      │                                         ╰───────────────────── missing value for field `requiredField`
 ─────╯
 Error: expected value of type Boolean!, found null
-     ╭─[0102_invalid_string_values.graphql:296:39]
+     ╭─[ 0102_invalid_string_values.graphql:296:39 ]
      │
   32 │   requiredField: Boolean!
      │                  ────┬───  
@@ -485,7 +485,7 @@ Error: expected value of type Boolean!, found null
      │                                         ╰─── provided value is null
 ─────╯
 Error: expected value of type Int, found a string
-     ╭─[0102_invalid_string_values.graphql:306:13]
+     ╭─[ 0102_invalid_string_values.graphql:306:13 ]
      │
  306 │   $a: Int = "one",
      │       ─┬─   ──┬──  
@@ -494,7 +494,7 @@ Error: expected value of type Int, found a string
      │               ╰──── provided value is a string
 ─────╯
 Error: expected value of type String, found an integer
-     ╭─[0102_invalid_string_values.graphql:307:16]
+     ╭─[ 0102_invalid_string_values.graphql:307:16 ]
      │
  307 │   $b: String = 4,
      │       ───┬──   ┬  
@@ -503,7 +503,7 @@ Error: expected value of type String, found an integer
      │                ╰── provided value is an integer
 ─────╯
 Error: expected value of type ComplexInput, found a string
-     ╭─[0102_invalid_string_values.graphql:308:22]
+     ╭─[ 0102_invalid_string_values.graphql:308:22 ]
      │
  308 │   $c: ComplexInput = "NotVeryComplex"
      │       ──────┬─────   ────────┬───────  
@@ -512,7 +512,7 @@ Error: expected value of type ComplexInput, found a string
      │                              ╰───────── provided value is a string
 ─────╯
 Error: expected value of type Boolean!, found an integer
-     ╭─[0102_invalid_string_values.graphql:319:39]
+     ╭─[ 0102_invalid_string_values.graphql:319:39 ]
      │
   32 │   requiredField: Boolean!
      │                  ────┬───  
@@ -523,7 +523,7 @@ Error: expected value of type Boolean!, found an integer
      │                                        ╰─── provided value is an integer
 ─────╯
 Error: expected value of type Int, found a string
-     ╭─[0102_invalid_string_values.graphql:319:54]
+     ╭─[ 0102_invalid_string_values.graphql:319:54 ]
      │
   34 │   intField: Int
      │             ─┬─  
@@ -534,7 +534,7 @@ Error: expected value of type Int, found a string
      │                                                        ╰──── provided value is a string
 ─────╯
 Error: the required field `ComplexInput.requiredField` is not provided
-     ╭─[0102_invalid_string_values.graphql:327:22]
+     ╭─[ 0102_invalid_string_values.graphql:327:22 ]
      │
   32 │   requiredField: Boolean!
      │   ───────────┬───────────  
@@ -545,7 +545,7 @@ Error: the required field `ComplexInput.requiredField` is not provided
      │                            ╰──────── missing value for field `requiredField`
 ─────╯
 Error: expected value of type String, found an integer
-     ╭─[0102_invalid_string_values.graphql:336:26]
+     ╭─[ 0102_invalid_string_values.graphql:336:26 ]
      │
  336 │   $a: [String] = ["one", 2]
      │       ────┬───           ┬  

--- a/crates/apollo-compiler/test_data/diagnostics/0103_invalid_directive_on_input_value.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0103_invalid_directive_on_input_value.txt
@@ -1,5 +1,5 @@
 Error: the required argument `@example(arg:)` is not provided
-   ╭─[0103_invalid_directive_on_input_value.graphql:4:16]
+   ╭─[ 0103_invalid_directive_on_input_value.graphql:4:16 ]
    │
  1 │ directive @example(arg: String!) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
    │                    ──────┬─────  
@@ -10,7 +10,7 @@ Error: the required argument `@example(arg:)` is not provided
    │                    ╰───── missing value for argument `arg`
 ───╯
 Error: the required argument `@example(arg:)` is not provided
-   ╭─[0103_invalid_directive_on_input_value.graphql:7:32]
+   ╭─[ 0103_invalid_directive_on_input_value.graphql:7:32 ]
    │
  1 │ directive @example(arg: String!) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
    │                    ──────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0104_invalid_type_in_arg.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0104_invalid_type_in_arg.txt
@@ -1,5 +1,5 @@
 Error: `thisIsWrong` field must be of an input type
-   ╭─[0104_invalid_type_in_arg.graphql:7:3]
+   ╭─[ 0104_invalid_type_in_arg.graphql:7:3 ]
    │
  7 │   thisIsWrong: OutputType
    │                ─────┬────  
@@ -8,21 +8,21 @@ Error: `thisIsWrong` field must be of an input type
    │ Help: Scalars, Enums, and Input Objects are input types. Change `thisIsWrong` field to take one of these input types.
 ───╯
 Error: cannot find type `number` in this document
-    ╭─[0104_invalid_type_in_arg.graphql:12:21]
+    ╭─[ 0104_invalid_type_in_arg.graphql:12:21 ]
     │
  12 │   undefinedTypes(a: number, b: number): OperationResult!
     │                     ───┬──  
     │                        ╰──── not found in this scope
 ────╯
 Error: cannot find type `number` in this document
-    ╭─[0104_invalid_type_in_arg.graphql:12:32]
+    ╭─[ 0104_invalid_type_in_arg.graphql:12:32 ]
     │
  12 │   undefinedTypes(a: number, b: number): OperationResult!
     │                                ───┬──  
     │                                   ╰──── not found in this scope
 ────╯
 Error: `a` field must be of an input type
-    ╭─[0104_invalid_type_in_arg.graphql:13:15]
+    ╭─[ 0104_invalid_type_in_arg.graphql:13:15 ]
     │
  13 │   outputTypes(a: OutputType, b: OperationResult): ID!
     │                  ─────┬────  
@@ -31,7 +31,7 @@ Error: `a` field must be of an input type
     │ Help: Scalars, Enums, and Input Objects are input types. Change `a` field to take one of these input types.
 ────╯
 Error: `b` field must be of an input type
-    ╭─[0104_invalid_type_in_arg.graphql:13:30]
+    ╭─[ 0104_invalid_type_in_arg.graphql:13:30 ]
     │
  13 │   outputTypes(a: OutputType, b: OperationResult): ID!
     │                                 ───────┬───────  

--- a/crates/apollo-compiler/test_data/diagnostics/0105_executable_definition_in_type_system_document.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0105_executable_definition_in_type_system_document.txt
@@ -1,5 +1,5 @@
 Error: a schema document must not contain an operation definition
-   ╭─[0105_executable_definition_in_type_system_document.graphql:5:1]
+   ╭─[ 0105_executable_definition_in_type_system_document.graphql:5:1 ]
    │
  5 │ ╭─▶ query {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0106_type_system_definition_in_executable_document.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0106_type_system_definition_in_executable_document.txt
@@ -1,5 +1,5 @@
 Error: an executable document must not contain an object type definition
-   ╭─[0106_type_system_definition_in_executable_document.graphql:1:1]
+   ╭─[ 0106_type_system_definition_in_executable_document.graphql:1:1 ]
    │
  1 │ ╭─▶ type Query {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0107_built_in_directive_double_redefinition.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0107_built_in_directive_double_redefinition.txt
@@ -1,5 +1,5 @@
 Error: the directive `@deprecated` is defined multiple times in the schema
-    ╭─[0107_built_in_directive_double_redefinition.graphql:22:12]
+    ╭─[ 0107_built_in_directive_double_redefinition.graphql:22:12 ]
     │
  17 │ directive @deprecated(
     │            ─────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0108_implicit_schema_extension.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0108_implicit_schema_extension.txt
@@ -1,5 +1,5 @@
 Error: duplicate definitions for the `query` root operation type
-   ╭─[0108_implicit_schema_extension.graphql:6:5]
+   ╭─[ 0108_implicit_schema_extension.graphql:6:5 ]
    │
  6 │     query: Query
    │     ──────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0109_null_in_list_issue_738.txt
@@ -1,5 +1,5 @@
 Error: expected value of type CustomScalar!, found null
-    ╭─[0109_null_in_list_issue_738.graphql:14:16]
+    ╭─[ 0109_null_in_list_issue_738.graphql:14:16 ]
     │
   8 │   foo(arg: [CustomScalar!]!): String!
     │            ────────┬───────  
@@ -10,7 +10,7 @@ Error: expected value of type CustomScalar!, found null
     │                  ╰─── provided value is null
 ────╯
 Error: expected value of type CustomScalar!, found null
-    ╭─[0109_null_in_list_issue_738.graphql:15:16]
+    ╭─[ 0109_null_in_list_issue_738.graphql:15:16 ]
     │
   8 │   foo(arg: [CustomScalar!]!): String!
     │            ────────┬───────  
@@ -21,7 +21,7 @@ Error: expected value of type CustomScalar!, found null
     │                  ╰─── provided value is null
 ────╯
 Error: expected value of type CustomScalar!, found null
-    ╭─[0109_null_in_list_issue_738.graphql:15:22]
+    ╭─[ 0109_null_in_list_issue_738.graphql:15:22 ]
     │
   8 │   foo(arg: [CustomScalar!]!): String!
     │            ────────┬───────  
@@ -32,7 +32,7 @@ Error: expected value of type CustomScalar!, found null
     │                        ╰─── provided value is null
 ────╯
 Error: expected value of type String!, found null
-    ╭─[0109_null_in_list_issue_738.graphql:16:13]
+    ╭─[ 0109_null_in_list_issue_738.graphql:16:13 ]
     │
   9 │   bar(arg: [String!]): String!
     │            ────┬────  
@@ -43,7 +43,7 @@ Error: expected value of type String!, found null
     │               ╰─── provided value is null
 ────╯
 Error: expected value of type String!, found null
-    ╭─[0109_null_in_list_issue_738.graphql:17:27]
+    ╭─[ 0109_null_in_list_issue_738.graphql:17:27 ]
     │
   4 │   list: [String!]
     │         ────┬────  

--- a/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0110_list_usage_in_non_list_type.txt
@@ -1,5 +1,5 @@
 Error: expected value of type Int!, found a list
-    ╭─[0110_list_usage_in_non_list_type.graphql:20:10]
+    ╭─[ 0110_list_usage_in_non_list_type.graphql:20:10 ]
     │
   5 │   int: Int!
     │        ──┬─  
@@ -10,7 +10,7 @@ Error: expected value of type Int!, found a list
     │              ╰────── provided value is a list
 ────╯
 Error: expected value of type String!, found a list
-    ╭─[0110_list_usage_in_non_list_type.graphql:21:10]
+    ╭─[ 0110_list_usage_in_non_list_type.graphql:21:10 ]
     │
   6 │   str: String!
     │        ───┬───  
@@ -21,7 +21,7 @@ Error: expected value of type String!, found a list
     │            ╰──── provided value is a list
 ────╯
 Error: expected value of type Boolean!, found a list
-    ╭─[0110_list_usage_in_non_list_type.graphql:22:11]
+    ╭─[ 0110_list_usage_in_non_list_type.graphql:22:11 ]
     │
   7 │   bool: Boolean!
     │         ────┬───  
@@ -32,7 +32,7 @@ Error: expected value of type Boolean!, found a list
     │                 ╰──────── provided value is a list
 ────╯
 Error: expected value of type Int, found a list
-    ╭─[0110_list_usage_in_non_list_type.graphql:23:10]
+    ╭─[ 0110_list_usage_in_non_list_type.graphql:23:10 ]
     │
   8 │   opt: Int
     │        ─┬─  
@@ -43,7 +43,7 @@ Error: expected value of type Int, found a list
     │              ╰────── provided value is a list
 ────╯
 Error: expected value of type ID!, found a list
-    ╭─[0110_list_usage_in_non_list_type.graphql:24:9]
+    ╭─[ 0110_list_usage_in_non_list_type.graphql:24:9 ]
     │
   9 │   id: ID!
     │       ─┬─  

--- a/crates/apollo-compiler/test_data/diagnostics/0111_const_value.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0111_const_value.txt
@@ -1,26 +1,26 @@
 Error: syntax error: unexpected variable value in a Const context
-   ╭─[0111_const_value.graphql:3:23]
+   ╭─[ 0111_const_value.graphql:3:23 ]
    │
  3 │     $var2: Boolean! = $var1
    │                       ┬  
    │                       ╰── unexpected variable value in a Const context
 ───╯
 Error: variable `$var1` is not defined
-   ╭─[0111_const_value.graphql:3:23]
+   ╭─[ 0111_const_value.graphql:3:23 ]
    │
  3 │     $var2: Boolean! = $var1
    │                       ──┬──  
    │                         ╰──── not found in this scope
 ───╯
 Error: syntax error: unexpected variable value in a Const context
-    ╭─[0111_const_value.graphql:11:26]
+    ╭─[ 0111_const_value.graphql:11:26 ]
     │
  11 │ type Query @someDir(arg: $var1) {
     │                          ┬  
     │                          ╰── unexpected variable value in a Const context
 ────╯
 Error: variable `$var1` is not defined
-    ╭─[0111_const_value.graphql:11:26]
+    ╭─[ 0111_const_value.graphql:11:26 ]
     │
  11 │ type Query @someDir(arg: $var1) {
     │                          ──┬──  

--- a/crates/apollo-compiler/test_data/diagnostics/0112_anonymous_subscription_with_multiple_root_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0112_anonymous_subscription_with_multiple_root_fields.txt
@@ -1,5 +1,5 @@
 Error: anonymous subscription can only have one root field
-   ╭─[0112_anonymous_subscription_with_multiple_root_fields.graphql:1:1]
+   ╭─[ 0112_anonymous_subscription_with_multiple_root_fields.graphql:1:1 ]
    │
  1 │ ╭─▶ subscription {
    ┆ ┆   

--- a/crates/apollo-compiler/test_data/diagnostics/0113_partially_overlapping_fragments.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0113_partially_overlapping_fragments.txt
@@ -1,5 +1,5 @@
 Error: operation must not select different types using the same name `overlapping`
-    ╭─[0113_partially_overlapping_fragments.graphql:27:16]
+    ╭─[ 0113_partially_overlapping_fragments.graphql:27:16 ]
     │
  24 │     ... on B { overlapping }
     │                ─────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0114_interface_definition_with_missing_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0114_interface_definition_with_missing_fields.txt
@@ -1,5 +1,5 @@
 Error: `Node` has no fields
-   ╭─[0114_interface_definition_with_missing_fields.graphql:6:1]
+   ╭─[ 0114_interface_definition_with_missing_fields.graphql:6:1 ]
    │
  6 │ interface Node
    │ ───────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0115_object_definition_with_missing_fields.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0115_object_definition_with_missing_fields.txt
@@ -1,5 +1,5 @@
 Error: `User` has no fields
-   ╭─[0115_object_definition_with_missing_fields.graphql:7:1]
+   ╭─[ 0115_object_definition_with_missing_fields.graphql:7:1 ]
    │
  7 │ type User @foo
    │ ───────┬──────  

--- a/crates/apollo-compiler/test_data/diagnostics/0116_enum_definition_with_missing_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0116_enum_definition_with_missing_values.txt
@@ -1,5 +1,5 @@
 Error: `WEEKDAY` has no enum values
-   ╭─[0116_enum_definition_with_missing_values.graphql:6:1]
+   ╭─[ 0116_enum_definition_with_missing_values.graphql:6:1 ]
    │
  6 │ enum WEEKDAY
    │ ──────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0117_union_definition_with_missing_members.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0117_union_definition_with_missing_members.txt
@@ -1,5 +1,5 @@
 Error: `Search` has no member types
-   ╭─[0117_union_definition_with_missing_members.graphql:6:1]
+   ╭─[ 0117_union_definition_with_missing_members.graphql:6:1 ]
    │
  6 │ union Search
    │ ──────┬─────  

--- a/crates/apollo-compiler/test_data/diagnostics/0118_input_object_definition_with_missing_values.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0118_input_object_definition_with_missing_values.txt
@@ -1,5 +1,5 @@
 Error: `In` has no input values
-   ╭─[0118_input_object_definition_with_missing_values.graphql:6:1]
+   ╭─[ 0118_input_object_definition_with_missing_values.graphql:6:1 ]
    │
  6 │ input In
    │ ────┬───  

--- a/crates/apollo-compiler/test_data/diagnostics/0119_reserved_names.txt
+++ b/crates/apollo-compiler/test_data/diagnostics/0119_reserved_names.txt
@@ -1,68 +1,68 @@
 Error: a directive definition cannot be named `__Prime` as names starting with two underscores are reserved
-   ╭─[0119_reserved_names.graphql:1:12]
+   ╭─[ 0119_reserved_names.graphql:1:12 ]
    │
  1 │ directive @__Prime(__if: Boolean!) on SCHEMA
    │            ───┬───  
    │               ╰───── Pick a different name here
 ───╯
 Error: an argument cannot be named `__if` as names starting with two underscores are reserved
-   ╭─[0119_reserved_names.graphql:1:20]
+   ╭─[ 0119_reserved_names.graphql:1:20 ]
    │
  1 │ directive @__Prime(__if: Boolean!) on SCHEMA
    │                    ──┬─  
    │                      ╰─── Pick a different name here
 ───╯
 Error: an object type cannot be named `__MyQuery` as names starting with two underscores are reserved
-   ╭─[0119_reserved_names.graphql:7:6]
+   ╭─[ 0119_reserved_names.graphql:7:6 ]
    │
  7 │ type __MyQuery {
    │      ────┬────  
    │          ╰────── Pick a different name here
 ───╯
 Error: a field cannot be named `__secretField` as names starting with two underscores are reserved
-   ╭─[0119_reserved_names.graphql:8:5]
+   ╭─[ 0119_reserved_names.graphql:8:5 ]
    │
  8 │     __secretField(__heatedArgument: __In): Int
    │     ──────┬──────  
    │           ╰──────── Pick a different name here
 ───╯
 Error: an argument cannot be named `__heatedArgument` as names starting with two underscores are reserved
-   ╭─[0119_reserved_names.graphql:8:19]
+   ╭─[ 0119_reserved_names.graphql:8:19 ]
    │
  8 │     __secretField(__heatedArgument: __In): Int
    │                   ────────┬───────  
    │                           ╰───────── Pick a different name here
 ───╯
 Error: an input object type cannot be named `__In` as names starting with two underscores are reserved
-    ╭─[0119_reserved_names.graphql:11:7]
+    ╭─[ 0119_reserved_names.graphql:11:7 ]
     │
  11 │ input __In {
     │       ──┬─  
     │         ╰─── Pick a different name here
 ────╯
 Error: an input object field cannot be named `__amount` as names starting with two underscores are reserved
-    ╭─[0119_reserved_names.graphql:12:5]
+    ╭─[ 0119_reserved_names.graphql:12:5 ]
     │
  12 │     __amount: __BigInt
     │     ────┬───  
     │         ╰───── Pick a different name here
 ────╯
 Error: a scalar type cannot be named `__BigInt` as names starting with two underscores are reserved
-    ╭─[0119_reserved_names.graphql:15:8]
+    ╭─[ 0119_reserved_names.graphql:15:8 ]
     │
  15 │ scalar __BigInt
     │        ────┬───  
     │            ╰───── Pick a different name here
 ────╯
 Error: an enum type cannot be named `__Maybe` as names starting with two underscores are reserved
-    ╭─[0119_reserved_names.graphql:17:6]
+    ╭─[ 0119_reserved_names.graphql:17:6 ]
     │
  17 │ enum __Maybe {
     │      ───┬───  
     │         ╰───── Pick a different name here
 ────╯
 Error: an enum value cannot be named `__FileNotFound` as names starting with two underscores are reserved
-    ╭─[0119_reserved_names.graphql:20:5]
+    ╭─[ 0119_reserved_names.graphql:20:5 ]
     │
  20 │     __FileNotFound
     │     ───────┬──────  

--- a/crates/apollo-compiler/tests/validation/field_merging.rs
+++ b/crates/apollo-compiler/tests/validation/field_merging.rs
@@ -256,7 +256,7 @@ fn same_aliases_with_different_field_targets() {
     "#,
         expect![[r#"
             Error: cannot select different fields into the same alias `fido`
-               ╭─[query.graphql:3:3]
+               ╭─[ query.graphql:3:3 ]
                │
              2 │   fido: name
                │   ─────┬────  
@@ -302,7 +302,7 @@ fn alias_masking_direct_field_access() {
     "#,
         expect![[r#"
             Error: cannot select different fields into the same alias `name`
-               ╭─[query.graphql:3:3]
+               ╭─[ query.graphql:3:3 ]
                │
              2 │   name: nickname
                │   ───────┬──────  
@@ -330,7 +330,7 @@ fn different_args_second_adds_argument() {
     "#,
         expect![[r#"
             Error: operation must not provide conflicting field arguments for the same name `doesKnowCommand`
-               ╭─[query.graphql:3:3]
+               ╭─[ query.graphql:3:3 ]
                │
              2 │   doesKnowCommand
                │   ───────┬───────  
@@ -358,7 +358,7 @@ fn different_args_second_missess_argument() {
     "#,
         expect![[r#"
             Error: operation must not provide conflicting field arguments for the same name `doesKnowCommand`
-               ╭─[query.graphql:3:3]
+               ╭─[ query.graphql:3:3 ]
                │
              2 │   doesKnowCommand(dogCommand: SIT)
                │   ────────────────┬───────────────  
@@ -386,7 +386,7 @@ fn conflicting_arg_values() {
     "#,
         expect![[r#"
             Error: operation must not provide conflicting field arguments for the same name `doesKnowCommand`
-               ╭─[query.graphql:3:3]
+               ╭─[ query.graphql:3:3 ]
                │
              2 │   doesKnowCommand(dogCommand: SIT)
                │   ────────────────┬───────────────  
@@ -414,7 +414,7 @@ fn conflicting_arg_names() {
     "#,
         expect![[r#"
             Error: operation must not provide conflicting field arguments for the same name `isAtLocation`
-               ╭─[query.graphql:3:3]
+               ╭─[ query.graphql:3:3 ]
                │
              2 │   isAtLocation(x: 0)
                │   ─────────┬────────  
@@ -547,7 +547,7 @@ mod field_conflicts {
     "#,
             expect![[r#"
                 Error: cannot select different fields into the same alias `x`
-                    ╭─[query.graphql:11:3]
+                    ╭─[ query.graphql:11:3 ]
                     │
                   8 │   x: a
                     │   ──┬─  
@@ -591,7 +591,7 @@ mod field_conflicts {
     "#,
             expect![[r#"
                 Error: cannot select different fields into the same alias `x`
-                    ╭─[query.graphql:17:3]
+                    ╭─[ query.graphql:17:3 ]
                     │
                  17 │   x: a
                     │   ──┬─  
@@ -604,7 +604,7 @@ mod field_conflicts {
                     │ Help: Both fields may be present on the schema type, so it's not clear which one should be used to fill the response
                 ────╯
                 Error: cannot select different fields into the same alias `x`
-                    ╭─[query.graphql:17:3]
+                    ╭─[ query.graphql:17:3 ]
                     │
                  13 │     x: c
                     │     ──┬─  
@@ -617,7 +617,7 @@ mod field_conflicts {
                     │ Help: Both fields may be present on the schema type, so it's not clear which one should be used to fill the response
                 ────╯
                 Error: cannot select different fields into the same alias `x`
-                    ╭─[query.graphql:20:3]
+                    ╭─[ query.graphql:20:3 ]
                     │
                  17 │   x: a
                     │   ──┬─  
@@ -630,7 +630,7 @@ mod field_conflicts {
                     │ Help: Both fields may be present on the schema type, so it's not clear which one should be used to fill the response
                 ────╯
                 Error: cannot select different fields into the same alias `x`
-                    ╭─[query.graphql:20:3]
+                    ╭─[ query.graphql:20:3 ]
                     │
                  13 │     x: c
                     │     ──┬─  
@@ -661,7 +661,7 @@ mod field_conflicts {
     "#,
             expect![[r#"
                 Error: cannot select different fields into the same alias `x`
-                   ╭─[query.graphql:6:5]
+                   ╭─[ query.graphql:6:5 ]
                    │
                  3 │     x: a
                    │     ──┬─  
@@ -694,7 +694,7 @@ mod field_conflicts {
     "#,
             expect![[r#"
                 Error: cannot select different fields into the same alias `x`
-                   ╭─[query.graphql:7:5]
+                   ╭─[ query.graphql:7:5 ]
                    │
                  3 │     x: a
                    │     ──┬─  
@@ -707,7 +707,7 @@ mod field_conflicts {
                    │ Help: Both fields may be present on the schema type, so it's not clear which one should be used to fill the response
                 ───╯
                 Error: cannot select different fields into the same alias `y`
-                   ╭─[query.graphql:8:5]
+                   ╭─[ query.graphql:8:5 ]
                    │
                  4 │     y: c
                    │     ──┬─  
@@ -742,7 +742,7 @@ mod field_conflicts {
     "#,
             expect![[r#"
                 Error: cannot select different fields into the same alias `x`
-                   ╭─[query.graphql:9:7]
+                   ╭─[ query.graphql:9:7 ]
                    │
                  4 │       x: a
                    │       ──┬─  
@@ -787,7 +787,7 @@ mod field_conflicts {
     "#,
             expect![[r#"
                 Error: cannot select different fields into the same alias `y`
-                    ╭─[query.graphql:14:3]
+                    ╭─[ query.graphql:14:3 ]
                     │
                  14 │   y: c
                     │   ──┬─  
@@ -800,7 +800,7 @@ mod field_conflicts {
                     │ Help: Both fields may be present on the schema type, so it's not clear which one should be used to fill the response
                 ────╯
                 Error: cannot select different fields into the same alias `x`
-                    ╭─[query.graphql:21:3]
+                    ╭─[ query.graphql:21:3 ]
                     │
                  10 │   x: a
                     │   ──┬─  
@@ -932,7 +932,7 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: operation must not select different types using the same name `scalar`
-                   ╭─[query.graphql:7:7]
+                   ╭─[ query.graphql:7:7 ]
                    │
                  4 │       scalar
                    │       ───┬──  
@@ -985,7 +985,7 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: operation must not select different types using the same name `scalar`
-                   ╭─[query.graphql:7:7]
+                   ╭─[ query.graphql:7:7 ]
                    │
                  4 │       scalar
                    │       ───┬──  
@@ -1048,13 +1048,13 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: type `SomeBox` does not have a field `scalar`
-                    ╭─[query.graphql:38:3]
+                    ╭─[ query.graphql:38:3 ]
                     │
                  38 │   scalar
                     │   ───┬──  
                     │      ╰──── field `scalar` selected here
                     │
-                    ├─[schema.graphql:1:11]
+                    ├─[ schema.graphql:1:11 ]
                     │
                   1 │ interface SomeBox {
                     │           ───┬───  
@@ -1083,7 +1083,7 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: operation must not select different types using the same name `scalar`
-                   ╭─[query.graphql:7:7]
+                   ╭─[ query.graphql:7:7 ]
                    │
                  4 │       scalar
                    │       ───┬──  
@@ -1118,7 +1118,7 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: operation must not select different types using the same name `box`
-                    ╭─[query.graphql:9:7]
+                    ╭─[ query.graphql:9:7 ]
                     │
                   4 │ ╭───▶       box: listStringBox {
                     ┆ ┆     
@@ -1154,7 +1154,7 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: operation must not select different types using the same name `box`
-                    ╭─[query.graphql:9:7]
+                    ╭─[ query.graphql:9:7 ]
                     │
                   4 │   ╭─▶       box: stringBox {
                     ┆   ┆   
@@ -1194,7 +1194,7 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: cannot select different fields into the same alias `val`
-                   ╭─[query.graphql:6:9]
+                   ╭─[ query.graphql:6:9 ]
                    │
                  5 │         val: scalar
                    │         ─────┬─────  
@@ -1230,7 +1230,7 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: operation must not select different types using the same name `scalar`
-                    ╭─[query.graphql:10:9]
+                    ╭─[ query.graphql:10:9 ]
                     │
                   5 │         scalar
                     │         ───┬──  
@@ -1305,7 +1305,7 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: operation must not select different types using the same name `id`
-                    ╭─[query.graphql:15:7]
+                    ╭─[ query.graphql:15:7 ]
                     │
                   6 │         id: name
                     │         ────┬───  
@@ -1316,7 +1316,7 @@ mod return_types {
                     │        ╰── `id` is selected from `Node.id: ID` here
                 ────╯
                 Error: cannot select different fields into the same alias `id`
-                    ╭─[query.graphql:15:7]
+                    ╭─[ query.graphql:15:7 ]
                     │
                   6 │         id: name
                     │         ────┬───  
@@ -1349,14 +1349,14 @@ mod return_types {
         "#,
             expect![[r#"
                 Error: syntax error: expected definition
-                   ╭─[query.graphql:1:3]
+                   ╭─[ query.graphql:1:3 ]
                    │
                  1 │   someBox {
                    │   ───┬───  
                    │      ╰───── expected definition
                 ───╯
                 Error: type condition `UnknownType` of inline fragment is not a type defined in the schema
-                   ╭─[query.graphql:2:11]
+                   ╭─[ query.graphql:2:11 ]
                    │
                  2 │     ...on UnknownType {
                    │           ─────┬─────  
@@ -1365,7 +1365,7 @@ mod return_types {
                    │ Note: path to the inline fragment: `query → ...`
                 ───╯
                 Error: inline fragment with type condition `NonNullStringBox2` cannot be applied to `Query`
-                    ╭─[query.graphql:5:5]
+                    ╭─[ query.graphql:5:5 ]
                     │
                   5 │ ╭─▶     ...on NonNullStringBox2 {
                     ┆ ┆   
@@ -1373,7 +1373,7 @@ mod return_types {
                     │ │           
                     │ ╰─────────── inline fragment cannot be applied
                     │
-                    ├─[schema.graphql:57:1]
+                    ├─[ schema.graphql:57:1 ]
                     │
                  57 │ ╭─▶ type Query {
                     ┆ ┆   
@@ -1382,7 +1382,7 @@ mod return_types {
                     │ ╰─────── type condition `NonNullStringBox2` is not assignable to this type
                 ────╯
                 Error: syntax error: expected a StringValue, Name or OperationDefinition
-                   ╭─[query.graphql:9:1]
+                   ╭─[ query.graphql:9:1 ]
                    │
                  9 │ }
                    │ ┬  

--- a/crates/apollo-compiler/tests/validation/mod.rs
+++ b/crates/apollo-compiler/tests/validation/mod.rs
@@ -328,7 +328,7 @@ type TestObject {
     let actual = err.to_string();
     let expected = expect_test::expect![[r#"
         Error: cannot find fragment `q` in this document
-           ╭─[query.graphql:4:11]
+           ╭─[ query.graphql:4:11 ]
            │
          4 │     obj { ...q }
            │           ──┬─  

--- a/crates/apollo-compiler/tests/validation/recursion.rs
+++ b/crates/apollo-compiler/tests/validation/recursion.rs
@@ -121,7 +121,7 @@ fn long_fragment_chains_do_not_overflow_stack() {
     let expected = expect_test::expect![[r#"
         Error: too much recursion
         Error: `typeFragment1` contains too much nesting
-            ╭─[overflow.graphql:11:11]
+            ╭─[ overflow.graphql:11:11 ]
             │
          11 │           fragment typeFragment1 on __Type {
             │           ───────────┬──────────  

--- a/crates/apollo-compiler/tests/validation/types.rs
+++ b/crates/apollo-compiler/tests/validation/types.rs
@@ -342,13 +342,13 @@ mod invalid_string_values {
       ",
             expect![[r#"
                 Error: expected value of type String, found an integer
-                    ╭─[query.graphql:3:31]
+                    ╭─[ query.graphql:3:31 ]
                     │
                   3 │     stringArgField(stringArg: 1)
                     │                               ┬  
                     │                               ╰── provided value is an integer
                     │
-                    ├─[schema.graphql:80:29]
+                    ├─[ schema.graphql:80:29 ]
                     │
                  80 │   stringArgField(stringArg: String): String
                     │                             ───┬──  
@@ -370,13 +370,13 @@ mod invalid_string_values {
       ",
             expect![[r#"
                 Error: expected value of type String, found a float
-                    ╭─[query.graphql:3:31]
+                    ╭─[ query.graphql:3:31 ]
                     │
                   3 │     stringArgField(stringArg: 1.0)
                     │                               ─┬─  
                     │                                ╰─── provided value is a float
                     │
-                    ├─[schema.graphql:80:29]
+                    ├─[ schema.graphql:80:29 ]
                     │
                  80 │   stringArgField(stringArg: String): String
                     │                             ───┬──  
@@ -398,13 +398,13 @@ mod invalid_string_values {
       ",
             expect![[r#"
                 Error: expected value of type String, found a boolean
-                    ╭─[query.graphql:3:31]
+                    ╭─[ query.graphql:3:31 ]
                     │
                   3 │     stringArgField(stringArg: true)
                     │                               ──┬─  
                     │                                 ╰─── provided value is a boolean
                     │
-                    ├─[schema.graphql:80:29]
+                    ├─[ schema.graphql:80:29 ]
                     │
                  80 │   stringArgField(stringArg: String): String
                     │                             ───┬──  
@@ -426,13 +426,13 @@ mod invalid_string_values {
       ",
             expect![[r#"
                 Error: expected value of type String, found an enum
-                    ╭─[query.graphql:3:31]
+                    ╭─[ query.graphql:3:31 ]
                     │
                   3 │     stringArgField(stringArg: BAR)
                     │                               ─┬─  
                     │                                ╰─── provided value is an enum
                     │
-                    ├─[schema.graphql:80:29]
+                    ├─[ schema.graphql:80:29 ]
                     │
                  80 │   stringArgField(stringArg: String): String
                     │                             ───┬──  
@@ -459,13 +459,13 @@ mod invalid_int_values {
       "#,
             expect![[r#"
                 Error: expected value of type Int, found a string
-                    ╭─[query.graphql:3:25]
+                    ╭─[ query.graphql:3:25 ]
                     │
                   3 │     intArgField(intArg: "3")
                     │                         ─┬─  
                     │                          ╰─── provided value is a string
                     │
-                    ├─[schema.graphql:78:23]
+                    ├─[ schema.graphql:78:23 ]
                     │
                  78 │   intArgField(intArg: Int): String
                     │                       ─┬─  
@@ -487,7 +487,7 @@ mod invalid_int_values {
       ",
             expect![[r#"
                 Error: int cannot represent non 32-bit signed integer value
-                   ╭─[query.graphql:3:25]
+                   ╭─[ query.graphql:3:25 ]
                    │
                  3 │     intArgField(intArg: 829384293849283498239482938)
                    │                         ─────────────┬─────────────  
@@ -509,13 +509,13 @@ mod invalid_int_values {
       ",
             expect![[r#"
                 Error: expected value of type Int, found an enum
-                    ╭─[query.graphql:3:25]
+                    ╭─[ query.graphql:3:25 ]
                     │
                   3 │     intArgField(intArg: FOO)
                     │                         ─┬─  
                     │                          ╰─── provided value is an enum
                     │
-                    ├─[schema.graphql:78:23]
+                    ├─[ schema.graphql:78:23 ]
                     │
                  78 │   intArgField(intArg: Int): String
                     │                       ─┬─  
@@ -537,13 +537,13 @@ mod invalid_int_values {
       ",
             expect![[r#"
                 Error: expected value of type Int, found a float
-                    ╭─[query.graphql:3:25]
+                    ╭─[ query.graphql:3:25 ]
                     │
                   3 │     intArgField(intArg: 3.0)
                     │                         ─┬─  
                     │                          ╰─── provided value is a float
                     │
-                    ├─[schema.graphql:78:23]
+                    ├─[ schema.graphql:78:23 ]
                     │
                  78 │   intArgField(intArg: Int): String
                     │                       ─┬─  
@@ -565,13 +565,13 @@ mod invalid_int_values {
       ",
             expect![[r#"
                 Error: expected value of type Int, found a float
-                    ╭─[query.graphql:3:25]
+                    ╭─[ query.graphql:3:25 ]
                     │
                   3 │     intArgField(intArg: 3.333)
                     │                         ──┬──  
                     │                           ╰──── provided value is a float
                     │
-                    ├─[schema.graphql:78:23]
+                    ├─[ schema.graphql:78:23 ]
                     │
                  78 │   intArgField(intArg: Int): String
                     │                       ─┬─  
@@ -598,13 +598,13 @@ mod invalid_float_values {
       "#,
             expect![[r#"
                 Error: expected value of type Float, found a string
-                    ╭─[query.graphql:3:29]
+                    ╭─[ query.graphql:3:29 ]
                     │
                   3 │     floatArgField(floatArg: "3.333")
                     │                             ───┬───  
                     │                                ╰───── provided value is a string
                     │
-                    ├─[schema.graphql:83:27]
+                    ├─[ schema.graphql:83:27 ]
                     │
                  83 │   floatArgField(floatArg: Float): String
                     │                           ──┬──  
@@ -626,13 +626,13 @@ mod invalid_float_values {
       ",
             expect![[r#"
                 Error: expected value of type Float, found a boolean
-                    ╭─[query.graphql:3:29]
+                    ╭─[ query.graphql:3:29 ]
                     │
                   3 │     floatArgField(floatArg: true)
                     │                             ──┬─  
                     │                               ╰─── provided value is a boolean
                     │
-                    ├─[schema.graphql:83:27]
+                    ├─[ schema.graphql:83:27 ]
                     │
                  83 │   floatArgField(floatArg: Float): String
                     │                           ──┬──  
@@ -654,13 +654,13 @@ mod invalid_float_values {
       ",
             expect![[r#"
                 Error: expected value of type Float, found an enum
-                    ╭─[query.graphql:3:29]
+                    ╭─[ query.graphql:3:29 ]
                     │
                   3 │     floatArgField(floatArg: FOO)
                     │                             ─┬─  
                     │                              ╰─── provided value is an enum
                     │
-                    ├─[schema.graphql:83:27]
+                    ├─[ schema.graphql:83:27 ]
                     │
                  83 │   floatArgField(floatArg: Float): String
                     │                           ──┬──  
@@ -687,13 +687,13 @@ mod invalid_boolean_values {
       ",
             expect![[r#"
                 Error: expected value of type Boolean, found an integer
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     booleanArgField(booleanArg: 2)
                     │                                 ┬  
                     │                                 ╰── provided value is an integer
                     │
-                    ├─[schema.graphql:81:31]
+                    ├─[ schema.graphql:81:31 ]
                     │
                  81 │   booleanArgField(booleanArg: Boolean): String
                     │                               ───┬───  
@@ -715,13 +715,13 @@ mod invalid_boolean_values {
       ",
             expect![[r#"
                 Error: expected value of type Boolean, found a float
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     booleanArgField(booleanArg: 1.0)
                     │                                 ─┬─  
                     │                                  ╰─── provided value is a float
                     │
-                    ├─[schema.graphql:81:31]
+                    ├─[ schema.graphql:81:31 ]
                     │
                  81 │   booleanArgField(booleanArg: Boolean): String
                     │                               ───┬───  
@@ -743,13 +743,13 @@ mod invalid_boolean_values {
       "#,
             expect![[r#"
                 Error: expected value of type Boolean, found a string
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     booleanArgField(booleanArg: "true")
                     │                                 ───┬──  
                     │                                    ╰──── provided value is a string
                     │
-                    ├─[schema.graphql:81:31]
+                    ├─[ schema.graphql:81:31 ]
                     │
                  81 │   booleanArgField(booleanArg: Boolean): String
                     │                               ───┬───  
@@ -771,13 +771,13 @@ mod invalid_boolean_values {
       ",
             expect![[r#"
                 Error: expected value of type Boolean, found an enum
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     booleanArgField(booleanArg: TRUE)
                     │                                 ──┬─  
                     │                                   ╰─── provided value is an enum
                     │
-                    ├─[schema.graphql:81:31]
+                    ├─[ schema.graphql:81:31 ]
                     │
                  81 │   booleanArgField(booleanArg: Boolean): String
                     │                               ───┬───  
@@ -804,13 +804,13 @@ mod invalid_id_values {
       ",
             expect![[r#"
                 Error: expected value of type ID, found a float
-                    ╭─[query.graphql:3:23]
+                    ╭─[ query.graphql:3:23 ]
                     │
                   3 │     idArgField(idArg: 1.0)
                     │                       ─┬─  
                     │                        ╰─── provided value is a float
                     │
-                    ├─[schema.graphql:84:21]
+                    ├─[ schema.graphql:84:21 ]
                     │
                  84 │   idArgField(idArg: ID): String
                     │                     ─┬  
@@ -832,13 +832,13 @@ mod invalid_id_values {
       ",
             expect![[r#"
                 Error: expected value of type ID, found a boolean
-                    ╭─[query.graphql:3:23]
+                    ╭─[ query.graphql:3:23 ]
                     │
                   3 │     idArgField(idArg: true)
                     │                       ──┬─  
                     │                         ╰─── provided value is a boolean
                     │
-                    ├─[schema.graphql:84:21]
+                    ├─[ schema.graphql:84:21 ]
                     │
                  84 │   idArgField(idArg: ID): String
                     │                     ─┬  
@@ -860,13 +860,13 @@ mod invalid_id_values {
       ",
             expect![[r#"
                 Error: expected value of type ID, found an enum
-                    ╭─[query.graphql:3:23]
+                    ╭─[ query.graphql:3:23 ]
                     │
                   3 │     idArgField(idArg: SOMETHING)
                     │                       ────┬────  
                     │                           ╰────── provided value is an enum
                     │
-                    ├─[schema.graphql:84:21]
+                    ├─[ schema.graphql:84:21 ]
                     │
                  84 │   idArgField(idArg: ID): String
                     │                     ─┬  
@@ -893,13 +893,13 @@ mod invalid_enum_values {
       ",
             expect![[r#"
                 Error: expected value of type DogCommand, found an integer
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     doesKnowCommand(dogCommand: 2)
                     │                                 ┬  
                     │                                 ╰── provided value is an integer
                     │
-                    ├─[schema.graphql:27:31]
+                    ├─[ schema.graphql:27:31 ]
                     │
                  27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
                     │                               ─────┬────  
@@ -921,13 +921,13 @@ mod invalid_enum_values {
       ",
             expect![[r#"
                 Error: expected value of type DogCommand, found a float
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     doesKnowCommand(dogCommand: 1.0)
                     │                                 ─┬─  
                     │                                  ╰─── provided value is a float
                     │
-                    ├─[schema.graphql:27:31]
+                    ├─[ schema.graphql:27:31 ]
                     │
                  27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
                     │                               ─────┬────  
@@ -949,13 +949,13 @@ mod invalid_enum_values {
       "#,
             expect![[r#"
                 Error: expected value of type DogCommand, found a string
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     doesKnowCommand(dogCommand: "SIT")
                     │                                 ──┬──  
                     │                                   ╰──── provided value is a string
                     │
-                    ├─[schema.graphql:27:31]
+                    ├─[ schema.graphql:27:31 ]
                     │
                  27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
                     │                               ─────┬────  
@@ -977,13 +977,13 @@ mod invalid_enum_values {
       ",
             expect![[r#"
                 Error: expected value of type DogCommand, found a boolean
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     doesKnowCommand(dogCommand: true)
                     │                                 ──┬─  
                     │                                   ╰─── provided value is a boolean
                     │
-                    ├─[schema.graphql:27:31]
+                    ├─[ schema.graphql:27:31 ]
                     │
                  27 │   doesKnowCommand(dogCommand: DogCommand): Boolean
                     │                               ─────┬────  
@@ -1005,13 +1005,13 @@ mod invalid_enum_values {
       ",
             expect![[r#"
                 Error: value `JUGGLE` does not exist on `DogCommand`
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     doesKnowCommand(dogCommand: JUGGLE)
                     │                                 ───┬──  
                     │                                    ╰──── value does not exist on `DogCommand` enum
                     │
-                    ├─[schema.graphql:16:1]
+                    ├─[ schema.graphql:16:1 ]
                     │
                  16 │ ╭─▶ enum DogCommand {
                     ┆ ┆   
@@ -1035,13 +1035,13 @@ mod invalid_enum_values {
       ",
             expect![[r#"
                 Error: value `sit` does not exist on `DogCommand`
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     doesKnowCommand(dogCommand: sit)
                     │                                 ─┬─  
                     │                                  ╰─── value does not exist on `DogCommand` enum
                     │
-                    ├─[schema.graphql:16:1]
+                    ├─[ schema.graphql:16:1 ]
                     │
                  16 │ ╭─▶ enum DogCommand {
                     ┆ ┆   
@@ -1126,13 +1126,13 @@ mod invalid_list_values {
       "#,
             expect![[r#"
                 Error: expected value of type String, found an integer
-                    ╭─[query.graphql:3:47]
+                    ╭─[ query.graphql:3:47 ]
                     │
                   3 │     stringListArgField(stringListArg: ["one", 2])
                     │                                               ┬  
                     │                                               ╰── provided value is an integer
                     │
-                    ├─[schema.graphql:85:37]
+                    ├─[ schema.graphql:85:37 ]
                     │
                  85 │   stringListArgField(stringListArg: [String]): String
                     │                                     ────┬───  
@@ -1154,13 +1154,13 @@ mod invalid_list_values {
       ",
             expect![[r#"
                 Error: expected value of type [String], found an integer
-                    ╭─[query.graphql:3:39]
+                    ╭─[ query.graphql:3:39 ]
                     │
                   3 │     stringListArgField(stringListArg: 1)
                     │                                       ┬  
                     │                                       ╰── provided value is an integer
                     │
-                    ├─[schema.graphql:85:37]
+                    ├─[ schema.graphql:85:37 ]
                     │
                  85 │   stringListArgField(stringListArg: [String]): String
                     │                                     ────┬───  
@@ -1321,26 +1321,26 @@ mod invalid_non_nullable_values {
       "#,
             expect![[r#"
                 Error: expected value of type Int!, found a string
-                    ╭─[query.graphql:3:24]
+                    ╭─[ query.graphql:3:24 ]
                     │
                   3 │     multipleReqs(req2: "two", req1: "one")
                     │                        ──┬──  
                     │                          ╰──── provided value is a string
                     │
-                    ├─[schema.graphql:89:34]
+                    ├─[ schema.graphql:89:34 ]
                     │
                  89 │   multipleReqs(req1: Int!, req2: Int!): String
                     │                                  ──┬─  
                     │                                    ╰─── expected type declared here as Int!
                 ────╯
                 Error: expected value of type Int!, found a string
-                    ╭─[query.graphql:3:37]
+                    ╭─[ query.graphql:3:37 ]
                     │
                   3 │     multipleReqs(req2: "two", req1: "one")
                     │                                     ──┬──  
                     │                                       ╰──── provided value is a string
                     │
-                    ├─[schema.graphql:89:22]
+                    ├─[ schema.graphql:89:22 ]
                     │
                  89 │   multipleReqs(req1: Int!, req2: Int!): String
                     │                      ──┬─  
@@ -1362,26 +1362,26 @@ mod invalid_non_nullable_values {
       "#,
             expect![[r#"
                 Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
-                    ╭─[query.graphql:3:5]
+                    ╭─[ query.graphql:3:5 ]
                     │
                   3 │     multipleReqs(req1: "one")
                     │     ────────────┬────────────  
                     │                 ╰────────────── missing value for argument `req2`
                     │
-                    ├─[schema.graphql:89:28]
+                    ├─[ schema.graphql:89:28 ]
                     │
                  89 │   multipleReqs(req1: Int!, req2: Int!): String
                     │                            ─────┬────  
                     │                                 ╰────── argument defined here
                 ────╯
                 Error: expected value of type Int!, found a string
-                    ╭─[query.graphql:3:24]
+                    ╭─[ query.graphql:3:24 ]
                     │
                   3 │     multipleReqs(req1: "one")
                     │                        ──┬──  
                     │                          ╰──── provided value is a string
                     │
-                    ├─[schema.graphql:89:22]
+                    ├─[ schema.graphql:89:22 ]
                     │
                  89 │   multipleReqs(req1: Int!, req2: Int!): String
                     │                      ──┬─  
@@ -1403,39 +1403,39 @@ mod invalid_non_nullable_values {
       ",
             expect![[r#"
                 Error: the required argument `ComplicatedArgs.multipleReqs(req1:)` is not provided
-                    ╭─[query.graphql:3:5]
+                    ╭─[ query.graphql:3:5 ]
                     │
                   3 │     multipleReqs(req1: null)
                     │     ────────────┬───────────  
                     │                 ╰───────────── missing value for argument `req1`
                     │
-                    ├─[schema.graphql:89:16]
+                    ├─[ schema.graphql:89:16 ]
                     │
                  89 │   multipleReqs(req1: Int!, req2: Int!): String
                     │                ─────┬────  
                     │                     ╰────── argument defined here
                 ────╯
                 Error: the required argument `ComplicatedArgs.multipleReqs(req2:)` is not provided
-                    ╭─[query.graphql:3:5]
+                    ╭─[ query.graphql:3:5 ]
                     │
                   3 │     multipleReqs(req1: null)
                     │     ────────────┬───────────  
                     │                 ╰───────────── missing value for argument `req2`
                     │
-                    ├─[schema.graphql:89:28]
+                    ├─[ schema.graphql:89:28 ]
                     │
                  89 │   multipleReqs(req1: Int!, req2: Int!): String
                     │                            ─────┬────  
                     │                                 ╰────── argument defined here
                 ────╯
                 Error: expected value of type Int!, found null
-                    ╭─[query.graphql:3:24]
+                    ╭─[ query.graphql:3:24 ]
                     │
                   3 │     multipleReqs(req1: null)
                     │                        ──┬─  
                     │                          ╰─── provided value is null
                     │
-                    ├─[schema.graphql:89:22]
+                    ├─[ schema.graphql:89:22 ]
                     │
                  89 │   multipleReqs(req1: Int!, req2: Int!): String
                     │                      ──┬─  
@@ -1556,13 +1556,13 @@ mod invalid_input_object_values {
       ",
             expect![[r#"
                 Error: the required field `ComplexInput.requiredField` is not provided
-                    ╭─[query.graphql:3:33]
+                    ╭─[ query.graphql:3:33 ]
                     │
                   3 │     complexArgField(complexArg: { intField: 4 })
                     │                                 ───────┬───────  
                     │                                        ╰───────── missing value for field `requiredField`
                     │
-                    ├─[schema.graphql:60:3]
+                    ├─[ schema.graphql:60:3 ]
                     │
                  60 │   requiredField: Boolean!
                     │   ───────────┬───────────  
@@ -1587,13 +1587,13 @@ mod invalid_input_object_values {
       "#,
             expect![[r#"
                 Error: expected value of type String, found an integer
-                    ╭─[query.graphql:4:32]
+                    ╭─[ query.graphql:4:32 ]
                     │
                   4 │       stringListField: ["one", 2],
                     │                                ┬  
                     │                                ╰── provided value is an integer
                     │
-                    ├─[schema.graphql:65:20]
+                    ├─[ schema.graphql:65:20 ]
                     │
                  65 │   stringListField: [String]
                     │                    ────┬───  
@@ -1618,13 +1618,13 @@ mod invalid_input_object_values {
       ",
             expect![[r#"
                 Error: expected value of type Boolean!, found null
-                    ╭─[query.graphql:5:21]
+                    ╭─[ query.graphql:5:21 ]
                     │
                   5 │       nonNullField: null,
                     │                     ──┬─  
                     │                       ╰─── provided value is null
                     │
-                    ├─[schema.graphql:61:17]
+                    ├─[ schema.graphql:61:17 ]
                     │
                  61 │   nonNullField: Boolean! = false
                     │                 ────┬───  
@@ -1649,13 +1649,13 @@ mod invalid_input_object_values {
       "#,
             expect![[r#"
                 Error: field `invalidField` does not exist on `ComplexInput`
-                    ╭─[query.graphql:5:21]
+                    ╭─[ query.graphql:5:21 ]
                     │
                   5 │       invalidField: "value"
                     │                     ───┬───  
                     │                        ╰───── value does not exist on `ComplexInput` input object
                     │
-                    ├─[schema.graphql:59:1]
+                    ├─[ schema.graphql:59:1 ]
                     │
                  59 │ ╭─▶ input ComplexInput {
                     ┆ ┆   
@@ -1732,26 +1732,26 @@ mod directive_arguments {
       "#,
             expect![[r#"
                 Error: expected value of type Boolean!, found a string
-                     ╭─[query.graphql:2:20]
+                     ╭─[ query.graphql:2:20 ]
                      │
                    2 │   dog @include(if: "yes") {
                      │                    ──┬──  
                      │                      ╰──── provided value is a string
                      │
-                     ├─[built_in.graphql:146:7]
+                     ├─[ built_in.graphql:146:7 ]
                      │
                  146 │   if: Boolean!
                      │       ────┬───  
                      │           ╰───── expected type declared here as Boolean!
                 ─────╯
                 Error: expected value of type Boolean!, found an enum
-                     ╭─[query.graphql:3:20]
+                     ╭─[ query.graphql:3:20 ]
                      │
                    3 │     name @skip(if: ENUM)
                      │                    ──┬─  
                      │                      ╰─── provided value is an enum
                      │
-                     ├─[built_in.graphql:140:7]
+                     ├─[ built_in.graphql:140:7 ]
                      │
                  140 │   if: Boolean!
                      │       ────┬───  
@@ -1828,7 +1828,7 @@ mod variable_default_values {
       ",
             expect![[r#"
                 Error: expected value of type Int!, found null
-                   ╭─[query.graphql:2:14]
+                   ╭─[ query.graphql:2:14 ]
                    │
                  2 │   $a: Int! = null,
                    │       ──┬─   ──┬─  
@@ -1837,7 +1837,7 @@ mod variable_default_values {
                    │                ╰─── provided value is null
                 ───╯
                 Error: expected value of type String!, found null
-                   ╭─[query.graphql:3:17]
+                   ╭─[ query.graphql:3:17 ]
                    │
                  3 │   $b: String! = null,
                    │       ───┬───   ──┬─  
@@ -1846,26 +1846,26 @@ mod variable_default_values {
                    │                   ╰─── provided value is null
                 ───╯
                 Error: the required field `ComplexInput.requiredField` is not provided
-                    ╭─[query.graphql:4:22]
+                    ╭─[ query.graphql:4:22 ]
                     │
                   4 │   $c: ComplexInput = { requiredField: null, intField: null }
                     │                      ───────────────────┬───────────────────  
                     │                                         ╰───────────────────── missing value for field `requiredField`
                     │
-                    ├─[schema.graphql:60:3]
+                    ├─[ schema.graphql:60:3 ]
                     │
                  60 │   requiredField: Boolean!
                     │   ───────────┬───────────  
                     │              ╰───────────── field defined here
                 ────╯
                 Error: expected value of type Boolean!, found null
-                    ╭─[query.graphql:4:39]
+                    ╭─[ query.graphql:4:39 ]
                     │
                   4 │   $c: ComplexInput = { requiredField: null, intField: null }
                     │                                       ──┬─  
                     │                                         ╰─── provided value is null
                     │
-                    ├─[schema.graphql:60:18]
+                    ├─[ schema.graphql:60:18 ]
                     │
                  60 │   requiredField: Boolean!
                     │                  ────┬───  
@@ -1894,7 +1894,7 @@ mod variable_default_values {
       "#,
             expect![[r#"
                 Error: expected value of type Int, found a string
-                   ╭─[query.graphql:2:13]
+                   ╭─[ query.graphql:2:13 ]
                    │
                  2 │   $a: Int = "one",
                    │       ─┬─   ──┬──  
@@ -1903,7 +1903,7 @@ mod variable_default_values {
                    │               ╰──── provided value is a string
                 ───╯
                 Error: expected value of type String, found an integer
-                   ╭─[query.graphql:3:16]
+                   ╭─[ query.graphql:3:16 ]
                    │
                  3 │   $b: String = 4,
                    │       ───┬──   ┬  
@@ -1912,7 +1912,7 @@ mod variable_default_values {
                    │                ╰── provided value is an integer
                 ───╯
                 Error: expected value of type ComplexInput, found a string
-                   ╭─[query.graphql:4:22]
+                   ╭─[ query.graphql:4:22 ]
                    │
                  4 │   $c: ComplexInput = "NotVeryComplex"
                    │       ──────┬─────   ────────┬───────  
@@ -1937,26 +1937,26 @@ mod variable_default_values {
       "#,
             expect![[r#"
                 Error: expected value of type Boolean!, found an integer
-                    ╭─[query.graphql:2:39]
+                    ╭─[ query.graphql:2:39 ]
                     │
                   2 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
                     │                                       ─┬─  
                     │                                        ╰─── provided value is an integer
                     │
-                    ├─[schema.graphql:60:18]
+                    ├─[ schema.graphql:60:18 ]
                     │
                  60 │   requiredField: Boolean!
                     │                  ────┬───  
                     │                      ╰───── expected type declared here as Boolean!
                 ────╯
                 Error: expected value of type Int, found a string
-                    ╭─[query.graphql:2:54]
+                    ╭─[ query.graphql:2:54 ]
                     │
                   2 │   $a: ComplexInput = { requiredField: 123, intField: "abc" }
                     │                                                      ──┬──  
                     │                                                        ╰──── provided value is a string
                     │
-                    ├─[schema.graphql:62:13]
+                    ├─[ schema.graphql:62:13 ]
                     │
                  62 │   intField: Int
                     │             ─┬─  
@@ -1977,13 +1977,13 @@ mod variable_default_values {
       ",
             expect![[r#"
                 Error: the required field `ComplexInput.requiredField` is not provided
-                    ╭─[query.graphql:1:47]
+                    ╭─[ query.graphql:1:47 ]
                     │
                   1 │ query MissingRequiredField($a: ComplexInput = {intField: 3}) {
                     │                                               ──────┬──────  
                     │                                                     ╰──────── missing value for field `requiredField`
                     │
-                    ├─[schema.graphql:60:3]
+                    ├─[ schema.graphql:60:3 ]
                     │
                  60 │   requiredField: Boolean!
                     │   ───────────┬───────────  
@@ -2004,7 +2004,7 @@ mod variable_default_values {
       "#,
             expect![[r#"
                 Error: expected value of type String, found an integer
-                   ╭─[query.graphql:1:42]
+                   ╭─[ query.graphql:1:42 ]
                    │
                  1 │ query InvalidItem($a: [String] = ["one", 2]) {
                    │                       ────┬───           ┬  

--- a/crates/apollo-compiler/tests/validation/variable.rs
+++ b/crates/apollo-compiler/tests/validation/variable.rs
@@ -263,14 +263,14 @@ fn variables_in_const_contexts() {
     let errors = doc.validate(&schema).unwrap_err().errors;
     let expected = expect_test::expect![[r#"
         Error: variable `$x` is not defined
-            ╭─[input.graphql:72:33]
+            ╭─[ input.graphql:72:33 ]
             │
          72 │             $y: InputObj = {x: ["x"]} @dir(arg: {x: ["x"]})
             │                                 ─┬─  
             │                                  ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:72:54]
+            ╭─[ input.graphql:72:54 ]
             │
          72 │             $y: InputObj = {x: ["x"]} @dir(arg: {x: ["x"]})
             │                                                      ─┬─  
@@ -360,154 +360,154 @@ fn variables_in_const_contexts() {
     let errors = schema.validate().unwrap_err().errors;
     let expected = expect_test::expect![[r#"
         Error: variable `$x` is not defined
-           ╭─[input.graphql:3:51]
+           ╭─[ input.graphql:3:51 ]
            │
          3 │             arg: InputObj = {x: ["x"]} @dir2(arg: "x")
            │                                                   ─┬─  
            │                                                    ╰─── not found in this scope
         ───╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:32:31]
+            ╭─[ input.graphql:32:31 ]
             │
          32 │         schema @dir(arg: {x: ["x"]}) {
             │                               ─┬─  
             │                                ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:35:38]
+            ╭─[ input.graphql:35:38 ]
             │
          35 │         extend schema @dir(arg: {x: ["x"]})
             │                                      ─┬─  
             │                                       ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:37:33]
+            ╭─[ input.graphql:37:33 ]
             │
          37 │         scalar S @dir(arg: {x: ["x"]})
             │                                 ─┬─  
             │                                  ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:38:40]
+            ╭─[ input.graphql:38:40 ]
             │
          38 │         extend scalar S @dir(arg: {x: ["x"]})
             │                                        ─┬─  
             │                                         ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:40:52]
+            ╭─[ input.graphql:40:52 ]
             │
          40 │         type Query implements Inter @dir(arg: {x: ["x"]}) {
             │                                                    ─┬─  
             │                                                     ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:43:60]
+            ╭─[ input.graphql:43:60 ]
             │
          43 │                 arg2: InputObj = {x: ["x"]} @dir(arg: {x: ["x"]})
             │                                                            ─┬─  
             │                                                             ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:44:38]
+            ╭─[ input.graphql:44:38 ]
             │
          44 │             ): String @dir(arg: {x: ["x"]})
             │                                      ─┬─  
             │                                       ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:46:42]
+            ╭─[ input.graphql:46:42 ]
             │
          46 │         extend type Query @dir(arg: {x: ["x"]})
             │                                          ─┬─  
             │                                           ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:48:40]
+            ╭─[ input.graphql:48:40 ]
             │
          48 │         interface Inter @dir(arg: {x: ["x"]}) {
             │                                        ─┬─  
             │                                         ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:51:60]
+            ╭─[ input.graphql:51:60 ]
             │
          51 │                 arg2: InputObj = {x: ["x"]} @dir(arg: {x: ["x"]})
             │                                                            ─┬─  
             │                                                             ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:52:38]
+            ╭─[ input.graphql:52:38 ]
             │
          52 │             ): String @dir(arg: {x: ["x"]})
             │                                      ─┬─  
             │                                       ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:54:47]
+            ╭─[ input.graphql:54:47 ]
             │
          54 │         extend interface Inter @dir(arg: {x: ["x"]})
             │                                               ─┬─  
             │                                                ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:56:32]
+            ╭─[ input.graphql:56:32 ]
             │
          56 │         union U @dir(arg: {x: ["x"]}) = Query
             │                                ─┬─  
             │                                 ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:57:39]
+            ╭─[ input.graphql:57:39 ]
             │
          57 │         extend union U @dir(arg: {x: ["x"]})
             │                                       ─┬─  
             │                                        ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:59:35]
+            ╭─[ input.graphql:59:35 ]
             │
          59 │         enum Maybe @dir(arg: {x: ["x"]}) {
             │                                   ─┬─  
             │                                    ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:60:32]
+            ╭─[ input.graphql:60:32 ]
             │
          60 │             YES @dir(arg: {x: ["x"]})
             │                                ─┬─  
             │                                 ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:61:31]
+            ╭─[ input.graphql:61:31 ]
             │
          61 │             NO @dir(arg: {x: ["x"]})
             │                               ─┬─  
             │                                ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:63:42]
+            ╭─[ input.graphql:63:42 ]
             │
          63 │         extend enum Maybe @dir(arg: {x: ["x"]})
             │                                          ─┬─  
             │                                           ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:65:35]
+            ╭─[ input.graphql:65:35 ]
             │
          65 │         input InputObj @dir2(arg: "x") {
             │                                   ─┬─  
             │                                    ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:66:44]
+            ╭─[ input.graphql:66:44 ]
             │
          66 │             x: [String] = ["x"] @dir2(arg: "x")
             │                                            ─┬─  
             │                                             ╰─── not found in this scope
         ────╯
         Error: variable `$x` is not defined
-            ╭─[input.graphql:68:42]
+            ╭─[ input.graphql:68:42 ]
             │
          68 │         extend input InputObj @dir2(arg: "x")
             │                                          ─┬─  


### PR DESCRIPTION
fn fetch() and fn display() changed signatures in the latest patch release of ariadne (0.51.0).

* `fn fetch(&mut self, file_id: &FileId) -> Result<&ariadne::Source, Box<dyn fmt::Debug + '_>>` --> `fn fetch(&mut self, file_id: &FileId) -> Result<&ariadne::Source, impl fmt::Debug>`
* `fn display<'a>(&self, file_id: &'a FileId) -> Option<Box<dyn fmt::Display + 'a>> ` --> `fn display<'a>(&self, file_id: &'a FileId) -> Option<impl fmt::Display + 'a>`