### PR TITLE
deps: increase minimum ariadne version

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -20,7 +20,7 @@ autotests = false # Most tests/*.rs files are modules of tests/main.rs
 [dependencies]
 ahash = "0.8.11"
 apollo-parser = { path = "../apollo-parser", version = "0.8.0" }
-ariadne = { version = "0.5.0", features = ["auto-color"] }
+ariadne = { version = "0.5.1", features = ["auto-color"] }
 indexmap = "2.0.0"
 rowan = "0.16.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -22,7 +22,7 @@ rowan = "0.16.0"
 thiserror = "2.0.0"
 
 [dev-dependencies]
-ariadne = "0.5.0"
+ariadne = "0.5.1"
 indexmap = "2.0.0"
 anyhow = "1.0.66"
 pretty_assertions = "1.3.0"


### PR DESCRIPTION
After #960, apollo-rs does not work with ariadne 0.5.0, so we should bump the
minimum version to 0.5.1.
