### PR TITLE
Simplify directive mutation

### DIFF
--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -680,6 +680,8 @@ impl Directive {
     }
 
     /// Returns the value of the argument named `name`, as specified in the directive application.
+    /// If there are other [`Node`] pointers to the same argument, this method will clone the
+    /// argument using [`Node::make_mut`].
     ///
     /// Returns `None` if the directive application does not specify this argument.
     ///

--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -468,6 +468,13 @@ impl DirectiveDefinition {
         self.arguments.iter().find(|argument| argument.name == name)
     }
 
+    /// Returns the definition of an argument by a given name.
+    pub fn argument_by_name_mut(&mut self, name: &str) -> Option<&mut Node<InputValueDefinition>> {
+        self.arguments
+            .iter_mut()
+            .find(|argument| argument.name == name)
+    }
+
     serialize_method!();
 }
 
@@ -543,12 +550,31 @@ impl DirectiveList {
         self.0.iter().filter(move |dir| dir.name == name)
     }
 
+    /// Returns an iterator of mutable directives with the given name.
+    ///
+    /// This method is best for repeatable directives.
+    /// See also [`get_mut`][Self::get_mut] for non-repeatable directives.
+    pub fn get_all_mut<'def: 'name, 'name>(
+        &'def mut self,
+        name: &'name str,
+    ) -> impl Iterator<Item = &'def mut Node<Directive>> + 'name {
+        self.0.iter_mut().filter(move |dir| dir.name == name)
+    }
+
     /// Returns the first directive with the given name, if any.
     ///
     /// This method is best for non-repeatable directives.
     /// See also [`get_all`][Self::get_all] for repeatable directives.
     pub fn get(&self, name: &str) -> Option<&Node<Directive>> {
         self.get_all(name).next()
+    }
+
+    /// Returns the first mutable directive with the given name, if any.
+    ///
+    /// This method is best for non-repeatable directives.
+    /// See also [`get_all_mut`][Self::get_all_mut] for repeatable directives.
+    pub fn get_mut(&mut self, name: &str) -> Option<&mut Node<Directive>> {
+        self.get_all_mut(name).next()
     }
 
     /// Returns whether there is a directive with the given name
@@ -661,6 +687,16 @@ impl Directive {
         Argument::specified_argument_by_name(&self.arguments, name)
     }
 
+    /// Returns the value of the argument named `name`, as specified in the directive application.
+    ///
+    /// Returns `None` if the directive application does not specify this argument.
+    ///
+    /// If the directive definition makes this argument nullable or defines a default value,
+    /// consider using [`argument_by_name`][Self::argument_by_name] instead.
+    pub fn specified_argument_by_name_mut(&mut self, name: &str) -> Option<&mut Node<Value>> {
+        Argument::specified_argument_by_name_mut(&mut self.arguments, name)
+    }
+
     serialize_method!();
 }
 
@@ -691,6 +727,15 @@ impl Argument {
         arguments
             .iter()
             .find_map(|arg| (arg.name == name).then_some(&arg.value))
+    }
+
+    pub(crate) fn specified_argument_by_name_mut<'doc>(
+        arguments: &'doc mut [Node<Self>],
+        name: &str,
+    ) -> Option<&'doc mut Node<Value>> {
+        arguments
+            .iter_mut()
+            .find_map(|arg| (arg.name == name).then_some(&mut arg.value))
     }
 }
 

--- a/crates/apollo-compiler/src/ast/impls.rs
+++ b/crates/apollo-compiler/src/ast/impls.rs
@@ -553,7 +553,7 @@ impl DirectiveList {
     /// Returns an iterator of mutable directives with the given name.
     ///
     /// This method is best for repeatable directives.
-    /// See also [`get_mut`][Self::get_mut] for non-repeatable directives.
+    /// See also [`get`][Self::get] for non-repeatable directives.
     pub fn get_all_mut<'def: 'name, 'name>(
         &'def mut self,
         name: &'name str,
@@ -567,14 +567,6 @@ impl DirectiveList {
     /// See also [`get_all`][Self::get_all] for repeatable directives.
     pub fn get(&self, name: &str) -> Option<&Node<Directive>> {
         self.get_all(name).next()
-    }
-
-    /// Returns the first mutable directive with the given name, if any.
-    ///
-    /// This method is best for non-repeatable directives.
-    /// See also [`get_all_mut`][Self::get_all_mut] for repeatable directives.
-    pub fn get_mut(&mut self, name: &str) -> Option<&mut Node<Directive>> {
-        self.get_all_mut(name).next()
     }
 
     /// Returns whether there is a directive with the given name
@@ -735,7 +727,7 @@ impl Argument {
     ) -> Option<&'doc mut Node<Value>> {
         arguments
             .iter_mut()
-            .find_map(|arg| (arg.name == name).then_some(&mut arg.value))
+            .find_map(|arg| (arg.name == name).then_some(&mut arg.make_mut().value))
     }
 }
 

--- a/crates/apollo-compiler/src/node.rs
+++ b/crates/apollo-compiler/src/node.rs
@@ -144,12 +144,6 @@ impl<T: ?Sized> std::ops::Deref for Node<T> {
     }
 }
 
-impl<T: Clone> std::ops::DerefMut for Node<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.make_mut()
-    }
-}
-
 impl<T: ?Sized> Clone for Node<T> {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/crates/apollo-compiler/src/node.rs
+++ b/crates/apollo-compiler/src/node.rs
@@ -144,6 +144,12 @@ impl<T: ?Sized> std::ops::Deref for Node<T> {
     }
 }
 
+impl<T: Clone> std::ops::DerefMut for Node<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.make_mut()
+    }
+}
+
 impl<T: ?Sized> Clone for Node<T> {
     fn clone(&self) -> Self {
         Self(self.0.clone())


### PR DESCRIPTION
Implements mutable versions of some functions used to access directives and their arguments. This improves the ergonomics for some of the composition work we're doing in https://github.com/apollographql/router/pull/7235.