### PR TITLE
chore: make renovate not pin deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,7 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":preserveSemverRanges",
+  ],
 }


### PR DESCRIPTION
Pinning our dependencies to a specific version would cause a world of pain any time any Router dependency updates, and increase the maintenance burden of apollo-rs. Let's not do that.

Ref https://github.com/apollographql/apollo-rs/pull/969