### PR TITLE
Fix WASM compile test on CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,8 @@ xtask = "run --package xtask --"
 # circle seems to install cargo packages via ssh:// rather than https://
 [net]
 git-fetch-with-cli = true
+
+# WebAssembly support per https://docs.rs/getrandom/0.3.3/getrandom/#opt-in-backends
+# See examples/validation-wasm-demo/Cargo.toml
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/examples/validation-wasm-demo/Cargo.toml
+++ b/examples/validation-wasm-demo/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 apollo-compiler.path = "../../crates/apollo-compiler"
-# https://docs.rs/getrandom/0.2.15/getrandom/index.html#webassembly-support
-getrandom = { version = "0.2", features = ["js"] }
+# https://docs.rs/getrandom/0.3.3/getrandom/index.html#webassembly-support
+getrandom = { version = "0.3", features = ["wasm_js"] }
 wasm-bindgen = "0.2.100"

--- a/examples/validation-wasm-demo/Cargo.toml
+++ b/examples/validation-wasm-demo/Cargo.toml
@@ -9,5 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 apollo-compiler.path = "../../crates/apollo-compiler"
 # https://docs.rs/getrandom/0.3.3/getrandom/index.html#webassembly-support
+# Works together with the rustflags configuration in `.cargo/config.toml`
 getrandom = { version = "0.3", features = ["wasm_js"] }
 wasm-bindgen = "0.2.100"


### PR DESCRIPTION
A transitive dependency updated `getrandom` to v0.3, which requires more configuration.