### PR TITLE
fix: fix handling of directive arguments with nested types

### DIFF
--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -66,7 +66,12 @@ impl FindRecursiveDirective<'_> {
 
         let type_name = input_value.ty.inner_named_type();
         if let Some(type_def) = self.schema.types.get(type_name) {
-            self.type_definition(seen, type_def)?;
+            if seen.contains(type_def.name()) {
+                // input type was already processed
+                return Ok(());
+            }
+            let mut new_guard = seen.push(type_def.name())?;
+            self.type_definition(&mut new_guard, type_def)?;
         }
 
         Ok(())


### PR DESCRIPTION
`FindRecursiveDirective` was only checking whether for recursion chains on directive names (i.e. going from `@custom -> args -> directive on args -> @custom`) but was not handling recursion on the input types.