### PR TITLE
feat(compiler): allow SDL to contain built-in scalar definitions

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Features
 
-- **Adds `allow_builtin_redefinitions` option to `SchemaBuilder` to allow SDL to contain built-in
+- **Adds `ignore_builtin_redefinitions` option to `SchemaBuilder` to allow SDL to contain built-in
   scalar definitions - [dariuszkuc], [pull/990]**
 
 

--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,6 +17,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
+# [x.x.x] (unreleased) - 2025-mm-dd
+
+## Features
+
+- **Adds `allow_builtin_redefinitions` option to `SchemaBuilder` to allow SDL to contain built-in
+  scalar definitions- [dariuszkuc], [pull/990]**
+
+
 # [1.29.0](https://crates.io/crates/apollo-compiler/1.29.0) - 2025-08-08
 
 ## Features

--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Features
 
 - **Adds `allow_builtin_redefinitions` option to `SchemaBuilder` to allow SDL to contain built-in
-  scalar definitions- [dariuszkuc], [pull/990]**
+  scalar definitions - [dariuszkuc], [pull/990]**
 
 
 # [1.29.0](https://crates.io/crates/apollo-compiler/1.29.0) - 2025-08-08

--- a/crates/apollo-compiler/tests/validation/types.rs
+++ b/crates/apollo-compiler/tests/validation/types.rs
@@ -1,12 +1,13 @@
 //! Ported from graphql-js, 2023-11-16
 //! https://github.com/graphql/graphql-js/blob/0b7590f0a2b65e6210da2e49be0d8e6c27781af2/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+use apollo_compiler::schema::SchemaBuilder;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Schema;
-use expect_test::{expect, Expect};
+use expect_test::expect;
+use expect_test::Expect;
 use std::sync::OnceLock;
 use unindent::unindent;
-use apollo_compiler::schema::SchemaBuilder;
 
 const GRAPHQL_JS_TEST_SCHEMA: &str = r#"
   interface Mammal {
@@ -2042,7 +2043,9 @@ type Query {
     "#]];
     expected.assert_eq(&errors.to_string());
 
-    let builder = SchemaBuilder::new()
-        .allow_builtin_redefinitions();
-    let _ = builder.parse(schema, "schema.graphql").build().expect("schema parsed successfully");
+    let builder = SchemaBuilder::new().allow_builtin_redefinitions();
+    let _ = builder
+        .parse(schema, "schema.graphql")
+        .build()
+        .expect("schema parsed successfully");
 }

--- a/crates/apollo-compiler/tests/validation/types.rs
+++ b/crates/apollo-compiler/tests/validation/types.rs
@@ -2043,7 +2043,7 @@ type Query {
     "#]];
     expected.assert_eq(&errors.to_string());
 
-    let builder = SchemaBuilder::new().allow_builtin_redefinitions();
+    let builder = SchemaBuilder::new().ignore_builtin_redefinitions();
     let _ = builder
         .parse(schema, "schema.graphql")
         .build()


### PR DESCRIPTION
Adds new `ignore_builtin_redefinitions` option on the `SchemaBuilder` to allow SDL to contain built-in scalar re-definitions. Re-definitions are going to be effectively ignored and compiler will continue to use built-in GraphQL spec definitions. While [GraphQL spec](https://spec.graphql.org/October2021/#sec-Scalars) explicitly specifies following

```
When representing a GraphQL schema using the type system definition language, all built-in scalars must be omitted for brevity.
```

`graphql-js` reference implementation does not enforce this and does not report any errors even if built-in scalars are present in SDL. This change allows users to skip this validation to match `graphql-js` behavior.

<!-- FED-747 -->