### PR TITLE
fix(compiler): fix handling of orphan root type extensions

### DIFF
--- a/crates/apollo-compiler/tests/schema.rs
+++ b/crates/apollo-compiler/tests/schema.rs
@@ -1,3 +1,4 @@
+use apollo_compiler::schema::SchemaBuilder;
 use apollo_compiler::Schema;
 
 #[test]
@@ -225,4 +226,26 @@ fn test_default_root_op_name_ignored_with_explicit_schema_def() {
     "#;
     let schema = Schema::parse_and_validate(input, "schema.graphql").unwrap();
     assert!(schema.schema_definition.mutation.is_none())
+}
+
+#[test]
+fn handles_implicit_root_types() {
+    let sdl = r#"
+extend type Query {
+  foo: String
+}
+
+extend type Mutation {
+  bar: String
+}
+"#;
+
+    let builder = SchemaBuilder::new().adopt_orphan_extensions();
+    let schema = builder
+        .parse(sdl, "schema.graphql")
+        .build()
+        .expect("schema parsed successfully");
+
+    assert!(schema.schema_definition.query.is_some());
+    assert!(schema.schema_definition.mutation.is_some());
 }


### PR DESCRIPTION
When using `SchemaBuilder#adopt_orphan_extensions` option, we allow users to define type extensions without regular type (this was a common pattern in Apollo Federation v1). In situations where users would define root type extensions only, e.g.

```graphql
extend type Query {
  foo: String
}

extend type Mutation {
  bar: String
}
```

we were treating those as regular types and generate invalid schema definition with both `Query` and `Mutation` root operations as `None`. Our logic to add implicit root type operation mapping was invoked before handling the type extensions, meaning that we never made those associations as those types didn't exist in the schema at that time. The fix is to re-order our logic to first merge type extensions and then merge schema extensions.