### PR TITLE
Fix: Accept all valid Float value inputs on `coerce_variable_value`

### DIFF
--- a/crates/apollo-compiler/src/resolvers/input_coercion.rs
+++ b/crates/apollo-compiler/src/resolvers/input_coercion.rs
@@ -119,8 +119,10 @@ fn coerce_variable_value(
                 }
             }
             "Float" => {
-                // https://spec.graphql.org/October2021/#sec-Float.Input-Coercion
-                if value.is_f64() {
+                // https://spec.graphql.org/September2025/#sec-Float.Input-Coercion
+                // Accept any JSON number (`int` or `float`) that coerces to a finite f64,
+                // rejecting special values (NaN, +∞, -∞) as required by the GraphQL spec.
+                if value.as_f64().is_some_and(f64::is_finite) {
                     return Ok(value.clone());
                 }
             }

--- a/crates/apollo-compiler/tests/introspection.rs
+++ b/crates/apollo-compiler/tests/introspection.rs
@@ -321,3 +321,44 @@ fn mixed() {
         }"#]]
     .assert_eq(&response);
 }
+
+#[test]
+fn test_graphql_float_variable_coercion() {
+    // Small schema with a Float in the input object
+    let sdl = r#"
+      type Car { id: ID! kilometers: Float! }
+      input CarInput { kilometers: Float! }
+      type Query { getCarById(id: ID!): Car }
+      type Mutation { insertACar(car: CarInput!): Car!
+      }
+    "#;
+
+    let parsed_schema = Schema::parse_and_validate(sdl, "sdl").unwrap();
+
+    let executable_mutation = ExecutableDocument::parse_and_validate(
+        &parsed_schema,
+        "mutation MyCarInsertMutation($car: CarInput!){ insertACar(car:$car) { id kilometers } }",
+        "MyCarInsertMutation",
+    ).unwrap();
+    let operation = executable_mutation.operations.get(Some("MyCarInsertMutation")).unwrap();
+
+    let kilometers_value = 3000;
+
+    // Provide an integer for a Float field
+    let input_variables = serde_json_bytes::json!({ "car": { "kilometers": kilometers_value } });
+    let map = match input_variables {
+        serde_json_bytes::Value::Object(m) => m,
+        _ => unreachable!(),
+    };
+
+    // Coerce and validate.
+    let coerced = coerce_variable_values(&parsed_schema, operation, &map).unwrap();
+    let vars_for_exec = coerced.into_inner();
+
+    // ---- Assertions ----
+    let car = vars_for_exec
+        .get("car")
+        .and_then(|value| value.as_object())
+        .expect("coerced `car` object");
+    assert_eq!(car.get("kilometers").unwrap(), kilometers_value, "kilometers should be present and a valid amount.");
+}


### PR DESCRIPTION
This PR fixes the behaviour of `Float` input values in the `apollo-compiler` crate in `apollo_compiler::request::coerce_variable_values` to align with the [GraphQL specification](https://spec.graphql.org/September2025/#sec-Float.Input-Coercion).

The GraphQL specifications defines the input coercion like this:

> When expected as an input type, both integer and float input values are accepted. Integer input values are coerced to Float by adding an empty fractional part, for example `1.0` for the integer input value `1`.

The issue this PR solves is, that `coerce_variable_values` incorrectly rejects JSON numbers without fractional parts (e.g. 42) when the corresponding input variable type was `Float`.

The changes include accepting any JSON number (int or float) that can be converted to an `f64` for `Float` inputs as well as a small unit test `test_graphql_float_variable_coercion` showing the behaviour.

Big thanks to my colleague [David](https://github.com/DavidDiffusion), who identified where the changes needed to be applied and also reviewed the code updates. Much appreciated! 🙌