### PR TITLE
fix(smith): Return arbitrary::Error::IncorrectFormat for unsupported floats

### DIFF
--- a/crates/apollo-smith/src/response.rs
+++ b/crates/apollo-smith/src/response.rs
@@ -169,7 +169,10 @@ impl<'a, 'doc, 'schema> ResponseBuilder<'a, 'doc, 'schema> {
                     Ok(Value::Number(random_int.into()))
                 } else if scalar.name == "Float" {
                     let random_float = self.u.arbitrary::<f64>()?;
-                    Ok(Value::Number(Number::from_f64(random_float).unwrap()))
+                    let Some(random_number) = Number::from_f64(random_float) else {
+                        return Err(arbitrary::Error::IncorrectFormat);
+                    };
+                    Ok(Value::Number(random_number))
                 } else if scalar.name == "String" {
                     let random_string = self.u.arbitrary::<String>()?;
                     Ok(Value::String(random_string.into()))


### PR DESCRIPTION
When generating floats for GraphQL documents, we were naively unwrapping the conversion from `f64` to `serde_json::Number`. This would panic when `arbitrary` returned `f64::INFINITY` of `f64::NAN` because the `Number` conversion only works when its input is finite. In this case, the underlying bytes used to generate the value are considered to be in an invalid format. So, we return `arbitrary::Error::IncorrectFormat` to tell fuzzers to use a different seed in the future.