### PR TITLE
fix(smith): bump minimum `arbitrary` version

### DIFF
--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -24,7 +24,7 @@ categories = [
 [dependencies]
 apollo-compiler = { path = "../apollo-compiler", version = "1.25.0" }
 apollo-parser = { path = "../apollo-parser", version = "0.8.0" }
-arbitrary = { version = "1.3.0", features = ["derive"] }
+arbitrary = { version = "1.4.0", features = ["derive"] }
 indexmap = "2.0.0"
 once_cell = "1.9.0"
 serde_json_bytes = "0.2.5"


### PR DESCRIPTION
apollo-smith uses the `.choose_iter()` method, which was introduced in arbitrary v1.4.0. If used in a project that already depends on an older version of arbitrary, you could have problems.

I ran into this when I pulled the latest changes into a very old clone of the repo and ran tests: I still had 1.3.0 installed so compilation failed.