### PR TITLE
Add `definition_origin` field to type definitions

### DIFF
--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -43,6 +43,7 @@ impl SchemaBuilder {
                         query: None,
                         mutation: None,
                         subscription: None,
+                        definition_origin: None,
                     }),
                     directive_definitions: IndexMap::with_hasher(Default::default()),
                     types: IndexMap::with_hasher(Default::default()),
@@ -404,6 +405,7 @@ fn adopt_type_extensions(
             description: Default::default(),
             name,
             directives: Default::default(),
+            definition_origin: None,
         }
         ast::Definition::ObjectTypeExtension => "an object type" ObjectType {
             description: Default::default(),
@@ -411,6 +413,7 @@ fn adopt_type_extensions(
             implements_interfaces: Default::default(),
             directives: Default::default(),
             fields: Default::default(),
+            definition_origin: None,
         }
         ast::Definition::InterfaceTypeExtension => "an interface type" InterfaceType {
             description: Default::default(),
@@ -418,24 +421,28 @@ fn adopt_type_extensions(
             implements_interfaces: Default::default(),
             directives: Default::default(),
             fields: Default::default(),
+            definition_origin: None,
         }
         ast::Definition::UnionTypeExtension => "a union type" UnionType {
             description: Default::default(),
             name,
             directives: Default::default(),
             members: Default::default(),
+            definition_origin: None,
         }
         ast::Definition::EnumTypeExtension => "an enum type" EnumType {
             description: Default::default(),
             name,
             directives: Default::default(),
             values: Default::default(),
+            definition_origin: None,
         }
         ast::Definition::InputObjectTypeExtension => "an input object type" InputObjectType {
             description: Default::default(),
             name,
             directives: Default::default(),
             fields: Default::default(),
+            definition_origin: None,
         }
     }
 }
@@ -456,6 +463,7 @@ impl SchemaDefinition {
             query: None,
             mutation: None,
             subscription: None,
+            definition_origin: Some(ComponentOrigin::Definition),
         };
         root.add_root_operations(
             errors,
@@ -520,6 +528,7 @@ impl ScalarType {
                 .iter()
                 .map(|d| d.to_component(ComponentOrigin::Definition))
                 .collect(),
+            definition_origin: Some(ComponentOrigin::Definition),
         };
         for def in &extensions {
             if let ast::Definition::ScalarTypeExtension(ext) = def {
@@ -588,6 +597,7 @@ impl ObjectType {
                     )
                 },
             ),
+            definition_origin: Some(ComponentOrigin::Definition),
         };
         for def in &extensions {
             if let ast::Definition::ObjectTypeExtension(ext) = def {
@@ -688,6 +698,7 @@ impl InterfaceType {
                     )
                 },
             ),
+            definition_origin: Some(ComponentOrigin::Definition),
         };
         for def in &extensions {
             if let ast::Definition::InterfaceTypeExtension(ext) = def {
@@ -773,6 +784,7 @@ impl UnionType {
                     )
                 },
             ),
+            definition_origin: Some(ComponentOrigin::Definition),
         };
         for def in &extensions {
             if let ast::Definition::UnionTypeExtension(ext) = def {
@@ -844,6 +856,7 @@ impl EnumType {
                     )
                 },
             ),
+            definition_origin: Some(ComponentOrigin::Definition),
         };
         for def in &extensions {
             if let ast::Definition::EnumTypeExtension(ext) = def {
@@ -913,6 +926,7 @@ impl InputObjectType {
                     )
                 },
             ),
+            definition_origin: Some(ComponentOrigin::Definition),
         };
         for def in &extensions {
             if let ast::Definition::InputObjectTypeExtension(ext) = def {

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -142,6 +142,10 @@ pub struct SchemaDefinition {
 
     /// Name of the object type for the `subscription` root operation
     pub subscription: Option<ComponentName>,
+
+    /// Non-extension definition origin, if exists.
+    /// - We hold the origin here, so its reference can be returned from `iter_origins()`.
+    pub definition_origin: Option<ComponentOrigin>,
 }
 
 /// The list of [_Directives_](https://spec.graphql.org/draft/#Directives)
@@ -176,6 +180,9 @@ pub struct ScalarType {
     pub description: Option<Node<str>>,
     pub name: Name,
     pub directives: DirectiveList,
+    /// Non-extension definition origin, if exists.
+    /// - We hold the origin here, so its reference can be returned from `iter_origins()`.
+    pub definition_origin: Option<ComponentOrigin>,
 }
 
 /// The definition of an [object type](https://spec.graphql.org/draft/#sec-Objects),
@@ -192,6 +199,9 @@ pub struct ObjectType {
     /// When looking up a definition,
     /// consider using [`Schema::type_field`] instead to include meta-fields.
     pub fields: IndexMap<Name, Component<FieldDefinition>>,
+    /// Non-extension definition origin, if exists.
+    /// - We hold the origin here, so its reference can be returned from `iter_origins()`.
+    pub definition_origin: Option<ComponentOrigin>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -207,6 +217,9 @@ pub struct InterfaceType {
     /// When looking up a definition,
     /// consider using [`Schema::type_field`] instead to include meta-fields.
     pub fields: IndexMap<Name, Component<FieldDefinition>>,
+    /// Non-extension definition origin, if exists.
+    /// - We hold the origin here, so its reference can be returned from `iter_origins()`.
+    pub definition_origin: Option<ComponentOrigin>,
 }
 
 /// The definition of an [union type](https://spec.graphql.org/draft/#sec-Unions),
@@ -221,6 +234,9 @@ pub struct UnionType {
     /// * Value: which union type extension defined this implementation,
     ///   or `None` for the union type definition.
     pub members: IndexSet<ComponentName>,
+    /// Non-extension definition origin, if exists.
+    /// - We hold the origin here, so its reference can be returned from `iter_origins()`.
+    pub definition_origin: Option<ComponentOrigin>,
 }
 
 /// The definition of an [enum type](https://spec.graphql.org/draft/#sec-Enums),
@@ -231,6 +247,9 @@ pub struct EnumType {
     pub name: Name,
     pub directives: DirectiveList,
     pub values: IndexMap<Name, Component<EnumValueDefinition>>,
+    /// Non-extension definition origin, if exists.
+    /// - We hold the origin here, so its reference can be returned from `iter_origins()`.
+    pub definition_origin: Option<ComponentOrigin>,
 }
 
 /// The definition of an [input object type](https://spec.graphql.org/draft/#sec-Input-Objects),
@@ -241,6 +260,9 @@ pub struct InputObjectType {
     pub name: Name,
     pub directives: DirectiveList,
     pub fields: IndexMap<Name, Component<InputValueDefinition>>,
+    /// Non-extension definition origin, if exists.
+    /// - We hold the origin here, so its reference can be returned from `iter_origins()`.
+    pub definition_origin: Option<ComponentOrigin>,
 }
 
 /// The names of all types that implement a given interface.
@@ -669,6 +691,7 @@ impl SchemaDefinition {
             .chain(self.query.iter().map(|name| &name.origin))
             .chain(self.mutation.iter().map(|name| &name.origin))
             .chain(self.subscription.iter().map(|name| &name.origin))
+            .chain(self.definition_origin.iter())
     }
 
     /// Collect `schema` extensions that contribute any component
@@ -888,7 +911,10 @@ impl ScalarType {
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
-        self.directives.iter().map(|dir| &dir.origin)
+        self.directives
+            .iter()
+            .map(|dir| &dir.origin)
+            .chain(self.definition_origin.iter())
     }
 
     /// Collect scalar type extensions that contribute any component
@@ -919,6 +945,7 @@ impl ObjectType {
                     .map(|component| &component.origin),
             )
             .chain(self.fields.values().map(|field| &field.origin))
+            .chain(self.definition_origin.iter())
     }
 
     /// Collect object type extensions that contribute any component
@@ -949,6 +976,7 @@ impl InterfaceType {
                     .map(|component| &component.origin),
             )
             .chain(self.fields.values().map(|field| &field.origin))
+            .chain(self.definition_origin.iter())
     }
 
     /// Collect interface type extensions that contribute any component
@@ -974,6 +1002,7 @@ impl UnionType {
             .iter()
             .map(|dir| &dir.origin)
             .chain(self.members.iter().map(|component| &component.origin))
+            .chain(self.definition_origin.iter())
     }
 
     /// Collect union type extensions that contribute any component
@@ -999,6 +1028,7 @@ impl EnumType {
             .iter()
             .map(|dir| &dir.origin)
             .chain(self.values.values().map(|value| &value.origin))
+            .chain(self.definition_origin.iter())
     }
 
     /// Collect enum type extensions that contribute any component
@@ -1024,6 +1054,7 @@ impl InputObjectType {
             .iter()
             .map(|dir| &dir.origin)
             .chain(self.fields.values().map(|field| &field.origin))
+            .chain(self.definition_origin.iter())
     }
 
     /// Collect input object type extensions that contribute any component

--- a/crates/apollo-compiler/src/schema/serialize.rs
+++ b/crates/apollo-compiler/src/schema/serialize.rs
@@ -42,6 +42,7 @@ impl Node<SchemaDefinition> {
             query,
             mutation,
             subscription,
+            definition_origin: _,
         } = &**self;
         let extensions = self.extensions();
         let root_ops = |ext: Option<&ExtensionId>| -> Vec<Node<(OperationType, Name)>> {

--- a/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -58,6 +59,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Pet": Object(
@@ -80,6 +84,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -58,6 +59,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Pet": Object(
@@ -92,6 +96,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "PetOwner": Object(
@@ -114,6 +121,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
@@ -30,6 +30,9 @@ Schema {
                 name: "customPetSubscription",
             },
         ),
+        definition_origin: Some(
+            Definition,
+        ),
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -72,6 +75,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "customPetQuery": Object(
@@ -106,6 +112,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "customPetSubscription": Object(
@@ -128,6 +137,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "customPetMutation": Object(
@@ -169,6 +181,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Result": Object(
@@ -191,6 +206,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
+++ b/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -71,6 +72,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "URL": Scalar(
@@ -93,6 +97,9 @@ Schema {
                         },
                     },
                 ],
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -70,6 +71,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Pet": Enum(
@@ -103,6 +107,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Snack": Enum(
@@ -136,6 +143,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
@@ -20,6 +20,9 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: Some(
+            Definition,
+        ),
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -54,6 +57,9 @@ Schema {
                         name: "Person",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Person": Object(
@@ -88,6 +94,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Photo": Object(
@@ -122,6 +131,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "SearchQuery": Object(
@@ -144,6 +156,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -65,6 +66,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Node": Interface(
@@ -87,6 +91,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Resource": Interface(
@@ -138,6 +145,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Image": Interface(
@@ -205,6 +215,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -79,6 +80,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Book": Object(
@@ -130,6 +134,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -72,6 +73,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "URL": Scalar(
@@ -94,6 +98,9 @@ Schema {
                         },
                     },
                 ],
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Point2D": InputObject(
@@ -127,6 +134,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -102,6 +103,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Product": Object(
@@ -208,6 +212,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "join__Graph": Enum(
@@ -233,6 +240,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -59,6 +60,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Foo": Object(
@@ -81,6 +85,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Baz": Object(
@@ -103,6 +110,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
+++ b/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -59,6 +60,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -81,6 +82,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Review": Object(
@@ -103,6 +107,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Message": Object(
@@ -147,6 +154,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Product": Object(
@@ -191,6 +201,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0014_float_values.txt
+++ b/crates/apollo-compiler/test_data/ok/0014_float_values.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -69,6 +70,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "WithAllKindsOfFloats": InputObject(
@@ -154,6 +158,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
@@ -54,6 +54,9 @@ Schema {
             },
         ),
         subscription: None,
+        definition_origin: Some(
+            Definition,
+        ),
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -250,6 +253,9 @@ Schema {
                         name: "SMSAccount",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Amazon": Object(
@@ -272,6 +278,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Body": Union(
@@ -289,6 +298,9 @@ Schema {
                         name: "Text",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Book": Object(
@@ -769,6 +781,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Brand": Union(
@@ -786,6 +801,9 @@ Schema {
                         name: "Amazon",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Car": Object(
@@ -958,6 +976,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Error": Object(
@@ -992,6 +1013,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Furniture": Object(
@@ -1346,6 +1370,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Ikea": Object(
@@ -1368,6 +1395,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Image": Object(
@@ -1407,6 +1437,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "ImageAttributes": Object(
@@ -1429,6 +1462,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "join__FieldSet": Scalar(
@@ -1451,6 +1487,9 @@ Schema {
                         },
                     },
                 ],
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "join__Graph": Enum(
@@ -1616,6 +1655,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "KeyValue": Object(
@@ -1650,6 +1692,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Library": Object(
@@ -1807,6 +1852,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "MetadataOrError": Union(
@@ -1824,6 +1872,9 @@ Schema {
                         name: "Error",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Mutation": Object(
@@ -1988,6 +2039,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Name": Object(
@@ -2022,6 +2076,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "NamedObject": Interface(
@@ -2044,6 +2101,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "PasswordAccount": Object(
@@ -2113,6 +2173,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Product": Interface(
@@ -2209,6 +2272,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "ProductDetails": Interface(
@@ -2231,6 +2297,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "ProductDetailsBook": Object(
@@ -2270,6 +2339,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "ProductDetailsFurniture": Object(
@@ -2309,6 +2381,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -2683,6 +2758,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Review": Object(
@@ -2870,6 +2948,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "SMSAccount": Object(
@@ -2939,6 +3020,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Text": Object(
@@ -2978,6 +3062,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "TextAttributes": Object(
@@ -3012,6 +3099,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Thing": Union(
@@ -3029,6 +3119,9 @@ Schema {
                         name: "Ikea",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "UpdateReviewInput": InputObject(
@@ -3062,6 +3155,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "User": Object(
@@ -3501,6 +3597,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "UserMetadata": Object(
@@ -3547,6 +3646,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Van": Object(
@@ -3719,6 +3821,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Vehicle": Interface(
@@ -3777,6 +3882,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
+++ b/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -59,6 +60,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Dog": Object(
@@ -127,6 +131,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -105,6 +106,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "ComplexInput": InputObject(
@@ -138,6 +142,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -206,6 +213,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
+++ b/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -76,6 +77,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -98,6 +102,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0019_extensions.txt
+++ b/crates/apollo-compiler/test_data/ok/0019_extensions.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -65,6 +66,9 @@ Schema {
                         },
                     },
                 ],
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Object": Object(
@@ -110,6 +114,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Intf": Interface(
@@ -150,6 +157,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Input": InputObject(
@@ -189,6 +199,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Enum": Enum(
@@ -220,6 +233,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -242,6 +258,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -58,6 +59,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Dog": Object(
@@ -92,6 +96,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
+++ b/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -61,6 +62,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Dog": Object(
@@ -93,6 +97,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -115,6 +122,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
+++ b/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -59,6 +60,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "DogCommand": Enum(
@@ -84,6 +88,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "CatCommand": Enum(
@@ -101,6 +108,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -123,6 +133,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Dog": Object(
@@ -227,6 +240,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Cat": Object(
@@ -288,6 +304,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -93,6 +94,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -77,6 +78,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
+++ b/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -82,6 +83,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Date": Scalar(
@@ -104,6 +108,9 @@ Schema {
                         },
                     },
                 ],
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -82,6 +83,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Date": Scalar(
@@ -104,6 +108,9 @@ Schema {
                         },
                     },
                 ],
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -54,6 +55,9 @@ Schema {
                         name: "Person",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Person": Object(
@@ -88,6 +92,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Photo": Object(
@@ -122,6 +129,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -144,6 +154,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
+++ b/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -73,6 +74,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Opts": InputObject(
@@ -98,6 +102,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -132,6 +139,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
+++ b/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -81,6 +82,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "First": InputObject(
@@ -114,6 +118,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Second": InputObject(
@@ -149,6 +156,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Third": InputObject(
@@ -182,6 +192,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Fourth": InputObject(
@@ -203,6 +216,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
+++ b/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -60,6 +61,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Dog": Object(
@@ -99,6 +103,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Cat": Object(
@@ -138,6 +145,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "CatOrDog": Union(
@@ -155,6 +165,9 @@ Schema {
                         name: "Dog",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Human": Object(
@@ -179,6 +192,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "DogOrHuman": Union(
@@ -196,6 +212,9 @@ Schema {
                         name: "Human",
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Node": Interface(
@@ -218,6 +237,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Resource": Interface(
@@ -257,6 +279,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "ConcreteResource": Object(
@@ -300,6 +325,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -334,6 +362,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0032_valid_of_correct_type.txt
+++ b/crates/apollo-compiler/test_data/ok/0032_valid_of_correct_type.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -448,6 +449,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Custom": Scalar(
@@ -470,6 +474,9 @@ Schema {
                         },
                     },
                 ],
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "FurColor": Enum(
@@ -527,6 +534,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "ComplexInput": InputObject(
@@ -614,6 +624,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "DogCommand": Enum(
@@ -647,6 +660,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Dog": Object(
@@ -727,6 +743,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Pet": Interface(
@@ -759,6 +778,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -815,6 +837,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Human": Object(
@@ -875,6 +900,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
+++ b/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -59,6 +60,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Arguments": Object(
@@ -141,6 +145,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
+++ b/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
@@ -35,6 +35,9 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: Some(
+            Definition,
+        ),
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -100,6 +103,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0035_implicit_schema_definition_with_query_type.txt
+++ b/crates/apollo-compiler/test_data/ok/0035_implicit_schema_definition_with_query_type.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -58,6 +59,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0036_implicit_schema_definition_with_several_default_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0036_implicit_schema_definition_with_several_default_types.txt
@@ -25,6 +25,7 @@ Schema {
             },
         ),
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -63,6 +64,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Mutation": Object(
@@ -95,6 +99,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Result": Object(
@@ -117,6 +124,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
@@ -34,6 +34,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -81,6 +82,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
+++ b/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -106,6 +107,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0039_string_literals.txt
+++ b/crates/apollo-compiler/test_data/ok/0039_string_literals.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -349,6 +350,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0040_field_merging_issue_755.txt
+++ b/crates/apollo-compiler/test_data/ok/0040_field_merging_issue_755.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -59,6 +60,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Issue": Object(
@@ -95,6 +99,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -117,6 +124,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0041_unquoted_string_for_custom_scalar.txt
+++ b/crates/apollo-compiler/test_data/ok/0041_unquoted_string_for_custom_scalar.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -44,6 +45,9 @@ Schema {
                 description: None,
                 name: "Currency",
                 directives: [],
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -85,6 +89,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0042_used_variable_in_operation_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0042_used_variable_in_operation_directive.txt
@@ -30,6 +30,7 @@ Schema {
                 name: "Subscription",
             },
         ),
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -109,6 +110,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Mutation": Object(
@@ -131,6 +135,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Subscription": Object(
@@ -153,6 +160,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.txt
+++ b/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -58,6 +59,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Node": Interface(
@@ -86,6 +90,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0116_interface_without_implementations.txt
+++ b/crates/apollo-compiler/test_data/ok/0116_interface_without_implementations.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -59,6 +60,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Intf": Interface(
@@ -81,6 +85,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0117_subscription_conditions_not_at_root.txt
+++ b/crates/apollo-compiler/test_data/ok/0117_subscription_conditions_not_at_root.txt
@@ -25,6 +25,7 @@ Schema {
                 name: "Subscription",
             },
         ),
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -63,6 +64,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Message": Object(
@@ -109,6 +113,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Subscription": Object(
@@ -131,6 +138,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0118_directive_with_nested_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0118_directive_with_nested_input_types.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -89,6 +90,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -146,6 +150,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/test_data/ok/0119_directive_with_argument_type_collisions.txt
+++ b/crates/apollo-compiler/test_data/ok/0119_directive_with_argument_type_collisions.txt
@@ -20,6 +20,7 @@ Schema {
         ),
         mutation: None,
         subscription: None,
+        definition_origin: None,
     },
     directive_definitions: {
         "skip": built_in_directive!("skip"),
@@ -89,6 +90,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
         "Query": Object(
@@ -146,6 +150,9 @@ Schema {
                         },
                     },
                 },
+                definition_origin: Some(
+                    Definition,
+                ),
             },
         ),
     },

--- a/crates/apollo-compiler/tests/snapshot_tests.rs
+++ b/crates/apollo-compiler/tests/snapshot_tests.rs
@@ -252,6 +252,7 @@ fn test_invalid_synthetic_node() {
             )]
             .into_iter()
             .collect(),
+            definition_origin: Default::default(),
         }
         .into(),
     );


### PR DESCRIPTION
<!-- [FED-772] -->

## Motivation

This PR fixes an issue where `iter_origins()` methods fail to return the `Definition` origin, even if the element has a (non-extension) definition. This can happen with schema definition and most type definitions.

#### Example

```graphql
            type T # empty type definition

            extend type T { # an extension with a field
                field: Boolean
            }
```

`iter_origin()` method on the type `T` only returns an `Extension`, not `Definition`. That's because `type T` does not have fields nor directive applications and the current implementation does not record origins at all in this case.

## Fix

This PR adds `definition_origin` field to `SchemaDefinition` and other type definition structs like `Scalar` and `ObjectType`. The `definition_origin` field is expected to have `Some((ComponentOrigin::Definition)` value if a schema element has a non-extension definition. Otherwise, it is expected to have `None` value.

The field actually hold a `ComponentOrigin` value, instead of being `bool` type, because `iter_origins()` method is expected to return a reference to a `ComponentOrigin` value and the field allows the method to return a reference to an object held by `self`.

Note: Unfortunately, this PR would be a breaking change.

Downstream fix PR: https://github.com/apollographql/router/pull/8475

[FED-772]: https://apollographql.atlassian.net/browse/FED-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ