### PR TITLE
Add `iter_orphan_extension_types` method on `SchemaBuilder`

### DIFF
--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -268,6 +268,10 @@ impl SchemaBuilder {
         }
     }
 
+    pub fn iter_orphan_extension_types(&self) -> impl Iterator<Item = &Name> {
+        self.orphan_type_extensions.keys()
+    }
+
     /// Returns the schema built from all added documents
     #[allow(clippy::result_large_err)] // Typically not called very often
     pub fn build(self) -> Result<Schema, WithErrors<Schema>> {


### PR DESCRIPTION
This PR adds a public method on `SchemaBuilder` that exports the names of orphan extension types.

This is an alternative solution to https://github.com/apollographql/apollo-rs/pull/1009 without breaking the API.