### PR TITLE
chore(compiler): add test for report formatting with multibyte UTF-8 characters

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -63,9 +63,6 @@ harness = false
 [[test]]
 name = "main"
 
-[[test]]
-name = "multibyte_characters"
-
 # These need to run in a process where no other test runs concurrently
 [[test]]
 name = "snapshot_tests"

--- a/crates/apollo-compiler/tests/error_formatting.rs
+++ b/crates/apollo-compiler/tests/error_formatting.rs
@@ -1,6 +1,12 @@
-//! Tests for handling multibyte UTF-8 characters in GraphQL schemas and documents.
-//! This ensures the ariadne error reporting library correctly handles Japanese, Chinese,
-//! Korean, and other multibyte characters without panicking.
+//! Regression tests for ariadne error formatting with multibyte UTF-8 characters.
+//!
+//! These tests ensure that the ariadne error reporting library correctly formats
+//! errors when multibyte characters (Japanese, Chinese, Korean, emoji, etc.) are
+//! present in the source code, without panicking or producing garbled output.
+//!
+//! Note: Correctness of parsing multibyte characters is tested in the lexer,
+//! parser, and compiler test suites. These tests specifically focus on error
+//! formatting and display.
 
 use apollo_compiler::parser::Parser;
 

--- a/crates/apollo-compiler/tests/main.rs
+++ b/crates/apollo-compiler/tests/main.rs
@@ -1,3 +1,4 @@
+mod error_formatting;
 mod executable;
 mod extensions;
 mod field_set;


### PR DESCRIPTION
<!-- https://apollographql.atlassian.net/browse/AIR-67 -->

https://github.com/apollographql/apollo-mcp-server/issues/480 reported that Apollo MCP Server panics when handling GraphQL schemas containing multibyte characters (Japanese, Chinese, Korean, etc.) in field names or descriptions.

The root cause was in the `ariadne` library version 0.5.1, which did not properly handle UTF-8 character boundaries when slicing strings for error message formatting. This caused panics like:

```
thread 'tokio-runtime-worker' panicked at ariadne-0.5.1/src/write.rs:254:40:
byte index 8 is not a char boundary; it is inside '為' (bytes 6..9) of `月次為替`
```

This PR upgrades the `ariadne` dependency from version 0.5.1 to version 0.6.0, which includes fixes for UTF-8 character boundary handling. This fix will resolve the panic issue in apollo-mcp-server and any other downstream projects using apollo-rs for GraphQL schema validation with multibyte characters.


## Testing

The upgrade to ariadne 0.6.0 changed the ordering of error labels in diagnostic messages. Updated test expectations for:

- Field merging validation tests
- Interface and object type validation snapshot tests
- Various diagnostic output tests (23 snapshot files updated)

All changes are cosmetic (label ordering) and do not affect the correctness of error messages. 
Also added new test suite to validates that schemas with Japanese (日本語), Chinese (中文), Korean (한글), and emoji (🚀) characters

To verify the fix works with real-world multibyte characters:

```bash
cargo run --example validate <<EOF
"""
月次為替レート (Monthly Exchange Rate)
用户名 (User Name)
안녕하세요 (Hello)
"""
type Query {
  field: UndefinedType
}
EOF
```

This now produces a proper error message without panicking:

```
Error: cannot find type `UndefinedType` in this document
   ╭─[ stdin.graphql:7:9 ]
   │
 7 │   field: UndefinedType
   │          ──────┬──────  
   │                ╰──────── not found in this scope
───╯
```