### PR TITLE
feat(compiler): add CustomScalarCoercer trait for custom scalar validation and coercion

### DIFF
--- a/crates/apollo-compiler/src/resolvers/input_coercion.rs
+++ b/crates/apollo-compiler/src/resolvers/input_coercion.rs
@@ -152,12 +152,12 @@ fn coerce_variable_value(
             _ => {
                 // Custom scalar: delegate to registered coercer, or accept as-is.
                 if let Some(coercer) = schema.get_custom_scalar_coercer(ty_name.as_str()) {
-                    return coercer
-                        .coerce_variable_value(value)
-                        .map_err(|message| InputCoercionError::ValueError {
+                    return coercer.coerce_variable_value(value).map_err(|message| {
+                        InputCoercionError::ValueError {
                             message,
                             location: None,
-                        });
+                        }
+                    });
                 }
                 return Ok(value.clone());
             }

--- a/crates/apollo-compiler/src/resolvers/input_coercion.rs
+++ b/crates/apollo-compiler/src/resolvers/input_coercion.rs
@@ -150,8 +150,15 @@ fn coerce_variable_value(
                 }
             }
             _ => {
-                // Custom scalar
-                // TODO: have a hook for coercion of custom scalars?
+                // Custom scalar: delegate to registered coercer, or accept as-is.
+                if let Some(coercer) = schema.get_custom_scalar_coercer(ty_name.as_str()) {
+                    return coercer
+                        .coerce_variable_value(value)
+                        .map_err(|message| InputCoercionError::ValueError {
+                            message,
+                            location: None,
+                        });
+                }
                 return Ok(value.clone());
             }
         },
@@ -490,6 +497,7 @@ impl InputCoercionError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::CustomScalarCoercer;
     use crate::validation::Valid;
     use crate::ExecutableDocument;
     use crate::Schema;
@@ -596,5 +604,96 @@ mod tests {
             variables.as_object().unwrap(),
         )
         .unwrap_err();
+    }
+
+    /// A coercer that only accepts string values for a DateTime scalar.
+    struct DateTimeCoercer;
+
+    impl CustomScalarCoercer for DateTimeCoercer {
+        fn coerce_variable_value(&self, value: &JsonValue) -> Result<JsonValue, String> {
+            match value.as_str() {
+                Some(_) => Ok(value.clone()),
+                None => Err("DateTime must be a string in ISO 8601 format".to_string()),
+            }
+        }
+    }
+
+    fn schema_and_doc_with_custom_scalar(
+        coercer: impl CustomScalarCoercer + 'static,
+    ) -> (Valid<Schema>, Valid<ExecutableDocument>) {
+        let mut schema = Schema::parse(
+            r#"
+                scalar DateTime
+                type Query {
+                    event(at: DateTime!): String
+                }
+            "#,
+            "sdl",
+        )
+        .unwrap();
+        schema.add_custom_scalar_coercer("DateTime", coercer);
+        let schema = schema.validate().unwrap();
+        let doc = ExecutableDocument::parse_and_validate(
+            &schema,
+            "query ($at: DateTime!) { event(at: $at) }",
+            "op.graphql",
+        )
+        .unwrap();
+        (schema, doc)
+    }
+
+    #[test]
+    fn custom_scalar_coercer_accepts_valid_value() {
+        let (schema, doc) = schema_and_doc_with_custom_scalar(DateTimeCoercer);
+        let variables = serde_json_bytes::json!({ "at": "2024-01-15T10:30:00Z" });
+
+        let result = coerce_variable_values(
+            &schema,
+            doc.operations.anonymous.as_ref().unwrap(),
+            variables.as_object().unwrap(),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn custom_scalar_coercer_rejects_invalid_value() {
+        let (schema, doc) = schema_and_doc_with_custom_scalar(DateTimeCoercer);
+        let variables = serde_json_bytes::json!({ "at": 12345 });
+
+        let result = coerce_variable_values(
+            &schema,
+            doc.operations.anonymous.as_ref().unwrap(),
+            variables.as_object().unwrap(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn custom_scalar_without_coercer_accepts_any_value() {
+        // No coercer registered — should accept any value (default behavior).
+        let schema = Schema::parse_and_validate(
+            r#"
+                scalar DateTime
+                type Query {
+                    event(at: DateTime!): String
+                }
+            "#,
+            "sdl",
+        )
+        .unwrap();
+        let doc = ExecutableDocument::parse_and_validate(
+            &schema,
+            "query ($at: DateTime!) { event(at: $at) }",
+            "op.graphql",
+        )
+        .unwrap();
+        let variables = serde_json_bytes::json!({ "at": 12345 });
+
+        let result = coerce_variable_values(
+            &schema,
+            doc.operations.anonymous.as_ref().unwrap(),
+            variables.as_object().unwrap(),
+        );
+        assert!(result.is_ok());
     }
 }

--- a/crates/apollo-compiler/src/resolvers/input_coercion.rs
+++ b/crates/apollo-compiler/src/resolvers/input_coercion.rs
@@ -151,13 +151,13 @@ fn coerce_variable_value(
             }
             _ => {
                 // Custom scalar: delegate to registered coercer, or accept as-is.
-                if let Some(coercer) = schema.get_custom_scalar_coercer(ty_name.as_str()) {
-                    return coercer.coerce_variable_value(value).map_err(|message| {
-                        InputCoercionError::ValueError {
+                if let Some(coercer) = schema.custom_scalar_coercer() {
+                    return coercer
+                        .coerce_variable_value(ty_name.as_str(), value)
+                        .map_err(|message| InputCoercionError::ValueError {
                             message,
                             location: None,
-                        }
-                    });
+                        });
                 }
                 return Ok(value.clone());
             }
@@ -606,14 +606,21 @@ mod tests {
         .unwrap_err();
     }
 
-    /// A coercer that only accepts string values for a DateTime scalar.
-    struct DateTimeCoercer;
+    /// A blanket coercer that only accepts string values for DateTime scalars.
+    struct MyCoercer;
 
-    impl CustomScalarCoercer for DateTimeCoercer {
-        fn coerce_variable_value(&self, value: &JsonValue) -> Result<JsonValue, String> {
-            match value.as_str() {
-                Some(_) => Ok(value.clone()),
-                None => Err("DateTime must be a string in ISO 8601 format".to_string()),
+    impl CustomScalarCoercer for MyCoercer {
+        fn coerce_variable_value(
+            &self,
+            scalar_name: &str,
+            value: &JsonValue,
+        ) -> Result<JsonValue, String> {
+            match scalar_name {
+                "DateTime" => match value.as_str() {
+                    Some(_) => Ok(value.clone()),
+                    None => Err("DateTime must be a string in ISO 8601 format".to_string()),
+                },
+                _ => Ok(value.clone()),
             }
         }
     }
@@ -631,7 +638,7 @@ mod tests {
             "sdl",
         )
         .unwrap();
-        schema.add_custom_scalar_coercer("DateTime", coercer);
+        schema.set_custom_scalar_coercer(coercer);
         let schema = schema.validate().unwrap();
         let doc = ExecutableDocument::parse_and_validate(
             &schema,
@@ -644,7 +651,7 @@ mod tests {
 
     #[test]
     fn custom_scalar_coercer_accepts_valid_value() {
-        let (schema, doc) = schema_and_doc_with_custom_scalar(DateTimeCoercer);
+        let (schema, doc) = schema_and_doc_with_custom_scalar(MyCoercer);
         let variables = serde_json_bytes::json!({ "at": "2024-01-15T10:30:00Z" });
 
         let result = coerce_variable_values(
@@ -657,7 +664,7 @@ mod tests {
 
     #[test]
     fn custom_scalar_coercer_rejects_invalid_value() {
-        let (schema, doc) = schema_and_doc_with_custom_scalar(DateTimeCoercer);
+        let (schema, doc) = schema_and_doc_with_custom_scalar(MyCoercer);
         let variables = serde_json_bytes::json!({ "at": 12345 });
 
         let result = coerce_variable_values(

--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -46,6 +46,7 @@ impl SchemaBuilder {
                     }),
                     directive_definitions: IndexMap::with_hasher(Default::default()),
                     types: IndexMap::with_hasher(Default::default()),
+                    custom_scalar_coercers: Default::default(),
                 },
                 schema_definition: SchemaDefinitionStatus::NoneSoFar {
                     orphan_extensions: Vec::new(),

--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -46,7 +46,7 @@ impl SchemaBuilder {
                     }),
                     directive_definitions: IndexMap::with_hasher(Default::default()),
                     types: IndexMap::with_hasher(Default::default()),
-                    custom_scalar_coercers: Default::default(),
+                    custom_scalar_coercer: None,
                 },
                 schema_definition: SchemaDefinitionStatus::NoneSoFar {
                     orphan_extensions: Vec::new(),

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -73,11 +73,11 @@ use crate::response::JsonValue;
 use crate::ty;
 use crate::validation::DiagnosticList;
 use crate::validation::Valid;
-use std::sync::Arc;
 use crate::validation::WithErrors;
 pub use crate::Name;
 use crate::Node;
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 mod component;

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -69,9 +69,11 @@ use crate::name;
 use crate::parser::FileId;
 use crate::parser::Parser;
 use crate::parser::SourceSpan;
+use crate::response::JsonValue;
 use crate::ty;
 use crate::validation::DiagnosticList;
 use crate::validation::Valid;
+use std::sync::Arc;
 use crate::validation::WithErrors;
 pub use crate::Name;
 use crate::Node;
@@ -97,6 +99,58 @@ pub use crate::ast::InputValueDefinition;
 pub use crate::ast::NamedType;
 pub use crate::ast::Type;
 pub use crate::ast::Value;
+
+/// Trait for coercing and validating values of custom scalar types.
+///
+/// Implement this trait to define how a custom scalar type should validate and coerce
+/// its input values. Register implementations using [`Schema::add_custom_scalar_coercer`].
+///
+/// # Examples
+///
+/// ```rust
+/// use apollo_compiler::schema::CustomScalarCoercer;
+/// use apollo_compiler::ast::Value;
+/// use apollo_compiler::response::JsonValue;
+///
+/// struct DateTimeCoercer;
+///
+/// impl CustomScalarCoercer for DateTimeCoercer {
+///     fn coerce_variable_value(&self, value: &JsonValue) -> Result<JsonValue, String> {
+///         match value.as_str() {
+///             Some(s) if s.len() >= 10 => Ok(value.clone()),
+///             _ => Err("DateTime must be a string in ISO 8601 format".to_string()),
+///         }
+///     }
+///
+///     fn validate_ast_value(&self, value: &Value) -> bool {
+///         matches!(value, Value::String(_))
+///     }
+/// }
+/// ```
+pub trait CustomScalarCoercer: Send + Sync {
+    /// Coerce a JSON variable value for this custom scalar type.
+    ///
+    /// Called during variable coercion when a variable of this scalar type is provided.
+    /// Return `Ok(value)` with the (possibly transformed) value if valid,
+    /// or `Err(message)` with an error message if the value cannot be coerced.
+    ///
+    /// The default implementation accepts any value as-is.
+    fn coerce_variable_value(&self, value: &JsonValue) -> Result<JsonValue, String> {
+        Ok(value.clone())
+    }
+
+    /// Validate an AST value literal for this custom scalar type.
+    ///
+    /// Called during schema and document validation when a literal value
+    /// (e.g., a default value) is provided for a field of this scalar type.
+    /// Return `true` if the value is acceptable, `false` otherwise.
+    ///
+    /// The default implementation accepts any value.
+    fn validate_ast_value(&self, value: &ast::Value) -> bool {
+        let _ = value;
+        true
+    }
+}
 
 /// High-level representation of a GraphQL type system document a.k.a. schema.
 #[derive(Clone)]
@@ -125,6 +179,11 @@ pub struct Schema {
     ///   built-in scalar definitions for scalars that are used in the schema.
     ///   We reflect in this Rust API the behavior of `__Schema.types` in GraphQL introspection.
     pub types: IndexMap<NamedType, ExtendedType>,
+
+    /// Registered custom scalar coercers, keyed by scalar type name.
+    ///
+    /// Use [`Schema::add_custom_scalar_coercer`] to register a coercer.
+    custom_scalar_coercers: HashMap<Name, Arc<dyn CustomScalarCoercer>>,
 }
 
 /// The [`schema` definition](https://spec.graphql.org/draft/#sec-Schema) and its extensions,
@@ -445,6 +504,53 @@ impl Schema {
         let mut errors = DiagnosticList::new(self.sources.clone());
         validation::validate_schema(&mut errors, &mut self);
         errors.into_valid_result(self)
+    }
+
+    /// Register a custom scalar coercer for the given scalar type name.
+    ///
+    /// The coercer will be used during validation and input coercion to validate
+    /// and transform values of this scalar type, instead of the default behavior
+    /// of accepting any value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use apollo_compiler::Schema;
+    /// use apollo_compiler::schema::CustomScalarCoercer;
+    /// use apollo_compiler::ast::Value;
+    /// use apollo_compiler::response::JsonValue;
+    ///
+    /// struct DateTimeCoercer;
+    /// impl CustomScalarCoercer for DateTimeCoercer {
+    ///     fn coerce_variable_value(&self, value: &JsonValue) -> Result<JsonValue, String> {
+    ///         match value.as_str() {
+    ///             Some(_) => Ok(value.clone()),
+    ///             None => Err("DateTime must be a string".to_string()),
+    ///         }
+    ///     }
+    ///     fn validate_ast_value(&self, value: &Value) -> bool {
+    ///         matches!(value, Value::String(_))
+    ///     }
+    /// }
+    ///
+    /// let mut schema = Schema::parse(
+    ///     "scalar DateTime\ntype Query { now: DateTime }",
+    ///     "schema.graphql",
+    /// ).unwrap();
+    /// schema.add_custom_scalar_coercer("DateTime", DateTimeCoercer);
+    /// ```
+    pub fn add_custom_scalar_coercer(
+        &mut self,
+        scalar_name: &str,
+        coercer: impl CustomScalarCoercer + 'static,
+    ) {
+        self.custom_scalar_coercers
+            .insert(Name::new_unchecked(scalar_name.into()), Arc::new(coercer));
+    }
+
+    /// Returns the custom scalar coercer registered for the given type name, if any.
+    pub fn get_custom_scalar_coercer(&self, name: &str) -> Option<&dyn CustomScalarCoercer> {
+        self.custom_scalar_coercers.get(name).map(|c| c.as_ref())
     }
 
     /// Returns the type with the given name, if it is a scalar type
@@ -1148,6 +1254,7 @@ impl PartialEq for Schema {
             schema_definition,
             directive_definitions,
             types,
+            custom_scalar_coercers: _, // not compared
         } = self;
         *schema_definition == other.schema_definition
             && *directive_definitions == other.directive_definitions
@@ -1243,6 +1350,7 @@ impl std::fmt::Debug for Schema {
             schema_definition,
             directive_definitions,
             types,
+            custom_scalar_coercers: _,
         } = self;
         f.debug_struct("Schema")
             .field("sources", sources)

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -102,8 +102,11 @@ pub use crate::ast::Value;
 
 /// Trait for coercing and validating values of custom scalar types.
 ///
-/// Implement this trait to define how a custom scalar type should validate and coerce
-/// its input values. Register implementations using [`Schema::add_custom_scalar_coercer`].
+/// A single implementation handles **all** custom scalars in a schema.
+/// The `scalar_name` parameter lets you dispatch to per-scalar logic using
+/// a `match` statement, a `HashMap`, or any other approach you prefer.
+///
+/// Register an implementation using [`Schema::set_custom_scalar_coercer`].
 ///
 /// # Examples
 ///
@@ -112,42 +115,59 @@ pub use crate::ast::Value;
 /// use apollo_compiler::ast::Value;
 /// use apollo_compiler::response::JsonValue;
 ///
-/// struct DateTimeCoercer;
+/// struct MyCoercer;
 ///
-/// impl CustomScalarCoercer for DateTimeCoercer {
-///     fn coerce_variable_value(&self, value: &JsonValue) -> Result<JsonValue, String> {
-///         match value.as_str() {
-///             Some(s) if s.len() >= 10 => Ok(value.clone()),
-///             _ => Err("DateTime must be a string in ISO 8601 format".to_string()),
+/// impl CustomScalarCoercer for MyCoercer {
+///     fn coerce_variable_value(
+///         &self,
+///         scalar_name: &str,
+///         value: &JsonValue,
+///     ) -> Result<JsonValue, String> {
+///         match scalar_name {
+///             "DateTime" => match value.as_str() {
+///                 Some(_) => Ok(value.clone()),
+///                 None => Err("DateTime must be a string in ISO 8601 format".to_string()),
+///             },
+///             _ => Ok(value.clone()),
 ///         }
 ///     }
 ///
-///     fn validate_ast_value(&self, value: &Value) -> bool {
-///         matches!(value, Value::String(_))
+///     fn validate_ast_value(&self, scalar_name: &str, value: &Value) -> bool {
+///         match scalar_name {
+///             "DateTime" => matches!(value, Value::String(_)),
+///             _ => true,
+///         }
 ///     }
 /// }
 /// ```
 pub trait CustomScalarCoercer: Send + Sync {
-    /// Coerce a JSON variable value for this custom scalar type.
+    /// Coerce a JSON variable value for a custom scalar type.
     ///
-    /// Called during variable coercion when a variable of this scalar type is provided.
+    /// Called during variable coercion when a variable of a custom scalar type is provided.
+    /// `scalar_name` is the name of the scalar type being coerced.
     /// Return `Ok(value)` with the (possibly transformed) value if valid,
     /// or `Err(message)` with an error message if the value cannot be coerced.
     ///
     /// The default implementation accepts any value as-is.
-    fn coerce_variable_value(&self, value: &JsonValue) -> Result<JsonValue, String> {
+    fn coerce_variable_value(
+        &self,
+        scalar_name: &str,
+        value: &JsonValue,
+    ) -> Result<JsonValue, String> {
+        let _ = scalar_name;
         Ok(value.clone())
     }
 
-    /// Validate an AST value literal for this custom scalar type.
+    /// Validate an AST value literal for a custom scalar type.
     ///
     /// Called during schema and document validation when a literal value
-    /// (e.g., a default value) is provided for a field of this scalar type.
+    /// (e.g., a default value) is provided for a field of a custom scalar type.
+    /// `scalar_name` is the name of the scalar type being validated.
     /// Return `true` if the value is acceptable, `false` otherwise.
     ///
     /// The default implementation accepts any value.
-    fn validate_ast_value(&self, value: &ast::Value) -> bool {
-        let _ = value;
+    fn validate_ast_value(&self, scalar_name: &str, value: &ast::Value) -> bool {
+        let _ = (scalar_name, value);
         true
     }
 }
@@ -180,10 +200,10 @@ pub struct Schema {
     ///   We reflect in this Rust API the behavior of `__Schema.types` in GraphQL introspection.
     pub types: IndexMap<NamedType, ExtendedType>,
 
-    /// Registered custom scalar coercers, keyed by scalar type name.
+    /// Optional blanket coercer for all custom scalar types.
     ///
-    /// Use [`Schema::add_custom_scalar_coercer`] to register a coercer.
-    custom_scalar_coercers: HashMap<Name, Arc<dyn CustomScalarCoercer>>,
+    /// Use [`Schema::set_custom_scalar_coercer`] to register a coercer.
+    custom_scalar_coercer: Option<Arc<dyn CustomScalarCoercer>>,
 }
 
 /// The [`schema` definition](https://spec.graphql.org/draft/#sec-Schema) and its extensions,
@@ -506,11 +526,11 @@ impl Schema {
         errors.into_valid_result(self)
     }
 
-    /// Register a custom scalar coercer for the given scalar type name.
+    /// Register a blanket coercer that handles all custom scalar types.
     ///
-    /// The coercer will be used during validation and input coercion to validate
-    /// and transform values of this scalar type, instead of the default behavior
-    /// of accepting any value.
+    /// The coercer is called for every custom scalar during validation and input coercion.
+    /// The scalar type name is passed to each method so the implementation can dispatch
+    /// per-scalar logic using a `match` statement, a `HashMap`, or any other approach.
     ///
     /// # Examples
     ///
@@ -520,16 +540,26 @@ impl Schema {
     /// use apollo_compiler::ast::Value;
     /// use apollo_compiler::response::JsonValue;
     ///
-    /// struct DateTimeCoercer;
-    /// impl CustomScalarCoercer for DateTimeCoercer {
-    ///     fn coerce_variable_value(&self, value: &JsonValue) -> Result<JsonValue, String> {
-    ///         match value.as_str() {
-    ///             Some(_) => Ok(value.clone()),
-    ///             None => Err("DateTime must be a string".to_string()),
+    /// struct MyCoercer;
+    /// impl CustomScalarCoercer for MyCoercer {
+    ///     fn coerce_variable_value(
+    ///         &self,
+    ///         scalar_name: &str,
+    ///         value: &JsonValue,
+    ///     ) -> Result<JsonValue, String> {
+    ///         match scalar_name {
+    ///             "DateTime" => match value.as_str() {
+    ///                 Some(_) => Ok(value.clone()),
+    ///                 None => Err("DateTime must be a string".to_string()),
+    ///             },
+    ///             _ => Ok(value.clone()),
     ///         }
     ///     }
-    ///     fn validate_ast_value(&self, value: &Value) -> bool {
-    ///         matches!(value, Value::String(_))
+    ///     fn validate_ast_value(&self, scalar_name: &str, value: &Value) -> bool {
+    ///         match scalar_name {
+    ///             "DateTime" => matches!(value, Value::String(_)),
+    ///             _ => true,
+    ///         }
     ///     }
     /// }
     ///
@@ -537,20 +567,15 @@ impl Schema {
     ///     "scalar DateTime\ntype Query { now: DateTime }",
     ///     "schema.graphql",
     /// ).unwrap();
-    /// schema.add_custom_scalar_coercer("DateTime", DateTimeCoercer);
+    /// schema.set_custom_scalar_coercer(MyCoercer);
     /// ```
-    pub fn add_custom_scalar_coercer(
-        &mut self,
-        scalar_name: &str,
-        coercer: impl CustomScalarCoercer + 'static,
-    ) {
-        self.custom_scalar_coercers
-            .insert(Name::new_unchecked(scalar_name), Arc::new(coercer));
+    pub fn set_custom_scalar_coercer(&mut self, coercer: impl CustomScalarCoercer + 'static) {
+        self.custom_scalar_coercer = Some(Arc::new(coercer));
     }
 
-    /// Returns the custom scalar coercer registered for the given type name, if any.
-    pub fn get_custom_scalar_coercer(&self, name: &str) -> Option<&dyn CustomScalarCoercer> {
-        self.custom_scalar_coercers.get(name).map(|c| c.as_ref())
+    /// Returns the registered custom scalar coercer, if any.
+    pub fn custom_scalar_coercer(&self) -> Option<&dyn CustomScalarCoercer> {
+        self.custom_scalar_coercer.as_deref()
     }
 
     /// Returns the type with the given name, if it is a scalar type
@@ -1254,7 +1279,7 @@ impl PartialEq for Schema {
             schema_definition,
             directive_definitions,
             types,
-            custom_scalar_coercers: _, // not compared
+            custom_scalar_coercer: _, // not compared
         } = self;
         *schema_definition == other.schema_definition
             && *directive_definitions == other.directive_definitions
@@ -1350,7 +1375,7 @@ impl std::fmt::Debug for Schema {
             schema_definition,
             directive_definitions,
             types,
-            custom_scalar_coercers: _,
+            custom_scalar_coercer: _,
         } = self;
         f.debug_struct("Schema")
             .field("sources", sources)

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -545,7 +545,7 @@ impl Schema {
         coercer: impl CustomScalarCoercer + 'static,
     ) {
         self.custom_scalar_coercers
-            .insert(Name::new_unchecked(scalar_name.into()), Arc::new(coercer));
+            .insert(Name::new_unchecked(scalar_name), Arc::new(coercer));
     }
 
     /// Returns the custom scalar coercer registered for the given type name, if any.

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -20,6 +20,22 @@ fn unsupported_type(
     )
 }
 
+/// Validate a custom scalar value using the registered coercer, if any.
+/// Returns `true` if the value is acceptable (no coercer registered, or coercer accepts it).
+fn validate_custom_scalar(
+    diagnostics: &mut DiagnosticList,
+    schema: &crate::Schema,
+    scalar_name: &str,
+    arg_value: &Node<ast::Value>,
+    ty: &Node<ast::Type>,
+) {
+    if let Some(coercer) = schema.custom_scalar_coercer() {
+        if !coercer.validate_ast_value(scalar_name, arg_value) {
+            unsupported_type(diagnostics, arg_value, ty);
+        }
+    }
+}
+
 pub(crate) fn validate_values(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
@@ -53,11 +69,7 @@ pub(crate) fn value_of_correct_type(
         ast::Value::Int(int) => match &type_definition {
             // Custom scalar: delegate to registered coercer, or accept any value.
             schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {
-                if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
-                    if !coercer.validate_ast_value(arg_value) {
-                        unsupported_type(diagnostics, arg_value, ty);
-                    }
-                }
+                validate_custom_scalar(diagnostics, schema, scalar.name.as_str(), arg_value, ty);
             }
             schema::ExtendedType::Scalar(scalar) => match scalar.name.as_str() {
                 // Any integer sequence is valid for an ID.
@@ -93,11 +105,7 @@ pub(crate) fn value_of_correct_type(
         ast::Value::Float(float) => match &type_definition {
             // Custom scalar: delegate to registered coercer, or accept any value.
             schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {
-                if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
-                    if !coercer.validate_ast_value(arg_value) {
-                        unsupported_type(diagnostics, arg_value, ty);
-                    }
-                }
+                validate_custom_scalar(diagnostics, schema, scalar.name.as_str(), arg_value, ty);
             }
             schema::ExtendedType::Scalar(scalar) if scalar.name == "Float" => {
                 if float.try_to_f64().is_err() {
@@ -120,11 +128,13 @@ pub(crate) fn value_of_correct_type(
             schema::ExtendedType::Scalar(scalar) => {
                 if !scalar.is_built_in() {
                     // Custom scalar: delegate to registered coercer, or accept any value.
-                    if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
-                        if !coercer.validate_ast_value(arg_value) {
-                            unsupported_type(diagnostics, arg_value, ty);
-                        }
-                    }
+                    validate_custom_scalar(
+                        diagnostics,
+                        schema,
+                        scalar.name.as_str(),
+                        arg_value,
+                        ty,
+                    );
                 } else if !matches!(scalar.name.as_str(), "String" | "ID") {
                     // specifically return diagnostics for ints, floats, and booleans.
                     unsupported_type(diagnostics, arg_value, ty);
@@ -139,11 +149,13 @@ pub(crate) fn value_of_correct_type(
             schema::ExtendedType::Scalar(scalar) => {
                 if !scalar.is_built_in() {
                     // Custom scalar: delegate to registered coercer, or accept any value.
-                    if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
-                        if !coercer.validate_ast_value(arg_value) {
-                            unsupported_type(diagnostics, arg_value, ty);
-                        }
-                    }
+                    validate_custom_scalar(
+                        diagnostics,
+                        schema,
+                        scalar.name.as_str(),
+                        arg_value,
+                        ty,
+                    );
                 } else if scalar.name.as_str() != "Boolean" {
                     unsupported_type(diagnostics, arg_value, ty);
                 }
@@ -182,11 +194,7 @@ pub(crate) fn value_of_correct_type(
         ast::Value::Enum(value) => match &type_definition {
             schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {
                 // Custom scalar: delegate to registered coercer, or accept any value.
-                if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
-                    if !coercer.validate_ast_value(arg_value) {
-                        unsupported_type(diagnostics, arg_value, ty);
-                    }
-                }
+                validate_custom_scalar(diagnostics, schema, scalar.name.as_str(), arg_value, ty);
             }
             schema::ExtendedType::Enum(enum_) => {
                 if !enum_.values.contains_key(value) {
@@ -203,12 +211,12 @@ pub(crate) fn value_of_correct_type(
             _ => unsupported_type(diagnostics, arg_value, ty),
         },
         // When expected as an input, list values are accepted only when
-        // each item in the list can be accepted by the list’s item type.
+        // each item in the list can be accepted by the list's item type.
         //
         // If the value passed as an input to a list type is not a list and
         // not the null value, then the result of input coercion is a list
         // of size one, where the single item value is the result of input
-        // coercion for the list’s item type on the provided value (note
+        // coercion for the list's item type on the provided value (note
         // this may apply recursively for nested lists).
         ast::Value::List(li) => {
             let is_custom_scalar = matches!(&type_definition, schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in());
@@ -219,11 +227,13 @@ pub(crate) fn value_of_correct_type(
                 // Custom scalar accepting a list value directly:
                 // delegate to registered coercer, or accept any value.
                 if let schema::ExtendedType::Scalar(scalar) = &type_definition {
-                    if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
-                        if !coercer.validate_ast_value(arg_value) {
-                            unsupported_type(diagnostics, arg_value, ty);
-                        }
-                    }
+                    validate_custom_scalar(
+                        diagnostics,
+                        schema,
+                        scalar.name.as_str(),
+                        arg_value,
+                        ty,
+                    );
                 }
             } else {
                 let item_type = ty.same_location(ty.item_type().clone());
@@ -239,11 +249,7 @@ pub(crate) fn value_of_correct_type(
         ast::Value::Object(obj) => match &type_definition {
             schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {
                 // Custom scalar: delegate to registered coercer, or accept any value.
-                if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
-                    if !coercer.validate_ast_value(arg_value) {
-                        unsupported_type(diagnostics, arg_value, ty);
-                    }
-                }
+                validate_custom_scalar(diagnostics, schema, scalar.name.as_str(), arg_value, ty);
             }
             schema::ExtendedType::InputObject(input_obj) => {
                 let undefined_field = obj

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -120,9 +120,7 @@ pub(crate) fn value_of_correct_type(
             schema::ExtendedType::Scalar(scalar) => {
                 if !scalar.is_built_in() {
                     // Custom scalar: delegate to registered coercer, or accept any value.
-                    if let Some(coercer) =
-                        schema.get_custom_scalar_coercer(scalar.name.as_str())
-                    {
+                    if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
                         if !coercer.validate_ast_value(arg_value) {
                             unsupported_type(diagnostics, arg_value, ty);
                         }
@@ -141,9 +139,7 @@ pub(crate) fn value_of_correct_type(
             schema::ExtendedType::Scalar(scalar) => {
                 if !scalar.is_built_in() {
                     // Custom scalar: delegate to registered coercer, or accept any value.
-                    if let Some(coercer) =
-                        schema.get_custom_scalar_coercer(scalar.name.as_str())
-                    {
+                    if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
                         if !coercer.validate_ast_value(arg_value) {
                             unsupported_type(diagnostics, arg_value, ty);
                         }
@@ -223,9 +219,7 @@ pub(crate) fn value_of_correct_type(
                 // Custom scalar accepting a list value directly:
                 // delegate to registered coercer, or accept any value.
                 if let schema::ExtendedType::Scalar(scalar) = &type_definition {
-                    if let Some(coercer) =
-                        schema.get_custom_scalar_coercer(scalar.name.as_str())
-                    {
+                    if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
                         if !coercer.validate_ast_value(arg_value) {
                             unsupported_type(diagnostics, arg_value, ty);
                         }

--- a/crates/apollo-compiler/src/validation/value.rs
+++ b/crates/apollo-compiler/src/validation/value.rs
@@ -51,8 +51,14 @@ pub(crate) fn value_of_correct_type(
         // When expected as an input type, any string (such as "4") or
         // integer (such as 4 or -4) input value should be coerced to ID
         ast::Value::Int(int) => match &type_definition {
-            // Any value is valid for a custom scalar.
-            schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {}
+            // Custom scalar: delegate to registered coercer, or accept any value.
+            schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {
+                if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
+                    if !coercer.validate_ast_value(arg_value) {
+                        unsupported_type(diagnostics, arg_value, ty);
+                    }
+                }
+            }
             schema::ExtendedType::Scalar(scalar) => match scalar.name.as_str() {
                 // Any integer sequence is valid for an ID.
                 "ID" => {}
@@ -85,8 +91,14 @@ pub(crate) fn value_of_correct_type(
         // with numeric content, must raise a request error indicating an
         // incorrect type.
         ast::Value::Float(float) => match &type_definition {
-            // Any value is valid for a custom scalar.
-            schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {}
+            // Custom scalar: delegate to registered coercer, or accept any value.
+            schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {
+                if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
+                    if !coercer.validate_ast_value(arg_value) {
+                        unsupported_type(diagnostics, arg_value, ty);
+                    }
+                }
+            }
             schema::ExtendedType::Scalar(scalar) if scalar.name == "Float" => {
                 if float.try_to_f64().is_err() {
                     diagnostics.push(
@@ -106,11 +118,17 @@ pub(crate) fn value_of_correct_type(
         // integer (such as 4 or -4) input value should be coerced to ID
         ast::Value::String(_) => match &type_definition {
             schema::ExtendedType::Scalar(scalar) => {
-                // specifically return diagnostics for ints, floats, and
-                // booleans.
-                // string, ids and custom scalars are ok, and
-                // don't need a diagnostic.
-                if scalar.is_built_in() && !matches!(scalar.name.as_str(), "String" | "ID") {
+                if !scalar.is_built_in() {
+                    // Custom scalar: delegate to registered coercer, or accept any value.
+                    if let Some(coercer) =
+                        schema.get_custom_scalar_coercer(scalar.name.as_str())
+                    {
+                        if !coercer.validate_ast_value(arg_value) {
+                            unsupported_type(diagnostics, arg_value, ty);
+                        }
+                    }
+                } else if !matches!(scalar.name.as_str(), "String" | "ID") {
+                    // specifically return diagnostics for ints, floats, and booleans.
                     unsupported_type(diagnostics, arg_value, ty);
                 }
             }
@@ -121,7 +139,16 @@ pub(crate) fn value_of_correct_type(
         // indicating an incorrect type.
         ast::Value::Boolean(_) => match &type_definition {
             schema::ExtendedType::Scalar(scalar) => {
-                if scalar.is_built_in() && scalar.name.as_str() != "Boolean" {
+                if !scalar.is_built_in() {
+                    // Custom scalar: delegate to registered coercer, or accept any value.
+                    if let Some(coercer) =
+                        schema.get_custom_scalar_coercer(scalar.name.as_str())
+                    {
+                        if !coercer.validate_ast_value(arg_value) {
+                            unsupported_type(diagnostics, arg_value, ty);
+                        }
+                    }
+                } else if scalar.name.as_str() != "Boolean" {
                     unsupported_type(diagnostics, arg_value, ty);
                 }
             }
@@ -158,7 +185,12 @@ pub(crate) fn value_of_correct_type(
         }
         ast::Value::Enum(value) => match &type_definition {
             schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {
-                // Accept enum values as input for custom scalars
+                // Custom scalar: delegate to registered coercer, or accept any value.
+                if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
+                    if !coercer.validate_ast_value(arg_value) {
+                        unsupported_type(diagnostics, arg_value, ty);
+                    }
+                }
             }
             schema::ExtendedType::Enum(enum_) => {
                 if !enum_.values.contains_key(value) {
@@ -183,11 +215,22 @@ pub(crate) fn value_of_correct_type(
         // coercion for the list’s item type on the provided value (note
         // this may apply recursively for nested lists).
         ast::Value::List(li) => {
-            let accepts_list = ty.is_list()
-                // A named type can still accept a list if it is a custom scalar.
-                || matches!(type_definition, schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in());
+            let is_custom_scalar = matches!(&type_definition, schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in());
+            let accepts_list = ty.is_list() || is_custom_scalar;
             if !accepts_list {
                 unsupported_type(diagnostics, arg_value, ty)
+            } else if is_custom_scalar && !ty.is_list() {
+                // Custom scalar accepting a list value directly:
+                // delegate to registered coercer, or accept any value.
+                if let schema::ExtendedType::Scalar(scalar) = &type_definition {
+                    if let Some(coercer) =
+                        schema.get_custom_scalar_coercer(scalar.name.as_str())
+                    {
+                        if !coercer.validate_ast_value(arg_value) {
+                            unsupported_type(diagnostics, arg_value, ty);
+                        }
+                    }
+                }
             } else {
                 let item_type = ty.same_location(ty.item_type().clone());
                 if type_definition.is_input_type() {
@@ -200,7 +243,14 @@ pub(crate) fn value_of_correct_type(
             }
         }
         ast::Value::Object(obj) => match &type_definition {
-            schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {}
+            schema::ExtendedType::Scalar(scalar) if !scalar.is_built_in() => {
+                // Custom scalar: delegate to registered coercer, or accept any value.
+                if let Some(coercer) = schema.get_custom_scalar_coercer(scalar.name.as_str()) {
+                    if !coercer.validate_ast_value(arg_value) {
+                        unsupported_type(diagnostics, arg_value, ty);
+                    }
+                }
+            }
             schema::ExtendedType::InputObject(input_obj) => {
                 let undefined_field = obj
                     .iter()


### PR DESCRIPTION
Description:
Adds a CustomScalarCoercer trait that allows users to register custom
validation and coercion logic for custom scalar types. Previously, custom
scalars accepted any value without validation.

The trait provides two extension points:

coerce_variable_value: validates/transforms JSON variable values during input coercion
validate_ast_value: validates AST literal values (e.g., default values) during schema/document validation
Coercers are registered on the Schema via add_custom_scalar_coercer().
When no coercer is registered, the existing permissive behavior is preserved.