### PR TITLE
fix(compiler): validate interface field type covariance per GraphQL spec

### DIFF
--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -85,6 +85,20 @@ pub(crate) enum DiagnosticData {
         /// Location of the definition of the field in the interface
         field_location: Option<SourceSpan>,
     },
+    #[error(
+        "Interface field {interface}.{field} expects type {interface_type} but {name}.{field} of type {actual_type} is not a proper subtype."
+    )]
+    InvalidImplementationFieldType {
+        name: Name,
+        interface: Name,
+        field: Name,
+        interface_type: Type,
+        actual_type: Type,
+        /// Location of the field in the implementing type
+        field_location: Option<SourceSpan>,
+        /// Location of the field in the interface
+        interface_field_location: Option<SourceSpan>,
+    },
     #[error("the required argument `{coordinate}` is not provided")]
     RequiredArgument {
         name: Name,
@@ -472,6 +486,24 @@ impl DiagnosticData {
                 report.with_help(
                     "An object or interface must declare all fields required by the interfaces it implements",
                 )
+            }
+            DiagnosticData::InvalidImplementationFieldType {
+                name: _,
+                interface,
+                field,
+                interface_type: _,
+                actual_type: _,
+                field_location,
+                interface_field_location,
+            } => {
+                report.with_label_opt(
+                    *field_location,
+                    format_args!("field type is not a proper subtype of `{interface}.{field}`"),
+                );
+                report.with_label_opt(
+                    *interface_field_location,
+                    format_args!("`{interface}.{field}` originally defined here"),
+                );
             }
             DiagnosticData::TransitiveImplementedInterfaces {
                 interface: _,

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -99,6 +99,47 @@ pub(crate) enum DiagnosticData {
         /// Location of the field in the interface
         interface_field_location: Option<SourceSpan>,
     },
+    #[error(
+        "Interface field {interface}.{field} expects argument `{argument}` but {name}.{field} does not provide it."
+    )]
+    MissingInterfaceFieldArgument {
+        name: Name,
+        interface: Name,
+        field: Name,
+        argument: Name,
+        /// Location of the field in the implementing type
+        field_location: Option<SourceSpan>,
+        /// Location of the argument in the interface field
+        interface_argument_location: Option<SourceSpan>,
+    },
+    #[error(
+        "Interface field {interface}.{field} expects argument `{argument}` of type `{interface_type}` but {name}.{field} provides type `{actual_type}`."
+    )]
+    InvalidImplementationFieldArgumentType {
+        name: Name,
+        interface: Name,
+        field: Name,
+        argument: Name,
+        interface_type: Node<Type>,
+        actual_type: Node<Type>,
+        /// Location of the argument in the implementing type
+        argument_location: Option<SourceSpan>,
+        /// Location of the argument in the interface field
+        interface_argument_location: Option<SourceSpan>,
+    },
+    #[error(
+        "{name}.{field} has extra required argument `{argument}` not present in interface {interface}.{field}."
+    )]
+    ExtraRequiredImplementationFieldArgument {
+        name: Name,
+        interface: Name,
+        field: Name,
+        argument: Name,
+        /// Location of the extra argument in the implementing type
+        argument_location: Option<SourceSpan>,
+        /// Location of the field in the interface
+        interface_field_location: Option<SourceSpan>,
+    },
     #[error("the required argument `{coordinate}` is not provided")]
     RequiredArgument {
         name: Name,
@@ -503,6 +544,62 @@ impl DiagnosticData {
                 report.with_label_opt(
                     *interface_field_location,
                     format_args!("`{interface}.{field}` originally defined here"),
+                );
+            }
+            DiagnosticData::MissingInterfaceFieldArgument {
+                name: _,
+                interface,
+                field,
+                argument,
+                field_location,
+                interface_argument_location,
+            } => {
+                report.with_label_opt(
+                    *field_location,
+                    format_args!("missing argument `{argument}` on this field"),
+                );
+                report.with_label_opt(
+                    *interface_argument_location,
+                    format_args!("`{interface}.{field}({argument}:)` defined here"),
+                );
+            }
+            DiagnosticData::InvalidImplementationFieldArgumentType {
+                name: _,
+                interface,
+                field,
+                argument,
+                interface_type: _,
+                actual_type: _,
+                argument_location,
+                interface_argument_location,
+            } => {
+                report.with_label_opt(
+                    *argument_location,
+                    format_args!("argument type does not match `{interface}.{field}({argument}:)`"),
+                );
+                report.with_label_opt(
+                    *interface_argument_location,
+                    format_args!("`{interface}.{field}({argument}:)` defined here"),
+                );
+            }
+            DiagnosticData::ExtraRequiredImplementationFieldArgument {
+                name: _,
+                interface,
+                field,
+                argument,
+                argument_location,
+                interface_field_location,
+            } => {
+                report.with_label_opt(
+                    *argument_location,
+                    format_args!("required argument `{argument}` is not in the interface definition"),
+                );
+                report.with_label_opt(
+                    *interface_field_location,
+                    format_args!("`{interface}.{field}` defined here"),
+                );
+                report.with_help(
+                    "Additional arguments on implementing fields must be optional (nullable or have a default value)",
                 );
             }
             DiagnosticData::TransitiveImplementedInterfaces {

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -592,7 +592,9 @@ impl DiagnosticData {
             } => {
                 report.with_label_opt(
                     *argument_location,
-                    format_args!("required argument `{argument}` is not in the interface definition"),
+                    format_args!(
+                        "required argument `{argument}` is not in the interface definition"
+                    ),
                 );
                 report.with_label_opt(
                     *interface_field_location,

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -86,7 +86,7 @@ pub(crate) enum DiagnosticData {
         field_location: Option<SourceSpan>,
     },
     #[error(
-        "Interface field {interface}.{field} expects type {interface_type} but {name}.{field} of type {actual_type} is not a proper subtype."
+        "interface field `{interface}.{field}` expects type `{interface_type}` but `{name}.{field}` of type `{actual_type}` is not a proper subtype"
     )]
     InvalidImplementationFieldType {
         name: Name,
@@ -100,7 +100,7 @@ pub(crate) enum DiagnosticData {
         interface_field_location: Option<SourceSpan>,
     },
     #[error(
-        "Interface field {interface}.{field} expects argument `{argument}` but {name}.{field} does not provide it."
+        "interface field `{interface}.{field}` expects argument `{argument}` but `{name}.{field}` does not provide it"
     )]
     MissingInterfaceFieldArgument {
         name: Name,
@@ -113,7 +113,7 @@ pub(crate) enum DiagnosticData {
         interface_argument_location: Option<SourceSpan>,
     },
     #[error(
-        "Interface field {interface}.{field} expects argument `{argument}` of type `{interface_type}` but {name}.{field} provides type `{actual_type}`."
+        "interface field `{interface}.{field}` expects argument `{argument}` of type `{interface_type}` but `{name}.{field}` provides type `{actual_type}`"
     )]
     InvalidImplementationFieldArgumentType {
         name: Name,
@@ -128,7 +128,7 @@ pub(crate) enum DiagnosticData {
         interface_argument_location: Option<SourceSpan>,
     },
     #[error(
-        "{name}.{field} has extra required argument `{argument}` not present in interface {interface}.{field}."
+        "`{name}.{field}` has extra required argument `{argument}` not present in interface `{interface}.{field}`"
     )]
     ExtraRequiredImplementationFieldArgument {
         name: Name,

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -1,4 +1,5 @@
 use crate::ast;
+use crate::ast::Type;
 use crate::collections::IndexSet;
 use crate::parser::SourceSpan;
 use crate::schema::validation::BuiltInScalars;
@@ -104,6 +105,16 @@ pub(crate) fn validate_interface_definition(
             }
         }
     }
+
+    // Validate that fields in the implementing interface have return types that are
+    // proper subtypes of the super-interface fields.
+    validate_implementation_field_types(
+        diagnostics,
+        schema,
+        &interface.name,
+        &interface.fields,
+        &interface.implements_interfaces,
+    );
 }
 
 pub(crate) fn validate_implements_interfaces(
@@ -166,5 +177,74 @@ pub(crate) fn validate_implements_interfaces(
                 transitive_interface_location: transitive_loc,
             },
         );
+    }
+}
+
+/// GraphQL spec: [IsValidImplementationFieldType](https://spec.graphql.org/draft/#IsValidImplementationFieldType())
+pub(crate) fn is_valid_implementation_field_type(
+    schema: &crate::Schema,
+    interface_field_type: &Type,
+    impl_field_type: &Type,
+) -> bool {
+    match (interface_field_type, impl_field_type) {
+        // NonNull interface field requires NonNull implementation
+        (Type::NonNullNamed(_) | Type::NonNullList(_), Type::Named(_) | Type::List(_)) => false,
+        // Both NonNull named: inner names must match or impl must be a subtype
+        (Type::NonNullNamed(iface_name), Type::NonNullNamed(impl_name)) => {
+            iface_name == impl_name || schema.is_subtype(iface_name, impl_name)
+        }
+        // Both NonNull lists: recurse on item types
+        (Type::NonNullList(iface_inner), Type::NonNullList(impl_inner)) => {
+            is_valid_implementation_field_type(schema, iface_inner, impl_inner)
+        }
+        // NonNull list vs NonNull named or vice versa
+        (Type::NonNullNamed(_), Type::NonNullList(_))
+        | (Type::NonNullList(_), Type::NonNullNamed(_)) => false,
+        // Nullable named: impl can be nullable or non-null, same name or subtype
+        (Type::Named(iface_name), Type::Named(impl_name) | Type::NonNullNamed(impl_name)) => {
+            iface_name == impl_name || schema.is_subtype(iface_name, impl_name)
+        }
+        // Nullable list: impl can be nullable or non-null list, recurse on items
+        (Type::List(iface_inner), Type::List(impl_inner) | Type::NonNullList(impl_inner)) => {
+            is_valid_implementation_field_type(schema, iface_inner, impl_inner)
+        }
+        // Named vs List mismatch
+        (Type::Named(_), Type::List(_) | Type::NonNullList(_)) => false,
+        (Type::List(_), Type::Named(_) | Type::NonNullNamed(_)) => false,
+    }
+}
+
+/// Validates that fields in an implementing type have return types that are proper subtypes of
+/// the corresponding interface fields.
+pub(crate) fn validate_implementation_field_types(
+    diagnostics: &mut DiagnosticList,
+    schema: &crate::Schema,
+    implementor_name: &Name,
+    implementor_fields: &crate::collections::IndexMap<Name, crate::schema::Component<crate::ast::FieldDefinition>>,
+    implements_interfaces: &IndexSet<ComponentName>,
+) {
+    for interface_name in implements_interfaces {
+        let Some(interface) = schema.get_interface(interface_name) else {
+            continue;
+        };
+        for (field_name, interface_field) in &interface.fields {
+            let Some(impl_field) = implementor_fields.get(field_name) else {
+                continue; // Missing field is reported separately
+            };
+            if !is_valid_implementation_field_type(schema, &interface_field.ty, &impl_field.ty) {
+                diagnostics.push(
+                    impl_field.location(),
+                    DiagnosticData::InvalidImplementationFieldType {
+                        name: implementor_name.clone(),
+                        interface: interface_name.name.clone(),
+                        field: field_name.clone(),
+                        interface_type: Type::clone(&interface_field.ty),
+                        actual_type: Type::clone(&impl_field.ty),
+                        field_location: impl_field.location(),
+                        interface_field_location: interface_field.location(),
+                    },
+                );
+            }
+        }
     }
 }

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -220,7 +220,10 @@ pub(crate) fn validate_implementation_field_types(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
     implementor_name: &Name,
-    implementor_fields: &crate::collections::IndexMap<Name, crate::schema::Component<crate::ast::FieldDefinition>>,
+    implementor_fields: &crate::collections::IndexMap<
+        Name,
+        crate::schema::Component<crate::ast::FieldDefinition>,
+    >,
     implements_interfaces: &IndexSet<ComponentName>,
 ) {
     for interface_name in implements_interfaces {

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -1,8 +1,12 @@
 use crate::ast;
+use crate::ast::FieldDefinition;
+use crate::ast::InputValueDefinition;
 use crate::ast::Type;
+use crate::collections::IndexMap;
 use crate::collections::IndexSet;
 use crate::parser::SourceSpan;
 use crate::schema::validation::BuiltInScalars;
+use crate::schema::Component;
 use crate::schema::ComponentName;
 use crate::schema::InterfaceType;
 use crate::schema::Name;
@@ -106,9 +110,19 @@ pub(crate) fn validate_interface_definition(
         }
     }
 
-    // Validate that fields in the implementing interface have return types that are
+    // Validate that fields in the implementing type have return types that are
     // proper subtypes of the super-interface fields.
     validate_implementation_field_types(
+        diagnostics,
+        schema,
+        &interface.name,
+        &interface.fields,
+        &interface.implements_interfaces,
+    );
+
+    // Validate that fields in the implementing type have matching arguments
+    // per the IsValidImplementation rule.
+    validate_implementation_field_arguments(
         diagnostics,
         schema,
         &interface.name,
@@ -216,14 +230,13 @@ pub(crate) fn is_valid_implementation_field_type(
 
 /// Validates that fields in an implementing type have return types that are proper subtypes of
 /// the corresponding interface fields.
+///
+/// GraphQL spec: [IsValidImplementationFieldType](https://spec.graphql.org/draft/#IsValidImplementationFieldType())
 pub(crate) fn validate_implementation_field_types(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
     implementor_name: &Name,
-    implementor_fields: &crate::collections::IndexMap<
-        Name,
-        crate::schema::Component<crate::ast::FieldDefinition>,
-    >,
+    implementor_fields: &IndexMap<Name, Component<FieldDefinition>>,
     implements_interfaces: &IndexSet<ComponentName>,
 ) {
     for interface_name in implements_interfaces {
@@ -247,6 +260,97 @@ pub(crate) fn validate_implementation_field_types(
                         interface_field_location: interface_field.location(),
                     },
                 );
+            }
+        }
+    }
+}
+
+fn is_required_argument(arg: &InputValueDefinition) -> bool {
+    arg.ty.is_non_null() && arg.default_value.is_none()
+}
+
+/// GraphQL spec: [IsValidImplementation](https://spec.graphql.org/draft/#IsValidImplementation())
+///
+/// Validates that implementing field arguments satisfy the interface contract:
+/// - Every argument on the interface field must exist on the implementing field with the same type
+/// - Extra arguments on the implementing field must not be required
+pub(crate) fn validate_implementation_field_arguments(
+    diagnostics: &mut DiagnosticList,
+    schema: &crate::Schema,
+    implementor_name: &Name,
+    implementor_fields: &IndexMap<Name, Component<FieldDefinition>>,
+    implements_interfaces: &IndexSet<ComponentName>,
+) {
+    for interface_name in implements_interfaces {
+        let Some(interface) = schema.get_interface(interface_name) else {
+            continue;
+        };
+        for (field_name, interface_field) in &interface.fields {
+            let Some(impl_field) = implementor_fields.get(field_name) else {
+                continue; // Missing field is reported separately
+            };
+
+            // Every argument on the interface field must exist on the implementing field
+            // with the same type (invariant).
+            for iface_arg in &interface_field.arguments {
+                let impl_arg = impl_field
+                    .arguments
+                    .iter()
+                    .find(|a| a.name == iface_arg.name);
+
+                match impl_arg {
+                    None => {
+                        diagnostics.push(
+                            impl_field.location(),
+                            DiagnosticData::MissingInterfaceFieldArgument {
+                                name: implementor_name.clone(),
+                                interface: interface_name.name.clone(),
+                                field: field_name.clone(),
+                                argument: iface_arg.name.clone(),
+                                field_location: impl_field.location(),
+                                interface_argument_location: iface_arg.location(),
+                            },
+                        );
+                    }
+                    Some(impl_arg) => {
+                        if *iface_arg.ty != *impl_arg.ty {
+                            diagnostics.push(
+                                impl_arg.location(),
+                                DiagnosticData::InvalidImplementationFieldArgumentType {
+                                    name: implementor_name.clone(),
+                                    interface: interface_name.name.clone(),
+                                    field: field_name.clone(),
+                                    argument: iface_arg.name.clone(),
+                                    interface_type: iface_arg.ty.clone(),
+                                    actual_type: impl_arg.ty.clone(),
+                                    argument_location: impl_arg.location(),
+                                    interface_argument_location: iface_arg.location(),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Extra arguments on the implementing field must not be required.
+            for impl_arg in &impl_field.arguments {
+                let in_interface = interface_field
+                    .arguments
+                    .iter()
+                    .any(|a| a.name == impl_arg.name);
+                if !in_interface && is_required_argument(impl_arg) {
+                    diagnostics.push(
+                        impl_arg.location(),
+                        DiagnosticData::ExtraRequiredImplementationFieldArgument {
+                            name: implementor_name.clone(),
+                            interface: interface_name.name.clone(),
+                            field: field_name.clone(),
+                            argument: impl_arg.name.clone(),
+                            argument_location: impl_arg.location(),
+                            interface_field_location: interface_field.location(),
+                        },
+                    );
+                }
             }
         }
     }

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -314,9 +314,7 @@ impl DiagnosticData {
                     EmptyMemberSet { .. } => "EmptyMemberSet",
                     EmptyInputValueSet { .. } => "EmptyInputValueSet",
                     ReservedName { .. } => "ReservedName",
-                    InvalidImplementationFieldType { .. } => {
-                        "InvalidImplementationFieldType"
-                    }
+                    InvalidImplementationFieldType { .. } => "InvalidImplementationFieldType",
                 })
             }
             Details::ExecutableBuildError(error) => Some(match error {

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -314,6 +314,9 @@ impl DiagnosticData {
                     EmptyMemberSet { .. } => "EmptyMemberSet",
                     EmptyInputValueSet { .. } => "EmptyInputValueSet",
                     ReservedName { .. } => "ReservedName",
+                    InvalidImplementationFieldType { .. } => {
+                        "InvalidImplementationFieldType"
+                    }
                 })
             }
             Details::ExecutableBuildError(error) => Some(match error {
@@ -512,6 +515,16 @@ impl DiagnosticData {
                     EmptyMemberSet { .. } => None,
                     EmptyInputValueSet { .. } => None,
                     ReservedName { .. } => None,
+                    InvalidImplementationFieldType {
+                        name,
+                        interface,
+                        field,
+                        interface_type,
+                        actual_type,
+                        ..
+                    } => Some(format!(
+                        r#"Interface field {interface}.{field} expects type {interface_type} but {name}.{field} of type {actual_type} is not a proper subtype."#
+                    )),
                 }
             }
             Details::ExecutableBuildError(error) => match error {

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -315,6 +315,13 @@ impl DiagnosticData {
                     EmptyInputValueSet { .. } => "EmptyInputValueSet",
                     ReservedName { .. } => "ReservedName",
                     InvalidImplementationFieldType { .. } => "InvalidImplementationFieldType",
+                    MissingInterfaceFieldArgument { .. } => "MissingInterfaceFieldArgument",
+                    InvalidImplementationFieldArgumentType { .. } => {
+                        "InvalidImplementationFieldArgumentType"
+                    }
+                    ExtraRequiredImplementationFieldArgument { .. } => {
+                        "ExtraRequiredImplementationFieldArgument"
+                    }
                 })
             }
             Details::ExecutableBuildError(error) => Some(match error {
@@ -522,6 +529,35 @@ impl DiagnosticData {
                         ..
                     } => Some(format!(
                         r#"Interface field {interface}.{field} expects type {interface_type} but {name}.{field} of type {actual_type} is not a proper subtype."#
+                    )),
+                    MissingInterfaceFieldArgument {
+                        name,
+                        interface,
+                        field,
+                        argument,
+                        ..
+                    } => Some(format!(
+                        r#"Interface field argument {interface}.{field}({argument}:) expected but {name}.{field} does not provide it."#
+                    )),
+                    InvalidImplementationFieldArgumentType {
+                        name,
+                        interface,
+                        field,
+                        argument,
+                        interface_type,
+                        actual_type,
+                        ..
+                    } => Some(format!(
+                        r#"Interface field {interface}.{field}({argument}:) expects type {interface_type} but {name}.{field}({argument}:) is type {actual_type}."#
+                    )),
+                    ExtraRequiredImplementationFieldArgument {
+                        name,
+                        interface,
+                        field,
+                        argument,
+                        ..
+                    } => Some(format!(
+                        r#"Object field {name}.{field} includes required argument {argument} that is missing from the Interface field {interface}.{field}."#
                     )),
                 }
             }

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -85,4 +85,14 @@ pub(crate) fn validate_object_type_definition(
         &object.fields,
         &object.implements_interfaces,
     );
+
+    // Validate that fields in the implementing type have matching arguments
+    // per the IsValidImplementation rule.
+    super::interface::validate_implementation_field_arguments(
+        diagnostics,
+        schema,
+        &object.name,
+        &object.fields,
+        &object.implements_interfaces,
+    );
 }

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -75,4 +75,14 @@ pub(crate) fn validate_object_type_definition(
             }
         }
     }
+
+    // Validate that fields in the implementing type have return types that are
+    // proper subtypes of the interface fields.
+    super::interface::validate_implementation_field_types(
+        diagnostics,
+        schema,
+        &object.name,
+        &object.fields,
+        &object.implements_interfaces,
+    );
 }

--- a/crates/apollo-compiler/tests/validation/interface.rs
+++ b/crates/apollo-compiler/tests/validation/interface.rs
@@ -210,3 +210,92 @@ scalar Url @specifiedBy(url: "https://tools.ietf.org/html/rfc3986")
         "{errors}"
     );
 }
+
+#[test]
+fn it_fails_validation_when_object_field_type_is_not_subtype_of_interface_field() {
+    let input = r#"
+type Query implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+interface Product {
+  details: ProductDetails!
+}
+
+type ProductDetails {
+  name: String
+}
+
+type DigitalProduct implements Product {
+  details: ProductDetails
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Interface field Product.details expects type ProductDetails! but DigitalProduct.details of type ProductDetails is not a proper subtype"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn it_accepts_valid_covariant_interface_field_types() {
+    let input = r#"
+type Query implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+interface Animal {
+  name: String
+}
+
+type Dog implements Animal {
+  name: String!
+}
+"#;
+    Schema::parse_and_validate(input, "schema.graphql")
+        .expect("Expected validation to succeed for covariant non-null field");
+}
+
+#[test]
+fn it_fails_validation_when_list_item_type_is_not_subtype() {
+    let input = r#"
+type Query implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+interface Collection {
+  items: [Item!]!
+}
+
+type Item {
+  name: String
+}
+
+type MyCollection implements Collection {
+  items: [Item]!
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Interface field Collection.items expects type [Item!]! but MyCollection.items of type [Item]! is not a proper subtype"),
+        "{errors}"
+    );
+}

--- a/crates/apollo-compiler/tests/validation/interface.rs
+++ b/crates/apollo-compiler/tests/validation/interface.rs
@@ -353,8 +353,9 @@ type ResourcePage implements HasNode {
   node: Resource
 }
 "#;
-    Schema::parse_and_validate(input, "schema.graphql")
-        .expect("Expected validation to succeed: interface implementing interface is a valid subtype");
+    Schema::parse_and_validate(input, "schema.graphql").expect(
+        "Expected validation to succeed: interface implementing interface is a valid subtype",
+    );
 }
 
 #[test]
@@ -435,7 +436,9 @@ type MyNode implements Node {
         .errors
         .to_string();
     assert!(
-        errors.contains("Interface field Node.field expects argument `id` but MyNode.field does not provide it"),
+        errors.contains(
+            "Interface field Node.field expects argument `id` but MyNode.field does not provide it"
+        ),
         "{errors}"
     );
 }
@@ -485,7 +488,9 @@ type MyNode implements Node {
         .errors
         .to_string();
     assert!(
-        errors.contains("MyNode.field has extra required argument `extra` not present in interface Node.field"),
+        errors.contains(
+            "MyNode.field has extra required argument `extra` not present in interface Node.field"
+        ),
         "{errors}"
     );
 }

--- a/crates/apollo-compiler/tests/validation/interface.rs
+++ b/crates/apollo-compiler/tests/validation/interface.rs
@@ -299,3 +299,275 @@ type MyCollection implements Collection {
         "{errors}"
     );
 }
+
+#[test]
+fn it_accepts_union_member_as_subtype_of_union_interface_field() {
+    let input = r#"
+type Query {
+  search: SearchResult
+}
+
+union SearchResult = Photo | Person
+
+type Photo {
+  url: String
+}
+
+type Person {
+  name: String
+}
+
+interface HasSearch {
+  search: SearchResult
+}
+
+type SearchPage implements HasSearch {
+  search: Photo
+}
+"#;
+    Schema::parse_and_validate(input, "schema.graphql")
+        .expect("Expected validation to succeed: union member is a valid subtype of union");
+}
+
+#[test]
+fn it_accepts_interface_to_interface_covariance() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  id: ID!
+}
+
+interface Resource implements Node {
+  id: ID!
+  url: String
+}
+
+interface HasNode {
+  node: Node
+}
+
+type ResourcePage implements HasNode {
+  node: Resource
+}
+"#;
+    Schema::parse_and_validate(input, "schema.graphql")
+        .expect("Expected validation to succeed: interface implementing interface is a valid subtype");
+}
+
+#[test]
+fn it_fails_validation_when_interface_implementing_interface_has_non_covariant_field() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  id: ID!
+}
+
+interface Base {
+  node: Node!
+}
+
+interface Child implements Base {
+  node: Node
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Interface field Base.node expects type Node! but Child.node of type Node is not a proper subtype"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn it_fails_validation_with_nested_list_type_mismatch() {
+    let input = r#"
+type Query {
+  grid: [[Item]]
+}
+
+type Item {
+  name: String
+}
+
+interface HasGrid {
+  grid: [[Item]!]!
+}
+
+type MyGrid implements HasGrid {
+  grid: [[Item]]
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Interface field HasGrid.grid expects type [[Item]!]! but MyGrid.grid of type [[Item]] is not a proper subtype"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn it_fails_validation_when_object_field_missing_interface_argument() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  field(id: ID!): String
+}
+
+type MyNode implements Node {
+  field: String
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Interface field Node.field expects argument `id` but MyNode.field does not provide it"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn it_fails_validation_when_implementation_argument_type_differs() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  field(id: ID!): String
+}
+
+type MyNode implements Node {
+  field(id: String!): String
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Interface field Node.field expects argument `id` of type `ID!` but MyNode.field provides type `String!`"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn it_fails_validation_when_implementation_has_extra_required_argument() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  field(id: ID!): String
+}
+
+type MyNode implements Node {
+  field(id: ID!, extra: String!): String
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("MyNode.field has extra required argument `extra` not present in interface Node.field"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn it_accepts_implementation_with_extra_optional_argument() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  field(id: ID!): String
+}
+
+type MyNode implements Node {
+  field(id: ID!, extra: String): String
+}
+"#;
+    Schema::parse_and_validate(input, "schema.graphql")
+        .expect("Expected validation to succeed: extra optional arguments are allowed");
+}
+
+#[test]
+fn it_accepts_implementation_with_extra_argument_with_default() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  field(id: ID!): String
+}
+
+type MyNode implements Node {
+  field(id: ID!, extra: String! = "default"): String
+}
+"#;
+    Schema::parse_and_validate(input, "schema.graphql")
+        .expect("Expected validation to succeed: extra arguments with defaults are allowed");
+}
+
+#[test]
+fn it_fails_validation_when_interface_implementing_interface_has_mismatched_argument() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  field(id: ID!): String
+}
+
+interface Child implements Node {
+  field(id: String!): String
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Interface field Node.field expects argument `id` of type `ID!` but Child.field provides type `String!`"),
+        "{errors}"
+    );
+}
+
+#[test]
+fn it_accepts_matching_arguments_on_implementation() {
+    let input = r#"
+type Query {
+  node: Node
+}
+
+interface Node {
+  field(id: ID!, name: String): String
+}
+
+type MyNode implements Node {
+  field(id: ID!, name: String): String
+}
+"#;
+    Schema::parse_and_validate(input, "schema.graphql")
+        .expect("Expected validation to succeed: matching arguments are valid");
+}

--- a/crates/apollo-compiler/tests/validation/interface.rs
+++ b/crates/apollo-compiler/tests/validation/interface.rs
@@ -1,5 +1,6 @@
 use apollo_compiler::parser::Parser;
 use apollo_compiler::Schema;
+use expect_test::expect;
 
 #[test]
 fn it_fails_validation_with_duplicate_operation_fields() {
@@ -238,10 +239,22 @@ type DigitalProduct implements Product {
         .unwrap_err()
         .errors
         .to_string();
-    assert!(
-        errors.contains("Interface field Product.details expects type ProductDetails! but DigitalProduct.details of type ProductDetails is not a proper subtype"),
-        "{errors}"
-    );
+    let expected = expect![[r#"
+        Error: interface field `Product.details` expects type `ProductDetails!` but `DigitalProduct.details` of type `ProductDetails` is not a proper subtype
+            ╭─[ schema.graphql:19:3 ]
+            │
+         19 │   details: ProductDetails
+            │   ───────────┬───────────  
+            │              ╰───────────── field type is not a proper subtype of `Product.details`
+            │
+            ├─[ schema.graphql:19:3 ]
+            │
+         11 │   details: ProductDetails!
+            │   ────────────┬───────────  
+            │               ╰───────────── `Product.details` originally defined here
+        ────╯
+    "#]];
+    expected.assert_eq(&errors);
 }
 
 #[test]
@@ -294,10 +307,22 @@ type MyCollection implements Collection {
         .unwrap_err()
         .errors
         .to_string();
-    assert!(
-        errors.contains("Interface field Collection.items expects type [Item!]! but MyCollection.items of type [Item]! is not a proper subtype"),
-        "{errors}"
-    );
+    let expected = expect![[r#"
+        Error: interface field `Collection.items` expects type `[Item!]!` but `MyCollection.items` of type `[Item]!` is not a proper subtype
+            ╭─[ schema.graphql:19:3 ]
+            │
+         19 │   items: [Item]!
+            │   ───────┬──────  
+            │          ╰──────── field type is not a proper subtype of `Collection.items`
+            │
+            ├─[ schema.graphql:19:3 ]
+            │
+         11 │   items: [Item!]!
+            │   ───────┬───────  
+            │          ╰───────── `Collection.items` originally defined here
+        ────╯
+    "#]];
+    expected.assert_eq(&errors);
 }
 
 #[test]
@@ -381,10 +406,22 @@ interface Child implements Base {
         .unwrap_err()
         .errors
         .to_string();
-    assert!(
-        errors.contains("Interface field Base.node expects type Node! but Child.node of type Node is not a proper subtype"),
-        "{errors}"
-    );
+    let expected = expect![[r#"
+        Error: interface field `Base.node` expects type `Node!` but `Child.node` of type `Node` is not a proper subtype
+            ╭─[ schema.graphql:15:3 ]
+            │
+         15 │   node: Node
+            │   ─────┬────  
+            │        ╰────── field type is not a proper subtype of `Base.node`
+            │
+            ├─[ schema.graphql:15:3 ]
+            │
+         11 │   node: Node!
+            │   ─────┬─────  
+            │        ╰─────── `Base.node` originally defined here
+        ────╯
+    "#]];
+    expected.assert_eq(&errors);
 }
 
 #[test]
@@ -410,10 +447,22 @@ type MyGrid implements HasGrid {
         .unwrap_err()
         .errors
         .to_string();
-    assert!(
-        errors.contains("Interface field HasGrid.grid expects type [[Item]!]! but MyGrid.grid of type [[Item]] is not a proper subtype"),
-        "{errors}"
-    );
+    let expected = expect![[r#"
+        Error: interface field `HasGrid.grid` expects type `[[Item]!]!` but `MyGrid.grid` of type `[[Item]]` is not a proper subtype
+            ╭─[ schema.graphql:15:3 ]
+            │
+         15 │   grid: [[Item]]
+            │   ───────┬──────  
+            │          ╰──────── field type is not a proper subtype of `HasGrid.grid`
+            │
+            ├─[ schema.graphql:15:3 ]
+            │
+         11 │   grid: [[Item]!]!
+            │   ────────┬───────  
+            │           ╰───────── `HasGrid.grid` originally defined here
+        ────╯
+    "#]];
+    expected.assert_eq(&errors);
 }
 
 #[test]
@@ -435,12 +484,22 @@ type MyNode implements Node {
         .unwrap_err()
         .errors
         .to_string();
-    assert!(
-        errors.contains(
-            "Interface field Node.field expects argument `id` but MyNode.field does not provide it"
-        ),
-        "{errors}"
-    );
+    let expected = expect![[r#"
+        Error: interface field `Node.field` expects argument `id` but `MyNode.field` does not provide it
+            ╭─[ schema.graphql:11:3 ]
+            │
+         11 │   field: String
+            │   ──────┬──────  
+            │         ╰──────── missing argument `id` on this field
+            │
+            ├─[ schema.graphql:11:3 ]
+            │
+          7 │   field(id: ID!): String
+            │         ───┬───  
+            │            ╰───── `Node.field(id:)` defined here
+        ────╯
+    "#]];
+    expected.assert_eq(&errors);
 }
 
 #[test]
@@ -462,10 +521,22 @@ type MyNode implements Node {
         .unwrap_err()
         .errors
         .to_string();
-    assert!(
-        errors.contains("Interface field Node.field expects argument `id` of type `ID!` but MyNode.field provides type `String!`"),
-        "{errors}"
-    );
+    let expected = expect![[r#"
+        Error: interface field `Node.field` expects argument `id` of type `ID!` but `MyNode.field` provides type `String!`
+            ╭─[ schema.graphql:11:9 ]
+            │
+         11 │   field(id: String!): String
+            │         ─────┬─────  
+            │              ╰─────── argument type does not match `Node.field(id:)`
+            │
+            ├─[ schema.graphql:11:9 ]
+            │
+          7 │   field(id: ID!): String
+            │         ───┬───  
+            │            ╰───── `Node.field(id:)` defined here
+        ────╯
+    "#]];
+    expected.assert_eq(&errors);
 }
 
 #[test]
@@ -487,12 +558,24 @@ type MyNode implements Node {
         .unwrap_err()
         .errors
         .to_string();
-    assert!(
-        errors.contains(
-            "MyNode.field has extra required argument `extra` not present in interface Node.field"
-        ),
-        "{errors}"
-    );
+    let expected = expect![[r#"
+        Error: `MyNode.field` has extra required argument `extra` not present in interface `Node.field`
+            ╭─[ schema.graphql:11:18 ]
+            │
+         11 │   field(id: ID!, extra: String!): String
+            │                  ───────┬──────  
+            │                         ╰──────── required argument `extra` is not in the interface definition
+            │
+            ├─[ schema.graphql:11:18 ]
+            │
+          7 │   field(id: ID!): String
+            │   ───────────┬──────────  
+            │              ╰──────────── `Node.field` defined here
+            │ 
+            │ Help: Additional arguments on implementing fields must be optional (nullable or have a default value)
+        ────╯
+    "#]];
+    expected.assert_eq(&errors);
 }
 
 #[test]
@@ -552,10 +635,22 @@ interface Child implements Node {
         .unwrap_err()
         .errors
         .to_string();
-    assert!(
-        errors.contains("Interface field Node.field expects argument `id` of type `ID!` but Child.field provides type `String!`"),
-        "{errors}"
-    );
+    let expected = expect![[r#"
+        Error: interface field `Node.field` expects argument `id` of type `ID!` but `Child.field` provides type `String!`
+            ╭─[ schema.graphql:11:9 ]
+            │
+         11 │   field(id: String!): String
+            │         ─────┬─────  
+            │              ╰─────── argument type does not match `Node.field(id:)`
+            │
+            ├─[ schema.graphql:11:9 ]
+            │
+          7 │   field(id: ID!): String
+            │         ───┬───  
+            │            ╰───── `Node.field(id:)` defined here
+        ────╯
+    "#]];
+    expected.assert_eq(&errors);
 }
 
 #[test]


### PR DESCRIPTION
Add the missing GraphQL spec rule `IsValidImplementationFieldType` to validate that object and interface types implementing an interface have fields whose return types are proper subtypes of the interface fields.

Previously, apollo-compiler only checked that implementing types had all fields required by their interfaces but did not verify type compatibility. This meant schemas like `interface Foo { x: String! }` with `type Bar implements Foo { x: String }` (nullable where non-null is required) would pass validation silently.

The validation covers:
- Non-null covariance (non-null implementation satisfies nullable interface)
- List item type covariance (recursive check on list item types)
- Named type subtyping via `Schema::is_subtype()` (object/interface hierarchy)

GraphQL spec reference:
https://spec.graphql.org/draft/#IsValidImplementationFieldType()