### PR TITLE
fix(compiler): validate interface field arguments per GraphQL spec

### DIFF
--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -99,6 +99,46 @@ pub(crate) enum DiagnosticData {
         /// Location of the field in the interface
         interface_field_location: Option<SourceSpan>,
     },
+    #[error(
+        "Field `{name}.{field}` is missing the argument `{argument}` declared by interface `{interface}.{field}`."
+    )]
+    MissingImplementationFieldArgument {
+        name: Name,
+        interface: Name,
+        field: Name,
+        argument: Name,
+        /// Location of the field in the implementing type
+        field_location: Option<SourceSpan>,
+        /// Location of the argument in the interface
+        interface_argument_location: Option<SourceSpan>,
+    },
+    #[error(
+        "Argument `{name}.{field}({argument}:)` has type `{actual_type}` but interface `{interface}.{field}({argument}:)` declares type `{interface_type}`. Argument types must be invariant."
+    )]
+    InvalidImplementationFieldArgumentType {
+        name: Name,
+        interface: Name,
+        field: Name,
+        argument: Name,
+        interface_type: Type,
+        actual_type: Type,
+        /// Location of the argument in the implementing type
+        argument_location: Option<SourceSpan>,
+        /// Location of the argument in the interface
+        interface_argument_location: Option<SourceSpan>,
+    },
+    #[error(
+        "Argument `{name}.{field}({argument}:)` is not declared on interface `{interface}.{field}` and must therefore be a nullable type, but is `{actual_type}`."
+    )]
+    ExtraImplementationFieldArgumentMustBeNullable {
+        name: Name,
+        interface: Name,
+        field: Name,
+        argument: Name,
+        actual_type: Type,
+        /// Location of the extra argument in the implementing type
+        argument_location: Option<SourceSpan>,
+    },
     #[error("the required argument `{coordinate}` is not provided")]
     RequiredArgument {
         name: Name,
@@ -503,6 +543,55 @@ impl DiagnosticData {
                 report.with_label_opt(
                     *interface_field_location,
                     format_args!("`{interface}.{field}` originally defined here"),
+                );
+            }
+            DiagnosticData::MissingImplementationFieldArgument {
+                name: _,
+                interface,
+                field,
+                argument,
+                field_location,
+                interface_argument_location,
+            } => {
+                report.with_label_opt(
+                    *field_location,
+                    format_args!("missing argument `{argument}` required by `{interface}.{field}`"),
+                );
+                report.with_label_opt(
+                    *interface_argument_location,
+                    format_args!("argument `{argument}` declared on `{interface}.{field}` here"),
+                );
+            }
+            DiagnosticData::InvalidImplementationFieldArgumentType {
+                name: _,
+                interface,
+                field,
+                argument,
+                interface_type: _,
+                actual_type: _,
+                argument_location,
+                interface_argument_location,
+            } => {
+                report.with_label_opt(
+                    *argument_location,
+                    format_args!("argument type does not match `{interface}.{field}({argument}:)`"),
+                );
+                report.with_label_opt(
+                    *interface_argument_location,
+                    format_args!("`{interface}.{field}({argument}:)` originally declared here"),
+                );
+            }
+            DiagnosticData::ExtraImplementationFieldArgumentMustBeNullable {
+                name: _,
+                interface: _,
+                field: _,
+                argument: _,
+                actual_type: _,
+                argument_location,
+            } => {
+                report.with_label_opt(
+                    *argument_location,
+                    "extra argument on the implementing field must be nullable",
                 );
             }
             DiagnosticData::TransitiveImplementedInterfaces {

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -215,7 +215,8 @@ pub(crate) fn is_valid_implementation_field_type(
 }
 
 /// Validates that fields in an implementing type have return types that are proper subtypes of
-/// the corresponding interface fields.
+/// the corresponding interface fields, and that field arguments match per
+/// [IsValidImplementation](https://spec.graphql.org/draft/#IsValidImplementation()).
 pub(crate) fn validate_implementation_field_types(
     diagnostics: &mut DiagnosticList,
     schema: &crate::Schema,
@@ -248,6 +249,94 @@ pub(crate) fn validate_implementation_field_types(
                     },
                 );
             }
+
+            validate_implementation_field_arguments(
+                diagnostics,
+                implementor_name,
+                &interface_name.name,
+                field_name,
+                interface_field,
+                impl_field,
+            );
+        }
+    }
+}
+
+/// Argument-related sub-rules of GraphQL spec
+/// [IsValidImplementation](https://spec.graphql.org/draft/#IsValidImplementation()):
+///
+/// - "field must include an argument of the same name for every argument defined in
+///   implementedField."
+/// - "That named argument on field must accept the same type (invariant) as that named argument
+///   on implementedField."
+/// - "field may include additional arguments not defined in implementedField, but any additional
+///   argument must not be required, e.g. must not be of a non-nullable type."
+fn validate_implementation_field_arguments(
+    diagnostics: &mut DiagnosticList,
+    implementor_name: &Name,
+    interface_name: &Name,
+    field_name: &Name,
+    interface_field: &Node<crate::ast::FieldDefinition>,
+    impl_field: &Node<crate::ast::FieldDefinition>,
+) {
+    // Each interface argument must appear on the implementing field with an invariant type.
+    for iface_arg in &interface_field.arguments {
+        match impl_field
+            .arguments
+            .iter()
+            .find(|a| a.name == iface_arg.name)
+        {
+            None => {
+                diagnostics.push(
+                    impl_field.location(),
+                    DiagnosticData::MissingImplementationFieldArgument {
+                        name: implementor_name.clone(),
+                        interface: interface_name.clone(),
+                        field: field_name.clone(),
+                        argument: iface_arg.name.clone(),
+                        field_location: impl_field.location(),
+                        interface_argument_location: iface_arg.location(),
+                    },
+                );
+            }
+            Some(impl_arg) if impl_arg.ty != iface_arg.ty => {
+                diagnostics.push(
+                    impl_arg.location(),
+                    DiagnosticData::InvalidImplementationFieldArgumentType {
+                        name: implementor_name.clone(),
+                        interface: interface_name.clone(),
+                        field: field_name.clone(),
+                        argument: iface_arg.name.clone(),
+                        interface_type: Type::clone(&iface_arg.ty),
+                        actual_type: Type::clone(&impl_arg.ty),
+                        argument_location: impl_arg.location(),
+                        interface_argument_location: iface_arg.location(),
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+
+    // Any additional argument on the implementing field that is not on the interface
+    // must be nullable.
+    for impl_arg in &impl_field.arguments {
+        let on_interface = interface_field
+            .arguments
+            .iter()
+            .any(|a| a.name == impl_arg.name);
+        if !on_interface && impl_arg.ty.is_non_null() {
+            diagnostics.push(
+                impl_arg.location(),
+                DiagnosticData::ExtraImplementationFieldArgumentMustBeNullable {
+                    name: implementor_name.clone(),
+                    interface: interface_name.clone(),
+                    field: field_name.clone(),
+                    argument: impl_arg.name.clone(),
+                    actual_type: Type::clone(&impl_arg.ty),
+                    argument_location: impl_arg.location(),
+                },
+            );
         }
     }
 }

--- a/crates/apollo-compiler/src/validation/mod.rs
+++ b/crates/apollo-compiler/src/validation/mod.rs
@@ -315,6 +315,15 @@ impl DiagnosticData {
                     EmptyInputValueSet { .. } => "EmptyInputValueSet",
                     ReservedName { .. } => "ReservedName",
                     InvalidImplementationFieldType { .. } => "InvalidImplementationFieldType",
+                    MissingImplementationFieldArgument { .. } => {
+                        "MissingImplementationFieldArgument"
+                    }
+                    InvalidImplementationFieldArgumentType { .. } => {
+                        "InvalidImplementationFieldArgumentType"
+                    }
+                    ExtraImplementationFieldArgumentMustBeNullable { .. } => {
+                        "ExtraImplementationFieldArgumentMustBeNullable"
+                    }
                 })
             }
             Details::ExecutableBuildError(error) => Some(match error {
@@ -522,6 +531,36 @@ impl DiagnosticData {
                         ..
                     } => Some(format!(
                         r#"Interface field {interface}.{field} expects type {interface_type} but {name}.{field} of type {actual_type} is not a proper subtype."#
+                    )),
+                    MissingImplementationFieldArgument {
+                        name,
+                        interface,
+                        field,
+                        argument,
+                        ..
+                    } => Some(format!(
+                        r#"Field `{name}.{field}` is missing the argument `{argument}` declared by interface `{interface}.{field}`."#
+                    )),
+                    InvalidImplementationFieldArgumentType {
+                        name,
+                        interface,
+                        field,
+                        argument,
+                        interface_type,
+                        actual_type,
+                        ..
+                    } => Some(format!(
+                        r#"Argument `{name}.{field}({argument}:)` has type `{actual_type}` but interface `{interface}.{field}({argument}:)` declares type `{interface_type}`. Argument types must be invariant."#
+                    )),
+                    ExtraImplementationFieldArgumentMustBeNullable {
+                        name,
+                        interface,
+                        field,
+                        argument,
+                        actual_type,
+                        ..
+                    } => Some(format!(
+                        r#"Argument `{name}.{field}({argument}:)` is not declared on interface `{interface}.{field}` and must therefore be a nullable type, but is `{actual_type}`."#
                     )),
                 }
             }

--- a/crates/apollo-compiler/tests/validation/interface.rs
+++ b/crates/apollo-compiler/tests/validation/interface.rs
@@ -300,13 +300,10 @@ type MyCollection implements Collection {
     );
 }
 
-// FIXME: The argument-related sub-rules of the GraphQL spec rule `IsValidImplementation`
-// (https://spec.graphql.org/draft/#IsValidImplementation()) are not yet enforced.
-// The two `#[ignore]`d tests below document the gap: run them with `cargo test -- --ignored`
-// to observe the missing diagnostics. Remove the `#[ignore]` attribute once the rule is added.
+// Argument-related sub-rules of GraphQL spec IsValidImplementation:
+// https://spec.graphql.org/draft/#IsValidImplementation()
 
 #[test]
-#[ignore = "argument validation in IsValidImplementation not yet implemented"]
 fn it_fails_validation_when_implementing_field_is_missing_interface_argument() {
     let input = r#"
 type Query implements Node {
@@ -336,7 +333,6 @@ type Greeter implements HasGreeting {
 }
 
 #[test]
-#[ignore = "argument validation in IsValidImplementation not yet implemented"]
 fn it_fails_validation_when_implementing_field_argument_type_differs() {
     let input = r#"
 type Query implements Node {
@@ -362,5 +358,58 @@ type Greeter implements HasGreeting {
     assert!(
         errors.contains("Greeter.greeting") && errors.contains("language"),
         "expected a diagnostic about the `language` argument type mismatch (String vs Int); got: {errors}"
+    );
+}
+
+#[test]
+fn it_fails_validation_when_extra_implementing_field_argument_is_non_null() {
+    let input = r#"
+type Query implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+interface HasGreeting {
+  greeting: String
+}
+
+type Greeter implements HasGreeting {
+  greeting(language: String!): String
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Greeter.greeting") && errors.contains("language") && errors.contains("nullable"),
+        "expected a diagnostic about the extra non-null `language` argument on Greeter.greeting; got: {errors}"
+    );
+}
+
+#[test]
+fn it_accepts_extra_nullable_argument_on_implementing_field() {
+    let input = r#"
+type Query implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+interface HasGreeting {
+  greeting: String
+}
+
+type Greeter implements HasGreeting {
+  greeting(language: String): String
+}
+"#;
+    Schema::parse_and_validate(input, "schema.graphql").expect(
+        "Expected validation to succeed when extra implementing-field argument is nullable",
     );
 }

--- a/crates/apollo-compiler/tests/validation/interface.rs
+++ b/crates/apollo-compiler/tests/validation/interface.rs
@@ -299,3 +299,68 @@ type MyCollection implements Collection {
         "{errors}"
     );
 }
+
+// FIXME: The argument-related sub-rules of the GraphQL spec rule `IsValidImplementation`
+// (https://spec.graphql.org/draft/#IsValidImplementation()) are not yet enforced.
+// The two `#[ignore]`d tests below document the gap: run them with `cargo test -- --ignored`
+// to observe the missing diagnostics. Remove the `#[ignore]` attribute once the rule is added.
+
+#[test]
+#[ignore = "argument validation in IsValidImplementation not yet implemented"]
+fn it_fails_validation_when_implementing_field_is_missing_interface_argument() {
+    let input = r#"
+type Query implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+interface HasGreeting {
+  greeting(language: String): String
+}
+
+type Greeter implements HasGreeting {
+  greeting: String
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Greeter.greeting") && errors.contains("language"),
+        "expected a diagnostic about the missing `language` argument on Greeter.greeting; got: {errors}"
+    );
+}
+
+#[test]
+#[ignore = "argument validation in IsValidImplementation not yet implemented"]
+fn it_fails_validation_when_implementing_field_argument_type_differs() {
+    let input = r#"
+type Query implements Node {
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+interface HasGreeting {
+  greeting(language: String): String
+}
+
+type Greeter implements HasGreeting {
+  greeting(language: Int): String
+}
+"#;
+    let errors = Schema::parse_and_validate(input, "schema.graphql")
+        .unwrap_err()
+        .errors
+        .to_string();
+    assert!(
+        errors.contains("Greeter.greeting") && errors.contains("language"),
+        "expected a diagnostic about the `language` argument type mismatch (String vs Int); got: {errors}"
+    );
+}


### PR DESCRIPTION
## Summary

Stacks on top of #1036. Implements the argument-related sub-rules of the GraphQL spec rule [`IsValidImplementation`](https://spec.graphql.org/draft/#IsValidImplementation()) in apollo-compiler — raised alongside the existing `IsValidImplementationFieldType` return-type check that #1036 introduces.

The spec requires that, for every argument declared on the implemented (interface) field, the implementing field must declare an argument with the same name and exactly the same type (invariant). The implementing field may declare additional arguments, but each such extra argument must be nullable so callers conforming only to the interface contract are not required to supply it.

Three new diagnostic variants:
- `MissingImplementationFieldArgument` — implementor lacks an argument the interface declares
- `InvalidImplementationFieldArgumentType` — same-named argument has a different type
- `ExtraImplementationFieldArgumentMustBeNullable` — extra argument on the implementing field is non-null

The branch is structured as two commits:
1. A test-only commit that adds `#[ignore]`'d regression tests demonstrating the gap (CI-safe checkpoint).
2. The fix that implements the validation and removes the `#[ignore]` attributes.

The deprecation-propagation sub-rule of `IsValidImplementation` ("if `field` is deprecated then `implementedField` must also be deprecated") is **not** addressed here and remains a separate gap.

## Test plan

- [x] `cargo test -p apollo-compiler` — 282 integration tests, 0 failures
- [x] `cargo clippy -p apollo-compiler --tests -- -D warnings` clean
- [x] Existing `test_data/ok/*.graphql` golden files still validate (no false positives on previously-valid schemas)
- [x] Two negative tests + one positive test for the extra-argument nullability rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)