### PR TITLE
fix(compiler): preserve source location for adopted orphan type extensions

### DIFF
--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -377,7 +377,7 @@ fn adopt_type_extensions(
         ($( $ExtensionVariant: path => $describe: literal $empty_def: expr )+) => {
             match &extensions[0] {
                 $(
-                    $ExtensionVariant(_) => {
+                    $ExtensionVariant(first_ext) => {
                         let mut def = $empty_def;
                         for ext in extensions {
                             if let $ExtensionVariant(ext) = ext {
@@ -395,7 +395,7 @@ fn adopt_type_extensions(
                                 )
                             }
                         }
-                        def.into()
+                        ExtendedType::from(first_ext.same_location(def))
                     }
                 )+
                 _ => unreachable!(),

--- a/crates/apollo-compiler/tests/extensions.rs
+++ b/crates/apollo-compiler/tests/extensions.rs
@@ -189,6 +189,31 @@ fn test_orphan_extensions_kind_mismatch() {
     );
 }
 
+#[test]
+fn test_orphan_extension_preserves_source_location() {
+    let input = r#"
+        extend type T { foo: String }
+        type Query { x: Int }
+    "#;
+
+    let schema = Schema::builder()
+        .adopt_orphan_extensions()
+        .parse(input, "schema.graphql")
+        .build()
+        .unwrap();
+
+    let type_def = &schema.types["T"];
+    let obj = match type_def {
+        apollo_compiler::schema::ExtendedType::Object(obj) => obj,
+        _ => panic!("expected object type"),
+    };
+
+    assert!(
+        obj.location().is_some(),
+        "Adopted orphan extension type should have a source location from the extension"
+    );
+}
+
 /// https://github.com/apollographql/apollo-rs/issues/682
 #[test]
 fn test_extend_implicit_schema() {

--- a/crates/apollo-compiler/tests/extensions.rs
+++ b/crates/apollo-compiler/tests/extensions.rs
@@ -203,9 +203,8 @@ fn test_orphan_extension_preserves_source_location() {
         .unwrap();
 
     let type_def = &schema.types["T"];
-    let obj = match type_def {
-        apollo_compiler::schema::ExtendedType::Object(obj) => obj,
-        _ => panic!("expected object type"),
+    let apollo_compiler::schema::ExtendedType::Object(obj) = type_def else {
+        panic!("expected object type");
     };
 
     assert!(


### PR DESCRIPTION
When `adopt_orphan_extensions` created a type from orphan extensions (e.g., `extend type T { ... }` without a base `type T` definition), the synthesized `Node` was created via `def.into()` → `Node::new()`, which sets `location: None`. Downstream consumers that rely on node source locations (such as apollo-federation's `HasLocations` trait for composition hints) would silently drop these types from location metadata.

Use the first extension's source location for the synthesized type node via `first_ext.same_location(def)`, matching the pattern used by `from_ast` for base type definitions (`definition.same_location(ty)`).