### PR TITLE
feat(fuzz): add validate target

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -58,3 +58,9 @@ name = "coordinate"
 path = "fuzz_targets/coordinate.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "validate"
+path = "fuzz_targets/validate.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -1,0 +1,34 @@
+#![no_main]
+use apollo_compiler::ast::Document;
+use apollo_rs_fuzz::generate_valid_document;
+use apollo_rs_fuzz::log_gql_doc;
+use libfuzzer_sys::fuzz_target;
+use log::debug;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = env_logger::try_init();
+
+    let doc_generated = match generate_valid_document(data) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    debug!("======= DOCUMENT =======");
+    debug!("{doc_generated}");
+    debug!("========================");
+
+    let ast = match Document::parse(&doc_generated, "smith.graphql") {
+        Ok(ast) => ast,
+        Err(with_errors) => {
+            let errors = with_errors.errors.to_string();
+            log_gql_doc(&doc_generated, &errors);
+            panic!("apollo-smith produced un-parseable document:\n{errors}");
+        }
+    };
+
+    if let Err(errors) = ast.to_mixed_validate() {
+        let errors = errors.to_string();
+        log_gql_doc(&doc_generated, &errors);
+        panic!("apollo-smith produced invalid GraphQL:\n{errors}");
+    }
+});


### PR DESCRIPTION
Asserts that apollo-smith generated documents pass GraphQL validation via `to_mixed_validate`, complementing the existing parser/lexer targets which only check that smith output does not crash the parser. Eventually, this can be used to stress-test the validation logic, but it currently uncovers some fairly basic deficiencies in the smith logic (such as generating multiple types with the same name).