### PR TITLE
fix(smith): ensure unique type names across all type kinds

### DIFF
--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -1,6 +1,5 @@
 use crate::DocumentBuilder;
 use arbitrary::Result as ArbitraryResult;
-use std::collections::HashSet;
 use std::fmt::Write as _;
 
 // First char in a GraphQL name can't be a digit and we don't want it to be
@@ -81,23 +80,27 @@ impl DocumentBuilder<'_> {
         Ok(Name::new(self.limited_string(30)?))
     }
 
-    /// Create an arbitrary type `Name` that is unique across every type-like
-    /// definition the builder has produced so far. Per the GraphQL spec, all
-    /// type definitions share a single namespace, so a numeric suffix is
-    /// appended and incremented until the candidate is free.
+    /// Create an arbitrary type `Name`. Per the GraphQL spec, all type
+    /// definitions share a single namespace; if the randomly drawn base name
+    /// collides with anything already generated, append a numeric suffix
+    /// derived from the running count of every kind of definition the
+    /// builder has produced. The suffix grows monotonically across calls, so
+    /// disambiguation stays a constant-time addition rather than a search.
     pub fn type_name(&mut self) -> ArbitraryResult<Name> {
-        let base = self.limited_string(30)?;
-        let existing: HashSet<&str> = self
-            .list_existing_type_names()
-            .map(|n| n.name.as_str())
-            .collect();
-        let mut candidate = base.clone();
-        let mut suffix: usize = 0;
-        while existing.contains(candidate.as_str()) {
-            candidate = format!("{base}{suffix}");
-            suffix += 1;
+        let mut new_name = self.limited_string(30)?;
+        if self.list_existing_type_names().any(|n| n.name == new_name) {
+            let suffix = self.object_type_defs.len()
+                + self.interface_type_defs.len()
+                + self.union_type_defs.len()
+                + self.scalar_type_defs.len()
+                + self.enum_type_defs.len()
+                + self.input_object_type_defs.len()
+                + self.directive_defs.len()
+                + self.fragment_defs.len()
+                + self.operation_defs.len();
+            let _ = write!(new_name, "{suffix}");
         }
-        Ok(Name::new(candidate))
+        Ok(Name::new(new_name))
     }
 
     /// Create an arbitrary `Name` with an index included in the name (to avoid name conflict)

--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -80,12 +80,7 @@ impl DocumentBuilder<'_> {
         Ok(Name::new(self.limited_string(30)?))
     }
 
-    /// Create an arbitrary type `Name`. Per the GraphQL spec, all type
-    /// definitions share a single namespace; if the randomly drawn base name
-    /// collides with anything already generated, append a numeric suffix
-    /// derived from the running count of every kind of definition the
-    /// builder has produced. The suffix grows monotonically across calls, so
-    /// disambiguation stays a constant-time addition rather than a search.
+    /// Create an arbitrary type `Name` that does not yet exist in the document.
     pub fn type_name(&mut self) -> ArbitraryResult<Name> {
         let mut new_name = self.limited_string(30)?;
         if self.list_existing_type_names().any(|n| n.name == new_name) {

--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -1,5 +1,6 @@
 use crate::DocumentBuilder;
 use arbitrary::Result as ArbitraryResult;
+use std::collections::HashSet;
 use std::fmt::Write as _;
 
 // First char in a GraphQL name can't be a digit and we don't want it to be
@@ -80,17 +81,23 @@ impl DocumentBuilder<'_> {
         Ok(Name::new(self.limited_string(30)?))
     }
 
-    /// Create an arbitrary type `Name`
+    /// Create an arbitrary type `Name` that is unique across every type-like
+    /// definition the builder has produced so far. Per the GraphQL spec, all
+    /// type definitions share a single namespace, so a numeric suffix is
+    /// appended and incremented until the candidate is free.
     pub fn type_name(&mut self) -> ArbitraryResult<Name> {
-        let mut new_name = self.limited_string(30)?;
-        if self.list_existing_type_names().any(|n| n.name == new_name) {
-            let _ = write!(
-                new_name,
-                "{}",
-                self.object_type_defs.len() + self.enum_type_defs.len() + self.directive_defs.len()
-            );
+        let base = self.limited_string(30)?;
+        let existing: HashSet<&str> = self
+            .list_existing_type_names()
+            .map(|n| n.name.as_str())
+            .collect();
+        let mut candidate = base.clone();
+        let mut suffix: usize = 0;
+        while existing.contains(candidate.as_str()) {
+            candidate = format!("{base}{suffix}");
+            suffix += 1;
         }
-        Ok(Name::new(new_name))
+        Ok(Name::new(candidate))
     }
 
     /// Create an arbitrary `Name` with an index included in the name (to avoid name conflict)

--- a/crates/apollo-smith/src/snapshot_tests.rs
+++ b/crates/apollo-smith/src/snapshot_tests.rs
@@ -17,19 +17,19 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A2 on A1 {
+        fragment A5 on A2 {
           A0
         }
 
         schema {
-          query: A1
-          mutation: A1
-          subscription: A1
+          query: A2
+          mutation: A2
+          subscription: A2
         }
 
         scalar A
 
-        type A1 {
+        type A2 {
           A0: A0
           A1: A0
         }
@@ -39,19 +39,19 @@ fn snapshot_tests() {
           A1: A0
         }
 
-        union A2 = A1
+        union A3 = A2
 
         enum A0 {
           A0
           A1
         }
 
-        input A2 {
-          A0: A1
-          A1: A1
+        input A4 {
+          A0: A2
+          A1: A2
         }
 
-        directive @A2 on QUERY
+        directive @A6 on QUERY
     "#]]
     .assert_eq(&gen(0));
     expect![[r#"
@@ -59,29 +59,29 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A7 on A6 {
+        fragment A8 on A5 {
           A0
         }
 
         schema {
-          query: A6
-          mutation: A6
-          subscription: A6
+          query: A5
+          mutation: A5
+          subscription: A5
         }
 
         scalar CD
 
-        type A6 {
+        type A5 {
           A0: IJAAAAAA
           A1: IJAAAAAA
         }
 
-        interface A6 {
+        interface A4 {
           A0: IJAAAAAA
           A1: IJAAAAAA
         }
 
-        union A7 = A6
+        union A6 = A5
 
         enum IJAAAAAA {
           A0
@@ -89,6 +89,16 @@ fn snapshot_tests() {
         }
 
         enum A {
+          A0
+          A1
+        }
+
+        enum A0 {
+          A0
+          A1
+        }
+
+        enum A1 {
           A0
           A1
         }
@@ -103,22 +113,12 @@ fn snapshot_tests() {
           A1
         }
 
-        enum A4 {
-          A0
-          A1
-        }
-
-        enum A5 {
-          A0
-          A1
-        }
-
         input A7 {
-          A0: A6
-          A1: A6
+          A0: A5
+          A1: A5
         }
 
-        directive @A7 on QUERY
+        directive @A9 on QUERY
     "#]]
     .assert_eq(&gen(10));
     expect![[r#"
@@ -126,29 +126,29 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A7 on A6 {
+        fragment A8 on A5 {
           A0
         }
 
         schema {
-          query: A6
-          mutation: A6
-          subscription: A6
+          query: A5
+          mutation: A5
+          subscription: A5
         }
 
         scalar CD
 
-        type A6 {
+        type A5 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A6 {
+        interface A4 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        union A7 = A6
+        union A6 = A5
 
         enum IJKLMNOP {
           UVWXYZabcdefghijklmn0
@@ -168,6 +168,16 @@ fn snapshot_tests() {
           A1
         }
 
+        enum A0 {
+          A0
+          A1
+        }
+
+        enum A1 {
+          A0
+          A1
+        }
+
         enum A2 {
           A0
           A1
@@ -178,22 +188,12 @@ fn snapshot_tests() {
           A1
         }
 
-        enum A4 {
-          A0
-          A1
-        }
-
-        enum A5 {
-          A0
-          A1
-        }
-
         input A7 {
-          A0: A6
-          A1: A6
+          A0: A5
+          A1: A5
         }
 
-        directive @A7 on QUERY
+        directive @A9 on QUERY
     "#]]
     .assert_eq(&gen(100));
     expect![[r#"
@@ -201,19 +201,19 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A7 on A6 {
+        fragment A8 on A5 {
           A0
         }
 
         schema {
-          query: A6
-          mutation: A6
-          subscription: A6
+          query: A5
+          mutation: A5
+          subscription: A5
         }
 
         scalar CD
 
-        type A6 {
+        type A5 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
@@ -257,32 +257,32 @@ fn snapshot_tests() {
           A1: IJKLMNOP
         }
 
-        interface A6 {
+        interface A0 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A6 {
+        interface A1 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A6 {
+        interface A2 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A6 {
+        interface A3 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A6 {
+        interface A4 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        union A7 = A6
+        union A6 = A5
 
         enum IJKLMNOP {
           UVWXYZabcdefghijklmn0
@@ -343,11 +343,11 @@ fn snapshot_tests() {
         }
 
         input A7 {
-          A0: A6
-          A1: A6
+          A0: A5
+          A1: A5
         }
 
-        directive @A7 on QUERY
+        directive @A9 on QUERY
     "#]]
     .assert_eq(&gen(1000));
 }

--- a/crates/apollo-smith/src/snapshot_tests.rs
+++ b/crates/apollo-smith/src/snapshot_tests.rs
@@ -17,41 +17,41 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A5 on A2 {
+        fragment A6 on A3 {
           A0
         }
 
         schema {
-          query: A2
-          mutation: A2
-          subscription: A2
+          query: A3
+          mutation: A3
+          subscription: A3
         }
 
         scalar A
 
-        type A2 {
-          A0: A0
-          A1: A0
+        type A3 {
+          A0: A1
+          A1: A1
         }
 
-        interface A1 {
-          A0: A0
-          A1: A0
+        interface A2 {
+          A0: A1
+          A1: A1
         }
 
-        union A3 = A2
+        union A4 = A3
 
-        enum A0 {
+        enum A1 {
           A0
           A1
         }
 
-        input A4 {
-          A0: A2
-          A1: A2
+        input A5 {
+          A0: A3
+          A1: A3
         }
 
-        directive @A6 on QUERY
+        directive @A7 on QUERY
     "#]]
     .assert_eq(&gen(0));
     expect![[r#"
@@ -59,29 +59,29 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A8 on A5 {
+        fragment A11 on A8 {
           A0
         }
 
         schema {
-          query: A5
-          mutation: A5
-          subscription: A5
+          query: A8
+          mutation: A8
+          subscription: A8
         }
 
         scalar CD
 
-        type A5 {
+        type A8 {
           A0: IJAAAAAA
           A1: IJAAAAAA
         }
 
-        interface A4 {
+        interface A7 {
           A0: IJAAAAAA
           A1: IJAAAAAA
         }
 
-        union A6 = A5
+        union A9 = A8
 
         enum IJAAAAAA {
           A0
@@ -93,32 +93,32 @@ fn snapshot_tests() {
           A1
         }
 
-        enum A0 {
-          A0
-          A1
-        }
-
-        enum A1 {
-          A0
-          A1
-        }
-
-        enum A2 {
-          A0
-          A1
-        }
-
         enum A3 {
           A0
           A1
         }
 
-        input A7 {
-          A0: A5
-          A1: A5
+        enum A4 {
+          A0
+          A1
         }
 
-        directive @A9 on QUERY
+        enum A5 {
+          A0
+          A1
+        }
+
+        enum A6 {
+          A0
+          A1
+        }
+
+        input A10 {
+          A0: A8
+          A1: A8
+        }
+
+        directive @A12 on QUERY
     "#]]
     .assert_eq(&gen(10));
     expect![[r#"
@@ -126,29 +126,29 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A8 on A5 {
+        fragment A11 on A8 {
           A0
         }
 
         schema {
-          query: A5
-          mutation: A5
-          subscription: A5
+          query: A8
+          mutation: A8
+          subscription: A8
         }
 
         scalar CD
 
-        type A5 {
+        type A8 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A4 {
+        interface A7 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        union A6 = A5
+        union A9 = A8
 
         enum IJKLMNOP {
           UVWXYZabcdefghijklmn0
@@ -168,32 +168,32 @@ fn snapshot_tests() {
           A1
         }
 
-        enum A0 {
-          A0
-          A1
-        }
-
-        enum A1 {
-          A0
-          A1
-        }
-
-        enum A2 {
-          A0
-          A1
-        }
-
         enum A3 {
           A0
           A1
         }
 
-        input A7 {
-          A0: A5
-          A1: A5
+        enum A4 {
+          A0
+          A1
         }
 
-        directive @A9 on QUERY
+        enum A5 {
+          A0
+          A1
+        }
+
+        enum A6 {
+          A0
+          A1
+        }
+
+        input A10 {
+          A0: A8
+          A1: A8
+        }
+
+        directive @A12 on QUERY
     "#]]
     .assert_eq(&gen(100));
     expect![[r#"
@@ -201,19 +201,19 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A8 on A5 {
+        fragment A17 on A14 {
           A0
         }
 
         schema {
-          query: A5
-          mutation: A5
-          subscription: A5
+          query: A14
+          mutation: A14
+          subscription: A14
         }
 
         scalar CD
 
-        type A5 {
+        type A14 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
@@ -257,32 +257,32 @@ fn snapshot_tests() {
           A1: IJKLMNOP
         }
 
-        interface A0 {
+        interface A9 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A1 {
+        interface A10 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A2 {
+        interface A11 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A3 {
+        interface A12 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A4 {
+        interface A13 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        union A6 = A5
+        union A15 = A14
 
         enum IJKLMNOP {
           UVWXYZabcdefghijklmn0
@@ -342,12 +342,12 @@ fn snapshot_tests() {
           iNOPQRSTUVWXYZabcd4
         }
 
-        input A7 {
-          A0: A5
-          A1: A5
+        input A16 {
+          A0: A14
+          A1: A14
         }
 
-        directive @A9 on QUERY
+        directive @A18 on QUERY
     "#]]
     .assert_eq(&gen(1000));
 }

--- a/crates/apollo-smith/tests/type_name_uniqueness.rs
+++ b/crates/apollo-smith/tests/type_name_uniqueness.rs
@@ -1,0 +1,34 @@
+//! Generated documents must not reuse the same name for two type definitions
+//! (across object/interface/union/scalar/enum/input-object), because the
+//! GraphQL spec puts all of them in a single namespace.
+
+use apollo_compiler::ast::Document as AstDocument;
+use apollo_smith::DocumentBuilder;
+use arbitrary::Unstructured;
+
+fn assert_type_names_unique(seed: &[u8]) {
+    let mut u = Unstructured::new(seed);
+    let doc: String = DocumentBuilder::new(&mut u).unwrap().finish().into();
+    let ast = AstDocument::parse(&doc, "smith.graphql").expect("smith output must parse");
+
+    if let Err(errors) = ast.to_mixed_validate() {
+        let errors_str = errors.to_string();
+        assert!(
+            !errors_str.contains("is defined multiple times in the schema"),
+            "seed={seed:?}: smith produced colliding type names\n\nErrors:\n{errors_str}\n\nGenerated doc:\n{doc}"
+        );
+    }
+}
+
+#[test]
+fn empty_seed() {
+    assert_type_names_unique(&[]);
+}
+
+#[test]
+fn small_sequential_seeds() {
+    for n in [1usize, 4, 10, 64, 256] {
+        let seed: Vec<u8> = (0..n).map(|i| i as u8).collect();
+        assert_type_names_unique(&seed);
+    }
+}


### PR DESCRIPTION
## Summary
- `DocumentBuilder::type_name` previously could return the same identifier for two definitions of different kinds (e.g. `type A1` and `interface A1`, `union A2` and `input A2`). The GraphQL spec puts all type definitions in a single namespace, so these were validation errors.
- Build a `HashSet` of existing type-like names once and increment a numeric suffix until the candidate is free. Byte-stream layout is preserved; only the chosen suffix shifts (snapshot expectations regenerated).
- Follow-up for #1044 (validate fuzz target). With the validate target running ~60 s, "type defined multiple times" errors drop from ~79 k to ~9 k — an 88% reduction. The remaining count is from extension paths, addressed separately.