### PR TITLE
fix(smith): Ensure scalar and union extensions correctly extend original types

### DIFF
--- a/crates/apollo-smith/src/scalar.rs
+++ b/crates/apollo-smith/src/scalar.rs
@@ -81,8 +81,8 @@ impl TryFrom<apollo_parser::cst::ScalarTypeExtension> for ScalarTypeDef {
 impl DocumentBuilder<'_> {
     /// Create an arbitrary `ScalarTypeDef`
     pub fn scalar_type_definition(&mut self) -> ArbitraryResult<ScalarTypeDef> {
-        let extend = !self.scalar_type_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
-        let name = if extend {
+        let mut extend = !self.scalar_type_defs.is_empty() && self.u.arbitrary().unwrap_or(false);
+        let mut name = if extend {
             let available_scalars: Vec<&Name> = self
                 .scalar_type_defs
                 .iter()
@@ -105,8 +105,14 @@ impl DocumentBuilder<'_> {
             .then(|| self.description())
             .transpose()?;
         let directives = self.directives(DirectiveLocation::Scalar)?;
-        // Extended scalar must have directive
-        let extend = !directives.is_empty() && self.u.arbitrary().unwrap_or(false);
+
+        // A scalar extension must add at least one directive. If we picked the extend path
+        // but have no directives to add, fall back to a fresh unique scalar instead of
+        // emitting a duplicate definition.
+        if extend && directives.is_empty() {
+            extend = false;
+            name = self.type_name()?;
+        }
 
         Ok(ScalarTypeDef {
             name,

--- a/crates/apollo-smith/src/union.rs
+++ b/crates/apollo-smith/src/union.rs
@@ -134,7 +134,6 @@ impl DocumentBuilder<'_> {
             .then(|| self.description())
             .transpose()?;
         let directives = self.directives(DirectiveLocation::Union)?;
-        let extend = self.u.arbitrary().unwrap_or(false);
         let mut existing_types = self.list_existing_object_types();
         existing_types.extend(
             self.union_type_defs


### PR DESCRIPTION
The case when we rolled `true` on the choice to extend an existing type is causing duplicate type definitions to be generated. The fuzzer surfaced this issue both with scalars and with unions.

For unions, we were wrongly making the extend decision twice. This could result in us building a definition meant to extend an existing type, but dropping the `extend` keyword and resulting in a duplicate definition.

For scalars, we must extend the existing definition with at least one new directive which does not conflict with an existing non-repeatable directive (see https://spec.graphql.org/September2025/#sec-Scalar-Extensions). This change does not resolve the potential for non-repeatable directive conflicts. It does resolve the issue of extending an existing scalar `A` with an empty extension `extend scalar A` without directives. If we are extending, but generate no directives, we now generate a new type name and add the net new type to the schema with `extend: false`.