### PR TITLE
fix(smith): Ensure generated documents do not have unused fragment definitions

### DIFF
--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -1,12 +1,14 @@
 use crate::directive::Directive;
 use crate::directive::DirectiveLocation;
 use crate::name::Name;
+use crate::operation::OperationDef;
 use crate::selection_set::SelectionSet;
 use crate::ty::Ty;
 use crate::DocumentBuilder;
 use apollo_compiler::ast;
 use arbitrary::Result as ArbitraryResult;
 use indexmap::IndexMap;
+use indexmap::IndexSet;
 
 /// The __fragmentDef type represents a fragment definition
 ///
@@ -229,5 +231,142 @@ impl DocumentBuilder<'_> {
                 })
             }
         }
+    }
+}
+
+/// Compute the set of fragment names reachable from `operations`, walking
+/// through `fragments` transitively when one fragment spreads another.
+///
+/// A fragment is reachable iff some operation spreads it directly, or spreads
+/// some other reachable fragment whose chain leads to it. Chains like
+/// `A -> B` with no operation referencing A produce no reachable names, even
+/// though `A` syntactically references `B`.
+pub(crate) fn reachable_fragment_names(
+    operations: &[OperationDef],
+    fragments: &[FragmentDef],
+) -> IndexSet<Name> {
+    let mut reachable: IndexSet<Name> = IndexSet::new();
+    for op in operations {
+        op.selection_set.collect_fragment_spreads(&mut reachable);
+    }
+    let mut frontier: Vec<Name> = reachable.iter().cloned().collect();
+    while let Some(name) = frontier.pop() {
+        if let Some(frag) = fragments.iter().find(|f| f.name == name) {
+            let mut nested: IndexSet<Name> = IndexSet::new();
+            frag.selection_set.collect_fragment_spreads(&mut nested);
+            for n in nested {
+                if reachable.insert(n.clone()) {
+                    frontier.push(n);
+                }
+            }
+        }
+    }
+    reachable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operation::OperationType;
+    use crate::selection_set::Selection;
+    use crate::selection_set::SelectionSet;
+
+    fn n(s: &str) -> Name {
+        Name::new(s.to_string())
+    }
+
+    fn spread(target: &str) -> Selection {
+        Selection::FragmentSpread(FragmentSpread {
+            name: n(target),
+            directives: IndexMap::new(),
+        })
+    }
+
+    fn sset(selections: Vec<Selection>) -> SelectionSet {
+        SelectionSet { selections }
+    }
+
+    fn names(items: &[&str]) -> IndexSet<Name> {
+        items.iter().map(|s| n(s)).collect()
+    }
+
+    fn op(spreads: Vec<&str>) -> OperationDef {
+        OperationDef {
+            operation_type: OperationType::Query,
+            name: None,
+            variable_definitions: vec![],
+            directives: IndexMap::new(),
+            selection_set: sset(spreads.into_iter().map(spread).collect()),
+        }
+    }
+
+    fn frag(name: &str, on: &str, spreads: Vec<&str>) -> FragmentDef {
+        FragmentDef {
+            name: n(name),
+            type_condition: TypeCondition { name: n(on) },
+            directives: IndexMap::new(),
+            selection_set: sset(spreads.into_iter().map(spread).collect()),
+        }
+    }
+
+    #[test]
+    fn no_operations_means_nothing_reachable() {
+        let frags = vec![frag("A", "T", vec![])];
+        let result = reachable_fragment_names(&[], &frags);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn direct_spread_is_reachable() {
+        let ops = vec![op(vec!["A"])];
+        let frags = vec![frag("A", "T", vec![])];
+        let result = reachable_fragment_names(&ops, &frags);
+        assert_eq!(result, names(&["A"]));
+    }
+
+    #[test]
+    fn transitive_chain_is_reachable() {
+        // op -> A -> B -> C : all three reachable
+        let ops = vec![op(vec!["A"])];
+        let frags = vec![
+            frag("A", "T", vec!["B"]),
+            frag("B", "T", vec!["C"]),
+            frag("C", "T", vec![]),
+        ];
+        let result = reachable_fragment_names(&ops, &frags);
+        assert_eq!(result, names(&["A", "B", "C"]));
+    }
+
+    #[test]
+    fn orphan_chain_is_not_reachable() {
+        // A -> B with no operation referencing A: neither retained
+        let ops: Vec<OperationDef> = vec![];
+        let frags = vec![
+            frag("A", "T", vec!["B"]),
+            frag("B", "T", vec![]),
+        ];
+        let result = reachable_fragment_names(&ops, &frags);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn unreferenced_fragment_among_used_ones_is_pruned() {
+        // op -> A, but B exists in isolation -> only A reachable
+        let ops = vec![op(vec!["A"])];
+        let frags = vec![
+            frag("A", "T", vec![]),
+            frag("B", "T", vec![]),
+        ];
+        let result = reachable_fragment_names(&ops, &frags);
+        assert_eq!(result, names(&["A"]));
+    }
+
+    #[test]
+    fn cycle_terminates() {
+        // op -> A -> B -> A : both reachable, no infinite loop
+        let ops = vec![op(vec!["A"])];
+        let frags = vec![frag("A", "T", vec!["B"]), frag("B", "T", vec!["A"])];
+        let result = reachable_fragment_names(&ops, &frags);
+        assert_eq!(result, names(&["A", "B"]));
     }
 }

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -267,72 +267,59 @@ pub(crate) fn reachable_fragment_names(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::operation::OperationType;
-    use crate::selection_set::Selection;
-    use crate::selection_set::SelectionSet;
 
-    fn n(s: &str) -> Name {
-        Name::new(s.to_string())
-    }
-
-    fn spread(target: &str) -> Selection {
-        Selection::FragmentSpread(FragmentSpread {
-            name: n(target),
-            directives: IndexMap::new(),
-        })
-    }
-
-    fn sset(selections: Vec<Selection>) -> SelectionSet {
-        SelectionSet { selections }
+    fn parse(src: &str) -> (Vec<OperationDef>, Vec<FragmentDef>) {
+        let cst = apollo_parser::Parser::new(src).parse();
+        assert!(cst.errors().next().is_none(), "parse errors: {src}");
+        let mut ops = vec![];
+        let mut frags = vec![];
+        for def in cst.document().definitions() {
+            match def {
+                apollo_parser::cst::Definition::OperationDefinition(o) => {
+                    ops.push(o.try_into().unwrap())
+                }
+                apollo_parser::cst::Definition::FragmentDefinition(f) => {
+                    frags.push(f.try_into().unwrap())
+                }
+                _ => panic!("unexpected definition in test input"),
+            }
+        }
+        (ops, frags)
     }
 
     fn names(items: &[&str]) -> IndexSet<Name> {
-        items.iter().map(|s| n(s)).collect()
-    }
-
-    fn op(spreads: Vec<&str>) -> OperationDef {
-        OperationDef {
-            operation_type: OperationType::Query,
-            name: None,
-            variable_definitions: vec![],
-            directives: IndexMap::new(),
-            selection_set: sset(spreads.into_iter().map(spread).collect()),
-        }
-    }
-
-    fn frag(name: &str, on: &str, spreads: Vec<&str>) -> FragmentDef {
-        FragmentDef {
-            name: n(name),
-            type_condition: TypeCondition { name: n(on) },
-            directives: IndexMap::new(),
-            selection_set: sset(spreads.into_iter().map(spread).collect()),
-        }
+        items.iter().map(|s| Name::new(s.to_string())).collect()
     }
 
     #[test]
     fn no_operations_means_nothing_reachable() {
-        let frags = vec![frag("A", "T", vec![])];
-        let result = reachable_fragment_names(&[], &frags);
+        let (ops, frags) = parse("fragment A on T { __typename }");
+        let result = reachable_fragment_names(&ops, &frags);
         assert!(result.is_empty());
     }
 
     #[test]
     fn direct_spread_is_reachable() {
-        let ops = vec![op(vec!["A"])];
-        let frags = vec![frag("A", "T", vec![])];
+        let (ops, frags) = parse(
+            "
+            query { ...A }
+            fragment A on T { __typename }
+            ",
+        );
         let result = reachable_fragment_names(&ops, &frags);
         assert_eq!(result, names(&["A"]));
     }
 
     #[test]
     fn transitive_chain_is_reachable() {
-        // op -> A -> B -> C : all three reachable
-        let ops = vec![op(vec!["A"])];
-        let frags = vec![
-            frag("A", "T", vec!["B"]),
-            frag("B", "T", vec!["C"]),
-            frag("C", "T", vec![]),
-        ];
+        let (ops, frags) = parse(
+            "
+            query { ...A }
+            fragment A on T { ...B }
+            fragment B on T { ...C }
+            fragment C on T { __typename }
+            ",
+        );
         let result = reachable_fragment_names(&ops, &frags);
         assert_eq!(result, names(&["A", "B", "C"]));
     }
@@ -340,17 +327,25 @@ mod tests {
     #[test]
     fn orphan_chain_is_not_reachable() {
         // A -> B with no operation referencing A: neither retained
-        let ops: Vec<OperationDef> = vec![];
-        let frags = vec![frag("A", "T", vec!["B"]), frag("B", "T", vec![])];
+        let (ops, frags) = parse(
+            "
+            fragment A on T { ...B }
+            fragment B on T { __typename }
+            ",
+        );
         let result = reachable_fragment_names(&ops, &frags);
         assert!(result.is_empty());
     }
 
     #[test]
     fn unreferenced_fragment_among_used_ones_is_pruned() {
-        // op -> A, but B exists in isolation -> only A reachable
-        let ops = vec![op(vec!["A"])];
-        let frags = vec![frag("A", "T", vec![]), frag("B", "T", vec![])];
+        let (ops, frags) = parse(
+            "
+            query { ...A }
+            fragment A on T { __typename }
+            fragment B on T { __typename }
+            ",
+        );
         let result = reachable_fragment_names(&ops, &frags);
         assert_eq!(result, names(&["A"]));
     }
@@ -358,8 +353,13 @@ mod tests {
     #[test]
     fn cycle_terminates() {
         // op -> A -> B -> A : both reachable, no infinite loop
-        let ops = vec![op(vec!["A"])];
-        let frags = vec![frag("A", "T", vec!["B"]), frag("B", "T", vec!["A"])];
+        let (ops, frags) = parse(
+            "
+            query { ...A }
+            fragment A on T { ...B }
+            fragment B on T { ...A }
+            ",
+        );
         let result = reachable_fragment_names(&ops, &frags);
         assert_eq!(result, names(&["A", "B"]));
     }

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -341,10 +341,7 @@ mod tests {
     fn orphan_chain_is_not_reachable() {
         // A -> B with no operation referencing A: neither retained
         let ops: Vec<OperationDef> = vec![];
-        let frags = vec![
-            frag("A", "T", vec!["B"]),
-            frag("B", "T", vec![]),
-        ];
+        let frags = vec![frag("A", "T", vec!["B"]), frag("B", "T", vec![])];
         let result = reachable_fragment_names(&ops, &frags);
         assert!(result.is_empty());
     }
@@ -353,10 +350,7 @@ mod tests {
     fn unreferenced_fragment_among_used_ones_is_pruned() {
         // op -> A, but B exists in isolation -> only A reachable
         let ops = vec![op(vec!["A"])];
-        let frags = vec![
-            frag("A", "T", vec![]),
-            frag("B", "T", vec![]),
-        ];
+        let frags = vec![frag("A", "T", vec![]), frag("B", "T", vec![])];
         let result = reachable_fragment_names(&ops, &frags);
         assert_eq!(result, names(&["A"]));
     }

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -178,7 +178,7 @@ impl DocumentBuilder<'_> {
         let available_fragment: Vec<&FragmentDef> = self
             .fragment_defs
             .iter()
-            .filter(|f| excludes.contains(&f.name))
+            .filter(|f| !excludes.contains(&f.name))
             .collect();
 
         let name = if available_fragment.is_empty() {

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -237,7 +237,8 @@ impl<'a> DocumentBuilder<'a> {
         // We walk transitively from operations so chains like `op -> A -> B` keep
         // both A and B, while `A -> B` with no operation referencing A drops both
         // (B is only reachable through A, which is itself unused).
-        let reachable = fragment::reachable_fragment_names(&self.operation_defs, &self.fragment_defs);
+        let reachable =
+            fragment::reachable_fragment_names(&self.operation_defs, &self.fragment_defs);
         let fragment_definitions = self
             .fragment_defs
             .into_iter()

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) mod union;
 pub(crate) mod variable;
 
 use indexmap::IndexMap;
+use indexmap::IndexSet;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -230,6 +231,35 @@ impl<'a> DocumentBuilder<'a> {
 
     /// Convert a `DocumentBuilder` into a GraphQL `Document`
     pub fn finish(self) -> Document {
+        // Validation requires every fragment definition to be referenced by some
+        // operation (directly or transitively). Drop fragments that never get
+        // spread to avoid producing invalid documents.
+        //
+        // We walk transitively from operations so chains like `op -> A -> B` keep
+        // both A and B, while `A -> B` with no operation referencing A drops both
+        // (B is only reachable through A, which is itself unused).
+        let mut reachable: IndexSet<crate::name::Name> = IndexSet::new();
+        for op in &self.operation_defs {
+            op.selection_set.collect_fragment_spreads(&mut reachable);
+        }
+        let mut frontier: Vec<crate::name::Name> = reachable.iter().cloned().collect();
+        while let Some(name) = frontier.pop() {
+            if let Some(frag) = self.fragment_defs.iter().find(|f| f.name == name) {
+                let mut nested: IndexSet<crate::name::Name> = IndexSet::new();
+                frag.selection_set.collect_fragment_spreads(&mut nested);
+                for n in nested {
+                    if reachable.insert(n.clone()) {
+                        frontier.push(n);
+                    }
+                }
+            }
+        }
+        let fragment_definitions = self
+            .fragment_defs
+            .into_iter()
+            .filter(|f| reachable.contains(&f.name))
+            .collect();
+
         Document {
             schema_definition: self.schema_def,
             object_type_definitions: self.object_type_defs,
@@ -237,7 +267,7 @@ impl<'a> DocumentBuilder<'a> {
             enum_type_definitions: self.enum_type_defs,
             directive_definitions: self.directive_defs,
             operation_definitions: self.operation_defs,
-            fragment_definitions: self.fragment_defs,
+            fragment_definitions,
             scalar_type_definitions: self.scalar_type_defs,
             union_type_definitions: self.union_type_defs,
             input_object_type_definitions: self.input_object_type_defs,

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -26,7 +26,6 @@ pub(crate) mod union;
 pub(crate) mod variable;
 
 use indexmap::IndexMap;
-use indexmap::IndexSet;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -238,22 +237,7 @@ impl<'a> DocumentBuilder<'a> {
         // We walk transitively from operations so chains like `op -> A -> B` keep
         // both A and B, while `A -> B` with no operation referencing A drops both
         // (B is only reachable through A, which is itself unused).
-        let mut reachable: IndexSet<crate::name::Name> = IndexSet::new();
-        for op in &self.operation_defs {
-            op.selection_set.collect_fragment_spreads(&mut reachable);
-        }
-        let mut frontier: Vec<crate::name::Name> = reachable.iter().cloned().collect();
-        while let Some(name) = frontier.pop() {
-            if let Some(frag) = self.fragment_defs.iter().find(|f| f.name == name) {
-                let mut nested: IndexSet<crate::name::Name> = IndexSet::new();
-                frag.selection_set.collect_fragment_spreads(&mut nested);
-                for n in nested {
-                    if reachable.insert(n.clone()) {
-                        frontier.push(n);
-                    }
-                }
-            }
-        }
+        let reachable = fragment::reachable_fragment_names(&self.operation_defs, &self.fragment_defs);
         let fragment_definitions = self
             .fragment_defs
             .into_iter()

--- a/crates/apollo-smith/src/selection_set.rs
+++ b/crates/apollo-smith/src/selection_set.rs
@@ -24,6 +24,26 @@ impl From<SelectionSet> for Vec<ast::Selection> {
     }
 }
 
+impl SelectionSet {
+    pub(crate) fn collect_fragment_spreads(&self, into: &mut indexmap::IndexSet<Name>) {
+        for selection in &self.selections {
+            match selection {
+                Selection::Field(field) => {
+                    if let Some(inner) = &field.selection_set {
+                        inner.collect_fragment_spreads(into);
+                    }
+                }
+                Selection::FragmentSpread(spread) => {
+                    into.insert(spread.name.clone());
+                }
+                Selection::InlineFragment(inline) => {
+                    inline.selection_set.collect_fragment_spreads(into);
+                }
+            }
+        }
+    }
+}
+
 impl TryFrom<apollo_parser::cst::SelectionSet> for SelectionSet {
     type Error = crate::FromError;
 

--- a/crates/apollo-smith/src/selection_set.rs
+++ b/crates/apollo-smith/src/selection_set.rs
@@ -6,6 +6,7 @@ use crate::DocumentBuilder;
 use apollo_compiler::ast;
 use apollo_compiler::Node;
 use arbitrary::Result as ArbitraryResult;
+use indexmap::IndexSet;
 
 /// The __selectionSet type represents a selection_set type in a fragment spread, an operation or a field
 ///
@@ -15,7 +16,7 @@ use arbitrary::Result as ArbitraryResult;
 /// Detailed documentation can be found in [GraphQL spec](https://spec.graphql.org/October2021/#sec-Selection-Sets).
 #[derive(Debug, Clone)]
 pub struct SelectionSet {
-    selections: Vec<Selection>,
+    pub(crate) selections: Vec<Selection>,
 }
 
 impl From<SelectionSet> for Vec<ast::Selection> {
@@ -25,7 +26,7 @@ impl From<SelectionSet> for Vec<ast::Selection> {
 }
 
 impl SelectionSet {
-    pub(crate) fn collect_fragment_spreads(&self, into: &mut indexmap::IndexSet<Name>) {
+    pub(crate) fn collect_fragment_spreads(&self, into: &mut IndexSet<Name>) {
         for selection in &self.selections {
             match selection {
                 Selection::Field(field) => {

--- a/crates/apollo-smith/src/snapshot_tests.rs
+++ b/crates/apollo-smith/src/snapshot_tests.rs
@@ -17,10 +17,6 @@ fn snapshot_tests() {
           A0
         }
 
-        fragment A6 on A3 {
-          A0
-        }
-
         schema {
           query: A3
           mutation: A3
@@ -56,10 +52,6 @@ fn snapshot_tests() {
     .assert_eq(&gen(0));
     expect![[r#"
         {
-          A0
-        }
-
-        fragment A11 on A8 {
           A0
         }
 
@@ -123,10 +115,6 @@ fn snapshot_tests() {
     .assert_eq(&gen(10));
     expect![[r#"
         {
-          A0
-        }
-
-        fragment A11 on A8 {
           A0
         }
 
@@ -198,10 +186,6 @@ fn snapshot_tests() {
     .assert_eq(&gen(100));
     expect![[r#"
         {
-          A0
-        }
-
-        fragment A17 on A14 {
           A0
         }
 


### PR DESCRIPTION
# Summary

Fixes two bugs in apollo-smith that caused the validate fuzzer to produce documents with unused fragment definitions, which validation rejects.

## Changes

1. Fix inverted filter in fragment_spread (crates/apollo-smith/src/fragment.rs)
  
The excludes list, which tracks fragments already spread in the current selection set, was being used as an inclusion filter rather than an exclusion filter. Because excludes starts empty for each selection set, available_fragment was always empty and fragment_spread always returned None. Fragments were generated but never referenced.

2. Prune unused fragments in `finish()` (crates/apollo-smith/src/lib.rs, crates/apollo-smith/src/selection_set.rs)

Even with fragment spreads working, the random selection-set generator may still not reference every fragment definition we generated. Added a transitive reachability walk in `finish()` that starts from each operation's selection set and keeps only fragments reachable through fragment spreads. Chains like op → A → B retain both A and B; orphan chains like A → B (with no operation referencing A) drop both.

Helper `SelectionSet::collect_fragment_spreads` recursively walks a selection set (through nested fields and inline fragments) collecting all referenced fragment names.