### PR TITLE
fix(smith): allow directive applications when only one directive is defined

### DIFF
--- a/crates/apollo-smith/src/directive.rs
+++ b/crates/apollo-smith/src/directive.rs
@@ -143,7 +143,7 @@ impl DocumentBuilder<'_> {
             return Ok(IndexMap::new());
         }
 
-        let num_directives = self.u.int_in_range(0..=(self.directive_defs.len() - 1))?;
+        let num_directives = self.u.int_in_range(0..=self.directive_defs.len())?;
         let directives = (0..num_directives)
             .map(|_| self.directive(directive_location))
             .collect::<ArbitraryResult<Vec<_>>>()?


### PR DESCRIPTION
## Summary

`DocumentBuilder::directives` selects a *count* of directives to emit
from the range `0..=(directive_defs.len() - 1)`. When exactly one
directive is defined, that range collapses to `0..=0`, so smith always
picks zero directives — e.g. an API schema that only declares `@defer`
could never emit it.

Use `0..=directive_defs.len()` instead. The empty-defs case is already
guarded by the early return immediately above, so the `- 1` was the
only thing keeping `len == 1` from being a usable upper bound.

## Test plan

- [ ] `cargo test -p apollo-smith`
- [ ] Generate a document against a schema declaring only `@defer` and
      confirm `@defer` can now appear in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)