### PR TITLE
fix(smith): resolve operation and schema validation errors

### DIFF
--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -189,8 +189,13 @@ impl<'a> DocumentBuilder<'a> {
         let schema_def = builder.schema_definition()?;
         builder.schema_def = Some(schema_def);
 
-        for _ in 0..builder.u.int_in_range(1..=50)? {
-            let operation_def = builder.operation_definition()?;
+        // An anonymous operation may only exist as the sole operation
+        // in a document, so any time we're producing more than one,
+        // every operation must be named.
+        let num_ops = builder.u.int_in_range(1..=50)?;
+        let require_named = num_ops > 1;
+        for _ in 0..num_ops {
+            let operation_def = builder.operation_definition_in_document(require_named)?;
             // Could be None if there is no schema definition (in this case it never happens)
             if let Some(operation_def) = operation_def {
                 builder.operation_defs.push(operation_def);

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -1,6 +1,7 @@
 use crate::directive::Directive;
 use crate::directive::DirectiveLocation;
 use crate::name::Name;
+use crate::selection_set::Selection;
 use crate::selection_set::SelectionSet;
 use crate::variable::VariableDef;
 use crate::DocumentBuilder;
@@ -147,7 +148,17 @@ impl DocumentBuilder<'_> {
         // Stack
         self.stack_ty(chosen_ty);
 
-        let selection_set = self.selection_set()?;
+        let selection_set = if matches!(operation_type, OperationType::Subscription) {
+            // Subscription operations must have exactly one root field
+            // per <https://spec.graphql.org/October2021/#sec-Single-root-field>.
+            // Picking a `Field` directly avoids fragments at the top
+            // level, whose contents could otherwise widen the root.
+            SelectionSet {
+                selections: vec![Selection::Field(self.field(0)?)],
+            }
+        } else {
+            self.selection_set()?
+        };
 
         self.stack.pop();
         // Clear the chosen arguments for an operation

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -110,18 +110,39 @@ impl From<apollo_parser::cst::OperationType> for OperationType {
 }
 
 impl DocumentBuilder<'_> {
-    /// Create an arbitrary `OperationDef` taking the last `SchemaDef`
+    /// Create an arbitrary `OperationDef` taking the last `SchemaDef`.
     pub fn operation_definition(&mut self) -> ArbitraryResult<Option<OperationDef>> {
+        self.operation_definition_in_document(false)
+    }
+
+    /// Like [`operation_definition`], but forces the operation to be
+    /// named when `require_named` is true. A document with more than
+    /// one operation may not contain an anonymous operation.
+    ///
+    /// Operation Name Uniqueness across the document is upheld by
+    /// `type_name`, which never returns a name that already exists on
+    /// the builder.
+    ///
+    /// See <https://spec.graphql.org/October2021/#sec-Lone-Anonymous-Operations>
+    /// and <https://spec.graphql.org/October2021/#sec-Operation-Name-Uniqueness>.
+    ///
+    /// [`operation_definition`]: Self::operation_definition
+    pub(crate) fn operation_definition_in_document(
+        &mut self,
+        require_named: bool,
+    ) -> ArbitraryResult<Option<OperationDef>> {
         let schema = match self.schema_def.clone() {
             Some(schema_def) => schema_def,
             None => return Ok(None),
         };
-        let name = self
-            .u
-            .arbitrary()
-            .unwrap_or(false)
-            .then(|| self.type_name())
-            .transpose()?;
+
+        let want_name = require_named || self.u.arbitrary().unwrap_or(false);
+        let name = if want_name {
+            Some(self.type_name()?)
+        } else {
+            None
+        };
+
         let available_operations = {
             let mut ops = vec![];
             if let Some(query) = &schema.query {

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -123,7 +123,7 @@ impl DocumentBuilder<'_> {
     /// `type_name`, which never returns a name that already exists on
     /// the builder.
     ///
-    /// See <https://spec.graphql.org/October2021/#sec-Lone-Anonymous-Operations>
+    /// See <https://spec.graphql.org/October2021/#sec-Lone-Anonymous-Operation>
     /// and <https://spec.graphql.org/October2021/#sec-Operation-Name-Uniqueness>.
     ///
     /// [`operation_definition`]: Self::operation_definition
@@ -172,8 +172,8 @@ impl DocumentBuilder<'_> {
         let selection_set = if matches!(operation_type, OperationType::Subscription) {
             // Subscription operations must have exactly one root field
             // per <https://spec.graphql.org/October2021/#sec-Single-root-field>.
-            // Picking a `Field` directly avoids fragments at the top
-            // level, whose contents could otherwise widen the root.
+            // We generate exactly one field to satisfy that condition. The 0-index
+            // is sometimes used to create an alias for the field.
             SelectionSet {
                 selections: vec![Selection::Field(self.field(0)?)],
             }

--- a/crates/apollo-smith/src/schema.rs
+++ b/crates/apollo-smith/src/schema.rs
@@ -140,31 +140,22 @@ impl DocumentBuilder<'_> {
 
         let arbitrary_idx: usize = self.u.arbitrary::<usize>()?;
 
-        let mut query = arbitrary_idx
-            .is_multiple_of(2)
-            .then(|| self.u.choose(&named_types))
-            .transpose()?
-            .cloned();
-        let mut mutation = arbitrary_idx
+        // Every schema must declare a `query` root operation type, even
+        // when no operations reference it. Mutation and subscription are
+        // optional.
+        //
+        // See <https://spec.graphql.org/October2021/#sec-Root-Operation-Types>.
+        let query = Some(self.u.choose(&named_types)?.clone());
+        let mutation = arbitrary_idx
             .is_multiple_of(3)
             .then(|| self.u.choose(&named_types))
             .transpose()?
             .cloned();
-        let mut subscription = arbitrary_idx
+        let subscription = arbitrary_idx
             .is_multiple_of(5)
             .then(|| self.u.choose(&named_types))
             .transpose()?
             .cloned();
-        // If no one has been filled
-        if let (None, None, None) = (&query, &mutation, &subscription) {
-            let arbitrary_op_type_idx = self.u.int_in_range(0..=2usize)?;
-            match arbitrary_op_type_idx {
-                0 => query = Some(self.u.choose(&named_types)?.clone()),
-                1 => mutation = Some(self.u.choose(&named_types)?.clone()),
-                2 => subscription = Some(self.u.choose(&named_types)?.clone()),
-                _ => unreachable!(),
-            }
-        }
 
         Ok(SchemaDef {
             description,
@@ -172,7 +163,13 @@ impl DocumentBuilder<'_> {
             query,
             mutation,
             subscription,
-            extend: self.u.arbitrary().unwrap_or(false),
+            // A schema extension is only valid alongside a base schema
+            // definition. The builder only ever generates one schema
+            // node, so rendering it as an extension would produce an
+            // orphan `extend schema` block.
+            //
+            // See <https://spec.graphql.org/October2021/#sec-Schema-Extension>.
+            extend: false,
         })
     }
 }


### PR DESCRIPTION
## Summary

`apollo-smith` produced documents that violated three operation/schema rules the fuzzer kept hitting:

- **Schemas without a `query` root operation type.** The generator decided query, mutation, and subscription independently and only guaranteed that *one* was set, so mutation-only or subscription-only schemas were spec-invalid. The schema's `extend` flag was also arbitrary, but only one schema node is ever produced — so flipping `extend: true` rendered as an orphan `extend schema` block with no base definition.
- **Subscription operations with more than one root field.** The general-purpose `selection_set()` builds 1-5 selections of arbitrary kind (Field, FragmentSpread, InlineFragment), which both overshoots the root-field count and risks fragments widening the root.
- **Anonymous operations alongside named ones.** Each operation's name was decided independently, so a document with multiple operations could mix anonymous and named — invalid under the Lone Anonymous Operation rule.

The relevant spec sections:
- [Root Operation Types](https://spec.graphql.org/October2021/#sec-Root-Operation-Types)
- [Schema Extension](https://spec.graphql.org/October2021/#sec-Schema-Extension)
- [Single root field](https://spec.graphql.org/October2021/#sec-Single-root-field)
- [Lone Anonymous Operations](https://spec.graphql.org/October2021/#sec-Lone-Anonymous-Operation)

After this patch, none of these categories appear in fuzzer output across the existing `apollo-smith` corpus.

<!-- FED-1020 -->