### PR TITLE
fix(smith): restrict union members to object types

### DIFF
--- a/crates/apollo-smith/src/union.rs
+++ b/crates/apollo-smith/src/union.rs
@@ -2,7 +2,6 @@ use crate::description::Description;
 use crate::directive::Directive;
 use crate::directive::DirectiveLocation;
 use crate::name::Name;
-use crate::ty::Ty;
 use crate::DocumentBuilder;
 use apollo_compiler::ast;
 use arbitrary::Result as ArbitraryResult;
@@ -134,15 +133,14 @@ impl DocumentBuilder<'_> {
             .then(|| self.description())
             .transpose()?;
         let directives = self.directives(DirectiveLocation::Union)?;
-        let mut existing_types = self.list_existing_object_types();
-        existing_types.extend(
-            self.union_type_defs
-                .iter()
-                .map(|u| Ty::Named(u.name.clone())),
-        );
-
+        // Union members must be Object base types — built-in scalars,
+        // other unions, interfaces, enums, and input objects are all
+        // invalid as members.
+        //
+        // See <https://spec.graphql.org/October2021/#sec-Unions>.
+        let object_types = self.list_existing_object_types();
         let members = (0..self.u.int_in_range(2..=10)?)
-            .map(|_| Ok(self.choose_named_ty(&existing_types)?.name().clone()))
+            .map(|_| Ok(self.u.choose(&object_types)?.name().clone()))
             .collect::<ArbitraryResult<IndexSet<_>>>()?;
 
         Ok(UnionTypeDef {


### PR DESCRIPTION
## Summary

`apollo-smith` generated unions whose members weren't Object base types, producing documents the validator rejected with errors like `union member Int must be an object type` (and the same for `Float`, `String`, `Boolean`, `ID`, and other union names).

The generator built its member candidate pool from three sources:

1. `list_existing_object_types()` — valid.
2. `.extend(self.union_type_defs ...)` — added other union names, which can't be union members.
3. `choose_named_ty()`'s implicit fallback to `BUILTIN_SCALAR_NAMES` — added `Int`/`Float`/`String`/`Boolean`/`ID`, none of which are Object types.

Sources (2) and (3) both produce invalid documents. Pick directly from `list_existing_object_types()` instead.

See <https://spec.graphql.org/October2021/#sec-Unions>.