### PR TITLE
fix(smith)!: pass the correct directive location to input_values_def

### DIFF
--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -1,3 +1,4 @@
+use crate::directive::DirectiveLocation;
 use crate::input_value::Constness;
 use crate::input_value::InputValue;
 use crate::input_value::InputValueDef;
@@ -121,7 +122,8 @@ impl DocumentBuilder<'_> {
     /// Create an arbitrary `ArgumentsDef`
     pub fn arguments_definition(&mut self) -> ArbitraryResult<ArgumentsDef> {
         Ok(ArgumentsDef {
-            input_value_definitions: self.input_values_def()?,
+            input_value_definitions: self
+                .input_values_def(DirectiveLocation::ArgumentDefinition)?,
         })
     }
 }

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -141,7 +141,7 @@ impl DocumentBuilder<'_> {
             .unwrap_or(false)
             .then(|| self.description())
             .transpose()?;
-        let fields = self.input_values_def()?;
+        let fields = self.input_values_def(DirectiveLocation::InputFieldDefinition)?;
 
         Ok(InputObjectTypeDef {
             description,

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -282,8 +282,15 @@ impl DocumentBuilder<'_> {
         Ok(val)
     }
 
-    /// Create an arbitrary list of `InputValueDef`
-    pub fn input_values_def(&mut self) -> ArbitraryResult<Vec<InputValueDef>> {
+    /// Create an arbitrary list of `InputValueDef`. The caller passes
+    /// `directive_location` so directives applied to each value are
+    /// filtered against the right context — `InputFieldDefinition` for
+    /// input-object fields, `ArgumentDefinition` for argument lists on
+    /// fields and directives.
+    pub fn input_values_def(
+        &mut self,
+        directive_location: DirectiveLocation,
+    ) -> ArbitraryResult<Vec<InputValueDef>> {
         let arbitrary_iv_num = self.u.int_in_range(2..=5usize)?;
         let mut input_values = Vec::with_capacity(arbitrary_iv_num - 1);
 
@@ -296,8 +303,7 @@ impl DocumentBuilder<'_> {
                 .transpose()?;
             let name = self.name_with_index(i)?;
             let ty = self.choose_ty(&self.list_existing_input_types())?;
-            // TODO: incorrect because input_values_def is called from different locations
-            let directives = self.directives(DirectiveLocation::InputFieldDefinition)?;
+            let directives = self.directives(directive_location)?;
             // TODO: FIXME: it's not correct I need to generate default value corresponding to the ty above
             let default_value = self
                 .u
@@ -317,8 +323,13 @@ impl DocumentBuilder<'_> {
 
         Ok(input_values)
     }
-    /// Create an arbitrary `InputValueDef`
-    pub fn input_value_def(&mut self) -> ArbitraryResult<InputValueDef> {
+    /// Create an arbitrary `InputValueDef`. The caller passes
+    /// `directive_location` for the same reason as
+    /// [`input_values_def`](Self::input_values_def).
+    pub fn input_value_def(
+        &mut self,
+        directive_location: DirectiveLocation,
+    ) -> ArbitraryResult<InputValueDef> {
         let description = self
             .u
             .arbitrary()
@@ -327,8 +338,7 @@ impl DocumentBuilder<'_> {
             .transpose()?;
         let name = self.name()?;
         let ty = self.choose_ty(&self.list_existing_input_types())?;
-        // TODO: incorrect because input_values_def is called from different locations
-        let directives = self.directives(DirectiveLocation::InputFieldDefinition)?;
+        let directives = self.directives(directive_location)?;
         // TODO: FIXME: it's not correct I need to generate default value corresponding to the ty above
         let default_value = self
             .u


### PR DESCRIPTION
## Summary

`input_values_def` (and `input_value_def`) hardcoded the directive location to `InputFieldDefinition` for every call, so directives applied to argument-definition lists ended up filtered for the wrong context. Apollo's validator rejected those documents with errors like:

```
Error: `@A4` directive is not supported for ARGUMENT_DEFINITION location
```

The function is reached from two places that need different locations:

- `input_object_type_definition` generates input-object fields → `InputFieldDefinition`.
- `arguments_definition` generates field/directive arguments → `ArgumentDefinition`.

The original author left a TODO comment on both call sites. This PR takes the location as a parameter and has each caller pass the right one.

See <https://spec.graphql.org/October2021/#sec-Type-System.Directives>.