### PR TITLE
fix(smith)!: prevent extensions from duplicating existing values

### DIFF
--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -123,7 +123,7 @@ impl DocumentBuilder<'_> {
     pub fn arguments_definition(&mut self) -> ArbitraryResult<ArgumentsDef> {
         Ok(ArgumentsDef {
             input_value_definitions: self
-                .input_values_def(DirectiveLocation::ArgumentDefinition)?,
+                .input_values_def(DirectiveLocation::ArgumentDefinition, &[])?,
         })
     }
 }

--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -7,6 +7,7 @@ use crate::DocumentBuilder;
 use apollo_compiler::ast;
 use apollo_compiler::Node;
 use arbitrary::Result as ArbitraryResult;
+use indexmap::IndexSet;
 
 /// The `__ArgumentsDef` type represents an arguments definition
 ///
@@ -123,7 +124,7 @@ impl DocumentBuilder<'_> {
     pub fn arguments_definition(&mut self) -> ArbitraryResult<ArgumentsDef> {
         Ok(ArgumentsDef {
             input_value_definitions: self
-                .input_values_def(DirectiveLocation::ArgumentDefinition, &[])?,
+                .input_values_def(DirectiveLocation::ArgumentDefinition, &IndexSet::new())?,
         })
     }
 }

--- a/crates/apollo-smith/src/enum_.rs
+++ b/crates/apollo-smith/src/enum_.rs
@@ -187,7 +187,13 @@ impl DocumentBuilder<'_> {
         } else {
             self.type_name()?
         };
-        let enum_values_def = self.enum_values_definition()?;
+        let existing_values: IndexSet<Name> = self
+            .enum_type_defs
+            .iter()
+            .filter(|e| e.name == name)
+            .flat_map(|e| e.enum_values_def.iter().map(|v| v.value.clone()))
+            .collect();
+        let enum_values_def = self.enum_values_definition(&existing_values)?;
         let directives = self.directives(DirectiveLocation::Enum)?;
 
         Ok(EnumTypeDef {
@@ -216,7 +222,10 @@ impl DocumentBuilder<'_> {
     }
 
     /// Create an arbitrary `EnumValueDefinition`
-    pub fn enum_values_definition(&mut self) -> Result<IndexSet<EnumValueDefinition>> {
+    pub fn enum_values_definition(
+        &mut self,
+        exclude: &IndexSet<Name>,
+    ) -> Result<IndexSet<EnumValueDefinition>> {
         let mut enum_values_def = IndexSet::with_capacity(self.u.int_in_range(2..=10usize)?);
         for i in 0..self.u.int_in_range(2..=10usize)? {
             let description = self
@@ -228,11 +237,13 @@ impl DocumentBuilder<'_> {
             let value = self.name_with_index(i)?;
             let directives = self.directives(DirectiveLocation::EnumValue)?;
 
-            enum_values_def.insert(EnumValueDefinition {
-                description,
-                value,
-                directives,
-            });
+            if !exclude.contains(&value) {
+                enum_values_def.insert(EnumValueDefinition {
+                    description,
+                    value,
+                    directives,
+                });
+            }
         }
 
         Ok(enum_values_def)

--- a/crates/apollo-smith/src/enum_.rs
+++ b/crates/apollo-smith/src/enum_.rs
@@ -196,6 +196,10 @@ impl DocumentBuilder<'_> {
         let enum_values_def = self.enum_values_definition(&existing_values)?;
         let directives = self.directives(DirectiveLocation::Enum)?;
 
+        if extend && directives.is_empty() && enum_values_def.is_empty() {
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+
         Ok(EnumTypeDef {
             description,
             name,

--- a/crates/apollo-smith/src/field.rs
+++ b/crates/apollo-smith/src/field.rs
@@ -123,13 +123,16 @@ impl TryFrom<apollo_parser::cst::Field> for Field {
 
 impl DocumentBuilder<'_> {
     /// Create an arbitrary list of `FieldDef`
-    pub fn fields_definition(&mut self, exclude: &[&Name]) -> ArbitraryResult<Vec<FieldDef>> {
+    pub fn fields_definition(
+        &mut self,
+        exclude: &IndexSet<Name>,
+    ) -> ArbitraryResult<Vec<FieldDef>> {
         let num_fields = self.u.int_in_range(2..=50usize)?;
         let mut fields_names = IndexSet::with_capacity(num_fields);
 
         for i in 0..num_fields {
             let name = self.name_with_index(i)?;
-            if !exclude.contains(&&name) {
+            if !exclude.contains(&name) {
                 fields_names.insert(name);
             }
         }

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -151,9 +151,15 @@ impl DocumentBuilder<'_> {
         let fields =
             self.input_values_def(DirectiveLocation::InputFieldDefinition, &exclude_fields)?;
 
+        let directives = self.directives(DirectiveLocation::InputObject)?;
+
+        if extend && directives.is_empty() && fields.is_empty() {
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+
         Ok(InputObjectTypeDef {
             description,
-            directives: self.directives(DirectiveLocation::InputObject)?,
+            directives,
             name,
             extend,
             fields,

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -8,6 +8,7 @@ use apollo_compiler::ast;
 use apollo_compiler::Node;
 use arbitrary::Result as ArbitraryResult;
 use indexmap::IndexMap;
+use indexmap::IndexSet;
 
 /// Input objects are composite types used as inputs into queries defined as a list of named input values..
 ///
@@ -141,13 +142,12 @@ impl DocumentBuilder<'_> {
             .unwrap_or(false)
             .then(|| self.description())
             .transpose()?;
-        let existing_field_names: Vec<Name> = self
+        let exclude_fields: IndexSet<Name> = self
             .input_object_type_defs
             .iter()
             .filter(|io| io.name == name)
             .flat_map(|io| io.fields.iter().map(|f| f.name.clone()))
             .collect();
-        let exclude_fields: Vec<&Name> = existing_field_names.iter().collect();
         let fields =
             self.input_values_def(DirectiveLocation::InputFieldDefinition, &exclude_fields)?;
 

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -141,7 +141,14 @@ impl DocumentBuilder<'_> {
             .unwrap_or(false)
             .then(|| self.description())
             .transpose()?;
-        let fields = self.input_values_def(DirectiveLocation::InputFieldDefinition)?;
+        let existing_field_names: Vec<Name> = self
+            .input_object_type_defs
+            .iter()
+            .filter(|io| io.name == name)
+            .flat_map(|io| io.fields.iter().map(|f| f.name.clone()))
+            .collect();
+        let exclude_fields: Vec<&Name> = existing_field_names.iter().collect();
+        let fields = self.input_values_def(DirectiveLocation::InputFieldDefinition, &exclude_fields)?;
 
         Ok(InputObjectTypeDef {
             description,

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -148,7 +148,8 @@ impl DocumentBuilder<'_> {
             .flat_map(|io| io.fields.iter().map(|f| f.name.clone()))
             .collect();
         let exclude_fields: Vec<&Name> = existing_field_names.iter().collect();
-        let fields = self.input_values_def(DirectiveLocation::InputFieldDefinition, &exclude_fields)?;
+        let fields =
+            self.input_values_def(DirectiveLocation::InputFieldDefinition, &exclude_fields)?;
 
         Ok(InputObjectTypeDef {
             description,

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -290,6 +290,7 @@ impl DocumentBuilder<'_> {
     pub fn input_values_def(
         &mut self,
         directive_location: DirectiveLocation,
+        exclude: &[&Name],
     ) -> ArbitraryResult<Vec<InputValueDef>> {
         let arbitrary_iv_num = self.u.int_in_range(2..=5usize)?;
         let mut input_values = Vec::with_capacity(arbitrary_iv_num - 1);
@@ -312,13 +313,15 @@ impl DocumentBuilder<'_> {
                 .then(|| self.input_value(Constness::Const))
                 .transpose()?;
 
-            input_values.push(InputValueDef {
-                description,
-                name,
-                ty,
-                default_value,
-                directives,
-            });
+            if !exclude.contains(&&name) {
+                input_values.push(InputValueDef {
+                    description,
+                    name,
+                    ty,
+                    default_value,
+                    directives,
+                });
+            }
         }
 
         Ok(input_values)

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -8,6 +8,7 @@ use apollo_compiler::ast;
 use apollo_compiler::Node;
 use arbitrary::Result as ArbitraryResult;
 use indexmap::IndexMap;
+use indexmap::IndexSet;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Constness {
@@ -290,7 +291,7 @@ impl DocumentBuilder<'_> {
     pub fn input_values_def(
         &mut self,
         directive_location: DirectiveLocation,
-        exclude: &[&Name],
+        exclude: &IndexSet<Name>,
     ) -> ArbitraryResult<Vec<InputValueDef>> {
         let arbitrary_iv_num = self.u.int_in_range(2..=5usize)?;
         let mut input_values = Vec::with_capacity(arbitrary_iv_num - 1);
@@ -313,7 +314,7 @@ impl DocumentBuilder<'_> {
                 .then(|| self.input_value(Constness::Const))
                 .transpose()?;
 
-            if !exclude.contains(&&name) {
+            if !exclude.contains(&name) {
                 input_values.push(InputValueDef {
                     description,
                     name,

--- a/crates/apollo-smith/src/interface.rs
+++ b/crates/apollo-smith/src/interface.rs
@@ -169,6 +169,10 @@ impl DocumentBuilder<'_> {
         let fields_def = self.fields_definition(&exclude_fields)?;
         let directives = self.directives(DirectiveLocation::Interface)?;
 
+        if extend && directives.is_empty() && fields_def.is_empty() && interfaces.is_empty() {
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+
         Ok(InterfaceTypeDef {
             description,
             name,

--- a/crates/apollo-smith/src/interface.rs
+++ b/crates/apollo-smith/src/interface.rs
@@ -161,7 +161,12 @@ impl DocumentBuilder<'_> {
         // enforces all three given the existing signatures.
         let existing_field_signatures = field_signatures_for(&self.interface_type_defs, &name);
         let interfaces = self.additional_implements(&existing_field_signatures, Some(&name))?;
-        let fields_def = self.fields_definition(&[])?;
+        let existing_field_names: Vec<Name> = existing_field_signatures
+            .keys()
+            .map(|k| Name::new(k.clone()))
+            .collect();
+        let exclude_fields: Vec<&Name> = existing_field_names.iter().collect();
+        let fields_def = self.fields_definition(&exclude_fields)?;
         let directives = self.directives(DirectiveLocation::Interface)?;
 
         Ok(InterfaceTypeDef {

--- a/crates/apollo-smith/src/interface.rs
+++ b/crates/apollo-smith/src/interface.rs
@@ -161,11 +161,10 @@ impl DocumentBuilder<'_> {
         // enforces all three given the existing signatures.
         let existing_field_signatures = field_signatures_for(&self.interface_type_defs, &name);
         let interfaces = self.additional_implements(&existing_field_signatures, Some(&name))?;
-        let existing_field_names: Vec<Name> = existing_field_signatures
+        let exclude_fields: IndexSet<Name> = existing_field_signatures
             .keys()
             .map(|k| Name::new(k.clone()))
             .collect();
-        let exclude_fields: Vec<&Name> = existing_field_names.iter().collect();
         let fields_def = self.fields_definition(&exclude_fields)?;
         let directives = self.directives(DirectiveLocation::Interface)?;
 

--- a/crates/apollo-smith/src/object.rs
+++ b/crates/apollo-smith/src/object.rs
@@ -177,7 +177,12 @@ impl DocumentBuilder<'_> {
         // interface graph, so no cycle protection is needed.
         let existing_field_signatures = field_signatures_for(&self.object_type_defs, &name);
         let implements_interfaces = self.additional_implements(&existing_field_signatures, None)?;
-        let fields_def = self.fields_definition(&[])?;
+        let existing_field_names: Vec<Name> = existing_field_signatures
+            .keys()
+            .map(|k| Name::new(k.clone()))
+            .collect();
+        let exclude_fields: Vec<&Name> = existing_field_names.iter().collect();
+        let fields_def = self.fields_definition(&exclude_fields)?;
         let directives = self.directives(DirectiveLocation::Object)?;
 
         Ok(ObjectTypeDef {

--- a/crates/apollo-smith/src/object.rs
+++ b/crates/apollo-smith/src/object.rs
@@ -185,6 +185,14 @@ impl DocumentBuilder<'_> {
         let fields_def = self.fields_definition(&exclude_fields)?;
         let directives = self.directives(DirectiveLocation::Object)?;
 
+        if extend
+            && directives.is_empty()
+            && fields_def.is_empty()
+            && implements_interfaces.is_empty()
+        {
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+
         Ok(ObjectTypeDef {
             description,
             directives,

--- a/crates/apollo-smith/src/object.rs
+++ b/crates/apollo-smith/src/object.rs
@@ -177,11 +177,10 @@ impl DocumentBuilder<'_> {
         // interface graph, so no cycle protection is needed.
         let existing_field_signatures = field_signatures_for(&self.object_type_defs, &name);
         let implements_interfaces = self.additional_implements(&existing_field_signatures, None)?;
-        let existing_field_names: Vec<Name> = existing_field_signatures
+        let exclude_fields: IndexSet<Name> = existing_field_signatures
             .keys()
             .map(|k| Name::new(k.clone()))
             .collect();
-        let exclude_fields: Vec<&Name> = existing_field_names.iter().collect();
         let fields_def = self.fields_definition(&exclude_fields)?;
         let directives = self.directives(DirectiveLocation::Object)?;
 

--- a/crates/apollo-smith/src/union.rs
+++ b/crates/apollo-smith/src/union.rs
@@ -156,6 +156,10 @@ impl DocumentBuilder<'_> {
             .map(|_| Ok(self.u.choose(&object_types)?.name().clone()))
             .collect::<ArbitraryResult<IndexSet<_>>>()?;
 
+        if extend && directives.is_empty() && members.is_empty() {
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+
         Ok(UnionTypeDef {
             name,
             description,

--- a/crates/apollo-smith/src/union.rs
+++ b/crates/apollo-smith/src/union.rs
@@ -138,7 +138,20 @@ impl DocumentBuilder<'_> {
         // invalid as members.
         //
         // See <https://spec.graphql.org/October2021/#sec-Unions>.
-        let object_types = self.list_existing_object_types();
+        let existing_members: IndexSet<Name> = self
+            .union_type_defs
+            .iter()
+            .filter(|u| u.name == name)
+            .flat_map(|u| u.members.iter().cloned())
+            .collect();
+        let object_types: Vec<_> = self
+            .list_existing_object_types()
+            .into_iter()
+            .filter(|o| !existing_members.contains(o.name()))
+            .collect();
+        if object_types.is_empty() {
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
         let members = (0..self.u.int_in_range(2..=10)?)
             .map(|_| Ok(self.u.choose(&object_types)?.name().clone()))
             .collect::<ArbitraryResult<IndexSet<_>>>()?;


### PR DESCRIPTION
When we generate a new extension for an existing enum, we now gather the existing values from all previous definitions and exclude them from the in-progress extension. We apply equivalent logic for preventing duplicate union members and duplicate fields in objects, interfaces, and input definitions.

After we deduplicate, it's possible that we have produced an empty definition. In that case, we return an `IncorrectFormat` error so the fuzzer moves on to another byte string.

<!-- FED-1044 -->