### PR TITLE
fix(smith): guarantee unique type names

### DIFF
--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -1,5 +1,6 @@
 use crate::DocumentBuilder;
 use arbitrary::Result as ArbitraryResult;
+use std::collections::HashSet;
 use std::fmt::Write as _;
 
 // First char in a GraphQL name can't be a digit and we don't want it to be
@@ -82,18 +83,16 @@ impl DocumentBuilder<'_> {
 
     /// Create an arbitrary type `Name` that does not yet exist in the document.
     pub fn type_name(&mut self) -> ArbitraryResult<Name> {
-        let mut new_name = self.limited_string(30)?;
-        if self.list_existing_type_names().any(|n| n.name == new_name) {
-            let suffix = self.object_type_defs.len()
-                + self.interface_type_defs.len()
-                + self.union_type_defs.len()
-                + self.scalar_type_defs.len()
-                + self.enum_type_defs.len()
-                + self.input_object_type_defs.len()
-                + self.directive_defs.len()
-                + self.fragment_defs.len()
-                + self.operation_defs.len();
-            let _ = write!(new_name, "{suffix}");
+        let existing: HashSet<String> = self
+            .list_existing_type_names()
+            .map(|n| n.name.clone())
+            .collect();
+        let base = self.limited_string(30)?;
+        let mut suffix = 0usize;
+        let mut new_name = base.clone();
+        while existing.contains(new_name.as_str()) {
+            new_name = format!("{base}{suffix}");
+            suffix += 1;
         }
         Ok(Name::new(new_name))
     }
@@ -142,7 +141,6 @@ impl DocumentBuilder<'_> {
             .chain(self.union_type_defs.iter().map(|itf| &itf.name))
             .chain(self.input_object_type_defs.iter().map(|itf| &itf.name))
             .chain(self.scalar_type_defs.iter().map(|itf| &itf.name))
-            .chain(self.directive_defs.iter().map(|itf| &itf.name))
             .chain(self.fragment_defs.iter().map(|itf| &itf.name))
             .chain(self.operation_defs.iter().filter_map(|op| op.name.as_ref()))
     }

--- a/crates/apollo-smith/src/snapshot_tests.rs
+++ b/crates/apollo-smith/src/snapshot_tests.rs
@@ -18,36 +18,36 @@ fn snapshot_tests() {
         }
 
         schema {
-          query: A3
-          mutation: A3
-          subscription: A3
+          query: A2
+          mutation: A2
+          subscription: A2
         }
 
         scalar A
 
-        type A3 {
-          A0: A1
-          A1: A1
+        type A2 {
+          A0: A0
+          A1: A0
         }
 
-        interface A2 {
-          A0: A1
-          A1: A1
+        interface A1 {
+          A0: A0
+          A1: A0
         }
 
-        union A4 = A3
+        union A3 = A2
 
-        enum A1 {
+        enum A0 {
           A0
           A1
         }
 
-        input A5 {
+        input A4 {
           A0: A
           A1: A
         }
 
-        directive @A7 on QUERY
+        directive @A6 on QUERY
     "#]]
     .assert_eq(&gen(0));
     expect![[r#"
@@ -56,24 +56,24 @@ fn snapshot_tests() {
         }
 
         schema {
-          query: A8
-          mutation: A8
-          subscription: A8
+          query: A5
+          mutation: A5
+          subscription: A5
         }
 
         scalar CD
 
-        type A8 {
+        type A5 {
           A0: IJAAAAAA
           A1: IJAAAAAA
         }
 
-        interface A7 {
+        interface A4 {
           A0: IJAAAAAA
           A1: IJAAAAAA
         }
 
-        union A9 = A8
+        union A6 = A5
 
         enum IJAAAAAA {
           A0
@@ -85,32 +85,32 @@ fn snapshot_tests() {
           A1
         }
 
+        enum A0 {
+          A0
+          A1
+        }
+
+        enum A1 {
+          A0
+          A1
+        }
+
+        enum A2 {
+          A0
+          A1
+        }
+
         enum A3 {
           A0
           A1
         }
 
-        enum A4 {
-          A0
-          A1
-        }
-
-        enum A5 {
-          A0
-          A1
-        }
-
-        enum A6 {
-          A0
-          A1
-        }
-
-        input A10 {
+        input A7 {
           A0: CD
           A1: CD
         }
 
-        directive @A12 on QUERY
+        directive @A9 on QUERY
     "#]]
     .assert_eq(&gen(10));
     expect![[r#"
@@ -119,24 +119,24 @@ fn snapshot_tests() {
         }
 
         schema {
-          query: A8
-          mutation: A8
-          subscription: A8
+          query: A5
+          mutation: A5
+          subscription: A5
         }
 
         scalar CD
 
-        type A8 {
+        type A5 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A7 {
+        interface A4 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        union A9 = A8
+        union A6 = A5
 
         enum IJKLMNOP {
           UVWXYZabcdefghijklmn0
@@ -156,32 +156,32 @@ fn snapshot_tests() {
           A1
         }
 
+        enum A0 {
+          A0
+          A1
+        }
+
+        enum A1 {
+          A0
+          A1
+        }
+
+        enum A2 {
+          A0
+          A1
+        }
+
         enum A3 {
           A0
           A1
         }
 
-        enum A4 {
-          A0
-          A1
-        }
-
-        enum A5 {
-          A0
-          A1
-        }
-
-        enum A6 {
-          A0
-          A1
-        }
-
-        input A10 {
+        input A7 {
           A0: CD
           A1: CD
         }
 
-        directive @A12 on QUERY
+        directive @A9 on QUERY
     "#]]
     .assert_eq(&gen(100));
     expect![[r#"
@@ -190,14 +190,14 @@ fn snapshot_tests() {
         }
 
         schema {
-          query: A14
-          mutation: A14
-          subscription: A14
+          query: A5
+          mutation: A5
+          subscription: A5
         }
 
         scalar CD
 
-        type A14 {
+        type A5 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
@@ -241,32 +241,32 @@ fn snapshot_tests() {
           A1: IJKLMNOP
         }
 
-        interface A9 {
+        interface A0 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A10 {
+        interface A1 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A11 {
+        interface A2 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A12 {
+        interface A3 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        interface A13 {
+        interface A4 {
           A0: IJKLMNOP
           A1: IJKLMNOP
         }
 
-        union A15 = A14
+        union A6 = A5
 
         enum IJKLMNOP {
           UVWXYZabcdefghijklmn0
@@ -326,12 +326,12 @@ fn snapshot_tests() {
           iNOPQRSTUVWXYZabcd4
         }
 
-        input A16 {
+        input A7 {
           A0: CD
           A1: CD
         }
 
-        directive @A18 on QUERY
+        directive @A9 on QUERY
     "#]]
     .assert_eq(&gen(1000));
 }


### PR DESCRIPTION
Previously, we were appending a suffix with the number of existing type definitions in the builder. However, this could still generate a conflicting string. For example, generating the first type with random part `A1` would result in use appending suffix `0`, giving the type name `A10`. After adding 9 more types, randomly generating random part `A` would result in another type definition for `A10`, causing a conflict.

<!-- FED-1045 -->