### PR TITLE
fix(smith): disable alias generation to avoid field selection merging conflicts

### DIFF
--- a/crates/apollo-smith/src/field.rs
+++ b/crates/apollo-smith/src/field.rs
@@ -162,7 +162,7 @@ impl DocumentBuilder<'_> {
     }
 
     /// Create an arbitrary `Field` given an object type
-    pub fn field(&mut self, index: usize) -> ArbitraryResult<Field> {
+    pub fn field(&mut self, _index: usize) -> ArbitraryResult<Field> {
         let fields_defs = self
             .stack
             .last()
@@ -170,12 +170,6 @@ impl DocumentBuilder<'_> {
             .fields_def();
 
         let chosen_field_def = self.u.choose(fields_defs)?.clone();
-        let mut alias = self
-            .u
-            .arbitrary()
-            .unwrap_or(false)
-            .then(|| self.name_with_index(index))
-            .transpose()?;
 
         let name = chosen_field_def.name.clone();
         // To not have same selection with different arguments
@@ -207,34 +201,13 @@ impl DocumentBuilder<'_> {
             None
         };
 
-        // To not choose different alias name for the same field
-        // Useful in this situation
-        // {
-        //  me {
-        //      T1: name
-        //  }
-        //  me {
-        //    T0: id
-        //    T1: id
-        //  }
-        // }
-        if let Some(alias_name) = alias.take() {
-            match self.chosen_aliases.get(&alias_name) {
-                None => {
-                    self.chosen_aliases.insert(alias_name.clone(), name.clone());
-                    alias = Some(alias_name);
-                }
-                Some(original_field_name) => {
-                    // If the alias point to the same original field name then we can keep this alias, if not we don't use it
-                    if original_field_name == &name {
-                        alias = Some(alias_name);
-                    }
-                }
-            }
-        }
+        // TODO: Reintroduce alias generation logic which respects aliases on other fields
+        // or fragments. For now, we will not generate aliases to avoid conflicts.
+        // See <https://spec.graphql.org/October2021/#sec-Field-Selection-Merging> for merge
+        // requirements.
 
         Ok(Field {
-            alias,
+            alias: None,
             name,
             args,
             directives,

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -109,8 +109,6 @@ pub struct DocumentBuilder<'a> {
     pub(crate) stack: Vec<Box<dyn StackedEntity>>,
     // Useful to keep the same arguments for a specific field
     pub(crate) chosen_arguments: IndexMap<Name, Vec<Argument>>,
-    // Useful to keep the same aliases for a specific field name
-    pub(crate) chosen_aliases: IndexMap<Name, Name>,
     // Maximum number of generated definitions per kind
     max_scalar_types: usize,
     max_enum_types: usize,
@@ -158,7 +156,6 @@ impl<'a> DocumentBuilder<'a> {
             implements_graph: implements_graph::ImplementsGraph::new(),
             stack: Vec::new(),
             chosen_arguments: IndexMap::new(),
-            chosen_aliases: IndexMap::new(),
             max_scalar_types: DEFAULT_MAX,
             max_enum_types: DEFAULT_MAX,
             max_interface_types: DEFAULT_MAX,
@@ -340,7 +337,6 @@ impl<'a> DocumentBuilder<'a> {
             implements_graph,
             stack: Vec::new(),
             chosen_arguments: IndexMap::new(),
-            chosen_aliases: IndexMap::new(),
             max_scalar_types: DEFAULT_MAX,
             max_enum_types: DEFAULT_MAX,
             max_interface_types: DEFAULT_MAX,

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -182,8 +182,6 @@ impl DocumentBuilder<'_> {
         };
 
         self.stack.pop();
-        // Clear the chosen arguments for an operation
-        self.chosen_arguments.clear();
         assert!(
             self.stack.is_empty(),
             "the stack must be empty at the end of an operation definition"

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -184,9 +184,6 @@ impl DocumentBuilder<'_> {
         self.stack.pop();
         // Clear the chosen arguments for an operation
         self.chosen_arguments.clear();
-        // Clear the chosen aliases for field in an operation
-        self.chosen_aliases.clear();
-
         assert!(
             self.stack.is_empty(),
             "the stack must be empty at the end of an operation definition"


### PR DESCRIPTION
Aliases could produce response-name collisions where two fields share the same response name but select different schema fields, violating the Field Selection Merging rule. Generating a valid alias must account for aliases on other fields as well as fragments which could be spread over the current type. I attempted to resolve the conflicting aliases, but the logic seemed more complicated than it was worth.

In the spirit of quickly ensuring we output valid schemas, this disables alias generation entirely for now rather than adding complex deduplication logic.

https://spec.graphql.org/October2021/#sec-Field-Selection-Merging

<!-- FED-1025 -->