### PR TITLE
fix(smith): fix fragment spread and argument selection merging

### DIFF
--- a/crates/apollo-smith/src/field.rs
+++ b/crates/apollo-smith/src/field.rs
@@ -8,6 +8,7 @@ use crate::selection_set::SelectionSet;
 use crate::ty::Ty;
 use crate::DocumentBuilder;
 use apollo_compiler::ast;
+use apollo_compiler::coordinate::TypeAttributeCoordinate;
 use apollo_compiler::Node;
 use arbitrary::Result as ArbitraryResult;
 use indexmap::IndexMap;
@@ -178,8 +179,12 @@ impl DocumentBuilder<'_> {
             .transpose()?;
 
         let name = chosen_field_def.name.clone();
+        let coord = TypeAttributeCoordinate {
+            ty: self.stack.last().unwrap().name().clone().into(),
+            attribute: name.clone().into(),
+        };
         // To not have same selection with different arguments
-        let args = match self.chosen_arguments.get(&name) {
+        let args = match self.chosen_arguments.get(&coord) {
             Some(args) => args.clone(),
             None => {
                 let args = chosen_field_def
@@ -187,7 +192,7 @@ impl DocumentBuilder<'_> {
                     .clone()
                     .map(|args_def| self.arguments_with_def(&args_def))
                     .unwrap_or_else(|| Ok(vec![]))?;
-                self.chosen_arguments.insert(name.clone(), args.clone());
+                self.chosen_arguments.insert(coord, args.clone());
 
                 args
             }

--- a/crates/apollo-smith/src/fragment.rs
+++ b/crates/apollo-smith/src/fragment.rs
@@ -177,10 +177,14 @@ impl DocumentBuilder<'_> {
         &mut self,
         excludes: &mut Vec<Name>,
     ) -> ArbitraryResult<Option<FragmentSpread>> {
+        let current_type = self.stack.last().map(|e| e.name().clone());
         let available_fragment: Vec<&FragmentDef> = self
             .fragment_defs
             .iter()
-            .filter(|f| !excludes.contains(&f.name))
+            .filter(|f| {
+                !excludes.contains(&f.name)
+                    && self.fragment_spread_possible(&f.type_condition.name, current_type.as_ref())
+            })
             .collect();
 
         let name = if available_fragment.is_empty() {
@@ -210,6 +214,36 @@ impl DocumentBuilder<'_> {
             directives,
             selection_set,
         })
+    }
+
+    /// Whether a fragment with `fragment_type` can be spread inside a
+    /// selection set for `current_type`. The two types must share at
+    /// least one possible object type.
+    ///
+    /// See <https://spec.graphql.org/October2021/#sec-Fragment-spread-is-possible>.
+    fn fragment_spread_possible(&self, fragment_type: &Name, current_type: Option<&Name>) -> bool {
+        let Some(current) = current_type else {
+            return true;
+        };
+        let current_objects = self.possible_object_types(current);
+        let fragment_objects = self.possible_object_types(fragment_type);
+        current_objects.iter().any(|o| fragment_objects.contains(o))
+    }
+
+    /// The set of object types that `type_name` can resolve to at runtime.
+    fn possible_object_types(&self, type_name: &Name) -> IndexSet<Name> {
+        if self.object_type_defs.iter().any(|o| &o.name == type_name) {
+            return IndexSet::from([type_name.clone()]);
+        }
+        if let Some(u) = self.union_type_defs.iter().find(|u| &u.name == type_name) {
+            return u.members.clone();
+        }
+        // Interface: collect every object whose implements closure includes it
+        self.object_type_defs
+            .iter()
+            .filter(|o| self.implements_graph.closure(&o.name).contains(type_name))
+            .map(|o| o.name.clone())
+            .collect()
     }
 
     /// Create an arbitrary `TypeCondition`

--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -41,6 +41,7 @@ pub enum FromError {
     ParseBoolError(#[from] std::str::ParseBoolError),
 }
 
+use apollo_compiler::coordinate::TypeAttributeCoordinate;
 pub use arbitrary::Result;
 pub use arbitrary::Unstructured;
 use argument::Argument;
@@ -107,8 +108,8 @@ pub struct DocumentBuilder<'a> {
     pub(crate) implements_graph: implements_graph::ImplementsGraph,
     // A stack to set current ObjectTypeDef
     pub(crate) stack: Vec<Box<dyn StackedEntity>>,
-    // Useful to keep the same arguments for a specific field
-    pub(crate) chosen_arguments: IndexMap<Name, Vec<Argument>>,
+    // Useful to keep the same arguments for a specific field on a specific type
+    pub(crate) chosen_arguments: IndexMap<TypeAttributeCoordinate, Vec<Argument>>,
     // Useful to keep the same aliases for a specific field name
     pub(crate) chosen_aliases: IndexMap<Name, Name>,
     // Maximum number of generated definitions per kind

--- a/crates/apollo-smith/src/operation.rs
+++ b/crates/apollo-smith/src/operation.rs
@@ -182,11 +182,8 @@ impl DocumentBuilder<'_> {
         };
 
         self.stack.pop();
-        // Clear the chosen arguments for an operation
-        self.chosen_arguments.clear();
         // Clear the chosen aliases for field in an operation
         self.chosen_aliases.clear();
-
         assert!(
             self.stack.is_empty(),
             "the stack must be empty at the end of an operation definition"


### PR DESCRIPTION
## Summary

We were occasionally generating fragments which could not be spread on their parent type, and which could have fields with conflicting sets of arguments from the base type. Those are resolved with the following fixes:

- Filter fragment spreads by type condition compatibility, per [Fragment Spread Is Possible](https://spec.graphql.org/October2021/#sec-Fragment-spread-is-possible) — only spread a fragment when its type condition shares at least one possible object type with the parent selection set.
- Key `chosen_arguments` on `TypeAttributeCoordinate` (type + field name) instead of just field name, so fields with the same name on different types get independent argument choices. Stop clearing the map between operations so fragments and operations stay consistent per [Field Selection Merging](https://spec.graphql.org/October2021/#sec-Field-Selection-Merging).

<!-- FED-1047 -->