### PR TITLE
fix(smith)!: prevent non-null self-references in input objects

### DIFF
--- a/crates/apollo-smith/src/argument.rs
+++ b/crates/apollo-smith/src/argument.rs
@@ -123,8 +123,11 @@ impl DocumentBuilder<'_> {
     /// Create an arbitrary `ArgumentsDef`
     pub fn arguments_definition(&mut self) -> ArbitraryResult<ArgumentsDef> {
         Ok(ArgumentsDef {
-            input_value_definitions: self
-                .input_values_def(DirectiveLocation::ArgumentDefinition, &IndexSet::new())?,
+            input_value_definitions: self.input_values_def(
+                DirectiveLocation::ArgumentDefinition,
+                &IndexSet::new(),
+                None,
+            )?,
         })
     }
 }

--- a/crates/apollo-smith/src/input_object.rs
+++ b/crates/apollo-smith/src/input_object.rs
@@ -148,8 +148,11 @@ impl DocumentBuilder<'_> {
             .filter(|io| io.name == name)
             .flat_map(|io| io.fields.iter().map(|f| f.name.clone()))
             .collect();
-        let fields =
-            self.input_values_def(DirectiveLocation::InputFieldDefinition, &exclude_fields)?;
+        let fields = self.input_values_def(
+            DirectiveLocation::InputFieldDefinition,
+            &exclude_fields,
+            Some(&name),
+        )?;
 
         let directives = self.directives(DirectiveLocation::InputObject)?;
 

--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -292,6 +292,7 @@ impl DocumentBuilder<'_> {
         &mut self,
         directive_location: DirectiveLocation,
         exclude: &IndexSet<Name>,
+        self_name: Option<&Name>,
     ) -> ArbitraryResult<Vec<InputValueDef>> {
         let arbitrary_iv_num = self.u.int_in_range(2..=5usize)?;
         let mut input_values = Vec::with_capacity(arbitrary_iv_num - 1);
@@ -304,7 +305,14 @@ impl DocumentBuilder<'_> {
                 .then(|| self.description())
                 .transpose()?;
             let name = self.name_with_index(i)?;
-            let ty = self.choose_ty(&self.list_existing_input_types())?;
+            let mut ty = self.choose_ty(&self.list_existing_input_types())?;
+            // Prevent required self-referential input object fields, which
+            // would make the type impossible to construct.
+            if self_name.is_some_and(|n| ty.name() == n) {
+                if let Ty::NonNull(inner) = ty {
+                    ty = *inner;
+                }
+            }
             let directives = self.directives(directive_location)?;
             // TODO: FIXME: it's not correct I need to generate default value corresponding to the ty above
             let default_value = self


### PR DESCRIPTION
## Summary
- When generating input object fields, if the chosen type is a non-null self-reference (e.g. `MyInput!` as a field on `MyInput`), strip the `NonNull` wrapper to make it nullable. Non-null self-references are invalid GraphQL because the type becomes impossible to construct.
- Adds a `self_name` parameter to `input_values_def` so callers can indicate which input object is being defined. Arguments pass `None` since they aren't subject to self-referential constraints.

Note: this prevents the case where we generate `input A { field: A! }` by removing the non-null requirement to break the cycle. There is still an unhandled possible case where we end up with `input A { field: B!}` and `input B { field: A! }`.

<!-- FED-1026 -->