### PR TITLE
perf(smith): cache used type names to avoid O(n²) rebuilds

### DIFF
--- a/crates/apollo-smith/src/lib.rs
+++ b/crates/apollo-smith/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) mod union;
 pub(crate) mod variable;
 
 use indexmap::IndexMap;
+use std::collections::HashSet;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -112,6 +113,7 @@ pub struct DocumentBuilder<'a> {
     pub(crate) chosen_arguments: IndexMap<TypeAttributeCoordinate, Vec<Argument>>,
     // Useful to keep the same aliases for a specific field name
     pub(crate) chosen_aliases: IndexMap<Name, Name>,
+    pub(crate) used_type_names: HashSet<String>,
     // Maximum number of generated definitions per kind
     max_scalar_types: usize,
     max_enum_types: usize,
@@ -160,6 +162,7 @@ impl<'a> DocumentBuilder<'a> {
             stack: Vec::new(),
             chosen_arguments: IndexMap::new(),
             chosen_aliases: IndexMap::new(),
+            used_type_names: HashSet::new(),
             max_scalar_types: DEFAULT_MAX,
             max_enum_types: DEFAULT_MAX,
             max_interface_types: DEFAULT_MAX,
@@ -326,7 +329,7 @@ impl<'a> DocumentBuilder<'a> {
                 implements_graph.add_edge(&obj.name, parent);
             }
         }
-        let builder = Self {
+        let mut builder = Self {
             u,
             object_type_defs: document.object_type_definitions,
             interface_type_defs: document.interface_type_definitions,
@@ -342,6 +345,7 @@ impl<'a> DocumentBuilder<'a> {
             stack: Vec::new(),
             chosen_arguments: IndexMap::new(),
             chosen_aliases: IndexMap::new(),
+            used_type_names: HashSet::new(),
             max_scalar_types: DEFAULT_MAX,
             max_enum_types: DEFAULT_MAX,
             max_interface_types: DEFAULT_MAX,
@@ -352,6 +356,35 @@ impl<'a> DocumentBuilder<'a> {
             max_directive_definitions: DEFAULT_MAX,
             max_operation_definitions: DEFAULT_MAX,
         };
+        for def in &builder.object_type_defs {
+            builder.used_type_names.insert(def.name.name.clone());
+        }
+        for def in &builder.interface_type_defs {
+            builder.used_type_names.insert(def.name.name.clone());
+        }
+        for def in &builder.enum_type_defs {
+            builder.used_type_names.insert(def.name.name.clone());
+        }
+        for def in &builder.directive_defs {
+            builder.used_type_names.insert(def.name.name.clone());
+        }
+        for def in &builder.union_type_defs {
+            builder.used_type_names.insert(def.name.name.clone());
+        }
+        for def in &builder.input_object_type_defs {
+            builder.used_type_names.insert(def.name.name.clone());
+        }
+        for def in &builder.scalar_type_defs {
+            builder.used_type_names.insert(def.name.name.clone());
+        }
+        for def in &builder.fragment_defs {
+            builder.used_type_names.insert(def.name.name.clone());
+        }
+        for def in &builder.operation_defs {
+            if let Some(name) = &def.name {
+                builder.used_type_names.insert(name.name.clone());
+            }
+        }
 
         Ok(builder)
     }

--- a/crates/apollo-smith/src/name.rs
+++ b/crates/apollo-smith/src/name.rs
@@ -1,6 +1,5 @@
 use crate::DocumentBuilder;
 use arbitrary::Result as ArbitraryResult;
-use std::collections::HashSet;
 use std::fmt::Write as _;
 
 // First char in a GraphQL name can't be a digit and we don't want it to be
@@ -83,17 +82,15 @@ impl DocumentBuilder<'_> {
 
     /// Create an arbitrary type `Name` that does not yet exist in the document.
     pub fn type_name(&mut self) -> ArbitraryResult<Name> {
-        let existing: HashSet<String> = self
-            .list_existing_type_names()
-            .map(|n| n.name.clone())
-            .collect();
         let base = self.limited_string(30)?;
         let mut suffix = 0usize;
         let mut new_name = base.clone();
-        while existing.contains(new_name.as_str()) {
-            new_name = format!("{base}{suffix}");
+        while self.used_type_names.contains(new_name.as_str()) {
+            new_name.clear();
+            let _ = write!(new_name, "{base}{suffix}");
             suffix += 1;
         }
+        self.used_type_names.insert(new_name.clone());
         Ok(Name::new(new_name))
     }
 
@@ -129,19 +126,5 @@ impl DocumentBuilder<'_> {
                 break Ok(new_gen.to_string());
             }
         }
-    }
-
-    fn list_existing_type_names(&self) -> impl Iterator<Item = &Name> {
-        self.object_type_defs
-            .iter()
-            .map(|o| &o.name)
-            .chain(self.interface_type_defs.iter().map(|itf| &itf.name))
-            .chain(self.enum_type_defs.iter().map(|itf| &itf.name))
-            .chain(self.directive_defs.iter().map(|itf| &itf.name))
-            .chain(self.union_type_defs.iter().map(|itf| &itf.name))
-            .chain(self.input_object_type_defs.iter().map(|itf| &itf.name))
-            .chain(self.scalar_type_defs.iter().map(|itf| &itf.name))
-            .chain(self.fragment_defs.iter().map(|itf| &itf.name))
-            .chain(self.operation_defs.iter().filter_map(|op| op.name.as_ref()))
     }
 }


### PR DESCRIPTION
## Summary
- `type_name()` previously rebuilt a `HashSet` of all existing type names from 9 definition collections on every call, making total name generation O(n²)
- Maintain a persistent `HashSet<String>` on `DocumentBuilder` that is updated incrementally as names are created
- Reuse the `String` allocation in the collision-resolution loop via `write!` instead of `format!`

In a small local benchmark, this showed a 42% improvement, generating ~24k docs/sec compared to ~14k docs/sec before the change.

<!-- FED-1026 -->