### PR TITLE
feat(compiler): allow parsing FieldSet from a source span in an existing document

### DIFF
--- a/crates/apollo-compiler/examples/file_watcher.rs
+++ b/crates/apollo-compiler/examples/file_watcher.rs
@@ -92,14 +92,14 @@ impl FileWatcher {
                 Ok(Err(e)) => {
                     println!(
                         "unknown error while watching {},  {:?}",
-                        &dir.display(),
+                        dir.display(),
                         Some(anyhow!("{}", e)),
                     );
                 }
                 Err(e) => {
                     println!(
                         "unknown error while watching {},  {:?}",
-                        &dir.display(),
+                        dir.display(),
                         Some(anyhow!("{}", e)),
                     );
                 }

--- a/crates/apollo-compiler/src/ast/from_cst.rs
+++ b/crates/apollo-compiler/src/ast/from_cst.rs
@@ -9,13 +9,57 @@ use apollo_parser::cst::CstNode;
 use apollo_parser::SyntaxNode;
 use apollo_parser::S;
 
+#[derive(Copy, Clone)]
+pub(crate) struct SourceContext {
+    file_id: FileId,
+    base_offset: rowan::TextSize,
+}
+
+impl SourceContext {
+    pub(crate) fn new(file_id: FileId) -> Self {
+        Self {
+            file_id,
+            base_offset: 0.into(),
+        }
+    }
+
+    pub(crate) fn with_offset(file_id: FileId, base_offset: rowan::TextSize) -> Self {
+        Self {
+            file_id,
+            base_offset,
+        }
+    }
+}
+
+impl From<FileId> for SourceContext {
+    fn from(file_id: FileId) -> Self {
+        Self::new(file_id)
+    }
+}
+
+fn source_span(ctx: SourceContext, syntax_node: &SyntaxNode) -> SourceSpan {
+    let range = syntax_node.text_range();
+    SourceSpan {
+        file_id: ctx.file_id,
+        text_range: rowan::TextRange::new(
+            range.start() + ctx.base_offset,
+            range.end() + ctx.base_offset,
+        ),
+    }
+}
+
 impl Document {
-    pub(crate) fn from_cst(document: cst::Document, file_id: FileId, sources: SourceMap) -> Self {
+    pub(crate) fn from_cst(
+        document: cst::Document,
+        ctx: impl Into<SourceContext>,
+        sources: SourceMap,
+    ) -> Self {
+        let ctx = ctx.into();
         Self {
             sources,
             definitions: document
                 .definitions()
-                .filter_map(|def| def.convert(file_id))
+                .filter_map(|def| def.convert(ctx))
                 .collect(),
         }
     }
@@ -24,37 +68,31 @@ impl Document {
 /// Similar to `TryFrom`, but with an `Option` return type because AST uses Option a lot.
 pub(crate) trait Convert {
     type Target;
-    fn convert(&self, file_id: FileId) -> Option<Self::Target>;
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target>;
 }
 
-fn with_location<T>(file_id: FileId, syntax_node: &SyntaxNode, node: T) -> Node<T> {
-    Node::new_parsed(node, SourceSpan::new(file_id, syntax_node))
+fn with_location<T>(ctx: SourceContext, syntax_node: &SyntaxNode, node: T) -> Node<T> {
+    Node::new_parsed(node, source_span(ctx, syntax_node))
 }
 
 /// Convert and collect, silently skipping entries with conversion errors
 /// as they have corresponding parse errors in `SyntaxTree::errors`
 #[inline]
 fn collect<CstType, AstType>(
-    file_id: FileId,
+    ctx: SourceContext,
     iter: impl IntoIterator<Item = CstType>,
 ) -> Vec<Node<AstType>>
 where
     CstType: CstNode + Convert<Target = AstType>,
 {
     iter.into_iter()
-        .filter_map(|value| {
-            Some(with_location(
-                file_id,
-                value.syntax(),
-                value.convert(file_id)?,
-            ))
-        })
+        .filter_map(|value| Some(with_location(ctx, value.syntax(), value.convert(ctx)?)))
         .collect()
 }
 
 #[inline]
 fn collect_opt<CstType1, CstType2, AstType, F, I>(
-    file_id: FileId,
+    ctx: SourceContext,
     opt: Option<CstType1>,
     convert: F,
 ) -> Vec<Node<AstType>>
@@ -64,7 +102,7 @@ where
     CstType2: CstNode + Convert<Target = AstType>,
 {
     if let Some(cst) = opt {
-        collect(file_id, convert(cst))
+        collect(ctx, convert(cst))
     } else {
         Vec::new()
     }
@@ -73,9 +111,9 @@ where
 impl<T: Convert> Convert for Option<T> {
     type Target = Option<T::Target>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(if let Some(inner) = self {
-            Some(inner.convert(file_id)?)
+            Some(inner.convert(ctx)?)
         } else {
             None
         })
@@ -85,12 +123,12 @@ impl<T: Convert> Convert for Option<T> {
 impl Convert for cst::Definition {
     type Target = ast::Definition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         use ast::Definition as A;
         use cst::Definition as C;
         macro_rules! r {
             ($def: ident) => {
-                with_location(file_id, $def.syntax(), $def.convert(file_id)?)
+                with_location(ctx, $def.syntax(), $def.convert(ctx)?)
             };
         }
         Some(match self {
@@ -118,25 +156,23 @@ impl Convert for cst::Definition {
 impl Convert for cst::OperationDefinition {
     type Target = ast::OperationDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         let operation_type = if let Some(ty) = self.operation_type() {
-            ty.convert(file_id)?
+            ty.convert(ctx)?
         } else {
             ast::OperationType::Query
         };
         Some(Self::Target {
             operation_type,
-            name: self.name().convert(file_id)?,
-            variables: collect_opt(file_id, self.variable_definitions(), |x| {
+            name: self.name().convert(ctx)?,
+            variables: collect_opt(ctx, self.variable_definitions(), |x| {
                 x.variable_definitions()
             }),
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             selection_set: self
                 .selection_set()?
                 .selections()
-                .filter_map(|sel| sel.convert(file_id))
+                .filter_map(|sel| sel.convert(ctx))
                 .collect(),
         })
     }
@@ -145,14 +181,12 @@ impl Convert for cst::OperationDefinition {
 impl Convert for cst::FragmentDefinition {
     type Target = ast::FragmentDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.fragment_name()?.name()?.convert(file_id)?,
-            type_condition: self.type_condition()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            selection_set: self.selection_set().convert(file_id)??,
+            name: self.fragment_name()?.name()?.convert(ctx)?,
+            type_condition: self.type_condition()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            selection_set: self.selection_set().convert(ctx)??,
         })
     }
 }
@@ -160,19 +194,19 @@ impl Convert for cst::FragmentDefinition {
 impl Convert for cst::TypeCondition {
     type Target = ast::NamedType;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        self.named_type()?.name()?.convert(file_id)
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        self.named_type()?.name()?.convert(ctx)
     }
 }
 
 impl Convert for cst::DirectiveDefinition {
     type Target = ast::DirectiveDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            arguments: collect_opt(file_id, self.arguments_definition(), |x| {
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            arguments: collect_opt(ctx, self.arguments_definition(), |x| {
                 x.input_value_definitions()
             }),
             repeatable: self.repeatable_token().is_some(),
@@ -180,7 +214,7 @@ impl Convert for cst::DirectiveDefinition {
                 .directive_locations()
                 .map(|x| {
                     x.directive_locations()
-                        .filter_map(|location| location.convert(file_id))
+                        .filter_map(|location| location.convert(ctx))
                         .collect()
                 })
                 .unwrap_or_default(),
@@ -191,19 +225,17 @@ impl Convert for cst::DirectiveDefinition {
 impl Convert for cst::SchemaDefinition {
     type Target = ast::SchemaDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            description: self.description().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             // This may represent a syntactically invalid thing: a schema without any root
             // operation definitions. However the presence of a broken schema definition does
             // affect whether a default schema definition should be inserted, so we bubble up the
             // potentially invalid definition.
             root_operations: self
                 .root_operation_type_definitions()
-                .filter_map(|x| x.convert(file_id))
+                .filter_map(|x| x.convert(ctx))
                 .collect(),
         })
     }
@@ -212,13 +244,11 @@ impl Convert for cst::SchemaDefinition {
 impl Convert for cst::ScalarTypeDefinition {
     type Target = ast::ScalarTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -226,15 +256,13 @@ impl Convert for cst::ScalarTypeDefinition {
 impl Convert for cst::ObjectTypeDefinition {
     type Target = ast::ObjectTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            implements_interfaces: self.implements_interfaces().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.fields_definition(), |x| x.field_definitions()),
         })
     }
 }
@@ -242,15 +270,13 @@ impl Convert for cst::ObjectTypeDefinition {
 impl Convert for cst::InterfaceTypeDefinition {
     type Target = ast::InterfaceTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            implements_interfaces: self.implements_interfaces().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.fields_definition(), |x| x.field_definitions()),
         })
     }
 }
@@ -258,19 +284,17 @@ impl Convert for cst::InterfaceTypeDefinition {
 impl Convert for cst::UnionTypeDefinition {
     type Target = ast::UnionTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             members: self
                 .union_member_types()
                 .map_or_else(Default::default, |member_types| {
                     member_types
                         .named_types()
-                        .filter_map(|n| n.name()?.convert(file_id))
+                        .filter_map(|n| n.name()?.convert(ctx))
                         .collect()
                 }),
         })
@@ -280,14 +304,12 @@ impl Convert for cst::UnionTypeDefinition {
 impl Convert for cst::EnumTypeDefinition {
     type Target = ast::EnumTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            values: collect_opt(file_id, self.enum_values_definition(), |x| {
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            values: collect_opt(ctx, self.enum_values_definition(), |x| {
                 x.enum_value_definitions()
             }),
         })
@@ -297,14 +319,12 @@ impl Convert for cst::EnumTypeDefinition {
 impl Convert for cst::InputObjectTypeDefinition {
     type Target = ast::InputObjectTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.input_fields_definition(), |x| {
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.input_fields_definition(), |x| {
                 x.input_value_definitions()
             }),
         })
@@ -314,14 +334,12 @@ impl Convert for cst::InputObjectTypeDefinition {
 impl Convert for cst::SchemaExtension {
     type Target = ast::SchemaExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             root_operations: self
                 .root_operation_type_definitions()
-                .filter_map(|x| x.convert(file_id))
+                .filter_map(|x| x.convert(ctx))
                 .collect(),
         })
     }
@@ -330,12 +348,10 @@ impl Convert for cst::SchemaExtension {
 impl Convert for cst::ScalarTypeExtension {
     type Target = ast::ScalarTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -343,14 +359,12 @@ impl Convert for cst::ScalarTypeExtension {
 impl Convert for cst::ObjectTypeExtension {
     type Target = ast::ObjectTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
+            name: self.name()?.convert(ctx)?,
+            implements_interfaces: self.implements_interfaces().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.fields_definition(), |x| x.field_definitions()),
         })
     }
 }
@@ -358,14 +372,12 @@ impl Convert for cst::ObjectTypeExtension {
 impl Convert for cst::InterfaceTypeExtension {
     type Target = ast::InterfaceTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
+            name: self.name()?.convert(ctx)?,
+            implements_interfaces: self.implements_interfaces().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.fields_definition(), |x| x.field_definitions()),
         })
     }
 }
@@ -373,18 +385,16 @@ impl Convert for cst::InterfaceTypeExtension {
 impl Convert for cst::UnionTypeExtension {
     type Target = ast::UnionTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             members: self
                 .union_member_types()
                 .map_or_else(Default::default, |member_types| {
                     member_types
                         .named_types()
-                        .filter_map(|n| n.name()?.convert(file_id))
+                        .filter_map(|n| n.name()?.convert(ctx))
                         .collect()
                 }),
         })
@@ -394,13 +404,11 @@ impl Convert for cst::UnionTypeExtension {
 impl Convert for cst::EnumTypeExtension {
     type Target = ast::EnumTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            values: collect_opt(file_id, self.enum_values_definition(), |x| {
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            values: collect_opt(ctx, self.enum_values_definition(), |x| {
                 x.enum_value_definitions()
             }),
         })
@@ -410,13 +418,11 @@ impl Convert for cst::EnumTypeExtension {
 impl Convert for cst::InputObjectTypeExtension {
     type Target = ast::InputObjectTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.input_fields_definition(), |x| {
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.input_fields_definition(), |x| {
                 x.input_value_definitions()
             }),
         })
@@ -426,10 +432,10 @@ impl Convert for cst::InputObjectTypeExtension {
 impl Convert for cst::Description {
     type Target = Node<str>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Node::new_str_parsed(
             &String::from(self.string_value()?),
-            SourceSpan::new(file_id, self.syntax()),
+            source_span(ctx, self.syntax()),
         ))
     }
 }
@@ -437,10 +443,10 @@ impl Convert for cst::Description {
 impl Convert for cst::Directive {
     type Target = ast::Directive;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            arguments: collect_opt(file_id, self.arguments(), |x| x.arguments()),
+            name: self.name()?.convert(ctx)?,
+            arguments: collect_opt(ctx, self.arguments(), |x| x.arguments()),
         })
     }
 }
@@ -448,7 +454,7 @@ impl Convert for cst::Directive {
 impl Convert for cst::OperationType {
     type Target = ast::OperationType;
 
-    fn convert(&self, _file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, _ctx: SourceContext) -> Option<Self::Target> {
         let token = self.syntax().first_token()?;
         match token.kind() {
             S![query] => Some(ast::OperationType::Query),
@@ -462,17 +468,17 @@ impl Convert for cst::OperationType {
 impl Convert for cst::RootOperationTypeDefinition {
     type Target = Node<(ast::OperationType, ast::NamedType)>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        let ty = self.operation_type()?.convert(file_id)?;
-        let name = self.named_type()?.name()?.convert(file_id)?;
-        Some(with_location(file_id, self.syntax(), (ty, name)))
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        let ty = self.operation_type()?.convert(ctx)?;
+        let name = self.named_type()?.name()?.convert(ctx)?;
+        Some(with_location(ctx, self.syntax(), (ty, name)))
     }
 }
 
 impl Convert for cst::DirectiveLocation {
     type Target = ast::DirectiveLocation;
 
-    fn convert(&self, _file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, _ctx: SourceContext) -> Option<Self::Target> {
         let token = self.syntax().first_token()?;
         match token.kind() {
             S![QUERY] => Some(ast::DirectiveLocation::Query),
@@ -502,11 +508,11 @@ impl Convert for cst::DirectiveLocation {
 impl Convert for Option<cst::ImplementsInterfaces> {
     type Target = Vec<ast::NamedType>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(if let Some(inner) = self {
             inner
                 .named_types()
-                .filter_map(|n| n.name()?.convert(file_id))
+                .filter_map(|n| n.name()?.convert(ctx))
                 .collect()
         } else {
             Vec::new()
@@ -517,25 +523,19 @@ impl Convert for Option<cst::ImplementsInterfaces> {
 impl Convert for cst::VariableDefinition {
     type Target = ast::VariableDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         let default_value = if let Some(default) = self.default_value() {
             let value = default.value()?;
-            Some(with_location(
-                file_id,
-                value.syntax(),
-                value.convert(file_id)?,
-            ))
+            Some(with_location(ctx, value.syntax(), value.convert(ctx)?))
         } else {
             None
         };
         let ty = &self.ty()?;
         Some(Self::Target {
-            name: self.variable()?.name()?.convert(file_id)?,
-            ty: with_location(file_id, ty.syntax(), ty.convert(file_id)?),
+            name: self.variable()?.name()?.convert(ctx)?,
+            ty: with_location(ctx, ty.syntax(), ty.convert(ctx)?),
             default_value,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -543,17 +543,17 @@ impl Convert for cst::VariableDefinition {
 impl Convert for cst::Type {
     type Target = ast::Type;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         use ast::Type as A;
         use cst::Type as C;
         match self {
-            C::NamedType(name) => Some(A::Named(name.name()?.convert(file_id)?)),
-            C::ListType(inner) => Some(A::List(Box::new(inner.ty()?.convert(file_id)?))),
+            C::NamedType(name) => Some(A::Named(name.name()?.convert(ctx)?)),
+            C::ListType(inner) => Some(A::List(Box::new(inner.ty()?.convert(ctx)?))),
             C::NonNullType(inner) => {
                 if let Some(named) = inner.named_type() {
-                    Some(A::NonNullNamed(named.name()?.convert(file_id)?))
+                    Some(A::NonNullNamed(named.name()?.convert(ctx)?))
                 } else if let Some(list) = inner.list_type() {
-                    Some(A::NonNullList(Box::new(list.ty()?.convert(file_id)?)))
+                    Some(A::NonNullList(Box::new(list.ty()?.convert(ctx)?)))
                 } else {
                     None
                 }
@@ -565,17 +565,15 @@ impl Convert for cst::Type {
 impl Convert for cst::FieldDefinition {
     type Target = ast::FieldDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            arguments: collect_opt(file_id, self.arguments_definition(), |x| {
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            arguments: collect_opt(ctx, self.arguments_definition(), |x| {
                 x.input_value_definitions()
             }),
-            ty: self.ty()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            ty: self.ty()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -583,10 +581,10 @@ impl Convert for cst::FieldDefinition {
 impl Convert for cst::Argument {
     type Target = ast::Argument;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        let name = self.name()?.convert(file_id)?;
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        let name = self.name()?.convert(ctx)?;
         let value = self.value()?;
-        let value = with_location(file_id, value.syntax(), value.convert(file_id)?);
+        let value = with_location(ctx, value.syntax(), value.convert(ctx)?);
         Some(ast::Argument { name, value })
     }
 }
@@ -594,26 +592,20 @@ impl Convert for cst::Argument {
 impl Convert for cst::InputValueDefinition {
     type Target = ast::InputValueDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         let default_value = if let Some(default) = self.default_value() {
             let value = default.value()?;
-            Some(with_location(
-                file_id,
-                value.syntax(),
-                value.convert(file_id)?,
-            ))
+            Some(with_location(ctx, value.syntax(), value.convert(ctx)?))
         } else {
             None
         };
         let ty = &self.ty()?;
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            ty: with_location(file_id, ty.syntax(), ty.convert(file_id)?),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            ty: with_location(ctx, ty.syntax(), ty.convert(ctx)?),
             default_value,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -621,13 +613,11 @@ impl Convert for cst::InputValueDefinition {
 impl Convert for cst::EnumValueDefinition {
     type Target = ast::EnumValueDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            value: self.enum_value()?.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            description: self.description().convert(ctx)?,
+            value: self.enum_value()?.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -635,35 +625,36 @@ impl Convert for cst::EnumValueDefinition {
 impl Convert for cst::SelectionSet {
     type Target = Vec<ast::Selection>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        Some(convert_selection_set(self, file_id))
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        Some(convert_selection_set(self, ctx))
     }
 }
 
 pub(crate) fn convert_selection_set(
     selection_set: &cst::SelectionSet,
-    file_id: FileId,
+    ctx: impl Into<SourceContext>,
 ) -> Vec<ast::Selection> {
+    let ctx = ctx.into();
     selection_set
         .selections()
-        .filter_map(|selection| selection.convert(file_id))
+        .filter_map(|selection| selection.convert(ctx))
         .collect()
 }
 
 impl Convert for cst::Selection {
     type Target = ast::Selection;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         use ast::Selection as A;
         use cst::Selection as C;
 
         Some(match self {
-            C::Field(x) => A::Field(with_location(file_id, x.syntax(), x.convert(file_id)?)),
+            C::Field(x) => A::Field(with_location(ctx, x.syntax(), x.convert(ctx)?)),
             C::FragmentSpread(x) => {
-                A::FragmentSpread(with_location(file_id, x.syntax(), x.convert(file_id)?))
+                A::FragmentSpread(with_location(ctx, x.syntax(), x.convert(ctx)?))
             }
             C::InlineFragment(x) => {
-                A::InlineFragment(with_location(file_id, x.syntax(), x.convert(file_id)?))
+                A::InlineFragment(with_location(ctx, x.syntax(), x.convert(ctx)?))
             }
         })
     }
@@ -672,16 +663,14 @@ impl Convert for cst::Selection {
 impl Convert for cst::Field {
     type Target = ast::Field;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            alias: self.alias().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            arguments: collect_opt(file_id, self.arguments(), |x| x.arguments()),
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            alias: self.alias().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            arguments: collect_opt(ctx, self.arguments(), |x| x.arguments()),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             // Use an empty Vec for a field without sub-selections
-            selection_set: self.selection_set().convert(file_id)?.unwrap_or_default(),
+            selection_set: self.selection_set().convert(ctx)?.unwrap_or_default(),
         })
     }
 }
@@ -689,12 +678,10 @@ impl Convert for cst::Field {
 impl Convert for cst::FragmentSpread {
     type Target = ast::FragmentSpread;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            fragment_name: self.fragment_name()?.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            fragment_name: self.fragment_name()?.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -702,13 +689,11 @@ impl Convert for cst::FragmentSpread {
 impl Convert for cst::InlineFragment {
     type Target = ast::InlineFragment;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            type_condition: self.type_condition().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            selection_set: self.selection_set().convert(file_id)??,
+            type_condition: self.type_condition().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            selection_set: self.selection_set().convert(ctx)??,
         })
     }
 }
@@ -716,12 +701,12 @@ impl Convert for cst::InlineFragment {
 impl Convert for cst::Value {
     type Target = ast::Value;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         use ast::Value as A;
         use cst::Value as C;
 
         Some(match self {
-            C::Variable(v) => A::Variable(v.name()?.convert(file_id)?),
+            C::Variable(v) => A::Variable(v.name()?.convert(ctx)?),
             C::StringValue(v) => A::String(String::from(v)),
             C::FloatValue(v) => A::Float(ast::FloatValue::new_parsed(
                 v.syntax().first_token()?.text(),
@@ -729,13 +714,11 @@ impl Convert for cst::Value {
             C::IntValue(v) => A::Int(ast::IntValue::new_parsed(v.syntax().first_token()?.text())),
             C::BooleanValue(v) => A::Boolean(bool::try_from(v).ok()?),
             C::NullValue(_) => A::Null,
-            C::EnumValue(v) => A::Enum(v.name()?.convert(file_id)?),
-            C::ListValue(v) => A::List(collect(file_id, v.values())),
-            C::ObjectValue(v) => A::Object(
-                v.object_fields()
-                    .filter_map(|x| x.convert(file_id))
-                    .collect(),
-            ),
+            C::EnumValue(v) => A::Enum(v.name()?.convert(ctx)?),
+            C::ListValue(v) => A::List(collect(ctx, v.values())),
+            C::ObjectValue(v) => {
+                A::Object(v.object_fields().filter_map(|x| x.convert(ctx)).collect())
+            }
         })
     }
 }
@@ -743,10 +726,10 @@ impl Convert for cst::Value {
 impl Convert for cst::ObjectField {
     type Target = (crate::Name, Node<ast::Value>);
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        let name = self.name()?.convert(file_id)?;
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        let name = self.name()?.convert(ctx)?;
         let value = self.value()?;
-        let value = with_location(file_id, value.syntax(), value.convert(file_id)?);
+        let value = with_location(ctx, value.syntax(), value.convert(ctx)?);
         Some((name, value))
     }
 }
@@ -754,16 +737,16 @@ impl Convert for cst::ObjectField {
 impl Convert for cst::Alias {
     type Target = crate::Name;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        self.name()?.convert(file_id)
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        self.name()?.convert(ctx)
     }
 }
 
 impl Convert for cst::Name {
     type Target = crate::Name;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        let loc = SourceSpan::new(file_id, self.syntax());
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        let loc = source_span(ctx, self.syntax());
         let token = &self.syntax().first_token()?;
         let str = token.text();
         debug_assert!(crate::Name::is_valid_syntax(str));

--- a/crates/apollo-compiler/src/ast/serialize.rs
+++ b/crates/apollo-compiler/src/ast/serialize.rs
@@ -857,7 +857,7 @@ fn serialize_string_value(state: &mut State, is_description: bool, mut str: &str
 }
 
 fn serialize_block_string(state: &mut State, contains_newline: bool, str: &str) -> fmt::Result {
-    const TRIPLE_QUOTE: &str = "\"\"\"";
+    use crate::parser::TRIPLE_QUOTE;
     const ESCAPED_TRIPLE_QUOTE: &str = "\\\"\"\"";
     const _: () = assert!(TRIPLE_QUOTE.len() == 3);
     const _: () = assert!(ESCAPED_TRIPLE_QUOTE.len() == 4);

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -1071,9 +1071,8 @@ impl FieldSet {
     /// Parses and validates the field set at `source_span` within an
     /// already-parsed source file. Errors point to the original location.
     ///
-    /// `source_span` should be the span of the string argument value. If the
-    /// span covers a quoted string literal, the quotes are stripped
-    /// automatically.
+    /// `source_span` must be the span of a string literal value (`"..."` or
+    /// `"""..."""`); quotes are stripped automatically.
     pub fn parse_and_validate_at_span(
         schema: &Valid<Schema>,
         type_name: NamedType,

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -341,6 +341,7 @@ pub(crate) enum ExecutableDefinitionName {
     AnonymousOperation(ast::OperationType),
     NamedOperation(ast::OperationType, Name),
     Fragment(Name),
+    FieldSet(Name),
 }
 
 impl ExecutableDocument {
@@ -1067,6 +1068,23 @@ impl FieldSet {
         errors.into_valid_result(field_set)
     }
 
+    /// Parses and validates the field set at `source_span` within an
+    /// already-parsed source file. Errors point to the original location.
+    ///
+    /// `source_span` should be the span of the string argument value. If the
+    /// span covers a quoted string literal, the quotes are stripped
+    /// automatically.
+    pub fn parse_and_validate_at_span(
+        schema: &Valid<Schema>,
+        type_name: NamedType,
+        source_span: SourceSpan,
+    ) -> Result<Valid<Self>, WithErrors<Self>> {
+        let (field_set, mut errors) =
+            Parser::new().parse_field_set_at_span(schema, type_name, source_span);
+        validation::validate_field_set(&mut errors, schema, &field_set);
+        errors.into_valid_result(field_set)
+    }
+
     pub fn validate(&self, schema: &Valid<Schema>) -> Result<(), DiagnosticList> {
         let mut sources = IndexMap::clone(&schema.sources);
         sources.extend(self.sources.iter().map(|(k, v)| (*k, v.clone())));
@@ -1088,6 +1106,7 @@ impl fmt::Display for SelectionPath {
                 write!(f, "{operation_type} {name}")?
             }
             ExecutableDefinitionName::Fragment(name) => write!(f, "fragment {name}")?,
+            ExecutableDefinitionName::FieldSet(type_name) => write!(f, "{type_name}")?,
         }
         for name in &self.nested_fields {
             write!(f, " → {name}")?

--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -23,7 +23,6 @@ use crate::validation::Valid;
 use crate::validation::WithErrors;
 use crate::ExecutableDocument;
 use crate::Schema;
-use apollo_parser::SyntaxNode;
 use rowan::TextRange;
 use serde::Deserialize;
 use serde::Serialize;
@@ -162,7 +161,23 @@ impl Parser {
         errors: &mut DiagnosticList,
         parse: impl FnOnce(apollo_parser::Parser) -> apollo_parser::SyntaxTree<T>,
     ) -> apollo_parser::SyntaxTree<T> {
-        let mut parser = apollo_parser::Parser::new(&source_text);
+        let tree = self.parse_syntax(&source_text, parse);
+        let source_file = Arc::new(SourceFile {
+            path,
+            source_text,
+            source: OnceLock::new(),
+        });
+        Arc::make_mut(&mut errors.sources).insert(file_id, source_file);
+        Self::collect_parse_errors(&tree, file_id, 0.into(), errors);
+        tree
+    }
+
+    fn parse_syntax<T: apollo_parser::cst::CstNode>(
+        &mut self,
+        source_text: &str,
+        parse: impl FnOnce(apollo_parser::Parser) -> apollo_parser::SyntaxTree<T>,
+    ) -> apollo_parser::SyntaxTree<T> {
+        let mut parser = apollo_parser::Parser::new(source_text);
         if let Some(value) = self.recursion_limit {
             parser = parser.recursion_limit(value)
         }
@@ -172,25 +187,28 @@ impl Parser {
         let tree = parse(parser);
         self.recursion_reached = tree.recursion_limit().high;
         self.tokens_reached = tree.token_limit().high;
-        let source_file = Arc::new(SourceFile {
-            path,
-            source_text,
-            source: OnceLock::new(),
-        });
-        Arc::make_mut(&mut errors.sources).insert(file_id, source_file);
+        tree
+    }
+
+    fn collect_parse_errors<T: apollo_parser::cst::CstNode>(
+        tree: &apollo_parser::SyntaxTree<T>,
+        file_id: FileId,
+        base_offset: rowan::TextSize,
+        errors: &mut DiagnosticList,
+    ) {
         for parser_error in tree.errors() {
             // Silently skip parse errors at index beyond 4 GiB.
             // Rowan in apollo-parser might complain about files that large
             // before we get here anyway.
-            let Ok(index) = parser_error.index().try_into() else {
+            let Ok(index): Result<rowan::TextSize, _> = parser_error.index().try_into() else {
                 continue;
             };
-            let Ok(len) = parser_error.data().len().try_into() else {
+            let Ok(len): Result<rowan::TextSize, _> = parser_error.data().len().try_into() else {
                 continue;
             };
             let location = Some(SourceSpan {
                 file_id,
-                text_range: rowan::TextRange::at(index, len),
+                text_range: rowan::TextRange::at(index + base_offset, len),
             });
             let details = if parser_error.is_limit() {
                 Details::ParserLimit {
@@ -203,7 +221,6 @@ impl Parser {
             };
             errors.push(location, details)
         }
-        tree
     }
 
     /// Parse the given source text as the sole input file of a schema.
@@ -350,7 +367,8 @@ impl Parser {
         path: impl AsRef<Path>,
     ) -> (executable::FieldSet, DiagnosticList) {
         let file_id = FileId::new();
-        let mut errors = DiagnosticList::new(Default::default());
+        let sources = IndexMap::clone(&schema.sources);
+        let mut errors = DiagnosticList::new(Arc::new(sources));
         let tree = self.parse_common(
             source_text.into(),
             path.as_ref().to_owned(),
@@ -359,23 +377,64 @@ impl Parser {
             |parser| parser.parse_selection_set(),
         );
         let ast = ast::from_cst::convert_selection_set(&tree.field_set(), file_id);
-        let mut selection_set = executable::SelectionSet::new(type_name);
+        Self::build_field_set(schema, type_name, &ast, errors)
+    }
+
+    fn build_field_set(
+        schema: &Valid<Schema>,
+        type_name: ast::NamedType,
+        ast: &[ast::Selection],
+        mut errors: DiagnosticList,
+    ) -> (executable::FieldSet, DiagnosticList) {
+        let mut selection_set = executable::SelectionSet::new(type_name.clone());
         let mut build_errors = executable::from_ast::BuildErrors {
             errors: &mut errors,
             path: executable::SelectionPath {
                 nested_fields: Vec::new(),
-                // 🤷
-                root: executable::ExecutableDefinitionName::AnonymousOperation(
-                    ast::OperationType::Query,
-                ),
+                root: executable::ExecutableDefinitionName::FieldSet(type_name),
             },
         };
-        selection_set.extend_from_ast(Some(schema), &mut build_errors, &ast);
+        selection_set.extend_from_ast(Some(schema), &mut build_errors, ast);
         let field_set = executable::FieldSet {
             sources: errors.sources.clone(),
             selection_set,
         };
         (field_set, errors)
+    }
+
+    /// Parses the field set at `source_span` within an already-parsed source
+    /// file. The text is extracted from the schema's sources and errors point
+    /// to the original location. If the span covers a quoted string literal,
+    /// the quotes are stripped automatically.
+    pub(crate) fn parse_field_set_at_span(
+        &mut self,
+        schema: &Valid<Schema>,
+        type_name: ast::NamedType,
+        source_span: SourceSpan,
+    ) -> (executable::FieldSet, DiagnosticList) {
+        let sources = IndexMap::clone(&schema.sources);
+        let mut errors = DiagnosticList::new(Arc::new(sources));
+        let Some(source_file) = schema.sources.get(&source_span.file_id) else {
+            return Self::build_field_set(schema, type_name, &[], errors);
+        };
+        let start = source_span.offset();
+        let end = source_span.end_offset();
+        let spanned_text = &source_file.source_text[start..end];
+        let (source_text, base_offset) = match spanned_text
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+        {
+            Some(content) => (
+                content,
+                source_span.text_range.start() + rowan::TextSize::from(1),
+            ),
+            None => (spanned_text, source_span.text_range.start()),
+        };
+        let tree = self.parse_syntax(source_text, |p| p.parse_selection_set());
+        Self::collect_parse_errors(&tree, source_span.file_id, base_offset, &mut errors);
+        let ctx = ast::from_cst::SourceContext::with_offset(source_span.file_id, base_offset);
+        let ast = ast::from_cst::convert_selection_set(&tree.field_set(), ctx);
+        Self::build_field_set(schema, type_name, &ast, errors)
     }
 
     /// Parse the given source text (e.g. `[Foo!]!`) as a reference to a GraphQL type.
@@ -398,7 +457,7 @@ impl Parser {
         );
         errors.into_result().map(|()| {
             tree.ty()
-                .convert(file_id)
+                .convert(file_id.into())
                 .expect("conversion should be infallible if there were no syntax errors")
         })
     }
@@ -574,13 +633,6 @@ impl TaggedFileId {
 }
 
 impl SourceSpan {
-    pub(crate) fn new(file_id: FileId, node: &'_ SyntaxNode) -> Self {
-        Self {
-            file_id,
-            text_range: node.text_range(),
-        }
-    }
-
     /// Returns the file ID for this location
     pub fn file_id(&self) -> FileId {
         self.file_id

--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -35,6 +35,8 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+pub(crate) const TRIPLE_QUOTE: &str = "\"\"\"";
+
 /// Configuration for parsing an input string as GraphQL syntax
 #[derive(Default, Debug, Clone)]
 pub struct Parser {
@@ -403,9 +405,8 @@ impl Parser {
     }
 
     /// Parses the field set at `source_span` within an already-parsed source
-    /// file. The text is extracted from the schema's sources and errors point
-    /// to the original location. If the span covers a quoted string literal,
-    /// the quotes are stripped automatically.
+    /// file. The span must cover a string literal (`"..."` or `"""..."""`);
+    /// quotes are stripped and errors point to the original location.
     pub(crate) fn parse_field_set_at_span(
         &mut self,
         schema: &Valid<Schema>,
@@ -420,15 +421,30 @@ impl Parser {
         let start = source_span.offset();
         let end = source_span.end_offset();
         let spanned_text = &source_file.source_text[start..end];
-        let (source_text, base_offset) = match spanned_text
+        let (source_text, base_offset) = if let Some(content) = spanned_text
+            .strip_prefix(TRIPLE_QUOTE)
+            .and_then(|s| s.strip_suffix(TRIPLE_QUOTE))
+        {
+            (
+                content,
+                source_span.text_range.start() + rowan::TextSize::from(TRIPLE_QUOTE.len() as u32),
+            )
+        } else if let Some(content) = spanned_text
             .strip_prefix('"')
             .and_then(|s| s.strip_suffix('"'))
         {
-            Some(content) => (
+            (
                 content,
                 source_span.text_range.start() + rowan::TextSize::from(1),
-            ),
-            None => (spanned_text, source_span.text_range.start()),
+            )
+        } else {
+            errors.push(
+                Some(source_span),
+                Details::SyntaxError {
+                    message: "expected a string literal".to_owned(),
+                },
+            );
+            return Self::build_field_set(schema, type_name, &[], errors);
         };
         let tree = self.parse_syntax(source_text, |p| p.parse_selection_set());
         Self::collect_parse_errors(&tree, source_span.file_id, base_offset, &mut errors);

--- a/crates/apollo-compiler/tests/executable.rs
+++ b/crates/apollo-compiler/tests/executable.rs
@@ -452,8 +452,8 @@ fn builder_preserves_source_information() {
 
     // Verify that source information is tracked
     assert_eq!(doc.sources.len(), 2);
-    assert_eq!(doc.sources[0].path(), "query1.graphql");
-    assert_eq!(doc.sources[1].path(), "query2.graphql");
+    assert_eq!(doc.sources[0].path().to_str().unwrap(), "query1.graphql");
+    assert_eq!(doc.sources[1].path().to_str().unwrap(), "query2.graphql");
 }
 
 #[test]

--- a/crates/apollo-compiler/tests/field_set.rs
+++ b/crates/apollo-compiler/tests/field_set.rs
@@ -69,8 +69,8 @@ fn test_invalid_field_sets() {
     );
 }
 
-/// Helper: find the span of a string argument value on a directive applied to a type.
-fn string_arg_value_span(
+/// Helper: find the span of an argument value on a directive applied to a type.
+fn arg_value_span(
     schema: &Schema,
     type_name: &str,
     directive_name: &str,
@@ -102,7 +102,20 @@ fn parse_at_span_valid() {
         type Product @sel(fields: "id") { id: ID }
     "#;
     let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
-    let value_span = string_arg_value_span(&schema, "Product", "sel", "fields");
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[test]
+fn parse_at_span_block_string_valid() {
+    let sdl = r#"
+        directive @sel(fields: String!) on OBJECT
+        type Query { product: Product }
+        type Product @sel(fields: """id""") { id: ID }
+    "#;
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
     let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
@@ -115,7 +128,7 @@ fn parse_at_span_error_rendering() {
                directive @sel(fields: String!) on OBJECT\n\
                type Query { product: Product }\n";
     let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
-    let value_span = string_arg_value_span(&schema, "Product", "sel", "fields");
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
 
     let err =
         FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
@@ -139,6 +152,108 @@ fn parse_at_span_error_rendering() {
            │         ╰───── type `Details` defined here
            │ 
            │ Note: path to the field: `Product → details → nonexistent`
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_block_string_error_rendering() {
+    let sdl = r#"type Product @sel(fields: """
+id
+details { nonexistent }
+""") {
+  id: ID
+  details: Details
+}
+type Details { name: String }
+directive @sel(fields: String!) on OBJECT
+type Query { product: Product }
+"#;
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: interface, union and object types must have a subselection set
+           ╭─[ schema.graphql:3:1 ]
+           │
+         3 │ details { nonexistent }
+           │ ───────────┬───────────  
+           │            ╰───────────── `Product.details` is an object type `Details` and must select fields
+        ───╯
+        Error: type `Details` does not have a field `nonexistent`
+           ╭─[ schema.graphql:3:11 ]
+           │
+         3 │ details { nonexistent }
+           │           ─────┬─────  
+           │                ╰─────── field `nonexistent` selected here
+           │ 
+         8 │ type Details { name: String }
+           │      ───┬───  
+           │         ╰───── type `Details` defined here
+           │ 
+           │ Note: path to the field: `Product → details → nonexistent`
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_not_a_string() {
+    let sdl = "directive @sel(fields: Int!) on OBJECT\n\
+         type Query { product: Product }\n\
+         type Product @sel(fields: 42) { id: ID }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: syntax error: expected a string literal
+           ╭─[ schema.graphql:3:27 ]
+           │
+         3 │ type Product @sel(fields: 42) { id: ID }
+           │                           ─┬  
+           │                            ╰── expected a string literal
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_utf8_in_selection() {
+    // A multi-byte UTF-8 character inside the selection string is a parse error
+    // (GraphQL names are ASCII-only). Verify the diagnostic renders with the
+    // correct byte offset and file attribution.
+    let sdl = "directive @sel(fields: String!) on OBJECT\n\
+               type Query { product: Product }\n\
+               type Product @sel(fields: \"id café\") { id: ID }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: type `Product` does not have a field `caf`
+           ╭─[ schema.graphql:3:31 ]
+           │
+         3 │ type Product @sel(fields: "id café") { id: ID }
+           │      ───┬───                  ─┬─  
+           │         ╰────────────────────────── type `Product` defined here
+           │                                │   
+           │                                ╰─── field `caf` selected here
+           │ 
+           │ Note: path to the field: `Product → caf`
+        ───╯
+        Error: syntax error: Unexpected character "é"
+           ╭─[ schema.graphql:3:34 ]
+           │
+         3 │ type Product @sel(fields: "id café") { id: ID }
+           │                                  ┬  
+           │                                  ╰── Unexpected character "é"
         ───╯
     "#]]
     .assert_eq(&err.errors.to_string());

--- a/crates/apollo-compiler/tests/field_set.rs
+++ b/crates/apollo-compiler/tests/field_set.rs
@@ -1,7 +1,10 @@
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::name;
+use apollo_compiler::parser::SourceSpan;
+use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::Schema;
+use expect_test::expect;
 
 fn common_schema() -> Valid<Schema> {
     let input = r#"
@@ -64,4 +67,79 @@ fn test_invalid_field_sets() {
         errors.contains("the argument `arg` is not supported"),
         "{errors}"
     );
+}
+
+/// Helper: find the span of a string argument value on a directive applied to a type.
+fn string_arg_value_span(
+    schema: &Schema,
+    type_name: &str,
+    directive_name: &str,
+    arg_name: &str,
+) -> SourceSpan {
+    let ExtendedType::Object(obj) = &schema.types[type_name] else {
+        panic!("{type_name} is not an object type");
+    };
+    let dir = obj
+        .directives
+        .iter()
+        .find(|d| d.name == directive_name)
+        .unwrap_or_else(|| panic!("no @{directive_name} directive on {type_name}"));
+    let arg = dir
+        .arguments
+        .iter()
+        .find(|a| a.name == arg_name)
+        .unwrap_or_else(|| panic!("no {arg_name} argument"));
+    arg.value
+        .location()
+        .expect("argument value has no source location")
+}
+
+#[test]
+fn parse_at_span_valid() {
+    let sdl = r#"
+        directive @sel(fields: String!) on OBJECT
+        type Query { product: Product }
+        type Product @sel(fields: "id") { id: ID }
+    "#;
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = string_arg_value_span(&schema, "Product", "sel", "fields");
+    let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[test]
+fn parse_at_span_error_rendering() {
+    let sdl =
+        "type Product @sel(fields: \"id details { nonexistent }\") { id: ID, details: Details }\n\
+               type Details { name: String }\n\
+               directive @sel(fields: String!) on OBJECT\n\
+               type Query { product: Product }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = string_arg_value_span(&schema, "Product", "sel", "fields");
+
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: interface, union and object types must have a subselection set
+           ╭─[ schema.graphql:1:31 ]
+           │
+         1 │ type Product @sel(fields: "id details { nonexistent }") { id: ID, details: Details }
+           │                               ───────────┬───────────  
+           │                                          ╰───────────── `Product.details` is an object type `Details` and must select fields
+        ───╯
+        Error: type `Details` does not have a field `nonexistent`
+           ╭─[ schema.graphql:1:41 ]
+           │
+         1 │ type Product @sel(fields: "id details { nonexistent }") { id: ID, details: Details }
+           │                                         ─────┬─────  
+           │                                              ╰─────── field `nonexistent` selected here
+         2 │ type Details { name: String }
+           │      ───┬───  
+           │         ╰───── type `Details` defined here
+           │ 
+           │ Note: path to the field: `Product → details → nonexistent`
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
 }


### PR DESCRIPTION
# Parsing FieldSet from within an already-parsed document

We support parsing "free-standing" FieldSet instances for Federation, to support selections which are embedded in String-type directive arguments. So far, using `FieldSet::parse_and_validate()` cannot produce the rich diagnostic messages we get from the initial parser pass because that entrypoint creates a fake source file document from the string passed into the parser.

This change adds support for parsing a FieldSet by giving the parser a source span inside an existing schema, resulting in rich diagnostics about that selection within the context of the actual schema. To support this, this adds `FieldSet::parse_and_validate_at_span()`. The main difference from the existing `parse_and_validate()` is that we pass the source span instead of a string, and that span is used to locate the string content in the schema. Previously, the `Convert` API for turning the CST into an AST only accepted a `FileId` for source information. The bulk of this change is a mechanical substitution of those parameters for a new `SourceContext` which carries the `FileId` and an offset. These are internal APIs, so the change is contained to this project. The only public-facing change is the addition of `FieldSet::parse_and_validate_at_span()`.

<!-- FED-1067 -->