### PR TITLE
fix(smith): generate correctly shaped default values based on type being filled

### DIFF
--- a/crates/apollo-smith/src/input_value.rs
+++ b/crates/apollo-smith/src/input_value.rs
@@ -314,12 +314,11 @@ impl DocumentBuilder<'_> {
                 }
             }
             let directives = self.directives(directive_location)?;
-            // TODO: FIXME: it's not correct I need to generate default value corresponding to the ty above
             let default_value = self
                 .u
                 .arbitrary()
                 .unwrap_or(false)
-                .then(|| self.input_value(Constness::Const))
+                .then(|| self.input_value_for_type(&ty))
                 .transpose()?;
 
             if !exclude.contains(&name) {
@@ -351,12 +350,11 @@ impl DocumentBuilder<'_> {
         let name = self.name()?;
         let ty = self.choose_ty(&self.list_existing_input_types())?;
         let directives = self.directives(directive_location)?;
-        // TODO: FIXME: it's not correct I need to generate default value corresponding to the ty above
         let default_value = self
             .u
             .arbitrary()
             .unwrap_or(false)
-            .then(|| self.input_value(Constness::Const))
+            .then(|| self.input_value_for_type(&ty))
             .transpose()?;
 
         Ok(InputValueDef {

--- a/crates/apollo-smith/src/variable.rs
+++ b/crates/apollo-smith/src/variable.rs
@@ -1,6 +1,5 @@
 use crate::directive::Directive;
 use crate::directive::DirectiveLocation;
-use crate::input_value::Constness;
 use crate::input_value::InputValue;
 use crate::name::Name;
 use crate::ty::Ty;
@@ -51,7 +50,7 @@ impl DocumentBuilder<'_> {
             .u
             .arbitrary()
             .unwrap_or(false)
-            .then(|| self.input_value(Constness::Const))
+            .then(|| self.input_value_for_type(&ty))
             .transpose()?;
         let directives = self.directives(DirectiveLocation::VariableDefinition)?;
 


### PR DESCRIPTION
Fixes a longstanding issue where default values were generated without knowledge of the type they needed to be.

<!-- [FED-1080] -->

[FED-1080]: https://apollographql.atlassian.net/browse/FED-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ