### PR TITLE
feat(compiler): parse FieldSet from a source span, with escape-aware offsets

### DIFF
--- a/crates/apollo-compiler/src/ast/from_cst.rs
+++ b/crates/apollo-compiler/src/ast/from_cst.rs
@@ -10,48 +10,88 @@ use apollo_parser::SyntaxNode;
 use apollo_parser::S;
 
 #[derive(Copy, Clone)]
-pub(crate) struct SourceContext {
+pub(crate) struct SourceContext<'a> {
     file_id: FileId,
     base_offset: rowan::TextSize,
+    /// `(unescaped_offset, source_offset)` checkpoints recorded after each
+    /// escape sequence when the parsed text was unescaped from a string
+    /// literal in the source. Empty when parsed text matches the source 1:1.
+    /// Both offsets are relative: to the parsed text and to `base_offset`
+    /// respectively.
+    escape_checkpoints: &'a [(rowan::TextSize, rowan::TextSize)],
 }
 
-impl SourceContext {
+impl<'a> SourceContext<'a> {
     pub(crate) fn new(file_id: FileId) -> Self {
-        Self {
-            file_id,
-            base_offset: 0.into(),
-        }
+        Self::with_offset(file_id, 0.into())
     }
 
     pub(crate) fn with_offset(file_id: FileId, base_offset: rowan::TextSize) -> Self {
         Self {
             file_id,
             base_offset,
+            escape_checkpoints: &[],
+        }
+    }
+
+    pub(crate) fn with_escapes(
+        file_id: FileId,
+        base_offset: rowan::TextSize,
+        escape_checkpoints: &'a [(rowan::TextSize, rowan::TextSize)],
+    ) -> Self {
+        Self {
+            file_id,
+            base_offset,
+            escape_checkpoints,
+        }
+    }
+
+    /// Map an offset in the parsed text to an offset in the original source.
+    ///
+    /// Escape sequences make the parsed text shorter than its source form, so
+    /// a flat base offset is not enough: find the last escape checkpoint at or
+    /// before `offset`, then advance 1:1 from there. Offsets produced this way
+    /// always land on character boundaries of the source text.
+    fn map_offset(self, offset: rowan::TextSize) -> rowan::TextSize {
+        let mapped = match self
+            .escape_checkpoints
+            .binary_search_by_key(&offset, |&(unescaped, _)| unescaped)
+        {
+            Ok(index) => self.escape_checkpoints[index].1,
+            Err(0) => offset,
+            Err(index) => {
+                let (unescaped, source) = self.escape_checkpoints[index - 1];
+                source + (offset - unescaped)
+            }
+        };
+        self.base_offset + mapped
+    }
+
+    pub(crate) fn map_range(self, range: rowan::TextRange) -> SourceSpan {
+        SourceSpan {
+            file_id: self.file_id,
+            text_range: rowan::TextRange::new(
+                self.map_offset(range.start()),
+                self.map_offset(range.end()),
+            ),
         }
     }
 }
 
-impl From<FileId> for SourceContext {
+impl From<FileId> for SourceContext<'_> {
     fn from(file_id: FileId) -> Self {
         Self::new(file_id)
     }
 }
 
 fn source_span(ctx: SourceContext, syntax_node: &SyntaxNode) -> SourceSpan {
-    let range = syntax_node.text_range();
-    SourceSpan {
-        file_id: ctx.file_id,
-        text_range: rowan::TextRange::new(
-            range.start() + ctx.base_offset,
-            range.end() + ctx.base_offset,
-        ),
-    }
+    ctx.map_range(syntax_node.text_range())
 }
 
 impl Document {
-    pub(crate) fn from_cst(
+    pub(crate) fn from_cst<'a>(
         document: cst::Document,
-        ctx: impl Into<SourceContext>,
+        ctx: impl Into<SourceContext<'a>>,
         sources: SourceMap,
     ) -> Self {
         let ctx = ctx.into();
@@ -163,10 +203,10 @@ impl Convert for cst::OperationDefinition {
             ast::OperationType::Query
         };
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
+            description: self.description().convert(ctx)?,
             operation_type,
             name: self.name().convert(ctx)?,
-            variables: collect_opt(ctx, self.variable_definitions(), |x| {
+            variables: collect_opt(ctx, self.variables_definition(), |x| {
                 x.variable_definitions()
             }),
             directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
@@ -633,9 +673,9 @@ impl Convert for cst::SelectionSet {
     }
 }
 
-pub(crate) fn convert_selection_set(
+pub(crate) fn convert_selection_set<'a>(
     selection_set: &cst::SelectionSet,
-    ctx: impl Into<SourceContext>,
+    ctx: impl Into<SourceContext<'a>>,
 ) -> Vec<ast::Selection> {
     let ctx = ctx.into();
     selection_set

--- a/crates/apollo-compiler/src/ast/from_cst.rs
+++ b/crates/apollo-compiler/src/ast/from_cst.rs
@@ -9,13 +9,57 @@ use apollo_parser::cst::CstNode;
 use apollo_parser::SyntaxNode;
 use apollo_parser::S;
 
+#[derive(Copy, Clone)]
+pub(crate) struct SourceContext {
+    file_id: FileId,
+    base_offset: rowan::TextSize,
+}
+
+impl SourceContext {
+    pub(crate) fn new(file_id: FileId) -> Self {
+        Self {
+            file_id,
+            base_offset: 0.into(),
+        }
+    }
+
+    pub(crate) fn with_offset(file_id: FileId, base_offset: rowan::TextSize) -> Self {
+        Self {
+            file_id,
+            base_offset,
+        }
+    }
+}
+
+impl From<FileId> for SourceContext {
+    fn from(file_id: FileId) -> Self {
+        Self::new(file_id)
+    }
+}
+
+fn source_span(ctx: SourceContext, syntax_node: &SyntaxNode) -> SourceSpan {
+    let range = syntax_node.text_range();
+    SourceSpan {
+        file_id: ctx.file_id,
+        text_range: rowan::TextRange::new(
+            range.start() + ctx.base_offset,
+            range.end() + ctx.base_offset,
+        ),
+    }
+}
+
 impl Document {
-    pub(crate) fn from_cst(document: cst::Document, file_id: FileId, sources: SourceMap) -> Self {
+    pub(crate) fn from_cst(
+        document: cst::Document,
+        ctx: impl Into<SourceContext>,
+        sources: SourceMap,
+    ) -> Self {
+        let ctx = ctx.into();
         Self {
             sources,
             definitions: document
                 .definitions()
-                .filter_map(|def| def.convert(file_id))
+                .filter_map(|def| def.convert(ctx))
                 .collect(),
         }
     }
@@ -24,37 +68,31 @@ impl Document {
 /// Similar to `TryFrom`, but with an `Option` return type because AST uses Option a lot.
 pub(crate) trait Convert {
     type Target;
-    fn convert(&self, file_id: FileId) -> Option<Self::Target>;
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target>;
 }
 
-fn with_location<T>(file_id: FileId, syntax_node: &SyntaxNode, node: T) -> Node<T> {
-    Node::new_parsed(node, SourceSpan::new(file_id, syntax_node))
+fn with_location<T>(ctx: SourceContext, syntax_node: &SyntaxNode, node: T) -> Node<T> {
+    Node::new_parsed(node, source_span(ctx, syntax_node))
 }
 
 /// Convert and collect, silently skipping entries with conversion errors
 /// as they have corresponding parse errors in `SyntaxTree::errors`
 #[inline]
 fn collect<CstType, AstType>(
-    file_id: FileId,
+    ctx: SourceContext,
     iter: impl IntoIterator<Item = CstType>,
 ) -> Vec<Node<AstType>>
 where
     CstType: CstNode + Convert<Target = AstType>,
 {
     iter.into_iter()
-        .filter_map(|value| {
-            Some(with_location(
-                file_id,
-                value.syntax(),
-                value.convert(file_id)?,
-            ))
-        })
+        .filter_map(|value| Some(with_location(ctx, value.syntax(), value.convert(ctx)?)))
         .collect()
 }
 
 #[inline]
 fn collect_opt<CstType1, CstType2, AstType, F, I>(
-    file_id: FileId,
+    ctx: SourceContext,
     opt: Option<CstType1>,
     convert: F,
 ) -> Vec<Node<AstType>>
@@ -64,7 +102,7 @@ where
     CstType2: CstNode + Convert<Target = AstType>,
 {
     if let Some(cst) = opt {
-        collect(file_id, convert(cst))
+        collect(ctx, convert(cst))
     } else {
         Vec::new()
     }
@@ -73,9 +111,9 @@ where
 impl<T: Convert> Convert for Option<T> {
     type Target = Option<T::Target>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(if let Some(inner) = self {
-            Some(inner.convert(file_id)?)
+            Some(inner.convert(ctx)?)
         } else {
             None
         })
@@ -85,12 +123,12 @@ impl<T: Convert> Convert for Option<T> {
 impl Convert for cst::Definition {
     type Target = ast::Definition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         use ast::Definition as A;
         use cst::Definition as C;
         macro_rules! r {
             ($def: ident) => {
-                with_location(file_id, $def.syntax(), $def.convert(file_id)?)
+                with_location(ctx, $def.syntax(), $def.convert(ctx)?)
             };
         }
         Some(match self {
@@ -118,26 +156,24 @@ impl Convert for cst::Definition {
 impl Convert for cst::OperationDefinition {
     type Target = ast::OperationDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         let operation_type = if let Some(ty) = self.operation_type() {
-            ty.convert(file_id)?
+            ty.convert(ctx)?
         } else {
             ast::OperationType::Query
         };
         Some(Self::Target {
             description: self.description().convert(file_id)?,
             operation_type,
-            name: self.name().convert(file_id)?,
-            variables: collect_opt(file_id, self.variables_definition(), |x| {
+            name: self.name().convert(ctx)?,
+            variables: collect_opt(ctx, self.variable_definitions(), |x| {
                 x.variable_definitions()
             }),
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             selection_set: self
                 .selection_set()?
                 .selections()
-                .filter_map(|sel| sel.convert(file_id))
+                .filter_map(|sel| sel.convert(ctx))
                 .collect(),
         })
     }
@@ -146,15 +182,13 @@ impl Convert for cst::OperationDefinition {
 impl Convert for cst::FragmentDefinition {
     type Target = ast::FragmentDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.fragment_name()?.name()?.convert(file_id)?,
-            type_condition: self.type_condition()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            selection_set: self.selection_set().convert(file_id)??,
+            description: self.description().convert(ctx)?,
+            name: self.fragment_name()?.name()?.convert(ctx)?,
+            type_condition: self.type_condition()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            selection_set: self.selection_set().convert(ctx)??,
         })
     }
 }
@@ -162,19 +196,19 @@ impl Convert for cst::FragmentDefinition {
 impl Convert for cst::TypeCondition {
     type Target = ast::NamedType;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        self.named_type()?.name()?.convert(file_id)
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        self.named_type()?.name()?.convert(ctx)
     }
 }
 
 impl Convert for cst::DirectiveDefinition {
     type Target = ast::DirectiveDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            arguments: collect_opt(file_id, self.arguments_definition(), |x| {
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            arguments: collect_opt(ctx, self.arguments_definition(), |x| {
                 x.input_value_definitions()
             }),
             repeatable: self.repeatable_token().is_some(),
@@ -182,7 +216,7 @@ impl Convert for cst::DirectiveDefinition {
                 .directive_locations()
                 .map(|x| {
                     x.directive_locations()
-                        .filter_map(|location| location.convert(file_id))
+                        .filter_map(|location| location.convert(ctx))
                         .collect()
                 })
                 .unwrap_or_default(),
@@ -193,19 +227,17 @@ impl Convert for cst::DirectiveDefinition {
 impl Convert for cst::SchemaDefinition {
     type Target = ast::SchemaDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            description: self.description().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             // This may represent a syntactically invalid thing: a schema without any root
             // operation definitions. However the presence of a broken schema definition does
             // affect whether a default schema definition should be inserted, so we bubble up the
             // potentially invalid definition.
             root_operations: self
                 .root_operation_type_definitions()
-                .filter_map(|x| x.convert(file_id))
+                .filter_map(|x| x.convert(ctx))
                 .collect(),
         })
     }
@@ -214,13 +246,11 @@ impl Convert for cst::SchemaDefinition {
 impl Convert for cst::ScalarTypeDefinition {
     type Target = ast::ScalarTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -228,15 +258,13 @@ impl Convert for cst::ScalarTypeDefinition {
 impl Convert for cst::ObjectTypeDefinition {
     type Target = ast::ObjectTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            implements_interfaces: self.implements_interfaces().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.fields_definition(), |x| x.field_definitions()),
         })
     }
 }
@@ -244,15 +272,13 @@ impl Convert for cst::ObjectTypeDefinition {
 impl Convert for cst::InterfaceTypeDefinition {
     type Target = ast::InterfaceTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            implements_interfaces: self.implements_interfaces().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.fields_definition(), |x| x.field_definitions()),
         })
     }
 }
@@ -260,19 +286,17 @@ impl Convert for cst::InterfaceTypeDefinition {
 impl Convert for cst::UnionTypeDefinition {
     type Target = ast::UnionTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             members: self
                 .union_member_types()
                 .map_or_else(Default::default, |member_types| {
                     member_types
                         .named_types()
-                        .filter_map(|n| n.name()?.convert(file_id))
+                        .filter_map(|n| n.name()?.convert(ctx))
                         .collect()
                 }),
         })
@@ -282,14 +306,12 @@ impl Convert for cst::UnionTypeDefinition {
 impl Convert for cst::EnumTypeDefinition {
     type Target = ast::EnumTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            values: collect_opt(file_id, self.enum_values_definition(), |x| {
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            values: collect_opt(ctx, self.enum_values_definition(), |x| {
                 x.enum_value_definitions()
             }),
         })
@@ -299,14 +321,12 @@ impl Convert for cst::EnumTypeDefinition {
 impl Convert for cst::InputObjectTypeDefinition {
     type Target = ast::InputObjectTypeDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.input_fields_definition(), |x| {
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.input_fields_definition(), |x| {
                 x.input_value_definitions()
             }),
         })
@@ -316,14 +336,12 @@ impl Convert for cst::InputObjectTypeDefinition {
 impl Convert for cst::SchemaExtension {
     type Target = ast::SchemaExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             root_operations: self
                 .root_operation_type_definitions()
-                .filter_map(|x| x.convert(file_id))
+                .filter_map(|x| x.convert(ctx))
                 .collect(),
         })
     }
@@ -332,12 +350,10 @@ impl Convert for cst::SchemaExtension {
 impl Convert for cst::ScalarTypeExtension {
     type Target = ast::ScalarTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -345,14 +361,12 @@ impl Convert for cst::ScalarTypeExtension {
 impl Convert for cst::ObjectTypeExtension {
     type Target = ast::ObjectTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
+            name: self.name()?.convert(ctx)?,
+            implements_interfaces: self.implements_interfaces().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.fields_definition(), |x| x.field_definitions()),
         })
     }
 }
@@ -360,14 +374,12 @@ impl Convert for cst::ObjectTypeExtension {
 impl Convert for cst::InterfaceTypeExtension {
     type Target = ast::InterfaceTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            implements_interfaces: self.implements_interfaces().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.fields_definition(), |x| x.field_definitions()),
+            name: self.name()?.convert(ctx)?,
+            implements_interfaces: self.implements_interfaces().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.fields_definition(), |x| x.field_definitions()),
         })
     }
 }
@@ -375,18 +387,16 @@ impl Convert for cst::InterfaceTypeExtension {
 impl Convert for cst::UnionTypeExtension {
     type Target = ast::UnionTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             members: self
                 .union_member_types()
                 .map_or_else(Default::default, |member_types| {
                     member_types
                         .named_types()
-                        .filter_map(|n| n.name()?.convert(file_id))
+                        .filter_map(|n| n.name()?.convert(ctx))
                         .collect()
                 }),
         })
@@ -396,13 +406,11 @@ impl Convert for cst::UnionTypeExtension {
 impl Convert for cst::EnumTypeExtension {
     type Target = ast::EnumTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            values: collect_opt(file_id, self.enum_values_definition(), |x| {
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            values: collect_opt(ctx, self.enum_values_definition(), |x| {
                 x.enum_value_definitions()
             }),
         })
@@ -412,13 +420,11 @@ impl Convert for cst::EnumTypeExtension {
 impl Convert for cst::InputObjectTypeExtension {
     type Target = ast::InputObjectTypeExtension;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            fields: collect_opt(file_id, self.input_fields_definition(), |x| {
+            name: self.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            fields: collect_opt(ctx, self.input_fields_definition(), |x| {
                 x.input_value_definitions()
             }),
         })
@@ -428,10 +434,10 @@ impl Convert for cst::InputObjectTypeExtension {
 impl Convert for cst::Description {
     type Target = Node<str>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Node::new_str_parsed(
             &String::from(self.string_value()?),
-            SourceSpan::new(file_id, self.syntax()),
+            source_span(ctx, self.syntax()),
         ))
     }
 }
@@ -439,10 +445,10 @@ impl Convert for cst::Description {
 impl Convert for cst::Directive {
     type Target = ast::Directive;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            name: self.name()?.convert(file_id)?,
-            arguments: collect_opt(file_id, self.arguments(), |x| x.arguments()),
+            name: self.name()?.convert(ctx)?,
+            arguments: collect_opt(ctx, self.arguments(), |x| x.arguments()),
         })
     }
 }
@@ -450,7 +456,7 @@ impl Convert for cst::Directive {
 impl Convert for cst::OperationType {
     type Target = ast::OperationType;
 
-    fn convert(&self, _file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, _ctx: SourceContext) -> Option<Self::Target> {
         let token = self.syntax().first_token()?;
         match token.kind() {
             S![query] => Some(ast::OperationType::Query),
@@ -464,17 +470,17 @@ impl Convert for cst::OperationType {
 impl Convert for cst::RootOperationTypeDefinition {
     type Target = Node<(ast::OperationType, ast::NamedType)>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        let ty = self.operation_type()?.convert(file_id)?;
-        let name = self.named_type()?.name()?.convert(file_id)?;
-        Some(with_location(file_id, self.syntax(), (ty, name)))
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        let ty = self.operation_type()?.convert(ctx)?;
+        let name = self.named_type()?.name()?.convert(ctx)?;
+        Some(with_location(ctx, self.syntax(), (ty, name)))
     }
 }
 
 impl Convert for cst::DirectiveLocation {
     type Target = ast::DirectiveLocation;
 
-    fn convert(&self, _file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, _ctx: SourceContext) -> Option<Self::Target> {
         let token = self.syntax().first_token()?;
         match token.kind() {
             S![QUERY] => Some(ast::DirectiveLocation::Query),
@@ -504,11 +510,11 @@ impl Convert for cst::DirectiveLocation {
 impl Convert for Option<cst::ImplementsInterfaces> {
     type Target = Vec<ast::NamedType>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(if let Some(inner) = self {
             inner
                 .named_types()
-                .filter_map(|n| n.name()?.convert(file_id))
+                .filter_map(|n| n.name()?.convert(ctx))
                 .collect()
         } else {
             Vec::new()
@@ -519,26 +525,20 @@ impl Convert for Option<cst::ImplementsInterfaces> {
 impl Convert for cst::VariableDefinition {
     type Target = ast::VariableDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         let default_value = if let Some(default) = self.default_value() {
             let value = default.value()?;
-            Some(with_location(
-                file_id,
-                value.syntax(),
-                value.convert(file_id)?,
-            ))
+            Some(with_location(ctx, value.syntax(), value.convert(ctx)?))
         } else {
             None
         };
         let ty = &self.ty()?;
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.variable()?.name()?.convert(file_id)?,
-            ty: with_location(file_id, ty.syntax(), ty.convert(file_id)?),
+            description: self.description().convert(ctx)?,
+            name: self.variable()?.name()?.convert(ctx)?,
+            ty: with_location(ctx, ty.syntax(), ty.convert(ctx)?),
             default_value,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -546,17 +546,17 @@ impl Convert for cst::VariableDefinition {
 impl Convert for cst::Type {
     type Target = ast::Type;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         use ast::Type as A;
         use cst::Type as C;
         match self {
-            C::NamedType(name) => Some(A::Named(name.name()?.convert(file_id)?)),
-            C::ListType(inner) => Some(A::List(Box::new(inner.ty()?.convert(file_id)?))),
+            C::NamedType(name) => Some(A::Named(name.name()?.convert(ctx)?)),
+            C::ListType(inner) => Some(A::List(Box::new(inner.ty()?.convert(ctx)?))),
             C::NonNullType(inner) => {
                 if let Some(named) = inner.named_type() {
-                    Some(A::NonNullNamed(named.name()?.convert(file_id)?))
+                    Some(A::NonNullNamed(named.name()?.convert(ctx)?))
                 } else if let Some(list) = inner.list_type() {
-                    Some(A::NonNullList(Box::new(list.ty()?.convert(file_id)?)))
+                    Some(A::NonNullList(Box::new(list.ty()?.convert(ctx)?)))
                 } else {
                     None
                 }
@@ -568,17 +568,15 @@ impl Convert for cst::Type {
 impl Convert for cst::FieldDefinition {
     type Target = ast::FieldDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            arguments: collect_opt(file_id, self.arguments_definition(), |x| {
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            arguments: collect_opt(ctx, self.arguments_definition(), |x| {
                 x.input_value_definitions()
             }),
-            ty: self.ty()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            ty: self.ty()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -586,10 +584,10 @@ impl Convert for cst::FieldDefinition {
 impl Convert for cst::Argument {
     type Target = ast::Argument;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        let name = self.name()?.convert(file_id)?;
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        let name = self.name()?.convert(ctx)?;
         let value = self.value()?;
-        let value = with_location(file_id, value.syntax(), value.convert(file_id)?);
+        let value = with_location(ctx, value.syntax(), value.convert(ctx)?);
         Some(ast::Argument { name, value })
     }
 }
@@ -597,26 +595,20 @@ impl Convert for cst::Argument {
 impl Convert for cst::InputValueDefinition {
     type Target = ast::InputValueDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         let default_value = if let Some(default) = self.default_value() {
             let value = default.value()?;
-            Some(with_location(
-                file_id,
-                value.syntax(),
-                value.convert(file_id)?,
-            ))
+            Some(with_location(ctx, value.syntax(), value.convert(ctx)?))
         } else {
             None
         };
         let ty = &self.ty()?;
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            ty: with_location(file_id, ty.syntax(), ty.convert(file_id)?),
+            description: self.description().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            ty: with_location(ctx, ty.syntax(), ty.convert(ctx)?),
             default_value,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -624,13 +616,11 @@ impl Convert for cst::InputValueDefinition {
 impl Convert for cst::EnumValueDefinition {
     type Target = ast::EnumValueDefinition;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            description: self.description().convert(file_id)?,
-            value: self.enum_value()?.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            description: self.description().convert(ctx)?,
+            value: self.enum_value()?.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -638,35 +628,36 @@ impl Convert for cst::EnumValueDefinition {
 impl Convert for cst::SelectionSet {
     type Target = Vec<ast::Selection>;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        Some(convert_selection_set(self, file_id))
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        Some(convert_selection_set(self, ctx))
     }
 }
 
 pub(crate) fn convert_selection_set(
     selection_set: &cst::SelectionSet,
-    file_id: FileId,
+    ctx: impl Into<SourceContext>,
 ) -> Vec<ast::Selection> {
+    let ctx = ctx.into();
     selection_set
         .selections()
-        .filter_map(|selection| selection.convert(file_id))
+        .filter_map(|selection| selection.convert(ctx))
         .collect()
 }
 
 impl Convert for cst::Selection {
     type Target = ast::Selection;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         use ast::Selection as A;
         use cst::Selection as C;
 
         Some(match self {
-            C::Field(x) => A::Field(with_location(file_id, x.syntax(), x.convert(file_id)?)),
+            C::Field(x) => A::Field(with_location(ctx, x.syntax(), x.convert(ctx)?)),
             C::FragmentSpread(x) => {
-                A::FragmentSpread(with_location(file_id, x.syntax(), x.convert(file_id)?))
+                A::FragmentSpread(with_location(ctx, x.syntax(), x.convert(ctx)?))
             }
             C::InlineFragment(x) => {
-                A::InlineFragment(with_location(file_id, x.syntax(), x.convert(file_id)?))
+                A::InlineFragment(with_location(ctx, x.syntax(), x.convert(ctx)?))
             }
         })
     }
@@ -675,16 +666,14 @@ impl Convert for cst::Selection {
 impl Convert for cst::Field {
     type Target = ast::Field;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            alias: self.alias().convert(file_id)?,
-            name: self.name()?.convert(file_id)?,
-            arguments: collect_opt(file_id, self.arguments(), |x| x.arguments()),
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            alias: self.alias().convert(ctx)?,
+            name: self.name()?.convert(ctx)?,
+            arguments: collect_opt(ctx, self.arguments(), |x| x.arguments()),
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
             // Use an empty Vec for a field without sub-selections
-            selection_set: self.selection_set().convert(file_id)?.unwrap_or_default(),
+            selection_set: self.selection_set().convert(ctx)?.unwrap_or_default(),
         })
     }
 }
@@ -692,12 +681,10 @@ impl Convert for cst::Field {
 impl Convert for cst::FragmentSpread {
     type Target = ast::FragmentSpread;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            fragment_name: self.fragment_name()?.name()?.convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
+            fragment_name: self.fragment_name()?.name()?.convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
         })
     }
 }
@@ -705,13 +692,11 @@ impl Convert for cst::FragmentSpread {
 impl Convert for cst::InlineFragment {
     type Target = ast::InlineFragment;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         Some(Self::Target {
-            type_condition: self.type_condition().convert(file_id)?,
-            directives: ast::DirectiveList(collect_opt(file_id, self.directives(), |x| {
-                x.directives()
-            })),
-            selection_set: self.selection_set().convert(file_id)??,
+            type_condition: self.type_condition().convert(ctx)?,
+            directives: ast::DirectiveList(collect_opt(ctx, self.directives(), |x| x.directives())),
+            selection_set: self.selection_set().convert(ctx)??,
         })
     }
 }
@@ -719,12 +704,12 @@ impl Convert for cst::InlineFragment {
 impl Convert for cst::Value {
     type Target = ast::Value;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
         use ast::Value as A;
         use cst::Value as C;
 
         Some(match self {
-            C::Variable(v) => A::Variable(v.name()?.convert(file_id)?),
+            C::Variable(v) => A::Variable(v.name()?.convert(ctx)?),
             C::StringValue(v) => A::String(String::from(v)),
             C::FloatValue(v) => A::Float(ast::FloatValue::new_parsed(
                 v.syntax().first_token()?.text(),
@@ -732,13 +717,11 @@ impl Convert for cst::Value {
             C::IntValue(v) => A::Int(ast::IntValue::new_parsed(v.syntax().first_token()?.text())),
             C::BooleanValue(v) => A::Boolean(bool::try_from(v).ok()?),
             C::NullValue(_) => A::Null,
-            C::EnumValue(v) => A::Enum(v.name()?.convert(file_id)?),
-            C::ListValue(v) => A::List(collect(file_id, v.values())),
-            C::ObjectValue(v) => A::Object(
-                v.object_fields()
-                    .filter_map(|x| x.convert(file_id))
-                    .collect(),
-            ),
+            C::EnumValue(v) => A::Enum(v.name()?.convert(ctx)?),
+            C::ListValue(v) => A::List(collect(ctx, v.values())),
+            C::ObjectValue(v) => {
+                A::Object(v.object_fields().filter_map(|x| x.convert(ctx)).collect())
+            }
         })
     }
 }
@@ -746,10 +729,10 @@ impl Convert for cst::Value {
 impl Convert for cst::ObjectField {
     type Target = (crate::Name, Node<ast::Value>);
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        let name = self.name()?.convert(file_id)?;
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        let name = self.name()?.convert(ctx)?;
         let value = self.value()?;
-        let value = with_location(file_id, value.syntax(), value.convert(file_id)?);
+        let value = with_location(ctx, value.syntax(), value.convert(ctx)?);
         Some((name, value))
     }
 }
@@ -757,16 +740,16 @@ impl Convert for cst::ObjectField {
 impl Convert for cst::Alias {
     type Target = crate::Name;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        self.name()?.convert(file_id)
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        self.name()?.convert(ctx)
     }
 }
 
 impl Convert for cst::Name {
     type Target = crate::Name;
 
-    fn convert(&self, file_id: FileId) -> Option<Self::Target> {
-        let loc = SourceSpan::new(file_id, self.syntax());
+    fn convert(&self, ctx: SourceContext) -> Option<Self::Target> {
+        let loc = source_span(ctx, self.syntax());
         let token = &self.syntax().first_token()?;
         let str = token.text();
         debug_assert!(crate::Name::is_valid_syntax(str));

--- a/crates/apollo-compiler/src/ast/serialize.rs
+++ b/crates/apollo-compiler/src/ast/serialize.rs
@@ -865,7 +865,7 @@ fn serialize_string_value(state: &mut State, is_description: bool, mut str: &str
 }
 
 fn serialize_block_string(state: &mut State, contains_newline: bool, str: &str) -> fmt::Result {
-    const TRIPLE_QUOTE: &str = "\"\"\"";
+    use crate::parser::TRIPLE_QUOTE;
     const ESCAPED_TRIPLE_QUOTE: &str = "\\\"\"\"";
     const _: () = assert!(TRIPLE_QUOTE.len() == 3);
     const _: () = assert!(ESCAPED_TRIPLE_QUOTE.len() == 4);

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -385,6 +385,7 @@ pub(crate) enum ExecutableDefinitionName {
     AnonymousOperation(ast::OperationType),
     NamedOperation(ast::OperationType, Name),
     Fragment(Name),
+    FieldSet(Name),
 }
 
 impl ExecutableDocument {
@@ -1111,6 +1112,22 @@ impl FieldSet {
         errors.into_valid_result(field_set)
     }
 
+    /// Parses and validates the field set at `source_span` within an
+    /// already-parsed source file. Errors point to the original location.
+    ///
+    /// `source_span` must be the span of a string literal value (`"..."` or
+    /// `"""..."""`); quotes are stripped automatically.
+    pub fn parse_and_validate_at_span(
+        schema: &Valid<Schema>,
+        type_name: NamedType,
+        source_span: SourceSpan,
+    ) -> Result<Valid<Self>, WithErrors<Self>> {
+        let (field_set, mut errors) =
+            Parser::new().parse_field_set_at_span(schema, type_name, source_span);
+        validation::validate_field_set(&mut errors, schema, &field_set);
+        errors.into_valid_result(field_set)
+    }
+
     pub fn validate(&self, schema: &Valid<Schema>) -> Result<(), DiagnosticList> {
         let mut sources = IndexMap::clone(&schema.sources);
         sources.extend(self.sources.iter().map(|(k, v)| (*k, v.clone())));
@@ -1132,6 +1149,7 @@ impl fmt::Display for SelectionPath {
                 write!(f, "{operation_type} {name}")?
             }
             ExecutableDefinitionName::Fragment(name) => write!(f, "fragment {name}")?,
+            ExecutableDefinitionName::FieldSet(type_name) => write!(f, "{type_name}")?,
         }
         for name in &self.nested_fields {
             write!(f, " → {name}")?

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -1117,6 +1117,13 @@ impl FieldSet {
     ///
     /// `source_span` must be the span of a string literal value (`"..."` or
     /// `"""..."""`); quotes are stripped automatically.
+    ///
+    /// For `"..."` string literals, escape sequences are processed before
+    /// parsing and error locations are mapped back to the escaped source
+    /// text. Block string (`"""..."""`) content is parsed as written, since
+    /// block strings do not process escape sequences; their indentation is
+    /// also not stripped, which does not affect parsing because field sets
+    /// are whitespace-insensitive.
     pub fn parse_and_validate_at_span(
         schema: &Valid<Schema>,
         type_name: NamedType,

--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -23,7 +23,6 @@ use crate::validation::Valid;
 use crate::validation::WithErrors;
 use crate::ExecutableDocument;
 use crate::Schema;
-use apollo_parser::SyntaxNode;
 use rowan::TextRange;
 use serde::Deserialize;
 use serde::Serialize;
@@ -35,6 +34,8 @@ use std::sync::atomic;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::sync::OnceLock;
+
+pub(crate) const TRIPLE_QUOTE: &str = "\"\"\"";
 
 /// Configuration for parsing an input string as GraphQL syntax
 #[derive(Default, Debug, Clone)]
@@ -162,7 +163,23 @@ impl Parser {
         errors: &mut DiagnosticList,
         parse: impl FnOnce(apollo_parser::Parser) -> apollo_parser::SyntaxTree<T>,
     ) -> apollo_parser::SyntaxTree<T> {
-        let mut parser = apollo_parser::Parser::new(&source_text);
+        let tree = self.parse_syntax(&source_text, parse);
+        let source_file = Arc::new(SourceFile {
+            path,
+            source_text,
+            source: OnceLock::new(),
+        });
+        Arc::make_mut(&mut errors.sources).insert(file_id, source_file);
+        Self::collect_parse_errors(&tree, file_id, 0.into(), errors);
+        tree
+    }
+
+    fn parse_syntax<T: apollo_parser::cst::CstNode>(
+        &mut self,
+        source_text: &str,
+        parse: impl FnOnce(apollo_parser::Parser) -> apollo_parser::SyntaxTree<T>,
+    ) -> apollo_parser::SyntaxTree<T> {
+        let mut parser = apollo_parser::Parser::new(source_text);
         if let Some(value) = self.recursion_limit {
             parser = parser.recursion_limit(value)
         }
@@ -172,25 +189,28 @@ impl Parser {
         let tree = parse(parser);
         self.recursion_reached = tree.recursion_limit().high;
         self.tokens_reached = tree.token_limit().high;
-        let source_file = Arc::new(SourceFile {
-            path,
-            source_text,
-            source: OnceLock::new(),
-        });
-        Arc::make_mut(&mut errors.sources).insert(file_id, source_file);
+        tree
+    }
+
+    fn collect_parse_errors<T: apollo_parser::cst::CstNode>(
+        tree: &apollo_parser::SyntaxTree<T>,
+        file_id: FileId,
+        base_offset: rowan::TextSize,
+        errors: &mut DiagnosticList,
+    ) {
         for parser_error in tree.errors() {
             // Silently skip parse errors at index beyond 4 GiB.
             // Rowan in apollo-parser might complain about files that large
             // before we get here anyway.
-            let Ok(index) = parser_error.index().try_into() else {
+            let Ok(index): Result<rowan::TextSize, _> = parser_error.index().try_into() else {
                 continue;
             };
-            let Ok(len) = parser_error.data().len().try_into() else {
+            let Ok(len): Result<rowan::TextSize, _> = parser_error.data().len().try_into() else {
                 continue;
             };
             let location = Some(SourceSpan {
                 file_id,
-                text_range: rowan::TextRange::at(index, len),
+                text_range: rowan::TextRange::at(index + base_offset, len),
             });
             let details = if parser_error.is_limit() {
                 Details::ParserLimit {
@@ -203,7 +223,6 @@ impl Parser {
             };
             errors.push(location, details)
         }
-        tree
     }
 
     /// Parse the given source text as the sole input file of a schema.
@@ -350,7 +369,8 @@ impl Parser {
         path: impl AsRef<Path>,
     ) -> (executable::FieldSet, DiagnosticList) {
         let file_id = FileId::new();
-        let mut errors = DiagnosticList::new(Default::default());
+        let sources = IndexMap::clone(&schema.sources);
+        let mut errors = DiagnosticList::new(Arc::new(sources));
         let tree = self.parse_common(
             source_text.into(),
             path.as_ref().to_owned(),
@@ -359,23 +379,78 @@ impl Parser {
             |parser| parser.parse_selection_set(),
         );
         let ast = ast::from_cst::convert_selection_set(&tree.field_set(), file_id);
-        let mut selection_set = executable::SelectionSet::new(type_name);
+        Self::build_field_set(schema, type_name, &ast, errors)
+    }
+
+    fn build_field_set(
+        schema: &Valid<Schema>,
+        type_name: ast::NamedType,
+        ast: &[ast::Selection],
+        mut errors: DiagnosticList,
+    ) -> (executable::FieldSet, DiagnosticList) {
+        let mut selection_set = executable::SelectionSet::new(type_name.clone());
         let mut build_errors = executable::from_ast::BuildErrors {
             errors: &mut errors,
             path: executable::SelectionPath {
                 nested_fields: Vec::new(),
-                // 🤷
-                root: executable::ExecutableDefinitionName::AnonymousOperation(
-                    ast::OperationType::Query,
-                ),
+                root: executable::ExecutableDefinitionName::FieldSet(type_name),
             },
         };
-        selection_set.extend_from_ast(Some(schema), &mut build_errors, &ast);
+        selection_set.extend_from_ast(Some(schema), &mut build_errors, ast);
         let field_set = executable::FieldSet {
             sources: errors.sources.clone(),
             selection_set,
         };
         (field_set, errors)
+    }
+
+    /// Parses the field set at `source_span` within an already-parsed source
+    /// file. The span must cover a string literal (`"..."` or `"""..."""`);
+    /// quotes are stripped and errors point to the original location.
+    pub(crate) fn parse_field_set_at_span(
+        &mut self,
+        schema: &Valid<Schema>,
+        type_name: ast::NamedType,
+        source_span: SourceSpan,
+    ) -> (executable::FieldSet, DiagnosticList) {
+        let sources = IndexMap::clone(&schema.sources);
+        let mut errors = DiagnosticList::new(Arc::new(sources));
+        let Some(source_file) = schema.sources.get(&source_span.file_id) else {
+            return Self::build_field_set(schema, type_name, &[], errors);
+        };
+        let start = source_span.offset();
+        let end = source_span.end_offset();
+        let spanned_text = &source_file.source_text[start..end];
+        let (source_text, base_offset) = if let Some(content) = spanned_text
+            .strip_prefix(TRIPLE_QUOTE)
+            .and_then(|s| s.strip_suffix(TRIPLE_QUOTE))
+        {
+            (
+                content,
+                source_span.text_range.start() + rowan::TextSize::from(TRIPLE_QUOTE.len() as u32),
+            )
+        } else if let Some(content) = spanned_text
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+        {
+            (
+                content,
+                source_span.text_range.start() + rowan::TextSize::from(1),
+            )
+        } else {
+            errors.push(
+                Some(source_span),
+                Details::SyntaxError {
+                    message: "expected a string literal".to_owned(),
+                },
+            );
+            return Self::build_field_set(schema, type_name, &[], errors);
+        };
+        let tree = self.parse_syntax(source_text, |p| p.parse_selection_set());
+        Self::collect_parse_errors(&tree, source_span.file_id, base_offset, &mut errors);
+        let ctx = ast::from_cst::SourceContext::with_offset(source_span.file_id, base_offset);
+        let ast = ast::from_cst::convert_selection_set(&tree.field_set(), ctx);
+        Self::build_field_set(schema, type_name, &ast, errors)
     }
 
     /// Parse the given source text (e.g. `[Foo!]!`) as a reference to a GraphQL type.
@@ -398,7 +473,7 @@ impl Parser {
         );
         errors.into_result().map(|()| {
             tree.ty()
-                .convert(file_id)
+                .convert(file_id.into())
                 .expect("conversion should be infallible if there were no syntax errors")
         })
     }
@@ -574,13 +649,6 @@ impl TaggedFileId {
 }
 
 impl SourceSpan {
-    pub(crate) fn new(file_id: FileId, node: &'_ SyntaxNode) -> Self {
-        Self {
-            file_id,
-            text_range: node.text_range(),
-        }
-    }
-
     /// Returns the file ID for this location
     pub fn file_id(&self) -> FileId {
         self.file_id

--- a/crates/apollo-compiler/src/parser.rs
+++ b/crates/apollo-compiler/src/parser.rs
@@ -170,7 +170,7 @@ impl Parser {
             source: OnceLock::new(),
         });
         Arc::make_mut(&mut errors.sources).insert(file_id, source_file);
-        Self::collect_parse_errors(&tree, file_id, 0.into(), errors);
+        Self::collect_parse_errors(&tree, file_id.into(), errors);
         tree
     }
 
@@ -194,8 +194,7 @@ impl Parser {
 
     fn collect_parse_errors<T: apollo_parser::cst::CstNode>(
         tree: &apollo_parser::SyntaxTree<T>,
-        file_id: FileId,
-        base_offset: rowan::TextSize,
+        ctx: ast::from_cst::SourceContext<'_>,
         errors: &mut DiagnosticList,
     ) {
         for parser_error in tree.errors() {
@@ -208,10 +207,7 @@ impl Parser {
             let Ok(len): Result<rowan::TextSize, _> = parser_error.data().len().try_into() else {
                 continue;
             };
-            let location = Some(SourceSpan {
-                file_id,
-                text_range: rowan::TextRange::at(index + base_offset, len),
-            });
+            let location = Some(ctx.map_range(rowan::TextRange::at(index, len)));
             let details = if parser_error.is_limit() {
                 Details::ParserLimit {
                     message: parser_error.message().to_owned(),
@@ -421,20 +417,36 @@ impl Parser {
         let start = source_span.offset();
         let end = source_span.end_offset();
         let spanned_text = &source_file.source_text[start..end];
+        let mut escape_checkpoints: Vec<(rowan::TextSize, rowan::TextSize)> = Vec::new();
         let (source_text, base_offset) = if let Some(content) = spanned_text
             .strip_prefix(TRIPLE_QUOTE)
             .and_then(|s| s.strip_suffix(TRIPLE_QUOTE))
         {
+            // Block strings do not process escape sequences (other than
+            // `\"""`, which can never occur in a valid field set), so the raw
+            // content is parsed as-is and offsets already match the source.
             (
-                content,
+                std::borrow::Cow::Borrowed(content),
                 source_span.text_range.start() + rowan::TextSize::from(TRIPLE_QUOTE.len() as u32),
             )
         } else if let Some(content) = spanned_text
             .strip_prefix('"')
             .and_then(|s| s.strip_suffix('"'))
         {
+            let (unescaped, checkpoints) =
+                apollo_parser::cst::unescape_string_with_offsets(content);
+            // `content` is a slice of a rowan-indexed file, so offsets fit in u32
+            escape_checkpoints = checkpoints
+                .into_iter()
+                .map(|(unescaped, source)| {
+                    (
+                        rowan::TextSize::from(unescaped as u32),
+                        rowan::TextSize::from(source as u32),
+                    )
+                })
+                .collect();
             (
-                content,
+                std::borrow::Cow::Owned(unescaped),
                 source_span.text_range.start() + rowan::TextSize::from(1),
             )
         } else {
@@ -446,9 +458,13 @@ impl Parser {
             );
             return Self::build_field_set(schema, type_name, &[], errors);
         };
-        let tree = self.parse_syntax(source_text, |p| p.parse_selection_set());
-        Self::collect_parse_errors(&tree, source_span.file_id, base_offset, &mut errors);
-        let ctx = ast::from_cst::SourceContext::with_offset(source_span.file_id, base_offset);
+        let tree = self.parse_syntax(&source_text, |p| p.parse_selection_set());
+        let ctx = ast::from_cst::SourceContext::with_escapes(
+            source_span.file_id,
+            base_offset,
+            &escape_checkpoints,
+        );
+        Self::collect_parse_errors(&tree, ctx, &mut errors);
         let ast = ast::from_cst::convert_selection_set(&tree.field_set(), ctx);
         Self::build_field_set(schema, type_name, &ast, errors)
     }

--- a/crates/apollo-compiler/tests/field_set.rs
+++ b/crates/apollo-compiler/tests/field_set.rs
@@ -1,7 +1,10 @@
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::name;
+use apollo_compiler::parser::SourceSpan;
+use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::Schema;
+use expect_test::expect;
 
 fn common_schema() -> Valid<Schema> {
     let input = r#"
@@ -64,4 +67,194 @@ fn test_invalid_field_sets() {
         errors.contains("the argument `arg` is not supported"),
         "{errors}"
     );
+}
+
+/// Helper: find the span of an argument value on a directive applied to a type.
+fn arg_value_span(
+    schema: &Schema,
+    type_name: &str,
+    directive_name: &str,
+    arg_name: &str,
+) -> SourceSpan {
+    let ExtendedType::Object(obj) = &schema.types[type_name] else {
+        panic!("{type_name} is not an object type");
+    };
+    let dir = obj
+        .directives
+        .iter()
+        .find(|d| d.name == directive_name)
+        .unwrap_or_else(|| panic!("no @{directive_name} directive on {type_name}"));
+    let arg = dir
+        .arguments
+        .iter()
+        .find(|a| a.name == arg_name)
+        .unwrap_or_else(|| panic!("no {arg_name} argument"));
+    arg.value
+        .location()
+        .expect("argument value has no source location")
+}
+
+#[test]
+fn parse_at_span_valid() {
+    let sdl = r#"
+        directive @sel(fields: String!) on OBJECT
+        type Query { product: Product }
+        type Product @sel(fields: "id") { id: ID }
+    "#;
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[test]
+fn parse_at_span_block_string_valid() {
+    let sdl = r#"
+        directive @sel(fields: String!) on OBJECT
+        type Query { product: Product }
+        type Product @sel(fields: """id""") { id: ID }
+    "#;
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[test]
+fn parse_at_span_error_rendering() {
+    let sdl =
+        "type Product @sel(fields: \"id details { nonexistent }\") { id: ID, details: Details }\n\
+               type Details { name: String }\n\
+               directive @sel(fields: String!) on OBJECT\n\
+               type Query { product: Product }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: interface, union and object types must have a subselection set
+           ╭─[ schema.graphql:1:31 ]
+           │
+         1 │ type Product @sel(fields: "id details { nonexistent }") { id: ID, details: Details }
+           │                               ───────────┬───────────  
+           │                                          ╰───────────── `Product.details` is an object type `Details` and must select fields
+        ───╯
+        Error: type `Details` does not have a field `nonexistent`
+           ╭─[ schema.graphql:1:41 ]
+           │
+         1 │ type Product @sel(fields: "id details { nonexistent }") { id: ID, details: Details }
+           │                                         ─────┬─────  
+           │                                              ╰─────── field `nonexistent` selected here
+         2 │ type Details { name: String }
+           │      ───┬───  
+           │         ╰───── type `Details` defined here
+           │ 
+           │ Note: path to the field: `Product → details → nonexistent`
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_block_string_error_rendering() {
+    let sdl = r#"type Product @sel(fields: """
+id
+details { nonexistent }
+""") {
+  id: ID
+  details: Details
+}
+type Details { name: String }
+directive @sel(fields: String!) on OBJECT
+type Query { product: Product }
+"#;
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: interface, union and object types must have a subselection set
+           ╭─[ schema.graphql:3:1 ]
+           │
+         3 │ details { nonexistent }
+           │ ───────────┬───────────  
+           │            ╰───────────── `Product.details` is an object type `Details` and must select fields
+        ───╯
+        Error: type `Details` does not have a field `nonexistent`
+           ╭─[ schema.graphql:3:11 ]
+           │
+         3 │ details { nonexistent }
+           │           ─────┬─────  
+           │                ╰─────── field `nonexistent` selected here
+           │ 
+         8 │ type Details { name: String }
+           │      ───┬───  
+           │         ╰───── type `Details` defined here
+           │ 
+           │ Note: path to the field: `Product → details → nonexistent`
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_not_a_string() {
+    let sdl = "directive @sel(fields: Int!) on OBJECT\n\
+         type Query { product: Product }\n\
+         type Product @sel(fields: 42) { id: ID }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: syntax error: expected a string literal
+           ╭─[ schema.graphql:3:27 ]
+           │
+         3 │ type Product @sel(fields: 42) { id: ID }
+           │                           ─┬  
+           │                            ╰── expected a string literal
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_utf8_in_selection() {
+    // A multi-byte UTF-8 character inside the selection string is a parse error
+    // (GraphQL names are ASCII-only). Verify the diagnostic renders with the
+    // correct byte offset and file attribution.
+    let sdl = "directive @sel(fields: String!) on OBJECT\n\
+               type Query { product: Product }\n\
+               type Product @sel(fields: \"id café\") { id: ID }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: type `Product` does not have a field `caf`
+           ╭─[ schema.graphql:3:31 ]
+           │
+         3 │ type Product @sel(fields: "id café") { id: ID }
+           │      ───┬───                  ─┬─  
+           │         ╰────────────────────────── type `Product` defined here
+           │                                │   
+           │                                ╰─── field `caf` selected here
+           │ 
+           │ Note: path to the field: `Product → caf`
+        ───╯
+        Error: syntax error: Unexpected character "é"
+           ╭─[ schema.graphql:3:34 ]
+           │
+         3 │ type Product @sel(fields: "id café") { id: ID }
+           │                                  ┬  
+           │                                  ╰── Unexpected character "é"
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
 }

--- a/crates/apollo-compiler/tests/field_set.rs
+++ b/crates/apollo-compiler/tests/field_set.rs
@@ -70,12 +70,12 @@ fn test_invalid_field_sets() {
 }
 
 /// Helper: find the span of an argument value on a directive applied to a type.
-fn arg_value_span(
+fn arg_value(
     schema: &Schema,
     type_name: &str,
     directive_name: &str,
     arg_name: &str,
-) -> SourceSpan {
+) -> apollo_compiler::Node<apollo_compiler::ast::Argument> {
     let ExtendedType::Object(obj) = &schema.types[type_name] else {
         panic!("{type_name} is not an object type");
     };
@@ -84,11 +84,20 @@ fn arg_value_span(
         .iter()
         .find(|d| d.name == directive_name)
         .unwrap_or_else(|| panic!("no @{directive_name} directive on {type_name}"));
-    let arg = dir
-        .arguments
+    dir.arguments
         .iter()
         .find(|a| a.name == arg_name)
-        .unwrap_or_else(|| panic!("no {arg_name} argument"));
+        .unwrap_or_else(|| panic!("no {arg_name} argument"))
+        .clone()
+}
+
+fn arg_value_span(
+    schema: &Schema,
+    type_name: &str,
+    directive_name: &str,
+    arg_name: &str,
+) -> SourceSpan {
+    let arg = arg_value(schema, type_name, directive_name, arg_name);
     arg.value
         .location()
         .expect("argument value has no source location")
@@ -118,6 +127,63 @@ fn parse_at_span_block_string_valid() {
     let value_span = arg_value_span(&schema, "Product", "sel", "fields");
     let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
     assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[test]
+fn parse_at_span_escape_sequence_in_selection_valid() {
+    let sdl = r#"
+        directive @sel(fields: String!) on OBJECT
+        type Query { product: Product }
+        type Product @sel(fields: "id\naltId") { id: ID altId: ID }
+    "#;
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value = arg_value(&schema, "Product", "sel", "fields");
+    let old_result = FieldSet::parse_and_validate(
+        &schema,
+        name!("Product"),
+        value.value.as_str().unwrap().to_string(),
+        "schema.graphql",
+    );
+    assert!(old_result.is_ok(), "{}", old_result.unwrap_err());
+
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[test]
+fn parse_at_span_escape_sequence_in_block_selection_invalid() {
+    // Unlike the inline case tested in `parse_at_span_escape_sequence_in_selection_valid`,
+    // block strings do not process escape sequences and fail on both `FieldSet` parsers.
+    let sdl = r#"
+        directive @sel(fields: String!) on OBJECT
+        type Query { product: Product }
+        type Product @sel(fields: """
+            id\naltId
+        """) {
+            id: ID
+            altId: ID
+        }
+    "#;
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value = arg_value(&schema, "Product", "sel", "fields");
+    let old_result = FieldSet::parse_and_validate(
+        &schema,
+        name!("Product"),
+        value.value.as_str().unwrap().to_string(),
+        "schema.graphql",
+    );
+    assert!(
+        old_result.is_err(),
+        "FieldSet::parse_and_validate succeeded unexpectedly",
+    );
+
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
+    assert!(
+        result.is_err(),
+        "FieldSet::parse_and_validate_at_span succeeded unexpectedly",
+    );
 }
 
 #[test]
@@ -257,4 +323,88 @@ fn parse_at_span_utf8_in_selection() {
         ───╯
     "#]]
     .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_escaped_string_error_rendering() {
+    let sdl = "directive @sel(fields: String!) on OBJECT\n\
+               type Query { product: Product }\n\
+               type Product @sel(fields: \"id\\nmissing\") { id: ID }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: type `Product` does not have a field `missing`
+           ╭─[ schema.graphql:3:32 ]
+           │
+         3 │ type Product @sel(fields: "id\nmissing") { id: ID }
+           │      ───┬───                   ───┬───  
+           │         ╰─────────────────────────────── type `Product` defined here
+           │                                   │     
+           │                                   ╰───── field `missing` selected here
+           │ 
+           │ Note: path to the field: `Product → missing`
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_unicode_escape_before_multibyte_chars() {
+    // Regression test: a unicode escape sequence (6 source bytes -> 1 parsed
+    // byte) followed by multi-byte characters. Without escape-aware offset
+    // mapping, diagnostic spans land in the middle of a multi-byte character
+    // in the source text and panic when rendered.
+    let sdl = "directive @sel(fields: String!) on OBJECT\n\
+               type Query { product: Product }\n\
+               type Product @sel(fields: \"id\\u0020\u{D55C}\u{AE00}\") { id: ID }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+
+    let err =
+        FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span).unwrap_err();
+
+    expect![[r#"
+        Error: syntax error: Unexpected character "한"
+           ╭─[ schema.graphql:3:36 ]
+           │
+         3 │ type Product @sel(fields: "id\u0020한글") { id: ID }
+           │                                    ┬─   
+           │                                    ╰──── Unexpected character "한"
+        ───╯
+        Error: syntax error: Unexpected character "글"
+           ╭─[ schema.graphql:3:37 ]
+           │
+         3 │ type Product @sel(fields: "id\u0020한글") { id: ID }
+           │                                      ┬─  
+           │                                      ╰─── Unexpected character "글"
+        ───╯
+    "#]]
+    .assert_eq(&err.errors.to_string());
+}
+
+#[test]
+fn parse_at_span_unicode_escape_valid_selection() {
+    // A unicode escape for a space between two valid field names must parse
+    // successfully, matching `FieldSet::parse_and_validate` on the string value.
+    let sdl = "directive @sel(fields: String!) on OBJECT\n\
+               type Query { product: Product }\n\
+               type Product @sel(fields: \"id\\u0020altId\") { id: ID altId: ID }\n";
+    let schema = Schema::parse_and_validate(sdl, "schema.graphql").unwrap();
+
+    let value = arg_value(&schema, "Product", "sel", "fields");
+    let old_result = FieldSet::parse_and_validate(
+        &schema,
+        name!("Product"),
+        value.value.as_str().unwrap().to_string(),
+        "schema.graphql",
+    );
+    assert!(old_result.is_ok(), "{}", old_result.unwrap_err());
+
+    let value_span = arg_value_span(&schema, "Product", "sel", "fields");
+    let result = FieldSet::parse_and_validate_at_span(&schema, name!("Product"), value_span);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
 }

--- a/crates/apollo-parser/src/cst/node_ext.rs
+++ b/crates/apollo-parser/src/cst/node_ext.rs
@@ -637,6 +637,65 @@ mod string_tests {
             ("a\\".to_string(), vec![])
         );
     }
+
+    #[test]
+    fn it_records_offsets_at_escape_boundaries() {
+        // No escapes: no checkpoints
+        assert_eq!(
+            unescape_string_with_offsets("simple"),
+            ("simple".to_string(), vec![])
+        );
+        // Simple escape: 2 source bytes -> 1 output byte
+        assert_eq!(
+            unescape_string_with_offsets(r"a\nb"),
+            ("a\nb".to_string(), vec![(2, 3)])
+        );
+        // Unicode escape: 6 source bytes -> 1 output byte, followed by
+        // multi-byte characters advancing 1:1
+        assert_eq!(
+            unescape_string_with_offsets(r"id\u0020한글"),
+            ("id 한글".to_string(), vec![(3, 8)])
+        );
+        // Unicode escape producing a multi-byte character
+        assert_eq!(
+            unescape_string_with_offsets(r"\uCDEF!"),
+            ("\u{CDEF}!".to_string(), vec![(3, 6)])
+        );
+        // Consecutive escapes
+        assert_eq!(
+            unescape_string_with_offsets(r"\t\t"),
+            ("\t\t".to_string(), vec![(1, 2), (2, 4)])
+        );
+    }
+
+    #[test]
+    fn it_does_not_panic_on_invalid_escapes() {
+        // Unrecognized escapes produce no output, like `unescape_string`
+        assert_eq!(
+            unescape_string_with_offsets(r"a\qb"),
+            ("ab".to_string(), vec![(1, 3)])
+        );
+        // Too few hex digits
+        assert_eq!(
+            unescape_string_with_offsets(r"a\u12"),
+            ("a".to_string(), vec![(1, 5)])
+        );
+        // Non-hex characters after \u
+        assert_eq!(
+            unescape_string_with_offsets(r"a\uZZZZ"),
+            ("aZZZZ".to_string(), vec![(1, 3)])
+        );
+        // Surrogate code point is not a valid `char`
+        assert_eq!(
+            unescape_string_with_offsets(r"a\uD800b"),
+            ("ab".to_string(), vec![(1, 7)])
+        );
+        // Lone trailing backslash is kept
+        assert_eq!(
+            unescape_string_with_offsets("a\\"),
+            ("a\\".to_string(), vec![])
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/apollo-parser/src/cst/node_ext.rs
+++ b/crates/apollo-parser/src/cst/node_ext.rs
@@ -638,64 +638,6 @@ mod string_tests {
         );
     }
 
-    #[test]
-    fn it_records_offsets_at_escape_boundaries() {
-        // No escapes: no checkpoints
-        assert_eq!(
-            unescape_string_with_offsets("simple"),
-            ("simple".to_string(), vec![])
-        );
-        // Simple escape: 2 source bytes -> 1 output byte
-        assert_eq!(
-            unescape_string_with_offsets(r"a\nb"),
-            ("a\nb".to_string(), vec![(2, 3)])
-        );
-        // Unicode escape: 6 source bytes -> 1 output byte, followed by
-        // multi-byte characters advancing 1:1
-        assert_eq!(
-            unescape_string_with_offsets(r"id\u0020한글"),
-            ("id 한글".to_string(), vec![(3, 8)])
-        );
-        // Unicode escape producing a multi-byte character
-        assert_eq!(
-            unescape_string_with_offsets(r"\uCDEF!"),
-            ("\u{CDEF}!".to_string(), vec![(3, 6)])
-        );
-        // Consecutive escapes
-        assert_eq!(
-            unescape_string_with_offsets(r"\t\t"),
-            ("\t\t".to_string(), vec![(1, 2), (2, 4)])
-        );
-    }
-
-    #[test]
-    fn it_does_not_panic_on_invalid_escapes() {
-        // Unrecognized escapes produce no output, like `unescape_string`
-        assert_eq!(
-            unescape_string_with_offsets(r"a\qb"),
-            ("ab".to_string(), vec![(1, 3)])
-        );
-        // Too few hex digits
-        assert_eq!(
-            unescape_string_with_offsets(r"a\u12"),
-            ("a".to_string(), vec![(1, 5)])
-        );
-        // Non-hex characters after \u
-        assert_eq!(
-            unescape_string_with_offsets(r"a\uZZZZ"),
-            ("aZZZZ".to_string(), vec![(1, 3)])
-        );
-        // Surrogate code point is not a valid `char`
-        assert_eq!(
-            unescape_string_with_offsets(r"a\uD800b"),
-            ("ab".to_string(), vec![(1, 7)])
-        );
-        // Lone trailing backslash is kept
-        assert_eq!(
-            unescape_string_with_offsets("a\\"),
-            ("a\\".to_string(), vec![])
-        );
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Re-land #1065 with correct escape sequence handling

Stacked on #1083 (apollo-parser half). This re-lands #1065 (reverted in #1067) plus the fix for the escape-sequence problems @goto-bus-stop raised there:

1. **Correctness**: the at-span parser previously parsed the *source form* of the string literal, so `@key(fields: "a\nb")` — accepted by `FieldSet::parse_and_validate` since escapes are decoded at AST build — produced a spurious syntax error.
2. **Panic vector**: naively unescaping before parsing while keeping a flat base offset shifts every diagnostic offset after an escape (`\u0020` is 6 source bytes but 1 parsed byte), which can land spans in the middle of a multi-byte UTF-8 character and panic when rendering diagnostics (same class as #1023).

## How it works

`"..."` literals are unescaped with `unescape_string_with_offsets()` (from #1083) before parsing. Its `(unescaped_offset, source_offset)` checkpoints ride along in the internal `SourceContext`, and every AST node location and parse error is mapped from parsed-text offsets back to source offsets via binary search over the checkpoints + 1:1 advance. Since bytes between checkpoints are identical to the source, mapped offsets always land on character boundaries — the panic is ruled out structurally rather than per-escape-kind.

Block string (`"""..."""`) content is still parsed as written: block strings do not process escape sequences per the spec, and their indentation is irrelevant to whitespace-insensitive field sets. This is documented on `FieldSet::parse_and_validate_at_span()`.

## Test plan

- Regression test for the panic scenario: unicode escape followed by multi-byte characters (`"id\u0020한글"`), asserting diagnostics point exactly at the offending characters.
- Parity tests: escaped selections (`"id\naltId"`, `"id\u0020altId"`) accepted by both `parse_and_validate` and `parse_and_validate_at_span`; block strings containing `\n` rejected by both.
- Error-rendering snapshot showing diagnostics past an escape pointing at the right source columns.
- All 375 workspace tests pass.

<!-- FED-1067 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
