### PR TITLE
fix(compiler): align resolver execution and input coercion with the GraphQL spec

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -120,12 +120,45 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `@defer` is not a built-in directive in apollo-compiler, so a schema using it
   must declare the directive. `@stream` is out of scope.
 
+## Fixes
+
+- **Align resolver-based execution and input coercion with the GraphQL spec - [duckki], [pull/1089]**
+
+  Fixes several spec conformance issues in `apollo_compiler::resolvers`
+  execution, found by auditing it against the GraphQL specification and the
+  graphql-js reference implementation:
+
+  - An input object field whose value is a variable with no runtime value now
+    uses the field’s default value, or is omitted when it has no default.
+    Previously the field was set to explicit `null`, which is semantically
+    different and skipped defaults.
+  - A resolver error for a list item with a nullable item type now nullifies
+    only that item instead of the whole list. Items with non-null types still
+    propagate the error to the list position.
+  - Variables nested inside custom scalar argument literals (like
+    `arg: {id: $var}` for a JSON-like scalar) are now replaced with their
+    runtime values. Previously they raised a spurious execution error flagged
+    as a suspected validation bug.
+  - A `@skip` or `@include` directive whose `if` argument resolves to `null`
+    (possible with a nullable variable that has a non-null default value) now
+    raises an execution error, like in graphql-js. Previously the directive
+    was silently ignored.
+  - Integer variable values for `Float` inputs are now accepted up to and
+    including 2⁵³ − 1, the largest integer magnitude that is exactly
+    representable as an IEEE 754 double. The boundary value was previously
+    rejected by an off-by-one.
+
+  Also documents that execution of remaining sibling fields and list items is
+  canceled when an execution error propagates through a non-null position,
+  matching graphql-js.
+
 [graphql-spec#1110]: https://github.com/graphql/graphql-spec/pull/1110
 [graphql-spec#1170]: https://github.com/graphql/graphql-spec/pull/1170
 [duckki]: https://github.com/duckki
 [goto-bus-stop]: https://github.com/goto-bus-stop
 [pull/1069]: https://github.com/apollographql/apollo-rs/pull/1069
 [pull/974]: https://github.com/apollographql/apollo-rs/pull/974
+[pull/1089]: https://github.com/apollographql/apollo-rs/pull/1089
 
 # [1.32.0](https://crates.io/crates/apollo-compiler/1.32.0) - 2026-05-14
 

--- a/crates/apollo-compiler/src/resolvers/execution.rs
+++ b/crates/apollo-compiler/src/resolvers/execution.rs
@@ -92,11 +92,12 @@ pub(crate) async fn execute_selection_set<'a>(
     let mut grouped_field_set = IndexMap::default();
     collect_fields(
         ctx,
+        path,
         object_type,
         selections,
         &mut HashSet::default(),
         &mut grouped_field_set,
-    );
+    )?;
 
     match mode {
         ExecutionMode::Normal => {
@@ -138,18 +139,31 @@ pub(crate) async fn execute_selection_set<'a>(
 }
 
 /// <https://spec.graphql.org/September2025/#CollectFields()>
+///
+/// Returns `Err` when the `if` argument of a `@skip` or `@include` directive
+/// does not coerce to a Boolean, which is an execution error
+/// for the selection set being collected.
 fn collect_fields<'a>(
     ctx: &mut ExecutionContext<'a>,
+    path: LinkedPath<'_>,
     object_type: &ObjectType,
     selections: impl IntoIterator<Item = &'a Selection>,
     visited_fragments: &mut HashSet<&'a Name>,
     grouped_fields: &mut IndexMap<&'a Name, Vec<&'a Field>>,
-) {
+) -> Result<(), PropagateNull> {
     for selection in selections {
-        if eval_if_arg(selection, SKIP_DIRECTIVE_NAME, ctx.variable_values).unwrap_or(false)
-            || !eval_if_arg(selection, INCLUDE_DIRECTIVE_NAME, ctx.variable_values).unwrap_or(true)
-        {
-            continue;
+        match skipped_by_directives(selection, ctx.variable_values) {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(err) => {
+                ctx.errors.push(GraphQLError::execution_error(
+                    err.message,
+                    path,
+                    err.location,
+                    &ctx.document.sources,
+                ));
+                return Err(PropagateNull);
+            }
         }
         match selection {
             Selection::Field(field) => grouped_fields
@@ -169,11 +183,12 @@ fn collect_fields<'a>(
                 }
                 collect_fields(
                     ctx,
+                    path,
                     object_type,
                     &fragment.selection_set.selections,
                     visited_fragments,
                     grouped_fields,
-                )
+                )?
             }
             Selection::InlineFragment(inline) => {
                 if let Some(condition) = &inline.type_condition {
@@ -183,14 +198,16 @@ fn collect_fields<'a>(
                 }
                 collect_fields(
                     ctx,
+                    path,
                     object_type,
                     &inline.selection_set.selections,
                     visited_fragments,
                     grouped_fields,
-                )
+                )?
             }
         }
     }
+    Ok(())
 }
 
 /// <https://spec.graphql.org/September2025/#DoesFragmentTypeApply()>
@@ -210,20 +227,80 @@ fn does_fragment_type_apply(
     }
 }
 
+/// An execution error raised while evaluating `@skip` or `@include`,
+/// before its selection set is executed.
+struct DirectiveError {
+    message: String,
+    location: Option<SourceSpan>,
+}
+
+/// Whether this selection is excluded by its `@skip` or `@include` directives.
+///
+/// <https://spec.graphql.org/September2025/#CollectFields()>
+fn skipped_by_directives(
+    selection: &Selection,
+    variable_values: &Valid<JsonMap>,
+) -> Result<bool, DirectiveError> {
+    if eval_if_arg(selection, SKIP_DIRECTIVE_NAME, variable_values)? == Some(true) {
+        return Ok(true);
+    }
+    Ok(eval_if_arg(selection, INCLUDE_DIRECTIVE_NAME, variable_values)? == Some(false))
+}
+
+/// Returns the value of the `if` argument of the given directive on this selection,
+/// or `Ok(None)` if the directive is not present.
+///
+/// `if` is a non-null `Boolean!` argument, so a value that does not coerce
+/// to a Boolean is an execution error. That includes a nullable variable
+/// (valid there per the exception for variables with a non-null default value,
+/// <https://spec.graphql.org/September2025/#sec-All-Variable-Usages-Are-Allowed>)
+/// whose runtime value is null.
 fn eval_if_arg(
     selection: &Selection,
     directive_name: &str,
     variable_values: &Valid<JsonMap>,
-) -> Option<bool> {
-    match selection
-        .directives()
-        .get(directive_name)?
-        .specified_argument_by_name("if")?
-        .as_ref()
-    {
-        Value::Boolean(value) => Some(*value),
-        Value::Variable(var) => variable_values.get(var.as_str())?.as_bool(),
-        _ => None,
+) -> Result<Option<bool>, DirectiveError> {
+    let Some(directive) = selection.directives().get(directive_name) else {
+        return Ok(None);
+    };
+    let Some(arg) = directive.specified_argument_by_name("if") else {
+        // `if` is a required argument, so validation rejects its absence
+        return Err(DirectiveError {
+            message: format!(
+                "missing value for required argument if of directive @{directive_name}"
+            ),
+            location: directive.location(),
+        });
+    };
+    match arg.as_ref() {
+        Value::Boolean(value) => Ok(Some(*value)),
+        Value::Variable(var) => match variable_values.get(var.as_str()) {
+            Some(JsonValue::Bool(value)) => Ok(Some(*value)),
+            Some(JsonValue::Null) => Err(DirectiveError {
+                message: format!(
+                    "null value for non-null argument if of directive @{directive_name}"
+                ),
+                location: arg.location(),
+            }),
+            None => Err(DirectiveError {
+                message: format!(
+                    "missing variable for non-null argument if of directive @{directive_name}"
+                ),
+                location: arg.location(),
+            }),
+            // Validation restricts variables used here to Boolean types
+            Some(_) => Err(DirectiveError {
+                message: format!(
+                    "non-boolean value for argument if of directive @{directive_name}"
+                ),
+                location: arg.location(),
+            }),
+        },
+        // Validation restricts literals used here to Boolean values
+        _ => Err(DirectiveError {
+            message: format!("non-boolean value for argument if of directive @{directive_name}"),
+            location: arg.location(),
+        }),
     }
 }
 

--- a/crates/apollo-compiler/src/resolvers/input_coercion.rs
+++ b/crates/apollo-compiler/src/resolvers/input_coercion.rs
@@ -146,7 +146,7 @@ fn coerce_variable_value(
                 if value.is_f64()
                     || value
                         .as_f64()
-                        .is_some_and(|f| f.abs() < MAX_SAFE_INT as f64)
+                        .is_some_and(|f| f.abs() <= MAX_SAFE_INT as f64)
                 {
                     return Ok(value.clone());
                 }
@@ -279,20 +279,48 @@ fn coerce_variable_value(
     })
 }
 
+/// Converts a constant GraphQL value (like a default value) to JSON.
+///
+/// Values from a `Valid` document do not contain variables in const positions.
 fn graphql_value_to_json(
     description: &std::fmt::Arguments<'_>,
     value: &Node<Value>,
 ) -> Result<JsonValue, InputCoercionError> {
+    graphql_literal_to_json(description, value, None)
+}
+
+/// Converts a GraphQL value to JSON.
+///
+/// `variable_values` is `Some` when converting an argument literal from an
+/// executable document, where a custom scalar value may contain nested variables
+/// to substitute with their runtime values.
+/// It is `None` for const values (like default values), where validation
+/// guarantees the absence of variables.
+fn graphql_literal_to_json(
+    description: &std::fmt::Arguments<'_>,
+    value: &Node<Value>,
+    variable_values: Option<&Valid<JsonMap>>,
+) -> Result<JsonValue, InputCoercionError> {
     match value.as_ref() {
         Value::Null => Ok(JsonValue::Null),
-        Value::Variable(_) => {
-            // TODO: separate `ContValue` enum without this variant?
-            Err(InputCoercionError::SuspectedValidationBug(
-                SuspectedValidationBug {
-                    message: format!("variable in default value of {description}."),
-                    location: value.location(),
-                },
-            ))
+        Value::Variable(var_name) => {
+            if let Some(variable_values) = variable_values {
+                // A variable nested inside a custom scalar literal is replaced
+                // with its runtime value; with no runtime value it becomes null
+                // (like a missing list item in graphql-js).
+                Ok(variable_values
+                    .get(var_name.as_str())
+                    .cloned()
+                    .unwrap_or(JsonValue::Null))
+            } else {
+                // TODO: separate `ContValue` enum without this variant?
+                Err(InputCoercionError::SuspectedValidationBug(
+                    SuspectedValidationBug {
+                        message: format!("variable in default value of {description}."),
+                        location: value.location(),
+                    },
+                ))
+            }
         }
         Value::Enum(value) => Ok(value.as_str().into()),
         Value::String(value) => Ok(value.as_str().into()),
@@ -312,11 +340,26 @@ fn graphql_value_to_json(
         })?)),
         Value::List(value) => value
             .iter()
-            .map(|value| graphql_value_to_json(description, value))
+            .map(|value| graphql_literal_to_json(description, value, variable_values))
             .collect(),
         Value::Object(value) => value
             .iter()
-            .map(|(key, value)| Ok((key.as_str(), graphql_value_to_json(description, value)?)))
+            .filter(|(_key, value)| {
+                // An entry whose value is a variable with no runtime value
+                // is omitted entirely, like in graphql-js
+                match (value.as_ref(), variable_values) {
+                    (Value::Variable(var_name), Some(variable_values)) => {
+                        variable_values.contains_key(var_name.as_str())
+                    }
+                    _ => true,
+                }
+            })
+            .map(|(key, value)| {
+                Ok((
+                    key.as_str(),
+                    graphql_literal_to_json(description, value, variable_values)?,
+                ))
+            })
             .collect(),
     }
 }
@@ -523,7 +566,16 @@ fn coerce_argument_value(
                 let object: HashMap<_, _> = object.iter().map(|(k, v)| (k, v)).collect();
                 let mut coerced_object = JsonMap::new();
                 for (field_name, field_def) in &ty_def.fields {
-                    if let Some(field_value) = object.get(field_name) {
+                    // A field whose value is a variable with no runtime value
+                    // behaves as if the field was not provided at all:
+                    // fall back to the field’s default value, or omit the entry.
+                    // https://spec.graphql.org/September2025/#sec-Input-Objects.Input-Coercion
+                    let provided_value = object.get(field_name).copied().filter(|value| {
+                        value
+                            .as_variable()
+                            .is_none_or(|var| ctx.variable_values.contains_key(var.as_str()))
+                    });
+                    if let Some(field_value) = provided_value {
                         let coerced_value = coerce_argument_value(
                             ctx,
                             path,
@@ -583,12 +635,15 @@ fn coerce_argument_value(
             }
         }
         _ => {
-            // For scalar and enums, rely and validation and just convert between Rust types
-            return graphql_value_to_json(description, value).map_err(|err| {
-                ctx.errors
-                    .push(err.into_execution_error(path, &ctx.document.sources));
-                PropagateNull
-            });
+            // For scalars and enums, rely on validation and just convert between Rust types,
+            // substituting any variables nested inside custom scalar literals
+            return graphql_literal_to_json(description, value, Some(ctx.variable_values)).map_err(
+                |err| {
+                    ctx.errors
+                        .push(err.into_execution_error(path, &ctx.document.sources));
+                    PropagateNull
+                },
+            );
         }
     }
     ctx.errors.push(GraphQLError::execution_error(

--- a/crates/apollo-compiler/src/resolvers/mod.rs
+++ b/crates/apollo-compiler/src/resolvers/mod.rs
@@ -16,6 +16,18 @@
 //! or a single Rust enum with a variants per GraphQL object type,
 //! or some other strategy.
 //!
+//! # Execution errors and sibling cancellation
+//!
+//! When an [execution error] propagates through non-null response positions,
+//! execution of the remaining sibling fields (or remaining list items)
+//! in the affected selection set is canceled, like in graphql-js:
+//! their resolvers are not called,
+//! and no additional errors are reported for them.
+//! Response data is unaffected,
+//! since the enclosing response position is discarded either way.
+//!
+//! [execution error]: https://spec.graphql.org/September2025/#sec-Handling-Execution-Errors
+//!
 //! # Example
 //!
 //! ```

--- a/crates/apollo-compiler/src/resolvers/result_coercion.rs
+++ b/crates/apollo-compiler/src/resolvers/result_coercion.rs
@@ -201,24 +201,29 @@ async fn complete_list_value<'a, 'b>(
             element: ResponseDataPathSegment::ListIndex(index),
             next: path,
         };
-        let inner_resolved = inner_result.map_err(|err| {
-            ctx.errors.push(GraphQLError::execution_error(
-                format!("resolver error: {}", err.message),
-                Some(&inner_path),
-                fields[0].name.location(),
-                &ctx.document.sources,
-            ));
-            PropagateNull
-        })?;
-        let inner_result = complete_value(
-            ctx,
-            Some(&inner_path),
-            mode,
-            inner_ty,
-            inner_resolved,
-            fields,
-        )
-        .await;
+        let inner_result = match inner_result {
+            Ok(inner_resolved) => {
+                complete_value(
+                    ctx,
+                    Some(&inner_path),
+                    mode,
+                    inner_ty,
+                    inner_resolved,
+                    fields,
+                )
+                .await
+            }
+            // An error from the resolver’s iterator is an execution error at this item position
+            Err(err) => {
+                ctx.errors.push(GraphQLError::execution_error(
+                    format!("resolver error: {}", err.message),
+                    Some(&inner_path),
+                    fields[0].name.location(),
+                    &ctx.document.sources,
+                ));
+                Err(PropagateNull)
+            }
+        };
         // On execution error, try to nullify that item
         match try_nullify(inner_ty, inner_result) {
             Ok(None) => {}
@@ -375,7 +380,10 @@ fn test_error_path() {
             }
           ],
           "data": {
-            "f": null
+            "f": [
+              42,
+              null
+            ]
           }
         }"#]]
     .assert_eq(&response);

--- a/crates/apollo-compiler/tests/main.rs
+++ b/crates/apollo-compiler/tests/main.rs
@@ -11,6 +11,7 @@ mod merge_schemas;
 mod misc;
 mod name;
 mod parser;
+mod resolvers;
 mod schema;
 mod serde;
 mod validation;

--- a/crates/apollo-compiler/tests/resolvers.rs
+++ b/crates/apollo-compiler/tests/resolvers.rs
@@ -1,0 +1,314 @@
+//! Tests for GraphQL spec conformance of `apollo_compiler::resolvers` execution,
+//! written as reproducers for known deviations.
+//!
+//! Expected behaviors below were cross-checked against the graphql-js (v17)
+//! reference implementation.
+
+use apollo_compiler::name;
+use apollo_compiler::request::coerce_variable_values;
+use apollo_compiler::resolvers;
+use apollo_compiler::resolvers::ResolvedValue;
+use apollo_compiler::response::ExecutionResponse;
+use apollo_compiler::response::JsonValue;
+use apollo_compiler::response::ResponseDataPathSegment::Field;
+use apollo_compiler::response::ResponseDataPathSegment::ListIndex;
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use serde_json_bytes::json;
+
+const SDL: &str = r#"
+    "Any JSON value, either a scalar or nested in lists or objects"
+    scalar JSON
+
+    input In {
+        a: Int = 7
+        b: Int
+    }
+
+    type Nested {
+        inner: Int
+    }
+
+    type Query {
+        echo(arg: In): JSON
+        echoJson(arg: JSON): JSON
+        id: ID
+        nullableItems: [Int]
+        nonNullItems: [Int!]
+        bang: Int!
+        ok: Int
+        nest: Nested
+        f(bar: Float!): Int
+    }
+"#;
+
+struct Root;
+struct Nested;
+
+impl resolvers::ObjectValue for Root {
+    fn type_name(&self) -> &str {
+        "Query"
+    }
+
+    fn resolve_field<'a>(
+        &'a self,
+        info: &'a resolvers::ResolveInfo<'a>,
+    ) -> Result<ResolvedValue<'a>, resolvers::ExecutionError> {
+        match info.field_name() {
+            // Echo the coerced `arg` argument back as a custom scalar leaf
+            "echo" | "echoJson" => Ok(ResolvedValue::leaf(
+                info.arguments()
+                    .get("arg")
+                    .cloned()
+                    .unwrap_or(JsonValue::Null),
+            )),
+            "id" => Ok(ResolvedValue::leaf(42)),
+            "nullableItems" => Ok(ResolvedValue::List(Box::new(
+                [
+                    Ok(ResolvedValue::leaf(1)),
+                    Err(resolvers::ExecutionError {
+                        message: "boom".into(),
+                    }),
+                    Ok(ResolvedValue::leaf(2)),
+                ]
+                .into_iter(),
+            ))),
+            "nonNullItems" => Ok(ResolvedValue::List(Box::new(
+                [
+                    Err(resolvers::ExecutionError {
+                        message: "boom 0".into(),
+                    }),
+                    Err(resolvers::ExecutionError {
+                        message: "boom 1".into(),
+                    }),
+                ]
+                .into_iter(),
+            ))),
+            "bang" => Err(resolvers::ExecutionError {
+                message: "boom bang".into(),
+            }),
+            "ok" => Ok(ResolvedValue::leaf(1)),
+            "nest" => Ok(ResolvedValue::object(Nested)),
+            _ => Err(self.unknown_field_error(info)),
+        }
+    }
+}
+
+impl resolvers::ObjectValue for Nested {
+    fn type_name(&self) -> &str {
+        "Nested"
+    }
+
+    fn resolve_field<'a>(
+        &'a self,
+        info: &'a resolvers::ResolveInfo<'a>,
+    ) -> Result<ResolvedValue<'a>, resolvers::ExecutionError> {
+        match info.field_name() {
+            "inner" => Ok(ResolvedValue::leaf(3)),
+            _ => Err(self.unknown_field_error(info)),
+        }
+    }
+}
+
+fn execute(query: &str, variables: JsonValue) -> ExecutionResponse {
+    let schema = Schema::parse_and_validate(SDL, "schema.graphql").unwrap();
+    let document = ExecutableDocument::parse_and_validate(&schema, query, "query.graphql").unwrap();
+    resolvers::Execution::new(&schema, &document)
+        .raw_variable_values(variables.as_object().unwrap())
+        .execute_sync(&Root)
+        .unwrap()
+}
+
+/// The `data` entry of the response, with `None` represented as JSON null
+/// like in the serialized response.
+fn data(response: &ExecutionResponse) -> JsonValue {
+    response
+        .data
+        .clone()
+        .map(JsonValue::Object)
+        .unwrap_or(JsonValue::Null)
+}
+
+/// An input object field whose value is a variable with no runtime value behaves
+/// as if the field were not provided at all: the field definition's default value
+/// applies, and a field without a default is absent from the coerced map
+/// (not an explicit null).
+///
+/// <https://spec.graphql.org/September2025/#sec-Input-Objects.Input-Coercion>
+#[test]
+fn input_object_field_with_unprovided_variable_uses_field_default() {
+    let response = execute(
+        "query($v: Int, $w: Int) { echo(arg: {a: $v, b: $w}) }",
+        json!({}),
+    );
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(data(&response), json!({"echo": {"a": 7}}));
+}
+
+/// ID results are serialized as strings, even when resolved from an integer.
+///
+/// <https://spec.graphql.org/September2025/#sec-ID.Result-Coercion>
+#[test]
+fn numeric_id_result_is_serialized_as_string() {
+    let response = execute("{ id }", json!({}));
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(data(&response), json!({"id": "42"}));
+}
+
+/// A resolver error for a list item with a nullable item type is handled at the
+/// item position: that item becomes null, the remaining items still complete,
+/// and the list itself is preserved.
+///
+/// <https://spec.graphql.org/September2025/#sec-Handling-Execution-Errors>
+#[test]
+fn nullable_list_item_resolver_error_nullifies_only_that_item() {
+    let response = execute("{ nullableItems }", json!({}));
+    assert_eq!(data(&response), json!({"nullableItems": [1, null, 2]}));
+    assert_eq!(response.errors.len(), 1);
+    assert_eq!(response.errors[0].message, "resolver error: boom");
+    assert_eq!(
+        response.errors[0].path,
+        vec![Field(name!("nullableItems")), ListIndex(1)]
+    );
+}
+
+/// With a non-null item type the item error propagates to the list position.
+/// Like in graphql-js, execution of the remaining items is canceled,
+/// so only the first item error is reported.
+#[test]
+fn non_null_list_item_resolver_error_nullifies_list() {
+    let response = execute("{ nonNullItems }", json!({}));
+    assert_eq!(data(&response), json!({"nonNullItems": null}));
+    assert_eq!(response.errors.len(), 1);
+    assert_eq!(response.errors[0].message, "resolver error: boom 0");
+    assert_eq!(
+        response.errors[0].path,
+        vec![Field(name!("nonNullItems")), ListIndex(0)]
+    );
+}
+
+/// When an execution error propagates through a non-null field to the enclosing
+/// selection set, execution of the remaining sibling fields is canceled
+/// (their resolvers do not run and no additional errors are reported),
+/// like in graphql-js. Response data is unaffected: the whole selection set
+/// is discarded either way.
+#[test]
+fn non_null_field_error_cancels_sibling_execution() {
+    let response = execute("{ bang ok }", json!({}));
+    assert_eq!(response.data, None, "expected `data: null`");
+    assert_eq!(response.errors.len(), 1);
+    assert_eq!(response.errors[0].message, "resolver error: boom bang");
+    assert_eq!(response.errors[0].path, vec![Field(name!("bang"))]);
+}
+
+/// Variables nested inside a custom scalar literal are replaced
+/// with their runtime values.
+///
+/// Validation accepts such a document: “value must be coercible to type
+/// (with the assumption that any variableUsage nested within value will
+/// represent a runtime value valid for usage in its position)”,
+/// so execution must substitute the runtime value instead of erroring.
+///
+/// <https://spec.graphql.org/September2025/#sec-Values-of-Correct-Type>
+#[test]
+fn custom_scalar_argument_substitutes_nested_variables() {
+    let response = execute(
+        "query($v: Int) { echoJson(arg: {a: $v, b: [1, $v]}) }",
+        json!({"v": 1}),
+    );
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(data(&response), json!({"echoJson": {"a": 1, "b": [1, 1]}}));
+}
+
+/// A variable without a runtime value nested inside a custom scalar literal
+/// is dropped from object values and becomes null in list values,
+/// like in graphql-js.
+#[test]
+fn custom_scalar_argument_with_missing_nested_variable() {
+    let response = execute(
+        "query($v: Int) { echoJson(arg: {a: $v, b: [1, $v]}) }",
+        json!({}),
+    );
+    assert!(response.errors.is_empty(), "{:?}", response.errors);
+    assert_eq!(data(&response), json!({"echoJson": {"b": [1, null]}}));
+}
+
+/// The `if` argument of `@include` is a non-null `Boolean!`, so a variable
+/// whose runtime value is null raises a execution error for the selection set
+/// being collected. At the operation root this makes the response `data` null.
+///
+/// A nullable variable is valid there per the variable-usage exception for
+/// variables with a non-null default value:
+/// <https://spec.graphql.org/September2025/#sec-All-Variable-Usages-Are-Allowed>
+#[test]
+fn include_if_null_variable_raises_field_error() {
+    let response = execute(
+        "query($c: Boolean = true) { ok @include(if: $c) }",
+        json!({"c": null}),
+    );
+    assert_eq!(response.data, None, "expected `data: null`");
+    assert_eq!(response.errors.len(), 1);
+    let message = &response.errors[0].message;
+    assert!(
+        message.contains("argument if of directive @include"),
+        "unexpected message: {message}"
+    );
+    assert!(response.errors[0].path.is_empty());
+}
+
+/// Same as [`include_if_null_variable_raises_field_error`] for `@skip`.
+#[test]
+fn skip_if_null_variable_raises_field_error() {
+    let response = execute(
+        "query($c: Boolean = false) { ok @skip(if: $c) }",
+        json!({"c": null}),
+    );
+    assert_eq!(response.data, None, "expected `data: null`");
+    assert_eq!(response.errors.len(), 1);
+    let message = &response.errors[0].message;
+    assert!(
+        message.contains("argument if of directive @skip"),
+        "unexpected message: {message}"
+    );
+}
+
+/// In a nested selection set, the execution error for a null `if` value is handled
+/// at the nearest enclosing nullable field, like other execution errors.
+#[test]
+fn nested_include_if_null_variable_is_handled_at_nearest_field() {
+    let response = execute(
+        "query($c: Boolean = true) { ok nest { inner @include(if: $c) } }",
+        json!({"c": null}),
+    );
+    assert_eq!(data(&response), json!({"ok": 1, "nest": null}));
+    assert_eq!(response.errors.len(), 1);
+    assert_eq!(response.errors[0].path, vec![Field(name!("nest"))]);
+}
+
+/// Integer variable values for Float inputs are accepted up to and including
+/// 2^53 − 1, the largest integer magnitude that is always exactly representable
+/// as an IEEE 754 double. Only "a value outside the available precision"
+/// must raise a request error.
+///
+/// <https://spec.graphql.org/September2025/#sec-Float.Input-Coercion>
+#[test]
+fn float_variable_accepts_max_safe_integer_boundary() {
+    let schema = Schema::parse_and_validate(SDL, "schema.graphql").unwrap();
+    let document = ExecutableDocument::parse_and_validate(
+        &schema,
+        "query($bar: Float!) { f(bar: $bar) }",
+        "query.graphql",
+    )
+    .unwrap();
+    let operation = document.operations.get(None).unwrap();
+
+    let max_safe_int = (1_i64 << 53) - 1;
+    let values = json!({ "bar": max_safe_int });
+    let coerced = coerce_variable_values(&schema, operation, values.as_object().unwrap())
+        .expect("2^53 - 1 is exactly representable as an IEEE 754 double");
+    assert_eq!(coerced.get("bar"), Some(&json!(max_safe_int)));
+
+    let values = json!({ "bar": i64::MAX });
+    coerce_variable_values(&schema, operation, values.as_object().unwrap())
+        .expect_err("i64::MAX is not exactly representable as an IEEE 754 double");
+}


### PR DESCRIPTION
## Summary

Fixes six spec conformance issues in `apollo_compiler::resolvers` execution and input
coercion. Expected behaviors follow the September 2025 Edition and were verified
against graphql-js v17.

[Detailed walkthrough](https://gist.github.com/duckki/6379d510226bf2f6913596bbb7c5884d)

## Fixes

- An input object field whose value is a variable with no runtime value now uses the
  field's default value, or is omitted — previously it became explicit `null`.
- A resolver error for a list item with a nullable item type now nullifies only that
  item (`[1, null, 2]`), not the whole list.
- Variables nested inside custom scalar literals (`arg: {id: $var}`) are now replaced
  with their runtime values instead of raising a spurious execution error.
- `@skip` / `@include` with an `if` value of `null` now raises an execution error,
  like graphql-js, instead of being silently ignored.
- Float input coercion now accepts integer values up to and including 2⁵³ − 1
  (off-by-one at the boundary).

Stacked on #1087, which independently covers numeric-`ID`-as-string result coercion —
this PR keeps a regression test for it.

All changes are response-observable and move outputs toward graphql-js parity. Also
documents the existing sibling-cancellation behavior on non-null error propagation
(unchanged, matches graphql-js) in the module docs.

## Tests

New `crates/apollo-compiler/tests/resolvers.rs`: one reproducer per fix plus
regression pins for the cancellation semantics; expected outputs cross-checked
against graphql-js v17.0.1.