### PR TITLE
refactor!: replace ComponentName with Node<Name>

### DIFF
--- a/crates/apollo-compiler/examples/rename.rs
+++ b/crates/apollo-compiler/examples/rename.rs
@@ -30,13 +30,13 @@ fn renamed() -> Valid<Schema> {
     schema.types.insert(new_name.clone(), type_def);
 
     // 4. Update any existing reference to the old name
-    schema
+    *schema
         .schema_definition
         .make_mut()
         .query
         .as_mut()
         .unwrap()
-        .name = new_name;
+        .make_mut() = new_name;
 
     schema.validate().unwrap()
 }

--- a/crates/apollo-compiler/src/introspection/resolvers.rs
+++ b/crates/apollo-compiler/src/introspection/resolvers.rs
@@ -4,7 +4,7 @@ use crate::resolvers::ResolveInfo;
 use crate::resolvers::ResolvedValue;
 use crate::response::JsonMap;
 use crate::schema;
-use crate::schema::ComponentName;
+use crate::Name;
 use crate::Node;
 use std::borrow::Cow;
 
@@ -44,7 +44,7 @@ pub(crate) fn type_def<'a>(info: &'a ResolveInfo<'a>, name: &str) -> ResolvedVal
     )
 }
 
-fn type_def_opt<'a>(info: &'a ResolveInfo<'a>, name: &Option<ComponentName>) -> ResolvedValue<'a> {
+fn type_def_opt<'a>(info: &'a ResolveInfo<'a>, name: &Option<Node<Name>>) -> ResolvedValue<'a> {
     if let Some(name) = name {
         type_def(info, name)
     } else {
@@ -177,7 +177,7 @@ impl ObjectValue for TypeDefResolver<'_> {
                         .flat_map(|implementers| &implementers.objects))
                 }
                 schema::ExtendedType::Union(def) => {
-                    types!(def.members.iter().map(|c| &c.name))
+                    types!(def.members.iter().map(|c| c.as_ref()))
                 }
                 schema::ExtendedType::Object(_)
                 | schema::ExtendedType::Scalar(_)

--- a/crates/apollo-compiler/src/name.rs
+++ b/crates/apollo-compiler/src/name.rs
@@ -1,12 +1,12 @@
 use crate::diagnostic::CliReport;
 use crate::diagnostic::ToCliReport;
+use crate::node::ExtensionId;
 use crate::parser::FileId;
 use crate::parser::LineColumn;
 use crate::parser::SourceMap;
 use crate::parser::SourceSpan;
 use crate::parser::TaggedFileId;
-use crate::schema::ComponentName;
-use crate::schema::ComponentOrigin;
+use crate::Node;
 use rowan::TextRange;
 use std::fmt;
 use std::marker::PhantomData;
@@ -289,11 +289,14 @@ impl Name {
         byte.is_ascii_alphanumeric() || byte == b'_'
     }
 
-    pub fn to_component(&self, origin: ComponentOrigin) -> ComponentName {
-        ComponentName {
-            origin,
-            name: self.clone(),
+    /// Converts to a [`Node<Name>`] with the given extension ID,
+    /// keeping the source location of this name.
+    pub fn to_node(&self, extension_id: Option<ExtensionId>) -> Node<Name> {
+        let mut node = Node::new_opt_location(self.clone(), self.location());
+        if let Some(id) = extension_id {
+            node.set_extension_id(id);
         }
+        node
     }
 }
 
@@ -380,6 +383,30 @@ impl PartialOrd for Name {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl std::borrow::Borrow<str> for Node<Name> {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl PartialEq<Name> for Node<Name> {
+    fn eq(&self, other: &Name) -> bool {
+        self.as_ref() == other
+    }
+}
+
+impl PartialEq<str> for Node<Name> {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&'_ str> for Node<Name> {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
     }
 }
 

--- a/crates/apollo-compiler/src/name.rs
+++ b/crates/apollo-compiler/src/name.rs
@@ -392,21 +392,15 @@ impl std::borrow::Borrow<str> for Node<Name> {
     }
 }
 
-impl PartialEq<Name> for Node<Name> {
-    fn eq(&self, other: &Name) -> bool {
-        self.as_ref() == other
-    }
-}
-
 impl PartialEq<str> for Node<Name> {
     fn eq(&self, other: &str) -> bool {
         self.as_str() == other
     }
 }
 
-impl PartialEq<&'_ str> for Node<Name> {
-    fn eq(&self, other: &&str) -> bool {
-        self.as_str() == *other
+impl<T: AsRef<str>> PartialEq<T> for Node<Name> {
+    fn eq(&self, other: &T) -> bool {
+        self.as_str() == other.as_ref()
     }
 }
 

--- a/crates/apollo-compiler/src/resolvers/execution.rs
+++ b/crates/apollo-compiler/src/resolvers/execution.rs
@@ -329,7 +329,7 @@ async fn execute_field<'a>(
             .schema_definition
             .query
             .as_ref()
-            .is_some_and(|q| q.name == object_type.name)
+            .is_some_and(|q| **q == object_type.name)
     };
     let info = ResolveInfo {
         schema: ctx.schema,

--- a/crates/apollo-compiler/src/schema/component.rs
+++ b/crates/apollo-compiler/src/schema/component.rs
@@ -113,13 +113,19 @@ pub struct ComponentName {
 
 impl From<&Name> for ComponentName {
     fn from(value: &Name) -> Self {
-        value.to_component(ComponentOrigin::Definition)
+        Self {
+            origin: ComponentOrigin::Definition,
+            name: value.clone(),
+        }
     }
 }
 
 impl From<Name> for ComponentName {
     fn from(value: Name) -> Self {
-        value.to_component(ComponentOrigin::Definition)
+        Self {
+            origin: ComponentOrigin::Definition,
+            name: value,
+        }
     }
 }
 

--- a/crates/apollo-compiler/src/schema/from_ast.rs
+++ b/crates/apollo-compiler/src/schema/from_ast.rs
@@ -512,7 +512,7 @@ impl SchemaDefinition {
                 OperationType::Subscription => &mut self.subscription,
             };
             match entry {
-                None => *entry = Some(object_type_name.to_component(origin.clone())),
+                None => *entry = Some(object_type_name.to_node(origin.extension_id().cloned())),
                 Some(previous) => errors.push(
                     op.location(),
                     BuildError::DuplicateRootOperation {
@@ -576,12 +576,12 @@ impl ObjectType {
                 definition
                     .implements_interfaces
                     .iter()
-                    .map(|name| name.to_component(ComponentOrigin::Definition)),
+                    .map(|name| name.to_node(None)),
                 |prev, dup| {
                     errors.push(
                         dup.location(),
                         BuildError::DuplicateImplementsInterfaceInObject {
-                            name_at_previous_location: prev.name.clone(),
+                            name_at_previous_location: prev.as_ref().clone(),
                             type_name: definition.name.clone(),
                         },
                     )
@@ -633,12 +633,12 @@ impl ObjectType {
             extension
                 .implements_interfaces
                 .iter()
-                .map(|name| name.to_component(origin.clone())),
+                .map(|name| name.to_node(origin.extension_id().cloned())),
             |prev, dup| {
                 errors.push(
                     dup.location(),
                     BuildError::DuplicateImplementsInterfaceInObject {
-                        name_at_previous_location: prev.name.clone(),
+                        name_at_previous_location: prev.as_ref().clone(),
                         type_name: extension.name.clone(),
                     },
                 )
@@ -676,12 +676,12 @@ impl InterfaceType {
                 definition
                     .implements_interfaces
                     .iter()
-                    .map(|name| name.to_component(ComponentOrigin::Definition)),
+                    .map(|name| name.to_node(None)),
                 |prev, dup| {
                     errors.push(
                         dup.location(),
                         BuildError::DuplicateImplementsInterfaceInInterface {
-                            name_at_previous_location: prev.name.clone(),
+                            name_at_previous_location: prev.as_ref().clone(),
                             type_name: definition.name.clone(),
                         },
                     )
@@ -733,12 +733,12 @@ impl InterfaceType {
             extension
                 .implements_interfaces
                 .iter()
-                .map(|name| name.to_component(origin.clone())),
+                .map(|name| name.to_node(origin.extension_id().cloned())),
             |prev, dup| {
                 errors.push(
                     dup.location(),
                     BuildError::DuplicateImplementsInterfaceInInterface {
-                        name_at_previous_location: prev.name.clone(),
+                        name_at_previous_location: prev.as_ref().clone(),
                         type_name: extension.name.clone(),
                     },
                 )
@@ -778,15 +778,12 @@ impl UnionType {
                 .map(|d| d.to_component(ComponentOrigin::Definition))
                 .collect(),
             members: collect_sticky_set(
-                definition
-                    .members
-                    .iter()
-                    .map(|name| name.to_component(ComponentOrigin::Definition)),
+                definition.members.iter().map(|name| name.to_node(None)),
                 |prev, dup| {
                     errors.push(
                         dup.location(),
                         BuildError::UnionMemberNameCollision {
-                            name_at_previous_location: prev.name.clone(),
+                            name_at_previous_location: prev.as_ref().clone(),
                             type_name: definition.name.clone(),
                         },
                     )
@@ -818,12 +815,12 @@ impl UnionType {
             extension
                 .members
                 .iter()
-                .map(|name| name.to_component(origin.clone())),
+                .map(|name| name.to_node(origin.extension_id().cloned())),
             |prev, dup| {
                 errors.push(
                     dup.location(),
                     BuildError::UnionMemberNameCollision {
-                        name_at_previous_location: prev.name.clone(),
+                        name_at_previous_location: prev.as_ref().clone(),
                         type_name: extension.name.clone(),
                     },
                 )
@@ -1003,9 +1000,9 @@ fn collect_sticky<'a, V>(
 }
 
 fn extend_sticky_set(
-    set: &mut IndexSet<ComponentName>,
-    iter: impl IntoIterator<Item = ComponentName>,
-    mut duplicate: impl FnMut(&ComponentName, ComponentName),
+    set: &mut IndexSet<Node<Name>>,
+    iter: impl IntoIterator<Item = Node<Name>>,
+    mut duplicate: impl FnMut(&Node<Name>, Node<Name>),
 ) {
     for value in iter.into_iter() {
         match set.get(&value) {
@@ -1017,9 +1014,9 @@ fn extend_sticky_set(
     }
 }
 fn collect_sticky_set(
-    iter: impl IntoIterator<Item = ComponentName>,
-    duplicate: impl FnMut(&ComponentName, ComponentName),
-) -> IndexSet<ComponentName> {
+    iter: impl IntoIterator<Item = Node<Name>>,
+    duplicate: impl FnMut(&Node<Name>, Node<Name>),
+) -> IndexSet<Node<Name>> {
     let mut set = IndexSet::with_hasher(Default::default());
     extend_sticky_set(&mut set, iter, duplicate);
     set

--- a/crates/apollo-compiler/src/schema/mod.rs
+++ b/crates/apollo-compiler/src/schema/mod.rs
@@ -142,13 +142,13 @@ pub struct SchemaDefinition {
     pub directives: DirectiveList,
 
     /// Name of the object type for the `query` root operation
-    pub query: Option<ComponentName>,
+    pub query: Option<Node<Name>>,
 
     /// Name of the object type for the `mutation` root operation
-    pub mutation: Option<ComponentName>,
+    pub mutation: Option<Node<Name>>,
 
     /// Name of the object type for the `subscription` root operation
-    pub subscription: Option<ComponentName>,
+    pub subscription: Option<Node<Name>>,
 }
 
 /// The list of [_Directives_](https://spec.graphql.org/September2025/#Directives)
@@ -191,7 +191,7 @@ pub struct ScalarType {
 pub struct ObjectType {
     pub description: Option<Node<str>>,
     pub name: Name,
-    pub implements_interfaces: IndexSet<ComponentName>,
+    pub implements_interfaces: IndexSet<Node<Name>>,
     pub directives: DirectiveList,
 
     /// Explicit field definitions.
@@ -205,7 +205,7 @@ pub struct ObjectType {
 pub struct InterfaceType {
     pub description: Option<Node<str>>,
     pub name: Name,
-    pub implements_interfaces: IndexSet<ComponentName>,
+    pub implements_interfaces: IndexSet<Node<Name>>,
 
     pub directives: DirectiveList,
 
@@ -227,7 +227,7 @@ pub struct UnionType {
     /// * Key: name of a member object type
     /// * Value: which union type extension defined this implementation,
     ///   or `None` for the union type definition.
-    pub members: IndexSet<ComponentName>,
+    pub members: IndexSet<Node<Name>>,
 }
 
 /// The definition of an [enum type](https://spec.graphql.org/September2025/#sec-Enums),
@@ -516,7 +516,7 @@ impl Schema {
             ast::OperationType::Subscription => &self.schema_definition.subscription,
         }
         .as_ref()
-        .map(|component| &component.name)
+        .map(|component| component.as_ref())
     }
 
     /// Returns the definition of a type’s explicit field or meta-field.
@@ -572,7 +572,7 @@ impl Schema {
             match ty {
                 ExtendedType::Object(def) => {
                     for interface in &def.implements_interfaces {
-                        map.entry(interface.name.clone())
+                        map.entry(interface.as_ref().clone())
                             .or_default()
                             .objects
                             .insert(ty_name.clone());
@@ -580,7 +580,7 @@ impl Schema {
                 }
                 ExtendedType::Interface(def) => {
                     for interface in &def.implements_interfaces {
-                        map.entry(interface.name.clone())
+                        map.entry(interface.as_ref().clone())
                             .or_default()
                             .interfaces
                             .insert(ty_name.clone());
@@ -653,9 +653,7 @@ impl Schema {
 }
 
 impl SchemaDefinition {
-    pub fn iter_root_operations(
-        &self,
-    ) -> impl Iterator<Item = (ast::OperationType, &ComponentName)> {
+    pub fn iter_root_operations(&self) -> impl Iterator<Item = (ast::OperationType, &Node<Name>)> {
         [
             (ast::OperationType::Query, &self.query),
             (ast::OperationType::Mutation, &self.mutation),
@@ -665,17 +663,17 @@ impl SchemaDefinition {
         .filter_map(|(ty, maybe_op)| maybe_op.as_ref().map(|op| (ty, op)))
     }
 
-    /// Iterate over the `origins` of all components
+    /// Iterate over the extension IDs of all components
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
-    pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
+    pub fn iter_extension_ids(&self) -> impl Iterator<Item = Option<&ExtensionId>> {
         self.directives
             .iter()
-            .map(|dir| &dir.origin)
-            .chain(self.query.iter().map(|name| &name.origin))
-            .chain(self.mutation.iter().map(|name| &name.origin))
-            .chain(self.subscription.iter().map(|name| &name.origin))
+            .map(|dir| dir.origin.extension_id())
+            .chain(self.query.iter().map(|name| name.extension_id()))
+            .chain(self.mutation.iter().map(|name| name.extension_id()))
+            .chain(self.subscription.iter().map(|name| name.extension_id()))
     }
 
     /// Collect `schema` extensions that contribute any component
@@ -683,9 +681,7 @@ impl SchemaDefinition {
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn extensions(&self) -> IndexSet<&ExtensionId> {
-        self.iter_origins()
-            .filter_map(|origin| origin.extension_id())
-            .collect()
+        self.iter_extension_ids().flatten().collect()
     }
 }
 
@@ -861,41 +857,39 @@ impl ExtendedType {
         }
     }
 
-    /// Iterate over the `origins` of all components
+    /// Iterate over the extension IDs of all components
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
-    pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
+    pub fn iter_extension_ids(&self) -> impl Iterator<Item = Option<&ExtensionId>> {
         match self {
-            Self::Scalar(ty) => Box::new(ty.iter_origins()) as Box<dyn Iterator<Item = _>>,
-            Self::Object(ty) => Box::new(ty.iter_origins()),
-            Self::Interface(ty) => Box::new(ty.iter_origins()),
-            Self::Union(ty) => Box::new(ty.iter_origins()),
-            Self::Enum(ty) => Box::new(ty.iter_origins()),
-            Self::InputObject(ty) => Box::new(ty.iter_origins()),
+            Self::Scalar(ty) => Box::new(ty.iter_extension_ids()) as Box<dyn Iterator<Item = _>>,
+            Self::Object(ty) => Box::new(ty.iter_extension_ids()),
+            Self::Interface(ty) => Box::new(ty.iter_extension_ids()),
+            Self::Union(ty) => Box::new(ty.iter_extension_ids()),
+            Self::Enum(ty) => Box::new(ty.iter_extension_ids()),
+            Self::InputObject(ty) => Box::new(ty.iter_extension_ids()),
         }
     }
 
-    /// Collect `schema` extensions that contribute any component
+    /// Collect type extensions that contribute any component
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn extensions(&self) -> IndexSet<&ExtensionId> {
-        self.iter_origins()
-            .filter_map(|origin| origin.extension_id())
-            .collect()
+        self.iter_extension_ids().flatten().collect()
     }
 
     serialize_method!();
 }
 
 impl ScalarType {
-    /// Iterate over the `origins` of all components
+    /// Iterate over the extension IDs of all components
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
-    pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
-        self.directives.iter().map(|dir| &dir.origin)
+    pub fn iter_extension_ids(&self) -> impl Iterator<Item = Option<&ExtensionId>> {
+        self.directives.iter().map(|dir| dir.origin.extension_id())
     }
 
     /// Collect scalar type extensions that contribute any component
@@ -903,29 +897,31 @@ impl ScalarType {
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn extensions(&self) -> IndexSet<&ExtensionId> {
-        self.iter_origins()
-            .filter_map(|origin| origin.extension_id())
-            .collect()
+        self.iter_extension_ids().flatten().collect()
     }
 
     serialize_method!();
 }
 
 impl ObjectType {
-    /// Iterate over the `origins` of all components
+    /// Iterate over the extension IDs of all components
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
-    pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
+    pub fn iter_extension_ids(&self) -> impl Iterator<Item = Option<&ExtensionId>> {
         self.directives
             .iter()
-            .map(|dir| &dir.origin)
+            .map(|dir| dir.origin.extension_id())
             .chain(
                 self.implements_interfaces
                     .iter()
-                    .map(|component| &component.origin),
+                    .map(|name| name.extension_id()),
             )
-            .chain(self.fields.values().map(|field| &field.origin))
+            .chain(
+                self.fields
+                    .values()
+                    .map(|field| field.origin.extension_id()),
+            )
     }
 
     /// Collect object type extensions that contribute any component
@@ -933,29 +929,31 @@ impl ObjectType {
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn extensions(&self) -> IndexSet<&ExtensionId> {
-        self.iter_origins()
-            .filter_map(|origin| origin.extension_id())
-            .collect()
+        self.iter_extension_ids().flatten().collect()
     }
 
     serialize_method!();
 }
 
 impl InterfaceType {
-    /// Iterate over the `origins` of all components
+    /// Iterate over the extension IDs of all components
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
-    pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
+    pub fn iter_extension_ids(&self) -> impl Iterator<Item = Option<&ExtensionId>> {
         self.directives
             .iter()
-            .map(|dir| &dir.origin)
+            .map(|dir| dir.origin.extension_id())
             .chain(
                 self.implements_interfaces
                     .iter()
-                    .map(|component| &component.origin),
+                    .map(|name| name.extension_id()),
             )
-            .chain(self.fields.values().map(|field| &field.origin))
+            .chain(
+                self.fields
+                    .values()
+                    .map(|field| field.origin.extension_id()),
+            )
     }
 
     /// Collect interface type extensions that contribute any component
@@ -963,24 +961,22 @@ impl InterfaceType {
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn extensions(&self) -> IndexSet<&ExtensionId> {
-        self.iter_origins()
-            .filter_map(|origin| origin.extension_id())
-            .collect()
+        self.iter_extension_ids().flatten().collect()
     }
 
     serialize_method!();
 }
 
 impl UnionType {
-    /// Iterate over the `origins` of all components
+    /// Iterate over the extension IDs of all components
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
-    pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
+    pub fn iter_extension_ids(&self) -> impl Iterator<Item = Option<&ExtensionId>> {
         self.directives
             .iter()
-            .map(|dir| &dir.origin)
-            .chain(self.members.iter().map(|component| &component.origin))
+            .map(|dir| dir.origin.extension_id())
+            .chain(self.members.iter().map(|name| name.extension_id()))
     }
 
     /// Collect union type extensions that contribute any component
@@ -988,24 +984,26 @@ impl UnionType {
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn extensions(&self) -> IndexSet<&ExtensionId> {
-        self.iter_origins()
-            .filter_map(|origin| origin.extension_id())
-            .collect()
+        self.iter_extension_ids().flatten().collect()
     }
 
     serialize_method!();
 }
 
 impl EnumType {
-    /// Iterate over the `origins` of all components
+    /// Iterate over the extension IDs of all components
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
-    pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
+    pub fn iter_extension_ids(&self) -> impl Iterator<Item = Option<&ExtensionId>> {
         self.directives
             .iter()
-            .map(|dir| &dir.origin)
-            .chain(self.values.values().map(|value| &value.origin))
+            .map(|dir| dir.origin.extension_id())
+            .chain(
+                self.values
+                    .values()
+                    .map(|value| value.origin.extension_id()),
+            )
     }
 
     /// Collect enum type extensions that contribute any component
@@ -1013,9 +1011,7 @@ impl EnumType {
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn extensions(&self) -> IndexSet<&ExtensionId> {
-        self.iter_origins()
-            .filter_map(|origin| origin.extension_id())
-            .collect()
+        self.iter_extension_ids().flatten().collect()
     }
 
     serialize_method!();
@@ -1027,15 +1023,19 @@ impl InputObjectType {
         self.directives.get("oneOf").is_some()
     }
 
-    /// Iterate over the `origins` of all components
+    /// Iterate over the extension IDs of all components
     ///
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
-    pub fn iter_origins(&self) -> impl Iterator<Item = &ComponentOrigin> {
+    pub fn iter_extension_ids(&self) -> impl Iterator<Item = Option<&ExtensionId>> {
         self.directives
             .iter()
-            .map(|dir| &dir.origin)
-            .chain(self.fields.values().map(|field| &field.origin))
+            .map(|dir| dir.origin.extension_id())
+            .chain(
+                self.fields
+                    .values()
+                    .map(|field| field.origin.extension_id()),
+            )
     }
 
     /// Collect input object type extensions that contribute any component
@@ -1043,9 +1043,7 @@ impl InputObjectType {
     /// The order of the returned set is unspecified but deterministic
     /// for a given apollo-compiler version.
     pub fn extensions(&self) -> IndexSet<&ExtensionId> {
-        self.iter_origins()
-            .filter_map(|origin| origin.extension_id())
-            .collect()
+        self.iter_extension_ids().flatten().collect()
     }
 
     serialize_method!();

--- a/crates/apollo-compiler/src/schema/serialize.rs
+++ b/crates/apollo-compiler/src/schema/serialize.rs
@@ -46,8 +46,8 @@ impl Node<SchemaDefinition> {
         let extensions = self.extensions();
         let root_ops = |ext: Option<&ExtensionId>| -> Vec<Node<(OperationType, Name)>> {
             self.iter_root_operations()
-                .filter(|(_, op)| op.origin.extension_id() == ext)
-                .map(|(ty, op)| (ty, op.name.clone()).into())
+                .filter(|(_, op)| op.extension_id() == ext)
+                .map(|(ty, op)| (ty, op.as_ref().clone()).into())
                 .collect()
         };
         let orphan_extensions = root_ops(None).is_empty();
@@ -73,7 +73,7 @@ impl Node<SchemaDefinition> {
                     .get(&default_type_name).is_some_and(|def| def.is_object());
                 let implicit_root_operation = has_object.then_some(&default_type_name);
                 // What we have
-                let actual_root_operation = root_operation.as_ref().map(|r| &r.name);
+                let actual_root_operation = root_operation.as_ref().map(|r| r.as_ref());
                 // Only allow an implicit `schema` definition if they match
                 actual_root_operation == implicit_root_operation
             })
@@ -305,11 +305,11 @@ fn components<'a, T: 'a>(
         .collect()
 }
 
-fn names(names: &IndexSet<ComponentName>, ext: Option<&ExtensionId>) -> Vec<Name> {
+fn names(names: &IndexSet<Node<Name>>, ext: Option<&ExtensionId>) -> Vec<Name> {
     names
         .iter()
-        .filter(|component| component.origin.extension_id() == ext)
-        .map(|component| component.name.clone())
+        .filter(|component| component.extension_id() == ext)
+        .map(|component| component.as_ref().clone())
         .collect()
 }
 

--- a/crates/apollo-compiler/src/validation/fragment.rs
+++ b/crates/apollo-compiler/src/validation/fragment.rs
@@ -44,7 +44,7 @@ fn get_possible_types<'a>(
             union_
                 .members
                 .iter()
-                .map(|component| component.name.clone())
+                .map(|component| component.as_ref().clone())
                 .collect(),
         ),
         _ => Default::default(),

--- a/crates/apollo-compiler/src/validation/interface.rs
+++ b/crates/apollo-compiler/src/validation/interface.rs
@@ -7,7 +7,6 @@ use crate::collections::IndexSet;
 use crate::parser::SourceSpan;
 use crate::schema::validation::BuiltInScalars;
 use crate::schema::Component;
-use crate::schema::ComponentName;
 use crate::schema::InterfaceType;
 use crate::schema::Name;
 use crate::validation::diagnostics::DiagnosticData;
@@ -50,7 +49,7 @@ pub(crate) fn validate_interface_definition(
             diagnostics.push(
                 implements_interface.location(),
                 DiagnosticData::RecursiveInterfaceDefinition {
-                    name: implements_interface.name.clone(),
+                    name: implements_interface.as_ref().clone(),
                 },
             );
         }
@@ -101,7 +100,7 @@ pub(crate) fn validate_interface_definition(
                     DiagnosticData::MissingInterfaceField {
                         name: interface.name.clone(),
                         implements_location: implements_interface.location(),
-                        interface: implements_interface.name.clone(),
+                        interface: implements_interface.as_ref().clone(),
                         field: super_field.name.clone(),
                         field_location: super_field.location(),
                     },
@@ -136,7 +135,7 @@ pub(crate) fn validate_implements_interfaces(
     schema: &crate::Schema,
     implementor_name: &Name,
     implementor_location: Option<SourceSpan>,
-    implements_interfaces: &IndexSet<ComponentName>,
+    implements_interfaces: &IndexSet<Node<Name>>,
 ) {
     let interface_definitions = implements_interfaces
         .iter()
@@ -160,7 +159,7 @@ pub(crate) fn validate_implements_interfaces(
         diagnostics.push(
             loc,
             DiagnosticData::UndefinedDefinition {
-                name: interface_name.name.clone(),
+                name: interface_name.as_ref().clone(),
             },
         );
     }
@@ -173,7 +172,7 @@ pub(crate) fn validate_implements_interfaces(
         interface
             .implements_interfaces
             .iter()
-            .map(|component| &component.name)
+            .map(|component| component.as_ref())
             .zip(std::iter::repeat(name))
     });
     for (transitive_interface, via_interface) in transitive_interfaces {
@@ -186,7 +185,7 @@ pub(crate) fn validate_implements_interfaces(
             implementor_location,
             DiagnosticData::TransitiveImplementedInterfaces {
                 interface: implementor_name.clone(),
-                via_interface: via_interface.name.clone(),
+                via_interface: via_interface.as_ref().clone(),
                 missing_interface: transitive_interface.clone(),
                 transitive_interface_location: transitive_loc,
             },
@@ -237,7 +236,7 @@ pub(crate) fn validate_implementation_field_types(
     schema: &crate::Schema,
     implementor_name: &Name,
     implementor_fields: &IndexMap<Name, Component<FieldDefinition>>,
-    implements_interfaces: &IndexSet<ComponentName>,
+    implements_interfaces: &IndexSet<Node<Name>>,
 ) {
     for interface_name in implements_interfaces {
         let Some(interface) = schema.get_interface(interface_name) else {
@@ -252,7 +251,7 @@ pub(crate) fn validate_implementation_field_types(
                     impl_field.location(),
                     DiagnosticData::InvalidImplementationFieldType {
                         name: implementor_name.clone(),
-                        interface: interface_name.name.clone(),
+                        interface: interface_name.as_ref().clone(),
                         field: field_name.clone(),
                         interface_type: Type::clone(&interface_field.ty),
                         actual_type: Type::clone(&impl_field.ty),
@@ -270,7 +269,7 @@ pub(crate) fn validate_implementation_field_types(
                     impl_field.location(),
                     DiagnosticData::DeprecatedImplementationField {
                         name: implementor_name.clone(),
-                        interface: interface_name.name.clone(),
+                        interface: interface_name.as_ref().clone(),
                         field: field_name.clone(),
                         field_location: impl_field.location(),
                         interface_field_location: interface_field.location(),
@@ -295,7 +294,7 @@ pub(crate) fn validate_implementation_field_arguments(
     schema: &crate::Schema,
     implementor_name: &Name,
     implementor_fields: &IndexMap<Name, Component<FieldDefinition>>,
-    implements_interfaces: &IndexSet<ComponentName>,
+    implements_interfaces: &IndexSet<Node<Name>>,
 ) {
     for interface_name in implements_interfaces {
         let Some(interface) = schema.get_interface(interface_name) else {
@@ -320,7 +319,7 @@ pub(crate) fn validate_implementation_field_arguments(
                             impl_field.location(),
                             DiagnosticData::MissingInterfaceFieldArgument {
                                 name: implementor_name.clone(),
-                                interface: interface_name.name.clone(),
+                                interface: interface_name.as_ref().clone(),
                                 field: field_name.clone(),
                                 argument: iface_arg.name.clone(),
                                 field_location: impl_field.location(),
@@ -334,7 +333,7 @@ pub(crate) fn validate_implementation_field_arguments(
                                 impl_arg.location(),
                                 DiagnosticData::InvalidImplementationFieldArgumentType {
                                     name: implementor_name.clone(),
-                                    interface: interface_name.name.clone(),
+                                    interface: interface_name.as_ref().clone(),
                                     field: field_name.clone(),
                                     argument: iface_arg.name.clone(),
                                     interface_type: iface_arg.ty.clone(),
@@ -359,7 +358,7 @@ pub(crate) fn validate_implementation_field_arguments(
                         impl_arg.location(),
                         DiagnosticData::ExtraRequiredImplementationFieldArgument {
                             name: implementor_name.clone(),
-                            interface: interface_name.name.clone(),
+                            interface: interface_name.as_ref().clone(),
                             field: field_name.clone(),
                             argument: impl_arg.name.clone(),
                             argument_location: impl_arg.location(),

--- a/crates/apollo-compiler/src/validation/object.rs
+++ b/crates/apollo-compiler/src/validation/object.rs
@@ -67,7 +67,7 @@ pub(crate) fn validate_object_type_definition(
                     DiagnosticData::MissingInterfaceField {
                         name: object.name.clone(),
                         implements_location: implements_interface.location(),
-                        interface: implements_interface.name.clone(),
+                        interface: implements_interface.as_ref().clone(),
                         field: interface_field.name.clone(),
                         field_location: interface_field.location(),
                     },

--- a/crates/apollo-compiler/src/validation/schema.rs
+++ b/crates/apollo-compiler/src/validation/schema.rs
@@ -41,7 +41,7 @@ pub(crate) fn validate_root_operation_definitions(
                 diagnostics.push(
                     name.location(),
                     DiagnosticData::RootOperationObjectType {
-                        name: name.name.clone(),
+                        name: name.as_ref().clone(),
                         describe_type: type_def.describe(),
                     },
                 );
@@ -50,7 +50,7 @@ pub(crate) fn validate_root_operation_definitions(
             diagnostics.push(
                 name.location(),
                 DiagnosticData::UndefinedDefinition {
-                    name: name.name.clone(),
+                    name: name.as_ref().clone(),
                 },
             );
         }
@@ -62,7 +62,7 @@ pub(crate) fn validate_root_operation_definitions(
             diagnostics.push(
                 name.location(),
                 DiagnosticData::DuplicateRootOperationType {
-                    name: name.name.clone(),
+                    name: name.as_ref().clone(),
                     original_operation: *original_op,
                     original_definition: original_name.location(),
                     redefined_operation: op,

--- a/crates/apollo-compiler/src/validation/union_.rs
+++ b/crates/apollo-compiler/src/validation/union_.rs
@@ -23,13 +23,13 @@ pub(crate) fn validate_union_definition(
         let member_location = union_member.location();
         // TODO: (?) A Union type must include one or more unique member types.
 
-        match schema.types.get(&union_member.name) {
+        match schema.types.get(union_member.as_ref()) {
             None => {
                 // Union member must be defined.
                 diagnostics.push(
                     member_location,
                     DiagnosticData::UndefinedDefinition {
-                        name: union_member.name.clone(),
+                        name: union_member.as_ref().clone(),
                     },
                 );
             }
@@ -39,7 +39,7 @@ pub(crate) fn validate_union_definition(
                 diagnostics.push(
                     member_location,
                     DiagnosticData::UnionMemberObjectType {
-                        name: union_member.name.clone(),
+                        name: union_member.as_ref().clone(),
                         describe_type: ty.describe(),
                     },
                 );

--- a/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0001_annonymous_operation_definition.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0002_multiple_named_operation_definitions.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0003_schema_definition_with_custom_operation_types.txt
@@ -13,22 +13,13 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "customPetQuery",
-            },
+            18..32 @5 "customPetQuery",
         ),
         mutation: Some(
-            ComponentName {
-                origin: Definition,
-                name: "customPetMutation",
-            },
+            84..101 @5 "customPetMutation",
         ),
         subscription: Some(
-            ComponentName {
-                origin: Definition,
-                name: "customPetSubscription",
-            },
+            50..71 @5 "customPetSubscription",
         ),
     },
     directive_definitions: {

--- a/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
+++ b/crates/apollo-compiler/test_data/ok/0004_schema_with_custom_scalars.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0005_schema_with_valid_enum_definitions.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0006_schema_with_valid_union.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "SearchQuery",
-            },
+            18..29 @8 "SearchQuery",
         ),
         mutation: None,
         subscription: None,
@@ -46,14 +43,8 @@ Schema {
                 name: "SearchResult",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Photo",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Person",
-                    },
+                    54..59 @8 "Photo",
+                    62..68 @8 "Person",
                 },
             },
         ),

--- a/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0007_schema_with_interface_definition.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,
@@ -46,10 +43,7 @@ Schema {
                 description: None,
                 name: "Query",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Node",
-                    },
+                    22..26 @9 "Node",
                 },
                 directives: [],
                 fields: {
@@ -95,10 +89,7 @@ Schema {
                 description: None,
                 name: "Resource",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Node",
-                    },
+                    104..108 @9 "Node",
                 },
                 directives: [],
                 fields: {
@@ -146,14 +137,8 @@ Schema {
                 description: None,
                 name: "Image",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Resource",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Node",
-                    },
+                    178..186 @9 "Resource",
+                    189..193 @9 "Node",
                 },
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0009_schema_with_input_object.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
+++ b/crates/apollo-compiler/test_data/ok/0011_fragment_spreads_in_fragment_definitions.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
+++ b/crates/apollo-compiler/test_data/ok/0012_introspection_query.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
+++ b/crates/apollo-compiler/test_data/ok/0013_operation_with_used_variable_in_fragment.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0014_float_values.txt
+++ b/crates/apollo-compiler/test_data/ok/0014_float_values.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
@@ -42,16 +42,10 @@ Schema {
             },
         ],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            125..130 @17 "Query",
         ),
         mutation: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Mutation",
-            },
+            143..151 @17 "Mutation",
         ),
         subscription: None,
     },
@@ -242,14 +236,8 @@ Schema {
                 name: "AccountType",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "PasswordAccount",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "SMSAccount",
-                    },
+                    647..662 @17 "PasswordAccount",
+                    665..675 @17 "SMSAccount",
                 },
             },
         ),
@@ -281,14 +269,8 @@ Schema {
                 name: "Body",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Image",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Text",
-                    },
+                    726..731 @17 "Image",
+                    734..738 @17 "Text",
                 },
             },
         ),
@@ -297,10 +279,7 @@ Schema {
                 description: None,
                 name: "Book",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Product",
-                    },
+                    761..768 @17 "Product",
                 },
                 directives: [
                     Component {
@@ -778,14 +757,8 @@ Schema {
                 name: "Brand",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Ikea",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Amazon",
-                    },
+                    1741..1745 @17 "Ikea",
+                    1748..1754 @17 "Amazon",
                 },
             },
         ),
@@ -794,10 +767,7 @@ Schema {
                 description: None,
                 name: "Car",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Vehicle",
-                    },
+                    1776..1783 @17 "Vehicle",
                 },
                 directives: [
                     Component {
@@ -1000,10 +970,7 @@ Schema {
                 description: None,
                 name: "Furniture",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Product",
-                    },
+                    2177..2184 @17 "Product",
                 },
                 directives: [
                     Component {
@@ -1376,10 +1343,7 @@ Schema {
                 description: None,
                 name: "Image",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "NamedObject",
-                    },
+                    2924..2935 @17 "NamedObject",
                 },
                 directives: [],
                 fields: {
@@ -1816,14 +1780,8 @@ Schema {
                 name: "MetadataOrError",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "KeyValue",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Error",
-                    },
+                    3760..3768 @17 "KeyValue",
+                    3771..3776 @17 "Error",
                 },
             },
         ),
@@ -2239,10 +2197,7 @@ Schema {
                 description: None,
                 name: "ProductDetailsBook",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "ProductDetails",
-                    },
+                    4571..4585 @17 "ProductDetails",
                 },
                 directives: [],
                 fields: {
@@ -2278,10 +2233,7 @@ Schema {
                 description: None,
                 name: "ProductDetailsFurniture",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "ProductDetails",
-                    },
+                    4662..4676 @17 "ProductDetails",
                 },
                 directives: [],
                 fields: {
@@ -2947,10 +2899,7 @@ Schema {
                 description: None,
                 name: "Text",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "NamedObject",
-                    },
+                    5875..5886 @17 "NamedObject",
                 },
                 directives: [],
                 fields: {
@@ -3021,14 +2970,8 @@ Schema {
                 name: "Thing",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Car",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Ikea",
-                    },
+                    6008..6011 @17 "Car",
+                    6014..6018 @17 "Ikea",
                 },
             },
         ),
@@ -3555,10 +3498,7 @@ Schema {
                 description: None,
                 name: "Van",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Vehicle",
-                    },
+                    7117..7124 @17 "Vehicle",
                 },
                 directives: [
                     Component {

--- a/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
+++ b/crates/apollo-compiler/test_data/ok/0016_same_variables_in_multiple_operations.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0017_variables_are_input_types.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
+++ b/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0019_extensions.txt
+++ b/crates/apollo-compiler/test_data/ok/0019_extensions.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,
@@ -73,10 +70,7 @@ Schema {
                 description: None,
                 name: "Object",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Intf",
-                    },
+                    38..42 @21 "Intf",
                 },
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0020_merge_identical_fields.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
+++ b/crates/apollo-compiler/test_data/ok/0021_merge_identical_fields_with_arguments.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
+++ b/crates/apollo-compiler/test_data/ok/0022_merge_differing_fields_and_args.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,
@@ -131,10 +128,7 @@ Schema {
                 description: None,
                 name: "Dog",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Pet",
-                    },
+                    144..147 @24 "Pet",
                 },
                 directives: [],
                 fields: {
@@ -235,10 +229,7 @@ Schema {
                 description: None,
                 name: "Cat",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Pet",
-                    },
+                    322..325 @24 "Pet",
                 },
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0024_used_variables_in_directives.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
+++ b/crates/apollo-compiler/test_data/ok/0026_type_introspection.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
+++ b/crates/apollo-compiler/test_data/ok/0027_typename_introspection_in_object.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
+++ b/crates/apollo-compiler/test_data/ok/0028_typename_introspection_in_union.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,
@@ -46,14 +43,8 @@ Schema {
                 name: "SearchResult",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Photo",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Person",
-                    },
+                    21..26 @29 "Photo",
+                    29..35 @29 "Person",
                 },
             },
         ),

--- a/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
+++ b/crates/apollo-compiler/test_data/ok/0029_used_variable_in_list_and_input.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
+++ b/crates/apollo-compiler/test_data/ok/0030_cyclical_nullable_input_objects.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
+++ b/crates/apollo-compiler/test_data/ok/0031_fragment_spread_possible.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,
@@ -68,10 +65,7 @@ Schema {
                 description: None,
                 name: "Dog",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Pet",
-                    },
+                    55..58 @32 "Pet",
                 },
                 directives: [],
                 fields: {
@@ -107,10 +101,7 @@ Schema {
                 description: None,
                 name: "Cat",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Pet",
-                    },
+                    118..121 @32 "Pet",
                 },
                 directives: [],
                 fields: {
@@ -147,14 +138,8 @@ Schema {
                 name: "CatOrDog",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Cat",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Dog",
-                    },
+                    178..181 @32 "Cat",
+                    184..187 @32 "Dog",
                 },
             },
         ),
@@ -188,14 +173,8 @@ Schema {
                 name: "DogOrHuman",
                 directives: [],
                 members: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Dog",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Human",
-                    },
+                    239..242 @32 "Dog",
+                    245..250 @32 "Human",
                 },
             },
         ),
@@ -226,10 +205,7 @@ Schema {
                 description: None,
                 name: "Resource",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Node",
-                    },
+                    1379..1383 @32 "Node",
                 },
                 directives: [],
                 fields: {
@@ -265,14 +241,8 @@ Schema {
                 description: None,
                 name: "ConcreteResource",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "Resource",
-                    },
-                    ComponentName {
-                        origin: Definition,
-                        name: "Node",
-                    },
+                    1509..1517 @32 "Resource",
+                    1520..1524 @32 "Node",
                 },
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/test_data/ok/0032_valid_of_correct_type.txt
+++ b/crates/apollo-compiler/test_data/ok/0032_valid_of_correct_type.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
+++ b/crates/apollo-compiler/test_data/ok/0033_valid_variable_usage.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
+++ b/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
@@ -28,10 +28,7 @@ Schema {
             },
         ],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            191..196 @35 "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0035_implicit_schema_definition_with_query_type.txt
+++ b/crates/apollo-compiler/test_data/ok/0035_implicit_schema_definition_with_query_type.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0036_implicit_schema_definition_with_several_default_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0036_implicit_schema_definition_with_several_default_types.txt
@@ -13,16 +13,10 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Mutation",
-            },
+            "Mutation",
         ),
         subscription: None,
     },

--- a/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
@@ -27,10 +27,7 @@ Schema {
             },
         ],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
+++ b/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0039_string_literals.txt
+++ b/crates/apollo-compiler/test_data/ok/0039_string_literals.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0040_field_merging_issue_755.txt
+++ b/crates/apollo-compiler/test_data/ok/0040_field_merging_issue_755.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0041_unquoted_string_for_custom_scalar.txt
+++ b/crates/apollo-compiler/test_data/ok/0041_unquoted_string_for_custom_scalar.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0042_used_variable_in_operation_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0042_used_variable_in_operation_directive.txt
@@ -13,22 +13,13 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Mutation",
-            },
+            "Mutation",
         ),
         subscription: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Subscription",
-            },
+            "Subscription",
         ),
     },
     directive_definitions: {

--- a/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.txt
+++ b/crates/apollo-compiler/test_data/ok/0115_interface_definition_with_extension_defines_field.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0116_interface_without_implementations.txt
+++ b/crates/apollo-compiler/test_data/ok/0116_interface_without_implementations.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0117_subscription_conditions_not_at_root.txt
+++ b/crates/apollo-compiler/test_data/ok/0117_subscription_conditions_not_at_root.txt
@@ -13,17 +13,11 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Subscription",
-            },
+            "Subscription",
         ),
     },
     directive_definitions: {

--- a/crates/apollo-compiler/test_data/ok/0118_directive_with_nested_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0118_directive_with_nested_input_types.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0119_directive_with_argument_type_collisions.txt
+++ b/crates/apollo-compiler/test_data/ok/0119_directive_with_argument_type_collisions.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0120_defer_in_subscription_under_variable_skip.txt
+++ b/crates/apollo-compiler/test_data/ok/0120_defer_in_subscription_under_variable_skip.txt
@@ -13,17 +13,11 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Subscription",
-            },
+            "Subscription",
         ),
     },
     directive_definitions: {

--- a/crates/apollo-compiler/test_data/ok/0121_executable_descriptions.txt
+++ b/crates/apollo-compiler/test_data/ok/0121_executable_descriptions.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0122_deprecated_input_values.txt
+++ b/crates/apollo-compiler/test_data/ok/0122_deprecated_input_values.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,

--- a/crates/apollo-compiler/test_data/ok/0123_deprecated_implementation_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0123_deprecated_implementation_fields.txt
@@ -13,10 +13,7 @@ Schema {
         description: None,
         directives: [],
         query: Some(
-            ComponentName {
-                origin: Definition,
-                name: "Query",
-            },
+            "Query",
         ),
         mutation: None,
         subscription: None,
@@ -84,10 +81,7 @@ Schema {
                 description: None,
                 name: "Query",
                 implements_interfaces: {
-                    ComponentName {
-                        origin: Definition,
-                        name: "I",
-                    },
+                    69..70 @52 "I",
                 },
                 directives: [],
                 fields: {

--- a/crates/apollo-compiler/tests/merge_schemas.rs
+++ b/crates/apollo-compiler/tests/merge_schemas.rs
@@ -3,8 +3,9 @@ use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::schema;
 use apollo_compiler::schema::Component;
-use apollo_compiler::schema::ComponentName;
 use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::Name;
+use apollo_compiler::Node;
 use apollo_compiler::Schema;
 
 type MergeError = &'static str;
@@ -91,7 +92,7 @@ where
     Ok(())
 }
 
-fn merge_sets(merged: &mut IndexSet<ComponentName>, new: &IndexSet<ComponentName>) {
+fn merge_sets(merged: &mut IndexSet<Node<Name>>, new: &IndexSet<Node<Name>>) {
     for value in new {
         if !merged.contains(value) {
             merged.insert(value.clone());

--- a/crates/apollo-smith/src/response.rs
+++ b/crates/apollo-smith/src/response.rs
@@ -191,7 +191,7 @@ impl<'a, 'doc, 'schema, R: RandomProvider> ResponseBuilder<'a, 'doc, 'schema, R>
                     .members
                     .get_index(idx)
                     .expect("choose_index returned valid index");
-                Ok(&member.name)
+                Ok(member.as_ref())
             }
             Some(ExtendedType::Interface(_)) => {
                 let count = self
@@ -236,7 +236,7 @@ impl<'a, 'doc, 'schema, R: RandomProvider> ResponseBuilder<'a, 'doc, 'schema, R>
                 Some(ExtendedType::Object(obj)) if obj.implements_interfaces.contains(cond)
             ),
             Some(ExtendedType::Union(union_ty)) => {
-                union_ty.members.iter().any(|m| m.name == *concrete)
+                union_ty.members.iter().any(|m| **m == *concrete)
             }
             _ => false,
         }


### PR DESCRIPTION
## Summary
- Replaces `ComponentName` wrapper with `Node<Name>`, using Node's built-in extension tracking
- `Name::to_component()` → `Name::to_node()`, taking `Option<ExtensionId>` instead of `ComponentOrigin`
- Updates `extensions()` methods to use `.flatten()` on the new `Option<&ExtensionId>` iterators

## Test plan
- [x] All 307 tests pass
- [x] No clippy warnings
- [x] Formatted with nightly rustfmt

Part 2 of a stacked PR series (#1090 → #1091 → #1092)

🤖 Generated with [Claude Code](https://claude.com/claude-code)