### PR TITLE
apollo-parser@0.9.0-beta.0

### DIFF
--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -19,7 +19,7 @@ autotests = false # Most tests/*.rs files are modules of tests/main.rs
 
 [dependencies]
 ahash = "0.8.11"
-apollo-parser = { path = "../apollo-parser", version = "0.8.0" }
+apollo-parser = { path = "../apollo-parser", version = "0.9.0-beta.0" }
 ariadne = { version = "0.6.0", features = ["auto-color"] }
 futures = "0.3"
 indexmap = "2.0.0"

--- a/crates/apollo-parser/CHANGELOG.md
+++ b/crates/apollo-parser/CHANGELOG.md
@@ -16,13 +16,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 ## Documentation -->
-# [x.x.x] (unreleased) - 2026-mm-dd
+# [0.9.0-beta.0](https://crates.io/crates/apollo-parser/0.9.0-beta.0) - 2026-08-21
 
 > Important: 1 breaking change below, indicated by **BREAKING**
 
 ## BREAKING
 
-- **Rename the `VariableDefinitions` CST node to `VariablesDefinition`**
+- **Rename the `VariableDefinitions` CST node to `VariablesDefinition` - [tninesling], [pull/1080]**
 
   The September 2025 specification renamed the `VariableDefinitions` grammar
   production to `VariablesDefinition`. The CST follows suit:
@@ -38,7 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Features
 
-- **September 2025 string and source character support**
+- **September 2025 string and source character support - [tninesling], [pull/1086]**
 
   * String values now support variable-width Unicode escape sequences
     (`"\u{1F4A9}"`) and legacy surrogate pairs, per the updated
@@ -59,6 +59,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   A description on a query shorthand (bare braced selection set) raises a
   parse error.
 
+[pull/1080]: https://github.com/apollographql/apollo-rs/pull/1080
+[pull/1086]: https://github.com/apollographql/apollo-rs/pull/1086
 [graphql-spec#1170]: https://github.com/graphql/graphql-spec/pull/1170
 [goto-bus-stop]: https://github.com/goto-bus-stop
 [pull/974]: https://github.com/apollographql/apollo-rs/pull/974

--- a/crates/apollo-parser/Cargo.toml
+++ b/crates/apollo-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-parser"
-version = "0.8.6" # When bumping, also update README.md
+version = "0.9.0-beta.0" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-parser/README.md
+++ b/crates/apollo-parser/README.md
@@ -35,7 +35,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
-apollo-parser = "0.8.6"
+apollo-parser = "0.9.0-beta.0"
 ```
 
 ## Rust versions

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
 
 [dependencies]
 apollo-compiler = { path = "../apollo-compiler", version = "1.32.0" }
-apollo-parser = { path = "../apollo-parser", version = "0.8.6" }
+apollo-parser = { path = "../apollo-parser", version = "0.9.0-beta.0" }
 arbitrary = { version = "1.4.0", features = ["derive"] }
 indexmap = "2.0.0"
 once_cell = "1.9.0"


### PR DESCRIPTION
## Summary
- Bump apollo-parser to 0.9.0-beta.0
- Update CHANGELOG with PR attribution
- Update apollo-parser dependency version in apollo-compiler and apollo-smith

Release for the September 2025 spec updates, including the `VariableDefinitions` → `VariablesDefinition` breaking rename and Unicode escape support.