### PR TITLE
apollo-smith@0.17.0-beta.0

### DIFF
--- a/crates/apollo-smith/CHANGELOG.md
+++ b/crates/apollo-smith/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 ## Documentation -->
-# [x.x.x] (unreleased) - 2026-mm-dd
+# [0.17.0-beta.0](https://crates.io/crates/apollo-smith/0.17.0-beta.0) - 2026-08-21
 
 ## Features
 
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   description, matching the latest GraphQL spec draft ([graphql-spec#1170]).
   Descriptions are preserved when converting from parsed documents.
 
-- **Generate `@oneOf` input objects during structure-aware fuzzing. - [abernix], [pull/1030]**
+- **Generate `@oneOf` input objects during structure-aware fuzzing - [abernix], [pull/1030]**
 
   `DocumentBuilder::input_object_type_definition` now has a ~1-in-5 chance
   of applying `@oneOf` to a generated input type.  When it does, every field
@@ -36,11 +36,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   always satisfies the spec invariants.  A new `Ty::as_nullable` helper strips
   the outermost `NonNull` wrapper from an arbitrary type.
 
+## Fixes
+
+- **Choose different types for schema roots - [tninesling], [pull/1072]**
+
+  The document builder now ensures query, mutation, and subscription root
+  operation types are distinct, matching the spec requirement.
+
+- **Generate correctly shaped default values based on type being filled - [tninesling], [pull/1075]**
+
+  Default value generation now produces values that match the declared type
+  of the field or argument being filled.
+
 [graphql-spec#1170]: https://github.com/graphql/graphql-spec/pull/1170
-[goto-bus-stop]: https://github.com/goto-bus-stop
 [abernix]: https://github.com/abernix
+[goto-bus-stop]: https://github.com/goto-bus-stop
+[tninesling]: https://github.com/tninesling
 [pull/974]: https://github.com/apollographql/apollo-rs/pull/974
 [pull/1030]: https://github.com/apollographql/apollo-rs/pull/1030
+[pull/1072]: https://github.com/apollographql/apollo-rs/pull/1072
+[pull/1075]: https://github.com/apollographql/apollo-rs/pull/1075
 
 # [0.16.0](https://crates.io/crates/apollo-smith/0.16.0) - 2026-07-21
 

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-smith"
-version = "0.16.0" # When bumping, also update README.md
+version = "0.17.0-beta.0" # When bumping, also update README.md
 edition = "2021"
 authors = ["Benjamin Coenen <benjamin.coenen@apollographql.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/apollo-smith/README.md
+++ b/crates/apollo-smith/README.md
@@ -50,7 +50,7 @@ and add `apollo-smith` to your Cargo.toml:
 ## fuzz/Cargo.toml
 
 [dependencies]
-apollo-smith = "0.16.0"
+apollo-smith = "0.17.0-beta.0"
 ```
 
 It can then be used in a `fuzz_target` along with the [`arbitrary`] crate,


### PR DESCRIPTION
## Summary
- Bump apollo-smith to 0.17.0-beta.0
- Update CHANGELOG with missing fix entries (#1072, #1075) and PR attribution
- Version bump needed so downstream consumers can resolve pinned dependencies on apollo-parser@0.9.0-beta.0 and apollo-compiler@2.0.0-beta.0