### PR TITLE
feat!(compiler): order-independent equality for directive locations

### DIFF
--- a/crates/apollo-compiler/src/ast/mod.rs
+++ b/crates/apollo-compiler/src/ast/mod.rs
@@ -55,7 +55,9 @@ use crate::collections::IndexSet;
 use crate::parser::SourceMap;
 use crate::Name;
 use crate::Node;
+use std::hash::DefaultHasher;
 use std::hash::Hash;
+use std::hash::Hasher;
 
 pub(crate) mod from_cst;
 pub(crate) mod impls;
@@ -139,7 +141,7 @@ pub struct FragmentDefinition {
 
 /// Type system AST for a `directive @foo`
 /// [_DirectiveDefinition_](https://spec.graphql.org/September2025/#DirectiveDefinition).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DirectiveDefinition {
     pub description: Option<Node<str>>,
     pub name: Name,
@@ -148,33 +150,21 @@ pub struct DirectiveDefinition {
     pub locations: IndexSet<DirectiveLocation>,
 }
 
-impl PartialEq for DirectiveDefinition {
-    fn eq(&self, other: &Self) -> bool {
-        self.description == other.description
-            && self.name == other.name
-            && self.repeatable == other.repeatable
-            && self.locations == other.locations
-            && input_value_definitions_eq(&self.arguments, &other.arguments)
-    }
-}
-
-impl Eq for DirectiveDefinition {}
-
-impl std::hash::Hash for DirectiveDefinition {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl Hash for DirectiveDefinition {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.description.hash(state);
         self.name.hash(state);
+        self.arguments.hash(state);
         self.repeatable.hash(state);
         // IndexSet: order-independent hash via commutative XOR
         self.locations.len().hash(state);
         let mut locations_hash = 0u64;
         for loc in &self.locations {
-            let mut h = std::hash::DefaultHasher::new();
+            let mut h = DefaultHasher::new();
             loc.hash(&mut h);
-            locations_hash ^= std::hash::Hasher::finish(&h);
+            locations_hash ^= h.finish();
         }
         locations_hash.hash(state);
-        input_value_definitions_hash(&self.arguments, state);
     }
 }
 
@@ -330,25 +320,10 @@ pub struct Argument {
 pub struct DirectiveList(pub Vec<Node<Directive>>);
 
 /// AST for a [_Directive_](https://spec.graphql.org/September2025/#Directive) application.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Directive {
     pub name: Name,
     pub arguments: Vec<Node<Argument>>,
-}
-
-impl PartialEq for Directive {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && arguments_eq(&self.arguments, &other.arguments)
-    }
-}
-
-impl Eq for Directive {}
-
-impl std::hash::Hash for Directive {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.name.hash(state);
-        arguments_hash(&self.arguments, state);
-    }
 }
 
 /// AST for the [_OperationType_](https://spec.graphql.org/September2025/#OperationType)
@@ -416,35 +391,13 @@ pub enum Type {
 
 /// Type system AST for a [_FieldDefinition_](https://spec.graphql.org/September2025/#FieldDefinition)
 /// in an object type or interface type defintion or extension.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct FieldDefinition {
     pub description: Option<Node<str>>,
     pub name: Name,
     pub arguments: Vec<Node<InputValueDefinition>>,
     pub ty: Type,
     pub directives: DirectiveList,
-}
-
-impl PartialEq for FieldDefinition {
-    fn eq(&self, other: &Self) -> bool {
-        self.description == other.description
-            && self.name == other.name
-            && self.ty == other.ty
-            && self.directives == other.directives
-            && input_value_definitions_eq(&self.arguments, &other.arguments)
-    }
-}
-
-impl Eq for FieldDefinition {}
-
-impl std::hash::Hash for FieldDefinition {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.description.hash(state);
-        self.name.hash(state);
-        self.ty.hash(state);
-        self.directives.hash(state);
-        input_value_definitions_hash(&self.arguments, state);
-    }
 }
 
 /// Type system AST for an
@@ -480,35 +433,13 @@ pub enum Selection {
 
 /// Executable AST for a [_Field_](https://spec.graphql.org/September2025/#Field) selection
 /// in a selection set.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Field {
     pub alias: Option<Name>,
     pub name: Name,
     pub arguments: Vec<Node<Argument>>,
     pub directives: DirectiveList,
     pub selection_set: Vec<Selection>,
-}
-
-impl PartialEq for Field {
-    fn eq(&self, other: &Self) -> bool {
-        self.alias == other.alias
-            && self.name == other.name
-            && self.directives == other.directives
-            && self.selection_set == other.selection_set
-            && arguments_eq(&self.arguments, &other.arguments)
-    }
-}
-
-impl Eq for Field {}
-
-impl std::hash::Hash for Field {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.alias.hash(state);
-        self.name.hash(state);
-        self.directives.hash(state);
-        self.selection_set.hash(state);
-        arguments_hash(&self.arguments, state);
-    }
 }
 
 /// Executable AST for a
@@ -592,85 +523,4 @@ pub enum ArgumentByNameError {
     /// The argument is required (does not define a default value and has non-null type)
     /// but not specified
     RequiredArgumentNotSpecified,
-}
-
-/// Order-independent equality for argument lists.
-///
-/// Uses multiset matching to handle duplicate names correctly in
-/// invalid-but-parseable documents.
-pub(crate) fn arguments_eq(a: &[Node<Argument>], b: &[Node<Argument>]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut matched = vec![false; b.len()];
-    a.iter().all(|arg_a| {
-        b.iter()
-            .enumerate()
-            .find(|(i, arg_b)| {
-                !matched[*i] && arg_a.name == arg_b.name && arg_a.value == arg_b.value
-            })
-            .map(|(i, _)| {
-                matched[i] = true;
-                true
-            })
-            .unwrap_or(false)
-    })
-}
-
-/// Order-independent hash for argument lists.
-pub(crate) fn arguments_hash<H: std::hash::Hasher>(args: &[Node<Argument>], state: &mut H) {
-    args.len().hash(state);
-    let mut combined = 0u64;
-    for arg in args {
-        let mut h = std::hash::DefaultHasher::new();
-        arg.name.hash(&mut h);
-        arg.value.hash(&mut h);
-        combined ^= std::hash::Hasher::finish(&h);
-    }
-    combined.hash(state);
-}
-
-/// Order-independent equality for input value definition lists.
-fn input_value_definitions_eq(
-    a: &[Node<InputValueDefinition>],
-    b: &[Node<InputValueDefinition>],
-) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut matched = vec![false; b.len()];
-    a.iter().all(|def_a| {
-        b.iter()
-            .enumerate()
-            .find(|(i, def_b)| {
-                !matched[*i]
-                    && def_a.name == def_b.name
-                    && def_a.ty == def_b.ty
-                    && def_a.default_value == def_b.default_value
-                    && def_a.directives == def_b.directives
-            })
-            .map(|(i, _)| {
-                matched[i] = true;
-                true
-            })
-            .unwrap_or(false)
-    })
-}
-
-/// Order-independent hash for input value definition lists.
-fn input_value_definitions_hash<H: std::hash::Hasher>(
-    defs: &[Node<InputValueDefinition>],
-    state: &mut H,
-) {
-    defs.len().hash(state);
-    let mut combined = 0u64;
-    for def in defs {
-        let mut h = std::hash::DefaultHasher::new();
-        def.name.hash(&mut h);
-        def.ty.hash(&mut h);
-        def.default_value.hash(&mut h);
-        def.directives.hash(&mut h);
-        combined ^= std::hash::Hasher::finish(&h);
-    }
-    combined.hash(state);
 }

--- a/crates/apollo-compiler/src/ast/mod.rs
+++ b/crates/apollo-compiler/src/ast/mod.rs
@@ -51,11 +51,11 @@
 //! assert_eq!(doc.serialize().no_indent().to_string(), "query @dir { field }")
 //! ```
 
+use crate::collections::hash_unordered;
 use crate::collections::IndexSet;
 use crate::parser::SourceMap;
 use crate::Name;
 use crate::Node;
-use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
 
@@ -156,15 +156,7 @@ impl Hash for DirectiveDefinition {
         self.name.hash(state);
         self.arguments.hash(state);
         self.repeatable.hash(state);
-        // IndexSet: order-independent hash via commutative XOR
-        self.locations.len().hash(state);
-        let mut locations_hash = 0u64;
-        for loc in &self.locations {
-            let mut h = DefaultHasher::new();
-            loc.hash(&mut h);
-            locations_hash ^= h.finish();
-        }
-        locations_hash.hash(state);
+        hash_unordered(self.locations.iter(), state, self.locations.len());
     }
 }
 

--- a/crates/apollo-compiler/src/ast/mod.rs
+++ b/crates/apollo-compiler/src/ast/mod.rs
@@ -51,9 +51,11 @@
 //! assert_eq!(doc.serialize().no_indent().to_string(), "query @dir { field }")
 //! ```
 
+use crate::collections::IndexSet;
 use crate::parser::SourceMap;
 use crate::Name;
 use crate::Node;
+use std::hash::Hash;
 
 pub(crate) mod from_cst;
 pub(crate) mod impls;
@@ -137,13 +139,43 @@ pub struct FragmentDefinition {
 
 /// Type system AST for a `directive @foo`
 /// [_DirectiveDefinition_](https://spec.graphql.org/September2025/#DirectiveDefinition).
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug)]
 pub struct DirectiveDefinition {
     pub description: Option<Node<str>>,
     pub name: Name,
     pub arguments: Vec<Node<InputValueDefinition>>,
     pub repeatable: bool,
-    pub locations: Vec<DirectiveLocation>,
+    pub locations: IndexSet<DirectiveLocation>,
+}
+
+impl PartialEq for DirectiveDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.description == other.description
+            && self.name == other.name
+            && self.repeatable == other.repeatable
+            && self.locations == other.locations
+            && input_value_definitions_eq(&self.arguments, &other.arguments)
+    }
+}
+
+impl Eq for DirectiveDefinition {}
+
+impl std::hash::Hash for DirectiveDefinition {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.description.hash(state);
+        self.name.hash(state);
+        self.repeatable.hash(state);
+        // IndexSet: order-independent hash via commutative XOR
+        self.locations.len().hash(state);
+        let mut locations_hash = 0u64;
+        for loc in &self.locations {
+            let mut h = std::hash::DefaultHasher::new();
+            loc.hash(&mut h);
+            locations_hash ^= std::hash::Hasher::finish(&h);
+        }
+        locations_hash.hash(state);
+        input_value_definitions_hash(&self.arguments, state);
+    }
 }
 
 /// Type system AST for a `schema`
@@ -298,10 +330,25 @@ pub struct Argument {
 pub struct DirectiveList(pub Vec<Node<Directive>>);
 
 /// AST for a [_Directive_](https://spec.graphql.org/September2025/#Directive) application.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Directive {
     pub name: Name,
     pub arguments: Vec<Node<Argument>>,
+}
+
+impl PartialEq for Directive {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && arguments_eq(&self.arguments, &other.arguments)
+    }
+}
+
+impl Eq for Directive {}
+
+impl std::hash::Hash for Directive {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        arguments_hash(&self.arguments, state);
+    }
 }
 
 /// AST for the [_OperationType_](https://spec.graphql.org/September2025/#OperationType)
@@ -369,13 +416,35 @@ pub enum Type {
 
 /// Type system AST for a [_FieldDefinition_](https://spec.graphql.org/September2025/#FieldDefinition)
 /// in an object type or interface type defintion or extension.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug)]
 pub struct FieldDefinition {
     pub description: Option<Node<str>>,
     pub name: Name,
     pub arguments: Vec<Node<InputValueDefinition>>,
     pub ty: Type,
     pub directives: DirectiveList,
+}
+
+impl PartialEq for FieldDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.description == other.description
+            && self.name == other.name
+            && self.ty == other.ty
+            && self.directives == other.directives
+            && input_value_definitions_eq(&self.arguments, &other.arguments)
+    }
+}
+
+impl Eq for FieldDefinition {}
+
+impl std::hash::Hash for FieldDefinition {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.description.hash(state);
+        self.name.hash(state);
+        self.ty.hash(state);
+        self.directives.hash(state);
+        input_value_definitions_hash(&self.arguments, state);
+    }
 }
 
 /// Type system AST for an
@@ -411,13 +480,35 @@ pub enum Selection {
 
 /// Executable AST for a [_Field_](https://spec.graphql.org/September2025/#Field) selection
 /// in a selection set.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Field {
     pub alias: Option<Name>,
     pub name: Name,
     pub arguments: Vec<Node<Argument>>,
     pub directives: DirectiveList,
     pub selection_set: Vec<Selection>,
+}
+
+impl PartialEq for Field {
+    fn eq(&self, other: &Self) -> bool {
+        self.alias == other.alias
+            && self.name == other.name
+            && self.directives == other.directives
+            && self.selection_set == other.selection_set
+            && arguments_eq(&self.arguments, &other.arguments)
+    }
+}
+
+impl Eq for Field {}
+
+impl std::hash::Hash for Field {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.alias.hash(state);
+        self.name.hash(state);
+        self.directives.hash(state);
+        self.selection_set.hash(state);
+        arguments_hash(&self.arguments, state);
+    }
 }
 
 /// Executable AST for a
@@ -501,4 +592,85 @@ pub enum ArgumentByNameError {
     /// The argument is required (does not define a default value and has non-null type)
     /// but not specified
     RequiredArgumentNotSpecified,
+}
+
+/// Order-independent equality for argument lists.
+///
+/// Uses multiset matching to handle duplicate names correctly in
+/// invalid-but-parseable documents.
+pub(crate) fn arguments_eq(a: &[Node<Argument>], b: &[Node<Argument>]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut matched = vec![false; b.len()];
+    a.iter().all(|arg_a| {
+        b.iter()
+            .enumerate()
+            .find(|(i, arg_b)| {
+                !matched[*i] && arg_a.name == arg_b.name && arg_a.value == arg_b.value
+            })
+            .map(|(i, _)| {
+                matched[i] = true;
+                true
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Order-independent hash for argument lists.
+pub(crate) fn arguments_hash<H: std::hash::Hasher>(args: &[Node<Argument>], state: &mut H) {
+    args.len().hash(state);
+    let mut combined = 0u64;
+    for arg in args {
+        let mut h = std::hash::DefaultHasher::new();
+        arg.name.hash(&mut h);
+        arg.value.hash(&mut h);
+        combined ^= std::hash::Hasher::finish(&h);
+    }
+    combined.hash(state);
+}
+
+/// Order-independent equality for input value definition lists.
+fn input_value_definitions_eq(
+    a: &[Node<InputValueDefinition>],
+    b: &[Node<InputValueDefinition>],
+) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut matched = vec![false; b.len()];
+    a.iter().all(|def_a| {
+        b.iter()
+            .enumerate()
+            .find(|(i, def_b)| {
+                !matched[*i]
+                    && def_a.name == def_b.name
+                    && def_a.ty == def_b.ty
+                    && def_a.default_value == def_b.default_value
+                    && def_a.directives == def_b.directives
+            })
+            .map(|(i, _)| {
+                matched[i] = true;
+                true
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Order-independent hash for input value definition lists.
+fn input_value_definitions_hash<H: std::hash::Hasher>(
+    defs: &[Node<InputValueDefinition>],
+    state: &mut H,
+) {
+    defs.len().hash(state);
+    let mut combined = 0u64;
+    for def in defs {
+        let mut h = std::hash::DefaultHasher::new();
+        def.name.hash(&mut h);
+        def.ty.hash(&mut h);
+        def.default_value.hash(&mut h);
+        def.directives.hash(&mut h);
+        combined ^= std::hash::Hasher::finish(&h);
+    }
+    combined.hash(state);
 }

--- a/crates/apollo-compiler/src/ast/serialize.rs
+++ b/crates/apollo-compiler/src/ast/serialize.rs
@@ -264,10 +264,11 @@ impl DirectiveDefinition {
         if *repeatable {
             state.write(" repeatable")?;
         }
-        if let Some((first, rest)) = locations.split_first() {
+        let mut loc_iter = locations.iter();
+        if let Some(first) = loc_iter.next() {
             state.write(" on ")?;
             state.write(first.name())?;
-            for location in rest {
+            for location in loc_iter {
                 state.write(" | ")?;
                 state.write(location.name())?;
             }

--- a/crates/apollo-compiler/src/collections.rs
+++ b/crates/apollo-compiler/src/collections.rs
@@ -1,6 +1,10 @@
 //! Type aliases for hashing-based collections configured with a specific hasher,
 //! as used in various places thorough the API
 
+use std::hash::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
+
 /// [`indexmap::IndexMap`] configured with a specific hasher
 pub type IndexMap<K, V> = indexmap::IndexMap<K, V, ahash::RandomState>;
 
@@ -12,3 +16,20 @@ pub type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;
 
 /// [`std::collections::HashSet`] configured with a specific hasher
 pub type HashSet<T> = std::collections::HashSet<T, ahash::RandomState>;
+
+/// Order-independent hash for collections whose `PartialEq` is order-independent
+/// (e.g. `IndexMap`, `IndexSet`). Uses commutative XOR of per-element hashes.
+pub(crate) fn hash_unordered<H: Hasher, T: Hash>(
+    items: impl Iterator<Item = T>,
+    state: &mut H,
+    len: usize,
+) {
+    len.hash(state);
+    let mut combined = 0u64;
+    for item in items {
+        let mut h = DefaultHasher::new();
+        item.hash(&mut h);
+        combined ^= h.finish();
+    }
+    combined.hash(state);
+}

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -161,7 +161,7 @@ pub enum Selection {
 
 /// A [_Field_](https://spec.graphql.org/September2025/#Field) selection,
 /// linked to the corresponding field definition in the schema.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub struct Field {
     /// The definition of this field in an object type or interface type definition in the schema
     pub definition: Node<schema::FieldDefinition>,
@@ -170,6 +170,30 @@ pub struct Field {
     pub arguments: Vec<Node<Argument>>,
     pub directives: DirectiveList,
     pub selection_set: SelectionSet,
+}
+
+impl PartialEq for Field {
+    fn eq(&self, other: &Self) -> bool {
+        self.definition == other.definition
+            && self.alias == other.alias
+            && self.name == other.name
+            && self.directives == other.directives
+            && self.selection_set == other.selection_set
+            && crate::ast::arguments_eq(&self.arguments, &other.arguments)
+    }
+}
+
+impl Eq for Field {}
+
+impl std::hash::Hash for Field {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.definition.hash(state);
+        self.alias.hash(state);
+        self.name.hash(state);
+        self.directives.hash(state);
+        self.selection_set.hash(state);
+        crate::ast::arguments_hash(&self.arguments, state);
+    }
 }
 
 /// A [_FragmentSpread_](https://spec.graphql.org/September2025/#FragmentSpread)

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -161,7 +161,7 @@ pub enum Selection {
 
 /// A [_Field_](https://spec.graphql.org/September2025/#Field) selection,
 /// linked to the corresponding field definition in the schema.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
     /// The definition of this field in an object type or interface type definition in the schema
     pub definition: Node<schema::FieldDefinition>,
@@ -170,30 +170,6 @@ pub struct Field {
     pub arguments: Vec<Node<Argument>>,
     pub directives: DirectiveList,
     pub selection_set: SelectionSet,
-}
-
-impl PartialEq for Field {
-    fn eq(&self, other: &Self) -> bool {
-        self.definition == other.definition
-            && self.alias == other.alias
-            && self.name == other.name
-            && self.directives == other.directives
-            && self.selection_set == other.selection_set
-            && crate::ast::arguments_eq(&self.arguments, &other.arguments)
-    }
-}
-
-impl Eq for Field {}
-
-impl std::hash::Hash for Field {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.definition.hash(state);
-        self.alias.hash(state);
-        self.name.hash(state);
-        self.directives.hash(state);
-        self.selection_set.hash(state);
-        crate::ast::arguments_hash(&self.arguments, state);
-    }
 }
 
 /// A [_FragmentSpread_](https://spec.graphql.org/September2025/#FragmentSpread)

--- a/crates/apollo-compiler/src/validation/diagnostics.rs
+++ b/crates/apollo-compiler/src/validation/diagnostics.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use thiserror::Error;
 
 /// Structured data about a diagnostic.
-#[derive(Debug, Error, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub(crate) enum DiagnosticData {
     #[error("the variable `${name}` is declared multiple times")]
@@ -229,7 +229,7 @@ pub(crate) enum DiagnosticData {
         /// The location where the directive is attempted to be used
         location: DirectiveLocation,
         /// Locations that *are* valid for this directive
-        valid_locations: Vec<DirectiveLocation>,
+        valid_locations: crate::collections::IndexSet<DirectiveLocation>,
         /// The source location where the directive that's being used was defined.
         definition_location: Option<SourceSpan>,
     },

--- a/crates/apollo-compiler/src/validation/directive.rs
+++ b/crates/apollo-compiler/src/validation/directive.rs
@@ -1,7 +1,6 @@
 use super::CycleError;
 use crate::ast;
 use crate::collections::HashMap;
-use crate::collections::HashSet;
 use crate::coordinate::DirectiveArgumentCoordinate;
 use crate::coordinate::DirectiveCoordinate;
 use crate::schema;
@@ -276,9 +275,7 @@ pub(crate) fn validate_directives<'dir>(
         }
 
         if let Some((schema, directive_definition)) = directive_definition {
-            let allowed_loc: HashSet<ast::DirectiveLocation> =
-                HashSet::from_iter(directive_definition.locations.iter().cloned());
-            if !allowed_loc.contains(&dir_loc) {
+            if !directive_definition.locations.contains(&dir_loc) {
                 diagnostics.push(
                     loc,
                     DiagnosticData::UnsupportedLocation {

--- a/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
+++ b/crates/apollo-compiler/test_data/ok/0008_schema_with_directive_definition.txt
@@ -39,10 +39,10 @@ Schema {
                 },
             ],
             repeatable: true,
-            locations: [
+            locations: {
                 "OBJECT",
                 "INTERFACE",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
+++ b/crates/apollo-compiler/test_data/ok/0010_operation_with_defined_fields.txt
@@ -39,9 +39,9 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "FIELD_DEFINITION",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
+++ b/crates/apollo-compiler/test_data/ok/0015_supergraph.txt
@@ -64,9 +64,9 @@ Schema {
                 },
             ],
             repeatable: true,
-            locations: [
+            locations: {
                 "SCHEMA",
-            ],
+            },
         },
         "join__field": 210..324 @17 DirectiveDefinition {
             description: None,
@@ -101,9 +101,9 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "FIELD_DEFINITION",
-            ],
+            },
         },
         "join__type": 325..421 @17 DirectiveDefinition {
             description: None,
@@ -129,10 +129,10 @@ Schema {
                 },
             ],
             repeatable: true,
-            locations: [
+            locations: {
                 "OBJECT",
                 "INTERFACE",
-            ],
+            },
         },
         "join__owner": 422..487 @17 DirectiveDefinition {
             description: None,
@@ -149,10 +149,10 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "OBJECT",
                 "INTERFACE",
-            ],
+            },
         },
         "join__graph": 488..553 @17 DirectiveDefinition {
             description: None,
@@ -178,18 +178,18 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "ENUM_VALUE",
-            ],
+            },
         },
         "stream": 554..580 @17 DirectiveDefinition {
             description: None,
             name: "stream",
             arguments: [],
             repeatable: false,
-            locations: [
+            locations: {
                 "FIELD",
-            ],
+            },
         },
         "transform": 581..625 @17 DirectiveDefinition {
             description: None,
@@ -206,9 +206,9 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "FIELD",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
+++ b/crates/apollo-compiler/test_data/ok/0018_non_clashing_names.txt
@@ -29,9 +29,9 @@ Schema {
             name: "A",
             arguments: [],
             repeatable: false,
-            locations: [
+            locations: {
                 "OBJECT",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
+++ b/crates/apollo-compiler/test_data/ok/0025_unique_directives.txt
@@ -29,18 +29,18 @@ Schema {
             name: "repeatable",
             arguments: [],
             repeatable: true,
-            locations: [
+            locations: {
                 "FIELD",
-            ],
+            },
         },
         "unique": 42..68 @26 DirectiveDefinition {
             description: None,
             name: "unique",
             arguments: [],
             repeatable: false,
-            locations: [
+            locations: {
                 "FIELD",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
+++ b/crates/apollo-compiler/test_data/ok/0034_built_in_directive_redefinition.txt
@@ -52,13 +52,13 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "FIELD_DEFINITION",
                 "ARGUMENT_DEFINITION",
                 "INPUT_FIELD_DEFINITION",
                 "ENUM_VALUE",
                 "SCHEMA",
-            ],
+            },
         },
         "oneOf": built_in_directive!("oneOf"),
         "specifiedBy": built_in_directive!("specifiedBy"),

--- a/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0037_implicit_schema_extension_with_directive.txt
@@ -34,9 +34,9 @@ Schema {
             name: "dir",
             arguments: [],
             repeatable: false,
-            locations: [
+            locations: {
                 "SCHEMA",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
+++ b/crates/apollo-compiler/test_data/ok/0038_argument_default.txt
@@ -52,10 +52,10 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "FRAGMENT_SPREAD",
                 "INLINE_FRAGMENT",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0042_used_variable_in_operation_directive.txt
+++ b/crates/apollo-compiler/test_data/ok/0042_used_variable_in_operation_directive.txt
@@ -43,11 +43,11 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "QUERY",
                 "MUTATION",
                 "SUBSCRIPTION",
-            ],
+            },
         },
         "z": 57..104 @43 DirectiveDefinition {
             description: None,
@@ -64,9 +64,9 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "FRAGMENT_DEFINITION",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0118_directive_with_nested_input_types.txt
+++ b/crates/apollo-compiler/test_data/ok/0118_directive_with_nested_input_types.txt
@@ -39,10 +39,10 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "OBJECT",
                 "INTERFACE",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0119_directive_with_argument_type_collisions.txt
+++ b/crates/apollo-compiler/test_data/ok/0119_directive_with_argument_type_collisions.txt
@@ -39,10 +39,10 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "OBJECT",
                 "INTERFACE",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/test_data/ok/0120_defer_in_subscription_under_variable_skip.txt
+++ b/crates/apollo-compiler/test_data/ok/0120_defer_in_subscription_under_variable_skip.txt
@@ -54,10 +54,10 @@ Schema {
                 },
             ],
             repeatable: false,
-            locations: [
+            locations: {
                 "FRAGMENT_SPREAD",
                 "INLINE_FRAGMENT",
-            ],
+            },
         },
     },
     types: {

--- a/crates/apollo-compiler/tests/equality_semantics.rs
+++ b/crates/apollo-compiler/tests/equality_semantics.rs
@@ -1,0 +1,144 @@
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+
+#[test]
+fn directive_definition_locations_are_order_independent() {
+    let schema_a = Schema::parse_and_validate(
+        "type Query { field: String }
+         directive @example on FIELD_DEFINITION | OBJECT",
+        "a.graphql",
+    )
+    .unwrap();
+
+    let schema_b = Schema::parse_and_validate(
+        "type Query { field: String }
+         directive @example on OBJECT | FIELD_DEFINITION",
+        "b.graphql",
+    )
+    .unwrap();
+
+    assert_eq!(schema_a, schema_b);
+}
+
+#[test]
+fn directive_definition_arguments_are_order_independent() {
+    let schema_a = Schema::parse_and_validate(
+        "type Query { field: String }
+         directive @example(a: Int, b: String) on FIELD_DEFINITION",
+        "a.graphql",
+    )
+    .unwrap();
+
+    let schema_b = Schema::parse_and_validate(
+        "type Query { field: String }
+         directive @example(b: String, a: Int) on FIELD_DEFINITION",
+        "b.graphql",
+    )
+    .unwrap();
+
+    assert_eq!(schema_a, schema_b);
+}
+
+#[test]
+fn field_definition_arguments_are_order_independent() {
+    let schema_a = Schema::parse_and_validate(
+        "type Query { field(x: Int, y: String): String }",
+        "a.graphql",
+    )
+    .unwrap();
+
+    let schema_b = Schema::parse_and_validate(
+        "type Query { field(y: String, x: Int): String }",
+        "b.graphql",
+    )
+    .unwrap();
+
+    assert_eq!(schema_a, schema_b);
+}
+
+#[test]
+fn applied_directive_arguments_are_order_independent() {
+    let schema = Schema::parse_and_validate(
+        "type Query { field: String }
+         directive @example(a: Int, b: String) on QUERY",
+        "schema.graphql",
+    )
+    .unwrap();
+
+    let doc_a = ExecutableDocument::parse_and_validate(
+        &schema,
+        "query @example(a: 1, b: \"hello\") { field }",
+        "a.graphql",
+    )
+    .unwrap();
+
+    let doc_b = ExecutableDocument::parse_and_validate(
+        &schema,
+        "query @example(b: \"hello\", a: 1) { field }",
+        "b.graphql",
+    )
+    .unwrap();
+
+    assert_eq!(doc_a, doc_b);
+}
+
+#[test]
+fn executable_field_arguments_are_order_independent() {
+    let schema = Schema::parse_and_validate(
+        "type Query { field(a: Int, b: String): String }",
+        "schema.graphql",
+    )
+    .unwrap();
+
+    let doc_a = ExecutableDocument::parse_and_validate(
+        &schema,
+        "{ field(a: 1, b: \"hello\") }",
+        "a.graphql",
+    )
+    .unwrap();
+
+    let doc_b = ExecutableDocument::parse_and_validate(
+        &schema,
+        "{ field(b: \"hello\", a: 1) }",
+        "b.graphql",
+    )
+    .unwrap();
+
+    assert_eq!(doc_a, doc_b);
+}
+
+#[test]
+fn applied_directives_are_order_dependent() {
+    let schema_a = Schema::parse_and_validate(
+        "directive @auth on FIELD_DEFINITION
+         directive @cache on FIELD_DEFINITION
+         type Query { field: String @auth @cache }",
+        "a.graphql",
+    )
+    .unwrap();
+
+    let schema_b = Schema::parse_and_validate(
+        "directive @auth on FIELD_DEFINITION
+         directive @cache on FIELD_DEFINITION
+         type Query { field: String @cache @auth }",
+        "b.graphql",
+    )
+    .unwrap();
+
+    assert_ne!(schema_a, schema_b);
+}
+
+#[test]
+fn selection_sets_are_order_dependent() {
+    let schema =
+        Schema::parse_and_validate("type Query { name: String, age: Int }", "schema.graphql")
+            .unwrap();
+
+    let doc_a =
+        ExecutableDocument::parse_and_validate(&schema, "{ name age }", "a.graphql").unwrap();
+
+    let doc_b =
+        ExecutableDocument::parse_and_validate(&schema, "{ age name }", "b.graphql").unwrap();
+
+    assert_ne!(doc_a, doc_b);
+}

--- a/crates/apollo-compiler/tests/equality_semantics.rs
+++ b/crates/apollo-compiler/tests/equality_semantics.rs
@@ -1,4 +1,3 @@
-use apollo_compiler::ExecutableDocument;
 use apollo_compiler::Schema;
 
 #[test]
@@ -21,93 +20,6 @@ fn directive_definition_locations_are_order_independent() {
 }
 
 #[test]
-fn directive_definition_arguments_are_order_independent() {
-    let schema_a = Schema::parse_and_validate(
-        "type Query { field: String }
-         directive @example(a: Int, b: String) on FIELD_DEFINITION",
-        "a.graphql",
-    )
-    .unwrap();
-
-    let schema_b = Schema::parse_and_validate(
-        "type Query { field: String }
-         directive @example(b: String, a: Int) on FIELD_DEFINITION",
-        "b.graphql",
-    )
-    .unwrap();
-
-    assert_eq!(schema_a, schema_b);
-}
-
-#[test]
-fn field_definition_arguments_are_order_independent() {
-    let schema_a = Schema::parse_and_validate(
-        "type Query { field(x: Int, y: String): String }",
-        "a.graphql",
-    )
-    .unwrap();
-
-    let schema_b = Schema::parse_and_validate(
-        "type Query { field(y: String, x: Int): String }",
-        "b.graphql",
-    )
-    .unwrap();
-
-    assert_eq!(schema_a, schema_b);
-}
-
-#[test]
-fn applied_directive_arguments_are_order_independent() {
-    let schema = Schema::parse_and_validate(
-        "type Query { field: String }
-         directive @example(a: Int, b: String) on QUERY",
-        "schema.graphql",
-    )
-    .unwrap();
-
-    let doc_a = ExecutableDocument::parse_and_validate(
-        &schema,
-        "query @example(a: 1, b: \"hello\") { field }",
-        "a.graphql",
-    )
-    .unwrap();
-
-    let doc_b = ExecutableDocument::parse_and_validate(
-        &schema,
-        "query @example(b: \"hello\", a: 1) { field }",
-        "b.graphql",
-    )
-    .unwrap();
-
-    assert_eq!(doc_a, doc_b);
-}
-
-#[test]
-fn executable_field_arguments_are_order_independent() {
-    let schema = Schema::parse_and_validate(
-        "type Query { field(a: Int, b: String): String }",
-        "schema.graphql",
-    )
-    .unwrap();
-
-    let doc_a = ExecutableDocument::parse_and_validate(
-        &schema,
-        "{ field(a: 1, b: \"hello\") }",
-        "a.graphql",
-    )
-    .unwrap();
-
-    let doc_b = ExecutableDocument::parse_and_validate(
-        &schema,
-        "{ field(b: \"hello\", a: 1) }",
-        "b.graphql",
-    )
-    .unwrap();
-
-    assert_eq!(doc_a, doc_b);
-}
-
-#[test]
 fn applied_directives_are_order_dependent() {
     let schema_a = Schema::parse_and_validate(
         "directive @auth on FIELD_DEFINITION
@@ -126,19 +38,4 @@ fn applied_directives_are_order_dependent() {
     .unwrap();
 
     assert_ne!(schema_a, schema_b);
-}
-
-#[test]
-fn selection_sets_are_order_dependent() {
-    let schema =
-        Schema::parse_and_validate("type Query { name: String, age: Int }", "schema.graphql")
-            .unwrap();
-
-    let doc_a =
-        ExecutableDocument::parse_and_validate(&schema, "{ name age }", "a.graphql").unwrap();
-
-    let doc_b =
-        ExecutableDocument::parse_and_validate(&schema, "{ age name }", "b.graphql").unwrap();
-
-    assert_ne!(doc_a, doc_b);
 }

--- a/crates/apollo-compiler/tests/main.rs
+++ b/crates/apollo-compiler/tests/main.rs
@@ -1,3 +1,4 @@
+mod equality_semantics;
 mod error_formatting;
 mod executable;
 mod extensions;


### PR DESCRIPTION
## Summary

Per the GraphQL September 2025 spec, directive locations are an unordered set and argument lists are unordered named collections. Previously these used `Vec` with derived `PartialEq`, making equality order-sensitive.

- Change `DirectiveDefinition.locations` from `Vec<DirectiveLocation>` to `IndexSet<DirectiveLocation>`
- Add custom `Hash` for `DirectiveDefinition` because `IndexSet` does not implement `Hash`
- Simplify directive validation by using `IndexSet.contains()` directly instead of building a temporary `HashSet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- FED-815 -->