### PR TITLE
feat(compiler): order-independent equality for argument fields

### DIFF
--- a/crates/apollo-compiler/src/ast/mod.rs
+++ b/crates/apollo-compiler/src/ast/mod.rs
@@ -51,6 +51,7 @@
 //! assert_eq!(doc.serialize().no_indent().to_string(), "query @dir { field }")
 //! ```
 
+use crate::collections::eq_unique_by_name;
 use crate::collections::hash_unordered;
 use crate::collections::IndexSet;
 use crate::parser::SourceMap;
@@ -141,7 +142,7 @@ pub struct FragmentDefinition {
 
 /// Type system AST for a `directive @foo`
 /// [_DirectiveDefinition_](https://spec.graphql.org/September2025/#DirectiveDefinition).
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq)]
 pub struct DirectiveDefinition {
     pub description: Option<Node<str>>,
     pub name: Name,
@@ -150,11 +151,21 @@ pub struct DirectiveDefinition {
     pub locations: IndexSet<DirectiveLocation>,
 }
 
+impl PartialEq for DirectiveDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.description == other.description
+            && self.name == other.name
+            && eq_unique_by_name(&self.arguments, &other.arguments, |a| &a.name)
+            && self.repeatable == other.repeatable
+            && self.locations == other.locations
+    }
+}
+
 impl Hash for DirectiveDefinition {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.description.hash(state);
         self.name.hash(state);
-        self.arguments.hash(state);
+        hash_unordered(self.arguments.iter(), state, self.arguments.len());
         self.repeatable.hash(state);
         hash_unordered(self.locations.iter(), state, self.locations.len());
     }
@@ -312,10 +323,23 @@ pub struct Argument {
 pub struct DirectiveList(pub Vec<Node<Directive>>);
 
 /// AST for a [_Directive_](https://spec.graphql.org/September2025/#Directive) application.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq)]
 pub struct Directive {
     pub name: Name,
     pub arguments: Vec<Node<Argument>>,
+}
+
+impl PartialEq for Directive {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && eq_unique_by_name(&self.arguments, &other.arguments, |a| &a.name)
+    }
+}
+
+impl Hash for Directive {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        hash_unordered(self.arguments.iter(), state, self.arguments.len());
+    }
 }
 
 /// AST for the [_OperationType_](https://spec.graphql.org/September2025/#OperationType)
@@ -383,13 +407,33 @@ pub enum Type {
 
 /// Type system AST for a [_FieldDefinition_](https://spec.graphql.org/September2025/#FieldDefinition)
 /// in an object type or interface type defintion or extension.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq)]
 pub struct FieldDefinition {
     pub description: Option<Node<str>>,
     pub name: Name,
     pub arguments: Vec<Node<InputValueDefinition>>,
     pub ty: Type,
     pub directives: DirectiveList,
+}
+
+impl PartialEq for FieldDefinition {
+    fn eq(&self, other: &Self) -> bool {
+        self.description == other.description
+            && self.name == other.name
+            && eq_unique_by_name(&self.arguments, &other.arguments, |a| &a.name)
+            && self.ty == other.ty
+            && self.directives == other.directives
+    }
+}
+
+impl Hash for FieldDefinition {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.description.hash(state);
+        self.name.hash(state);
+        hash_unordered(self.arguments.iter(), state, self.arguments.len());
+        self.ty.hash(state);
+        self.directives.hash(state);
+    }
 }
 
 /// Type system AST for an
@@ -425,13 +469,33 @@ pub enum Selection {
 
 /// Executable AST for a [_Field_](https://spec.graphql.org/September2025/#Field) selection
 /// in a selection set.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq)]
 pub struct Field {
     pub alias: Option<Name>,
     pub name: Name,
     pub arguments: Vec<Node<Argument>>,
     pub directives: DirectiveList,
     pub selection_set: Vec<Selection>,
+}
+
+impl PartialEq for Field {
+    fn eq(&self, other: &Self) -> bool {
+        self.alias == other.alias
+            && self.name == other.name
+            && eq_unique_by_name(&self.arguments, &other.arguments, |a| &a.name)
+            && self.directives == other.directives
+            && self.selection_set == other.selection_set
+    }
+}
+
+impl Hash for Field {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.alias.hash(state);
+        self.name.hash(state);
+        hash_unordered(self.arguments.iter(), state, self.arguments.len());
+        self.directives.hash(state);
+        self.selection_set.hash(state);
+    }
 }
 
 /// Executable AST for a

--- a/crates/apollo-compiler/src/collections.rs
+++ b/crates/apollo-compiler/src/collections.rs
@@ -17,6 +17,25 @@ pub type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;
 /// [`std::collections::HashSet`] configured with a specific hasher
 pub type HashSet<T> = std::collections::HashSet<T, ahash::RandomState>;
 
+/// Order-independent equality for collections of uniquely-named items
+/// (e.g. arguments, input value definitions). Assumes names are unique per the
+/// GraphQL spec; behavior is unspecified for duplicate names.
+pub(crate) fn eq_unique_by_name<T: PartialEq>(
+    a: &[crate::Node<T>],
+    b: &[crate::Node<T>],
+    get_name: impl Fn(&T) -> &crate::Name,
+) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().all(|item_a| {
+        let name = get_name(item_a);
+        b.iter()
+            .filter(|item_b| get_name(item_b) == name)
+            .any(|item_b| item_a == item_b)
+    })
+}
+
 /// Order-independent hash for collections whose `PartialEq` is order-independent
 /// (e.g. `IndexMap`, `IndexSet`). Uses commutative XOR of per-element hashes.
 pub(crate) fn hash_unordered<H: Hasher, T: Hash>(

--- a/crates/apollo-compiler/src/executable/mod.rs
+++ b/crates/apollo-compiler/src/executable/mod.rs
@@ -49,6 +49,8 @@
 //! and also implements `Display` and `ToString`.
 
 use crate::ast;
+use crate::collections::eq_unique_by_name;
+use crate::collections::hash_unordered;
 use crate::collections::IndexMap;
 use crate::coordinate::FieldArgumentCoordinate;
 use crate::coordinate::TypeAttributeCoordinate;
@@ -161,7 +163,7 @@ pub enum Selection {
 
 /// A [_Field_](https://spec.graphql.org/September2025/#Field) selection,
 /// linked to the corresponding field definition in the schema.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Eq)]
 pub struct Field {
     /// The definition of this field in an object type or interface type definition in the schema
     pub definition: Node<schema::FieldDefinition>,
@@ -170,6 +172,28 @@ pub struct Field {
     pub arguments: Vec<Node<Argument>>,
     pub directives: DirectiveList,
     pub selection_set: SelectionSet,
+}
+
+impl PartialEq for Field {
+    fn eq(&self, other: &Self) -> bool {
+        self.definition == other.definition
+            && self.alias == other.alias
+            && self.name == other.name
+            && eq_unique_by_name(&self.arguments, &other.arguments, |a| &a.name)
+            && self.directives == other.directives
+            && self.selection_set == other.selection_set
+    }
+}
+
+impl std::hash::Hash for Field {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.definition.hash(state);
+        self.alias.hash(state);
+        self.name.hash(state);
+        hash_unordered(self.arguments.iter(), state, self.arguments.len());
+        self.directives.hash(state);
+        self.selection_set.hash(state);
+    }
 }
 
 /// A [_FragmentSpread_](https://spec.graphql.org/September2025/#FragmentSpread)

--- a/crates/apollo-compiler/tests/equality_semantics.rs
+++ b/crates/apollo-compiler/tests/equality_semantics.rs
@@ -20,6 +20,42 @@ fn directive_definition_locations_are_order_independent() {
 }
 
 #[test]
+fn directive_arguments_are_order_independent() {
+    let schema_a = Schema::parse_and_validate(
+        "directive @example(a: Int, b: Int) on FIELD_DEFINITION
+         type Query { field: String @example(a: 1, b: 2) }",
+        "a.graphql",
+    )
+    .unwrap();
+
+    let schema_b = Schema::parse_and_validate(
+        "directive @example(a: Int, b: Int) on FIELD_DEFINITION
+         type Query { field: String @example(b: 2, a: 1) }",
+        "b.graphql",
+    )
+    .unwrap();
+
+    assert_eq!(schema_a, schema_b);
+}
+
+#[test]
+fn field_definition_arguments_are_order_independent() {
+    let schema_a = Schema::parse_and_validate(
+        "type Query { field(a: Int, b: String): String }",
+        "a.graphql",
+    )
+    .unwrap();
+
+    let schema_b = Schema::parse_and_validate(
+        "type Query { field(b: String, a: Int): String }",
+        "b.graphql",
+    )
+    .unwrap();
+
+    assert_eq!(schema_a, schema_b);
+}
+
+#[test]
 fn applied_directives_are_order_dependent() {
     let schema_a = Schema::parse_and_validate(
         "directive @auth on FIELD_DEFINITION


### PR DESCRIPTION
## Summary

Implements custom `PartialEq` for structures where arguments are unordered. Originally, the goal was to switch from `Vec` to `IndexMap`, but we need to hold duplicate arguments (by name, possibly with different values) until validation time so we can report them invalid. Instead, we just use a non-default equality check to get the order-agnostic equality behavior we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- FED-813 -->