### PR TITLE
apollo-smith@0.17.0-beta.1

### DIFF
--- a/crates/apollo-smith/CHANGELOG.md
+++ b/crates/apollo-smith/CHANGELOG.md
@@ -18,6 +18,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 
 ## Documentation -->
+# [0.17.0-beta.1](https://crates.io/crates/apollo-smith/0.17.0-beta.1) - 2026-08-28
+
+## BREAKING
+
+- **Update `Component<T>` to `Node<T>` following apollo-compiler changes - [tninesling], [pull/1091]**
+
+  Adapts to the compiler's removal of `ComponentName` in favor of `Node<Name>`.
+
+## Features
+
+- **Support partial response data in ResponseBuilder - [tninesling], [pull/1081]**
+
+  `ResponseBuilder::with_partial_data` accepts a response-shaped fragment that
+  the generated response must include verbatim. The builder walks the partial
+  data alongside the operation's selection set: leaf positions echo the partial
+  data exactly (never nulled by `with_null_ratio`), object positions recurse
+  with covered sub-fields echoed and uncovered sub-fields generated as usual,
+  and a `__typename` entry pins the concrete type at abstract positions.
+
+## Maintenance
+
+- **Bump `apollo-compiler` dependency to `2.0.0-beta.1` - [tninesling]**
+
+[pull/1081]: https://github.com/apollographql/apollo-rs/pull/1081
+[pull/1091]: https://github.com/apollographql/apollo-rs/pull/1091
+[tninesling]: https://github.com/tninesling
+
 # [0.17.0-beta.0](https://crates.io/crates/apollo-smith/0.17.0-beta.0) - 2026-08-21
 
 ## Features

--- a/crates/apollo-smith/Cargo.toml
+++ b/crates/apollo-smith/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-smith"
-version = "0.17.0-beta.0" # When bumping, also update README.md
+version = "0.17.0-beta.1" # When bumping, also update README.md
 edition = "2021"
 authors = ["Benjamin Coenen <benjamin.coenen@apollographql.com>"]
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ categories = [
 ]
 
 [dependencies]
-apollo-compiler = { path = "../apollo-compiler", version = "2.0.0-beta.0" }
+apollo-compiler = { path = "../apollo-compiler", version = "2.0.0-beta.1" }
 apollo-parser = { path = "../apollo-parser", version = "0.9.0-beta.0" }
 arbitrary = { version = "1.4.0", features = ["derive"] }
 indexmap = "2.0.0"

--- a/crates/apollo-smith/README.md
+++ b/crates/apollo-smith/README.md
@@ -50,7 +50,7 @@ and add `apollo-smith` to your Cargo.toml:
 ## fuzz/Cargo.toml
 
 [dependencies]
-apollo-smith = "0.17.0-beta.0"
+apollo-smith = "0.17.0-beta.1"
 ```
 
 It can then be used in a `fuzz_target` along with the [`arbitrary`] crate,


### PR DESCRIPTION
## Summary
- Bump `apollo-smith` version to `0.17.0-beta.1`
- Bump `apollo-compiler` dependency to `2.0.0-beta.1`
- Update CHANGELOG and README install instructions

## Changes since beta.0
- **BREAKING**: Update `Component<T>` to `Node<T>` following compiler changes (#1091)
- Support partial response data in `ResponseBuilder` (#1081)
- Bump `apollo-compiler` dependency to `2.0.0-beta.1`