### PR TITLE
test(compiler): deferred fragment spread multiple times is considered unique

### DIFF
--- a/crates/apollo-compiler/test_data/ok/0121_defer_label_fragment_spread_multiple_times.graphql
+++ b/crates/apollo-compiler/test_data/ok/0121_defer_label_fragment_spread_multiple_times.graphql
@@ -1,0 +1,34 @@
+# The label uniqueness rule counts @defer directives in the document as
+# written. A labeled @defer inside a fragment definition is a single
+# directive, so spreading the fragment in multiple places is valid, even
+# though execution emits multiple same-label pending payloads (clients
+# disambiguate by path/id). This mirrors Relay, which derives labels from
+# the enclosing fragment name.
+query Q {
+    me {
+        ...ItemFragment
+    }
+    friend {
+        ...ItemFragment
+    }
+}
+
+fragment ItemFragment on User {
+    ... @defer(label: "ItemFragment") {
+        id
+    }
+}
+
+directive @defer(
+    if: Boolean! = true
+    label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+    me: User
+    friend: User
+}
+
+type User {
+    id: ID
+}

--- a/crates/apollo-compiler/test_data/ok/0121_defer_label_fragment_spread_multiple_times.txt
+++ b/crates/apollo-compiler/test_data/ok/0121_defer_label_fragment_spread_multiple_times.txt
@@ -1,0 +1,273 @@
+Schema {
+    sources: {
+        1: SourceFile {
+            path: "built_in.graphql",
+            source_text: include_str!("built_in.graphql"),
+        },
+        50: SourceFile {
+            path: "0121_defer_label_fragment_spread_multiple_times.graphql",
+            source_text: "# The label uniqueness rule counts @defer directives in the document as\n# written. A labeled @defer inside a fragment definition is a single\n# directive, so spreading the fragment in multiple places is valid, even\n# though execution emits multiple same-label pending payloads (clients\n# disambiguate by path/id). This mirrors Relay, which derives labels from\n# the enclosing fragment name.\nquery Q {\n    me {\n        ...ItemFragment\n    }\n    friend {\n        ...ItemFragment\n    }\n}\n\nfragment ItemFragment on User {\n    ... @defer(label: \"ItemFragment\") {\n        id\n    }\n}\n\ndirective @defer(\n    if: Boolean! = true\n    label: String\n) on FRAGMENT_SPREAD | INLINE_FRAGMENT\n\ntype Query {\n    me: User\n    friend: User\n}\n\ntype User {\n    id: ID\n}\n",
+        },
+    },
+    schema_definition: SchemaDefinition {
+        description: None,
+        directives: [],
+        query: Some(
+            ComponentName {
+                origin: Definition,
+                name: "Query",
+            },
+        ),
+        mutation: None,
+        subscription: None,
+    },
+    directive_definitions: {
+        "skip": built_in_directive!("skip"),
+        "include": built_in_directive!("include"),
+        "deprecated": built_in_directive!("deprecated"),
+        "specifiedBy": built_in_directive!("specifiedBy"),
+        "defer": 577..675 @50 DirectiveDefinition {
+            description: None,
+            name: "defer",
+            arguments: [
+                599..618 @50 InputValueDefinition {
+                    description: None,
+                    name: "if",
+                    ty: 603..611 @50 NonNullNamed(
+                        "Boolean",
+                    ),
+                    default_value: Some(
+                        614..618 @50 Boolean(
+                            true,
+                        ),
+                    ),
+                    directives: [],
+                },
+                623..636 @50 InputValueDefinition {
+                    description: None,
+                    name: "label",
+                    ty: 630..636 @50 Named(
+                        "String",
+                    ),
+                    default_value: None,
+                    directives: [],
+                },
+            ],
+            repeatable: false,
+            locations: [
+                "FRAGMENT_SPREAD",
+                "INLINE_FRAGMENT",
+            ],
+        },
+    },
+    types: {
+        "__Schema": built_in_type!("__Schema"),
+        "__Type": built_in_type!("__Type"),
+        "__TypeKind": built_in_type!("__TypeKind"),
+        "__Field": built_in_type!("__Field"),
+        "__InputValue": built_in_type!("__InputValue"),
+        "__EnumValue": built_in_type!("__EnumValue"),
+        "__Directive": built_in_type!("__Directive"),
+        "__DirectiveLocation": built_in_type!("__DirectiveLocation"),
+        "String": built_in_type!("String"),
+        "Boolean": built_in_type!("Boolean"),
+        "ID": built_in_type!("ID"),
+        "Query": Object(
+            677..721 @50 ObjectType {
+                description: None,
+                name: "Query",
+                implements_interfaces: {},
+                directives: [],
+                fields: {
+                    "me": Component {
+                        origin: Definition,
+                        node: 694..702 @50 FieldDefinition {
+                            description: None,
+                            name: "me",
+                            arguments: [],
+                            ty: Named(
+                                "User",
+                            ),
+                            directives: [],
+                        },
+                    },
+                    "friend": Component {
+                        origin: Definition,
+                        node: 707..719 @50 FieldDefinition {
+                            description: None,
+                            name: "friend",
+                            arguments: [],
+                            ty: Named(
+                                "User",
+                            ),
+                            directives: [],
+                        },
+                    },
+                },
+            },
+        ),
+        "User": Object(
+            723..747 @50 ObjectType {
+                description: None,
+                name: "User",
+                implements_interfaces: {},
+                directives: [],
+                fields: {
+                    "id": Component {
+                        origin: Definition,
+                        node: 739..745 @50 FieldDefinition {
+                            description: None,
+                            name: "id",
+                            arguments: [],
+                            ty: Named(
+                                "ID",
+                            ),
+                            directives: [],
+                        },
+                    },
+                },
+            },
+        ),
+    },
+}
+ExecutableDocument {
+    sources: {
+        1: SourceFile {
+            path: "built_in.graphql",
+            source_text: include_str!("built_in.graphql"),
+        },
+        50: SourceFile {
+            path: "0121_defer_label_fragment_spread_multiple_times.graphql",
+            source_text: "# The label uniqueness rule counts @defer directives in the document as\n# written. A labeled @defer inside a fragment definition is a single\n# directive, so spreading the fragment in multiple places is valid, even\n# though execution emits multiple same-label pending payloads (clients\n# disambiguate by path/id). This mirrors Relay, which derives labels from\n# the enclosing fragment name.\nquery Q {\n    me {\n        ...ItemFragment\n    }\n    friend {\n        ...ItemFragment\n    }\n}\n\nfragment ItemFragment on User {\n    ... @defer(label: \"ItemFragment\") {\n        id\n    }\n}\n\ndirective @defer(\n    if: Boolean! = true\n    label: String\n) on FRAGMENT_SPREAD | INLINE_FRAGMENT\n\ntype Query {\n    me: User\n    friend: User\n}\n\ntype User {\n    id: ID\n}\n",
+        },
+    },
+    operations: OperationMap {
+        anonymous: None,
+        named: {
+            "Q": 390..483 @50 Operation {
+                operation_type: Query,
+                name: Some(
+                    "Q",
+                ),
+                variables: [],
+                directives: [],
+                selection_set: SelectionSet {
+                    ty: "Query",
+                    selections: [
+                        Field(
+                            404..438 @50 Field {
+                                definition: 694..702 @50 FieldDefinition {
+                                    description: None,
+                                    name: "me",
+                                    arguments: [],
+                                    ty: Named(
+                                        "User",
+                                    ),
+                                    directives: [],
+                                },
+                                alias: None,
+                                name: "me",
+                                arguments: [],
+                                directives: [],
+                                selection_set: SelectionSet {
+                                    ty: "User",
+                                    selections: [
+                                        FragmentSpread(
+                                            417..432 @50 FragmentSpread {
+                                                fragment_name: "ItemFragment",
+                                                directives: [],
+                                            },
+                                        ),
+                                    ],
+                                },
+                            },
+                        ),
+                        Field(
+                            443..481 @50 Field {
+                                definition: 707..719 @50 FieldDefinition {
+                                    description: None,
+                                    name: "friend",
+                                    arguments: [],
+                                    ty: Named(
+                                        "User",
+                                    ),
+                                    directives: [],
+                                },
+                                alias: None,
+                                name: "friend",
+                                arguments: [],
+                                directives: [],
+                                selection_set: SelectionSet {
+                                    ty: "User",
+                                    selections: [
+                                        FragmentSpread(
+                                            460..475 @50 FragmentSpread {
+                                                fragment_name: "ItemFragment",
+                                                directives: [],
+                                            },
+                                        ),
+                                    ],
+                                },
+                            },
+                        ),
+                    ],
+                },
+            },
+        },
+    },
+    fragments: {
+        "ItemFragment": 485..575 @50 Fragment {
+            name: "ItemFragment",
+            directives: [],
+            selection_set: SelectionSet {
+                ty: "User",
+                selections: [
+                    InlineFragment(
+                        521..573 @50 InlineFragment {
+                            type_condition: None,
+                            directives: [
+                                525..554 @50 Directive {
+                                    name: "defer",
+                                    arguments: [
+                                        532..553 @50 Argument {
+                                            name: "label",
+                                            value: 539..553 @50 String(
+                                                "ItemFragment",
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ],
+                            selection_set: SelectionSet {
+                                ty: "User",
+                                selections: [
+                                    Field(
+                                        565..567 @50 Field {
+                                            definition: 739..745 @50 FieldDefinition {
+                                                description: None,
+                                                name: "id",
+                                                arguments: [],
+                                                ty: Named(
+                                                    "ID",
+                                                ),
+                                                directives: [],
+                                            },
+                                            alias: None,
+                                            name: "id",
+                                            arguments: [],
+                                            directives: [],
+                                            selection_set: SelectionSet {
+                                                ty: "ID",
+                                                selections: [],
+                                            },
+                                        },
+                                    ),
+                                ],
+                            },
+                        },
+                    ),
+                ],
+            },
+        },
+    },
+}

--- a/crates/apollo-compiler/test_data/serializer/ok/0121_defer_label_fragment_spread_multiple_times.graphql
+++ b/crates/apollo-compiler/test_data/serializer/ok/0121_defer_label_fragment_spread_multiple_times.graphql
@@ -1,0 +1,25 @@
+query Q {
+  me {
+    ...ItemFragment
+  }
+  friend {
+    ...ItemFragment
+  }
+}
+
+fragment ItemFragment on User {
+  ... @defer(label: "ItemFragment") {
+    id
+  }
+}
+
+directive @defer(if: Boolean! = true, label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  me: User
+  friend: User
+}
+
+type User {
+  id: ID
+}


### PR DESCRIPTION
Adds an `ok/` validation fixture confirming that the "Defer And Stream Directive Labels Are Unique" rule ([graphql-spec#1110](https://github.com/graphql/graphql-spec/pull/1110)) is evaluated over the document as written: a labeled `@defer` inside a fragment definition is a single directive, so spreading that fragment in multiple places must pass validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)