### PR TITLE
apollo-compiler@1.33.0

### DIFF
--- a/crates/apollo-compiler/CHANGELOG.md
+++ b/crates/apollo-compiler/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Maintenance
 ## Documentation-->
 
-# [x.x.x] (unreleased) - 2026-mm-dd
+# [1.33.0](https://crates.io/crates/apollo-compiler/1.33.0) - 2026-09-03
 
 ## Features
 
@@ -43,6 +43,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [graphql-spec#1110]: https://github.com/graphql/graphql-spec/pull/1110
 [duckki]: https://github.com/duckki
 [pull/1069]: https://github.com/apollographql/apollo-rs/pull/1069
+
+## Fixes
+
+- **Validate that root operations use different types - [tninesling], [pull/1071]**
+
+  The GraphQL spec requires the query, mutation, and subscription root
+  operations of a schema to use distinct Object types. Schemas that reused a
+  type across root operations previously validated successfully; they are now
+  rejected.
+
+## Maintenance
+
+- **Update `serial_test` dev-dependency to v4 - [pull/1073]**
+
+  Dev-dependency only; no effect on library consumers. Note that building the
+  apollo-rs test suite now requires rustc 1.93.1 or newer.
+
+[tninesling]: https://github.com/tninesling
+[pull/1071]: https://github.com/apollographql/apollo-rs/pull/1071
+[pull/1073]: https://github.com/apollographql/apollo-rs/pull/1073
 
 # [1.32.0](https://crates.io/crates/apollo-compiler/1.32.0) - 2026-05-14
 

--- a/crates/apollo-compiler/Cargo.toml
+++ b/crates/apollo-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-compiler"
-version = "1.32.0" # When bumping, also update README.md
+version = "1.33.0" # When bumping, also update README.md
 authors = ["Irina Shestak <shestak.irina@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/apollographql/apollo-rs"

--- a/crates/apollo-compiler/README.md
+++ b/crates/apollo-compiler/README.md
@@ -41,7 +41,7 @@ Or add this to your `Cargo.toml` for a manual installation:
 ```toml
 # Just an example, change to the necessary package version.
 [dependencies]
-apollo-compiler = "1.32.0"
+apollo-compiler = "1.33.0"
 ```
 
 ## Rust versions


### PR DESCRIPTION
Release prep for apollo-compiler 1.33.0.

- **Features**: `@defer` validation per the GraphQL Defer & Stream draft (#1069) — label uniqueness (document-level, so fragment reuse à la Relay stays valid), no `@defer` on mutation/subscription roots, subscription `if` requirements.
- **Fixes**: root operations must use distinct types (#1071).
- **Maintenance**: `serial_test` v4 (dev-dependency, #1073).

🤖 Generated with [Claude Code](https://claude.com/claude-code)